### PR TITLE
Add MLX Apple Silicon and NVIDIA GB10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/analyze-trac
 
 **Upload your trace file:**
 ```bash
-curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/upload-trace" \
-     -F "file=@your_trace.json" -F "gpu_type=A10G" -F "enable_claude=true"
+curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/upload-trace?gpu_type=A10G&enable_claude=true" \
+     -F "file=@your_trace.json"
 ```
 
 ---
@@ -194,7 +194,7 @@ ssh -L 8080:localhost:8080 -L 8501:localhost:8501 \
 ## 🎯 Features
 
 - **Token-level profiling** of LLM inference with kernel timing analysis
-- **GPU bottleneck detection** (stall %, launch delays, memory issues)
+- **GPU bottleneck heuristics** from measured metadata or deterministic estimates
 - **AI explanations** using Claude API for performance insights
 - **Interactive visualizations** with flame graphs and dashboards
 - **Modal.com deployment** with GPU acceleration
@@ -215,7 +215,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Create virtual environment and install dependencies
 uv sync
 
-# Or install in development mode with optional dependencies
+# Install development and test tools
 uv sync --extra dev --extra test
 
 # Apple Silicon only: install the optional MLX recorder dependency
@@ -231,6 +231,9 @@ pip install -r llmtracefx/requirements.txt
 
 # Or install as editable package
 pip install -e .
+
+# Apple Silicon only
+pip install -e ".[mlx]"
 ```
 
 ## 🔧 Quick Start
@@ -239,25 +242,24 @@ pip install -e .
 
 ```bash
 # With uv
-uv run llmtracefx --trace sample
-uv run llmtracefx --trace your_trace.json --gpu-type A10G
 uv run llmtracefx --trace sample --no-claude
+uv run llmtracefx --trace your_trace.json --gpu-type A10G --no-claude
 
 # Or activate virtual environment first
 uv sync
 source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-llmtracefx --trace sample
+llmtracefx --trace sample --no-claude
 
 # With pip/python
-python -m llmtracefx.main --trace sample
-python -m llmtracefx.main --trace your_trace.json --gpu-type A10G
+python -m llmtracefx.main --trace sample --no-claude
+python -m llmtracefx.main --trace your_trace.json --gpu-type A10G --no-claude
 python -m llmtracefx.main --trace sample --no-claude
 ```
 
 ### Apple Silicon with MLX
 
-`MLXTraceRecorder` evaluates and synchronizes lazy MLX work, records real
-per-operation durations, and writes JSON that the existing CLI can read.
+`MLXTraceRecorder` runs on Apple Silicon. It evaluates lazy MLX results,
+synchronizes the device, and writes JSON that the existing CLI can read.
 
 ```bash
 uv sync --extra mlx
@@ -276,20 +278,33 @@ with MLXTraceRecorder("mlx_trace.json") as trace:
         next_token = trace.measure("sample", sample, logits)
 ```
 
-For a native Xcode GPU capture of the same region, pass
-`metal_capture_path="mlx_trace.gputrace"` and run with
-`MTL_CAPTURE_ENABLED=1`. The `.gputrace` path must not already exist.
+Each duration is synchronized wall-clock time for the callable plus forced MLX
+evaluation. It is not an individual Metal kernel-counter measurement. The
+recorder also saves MLX allocator snapshots after each operation.
+
+For a native Xcode GPU capture of the same region:
+
+```bash
+MTL_CAPTURE_ENABLED=1 uv run python examples/mlx_trace.py \
+  --metal-capture mlx_trace.gputrace
+```
+
+The `.gputrace` path must not already exist. Open it in Xcode for kernel-level
+inspection. See the [MLX Metal debugger guide](https://ml-explore.github.io/mlx/build/html/dev/metal_debugger.html).
 
 ### NVIDIA GB10 / DGX Spark
 
-Use the `GB10` profile with an existing LLMTraceFX, vLLM, or event trace:
+No extra dependency is needed for GB10. Analyze an existing LLMTraceFX, vLLM,
+or event trace with the static GB10 hardware profile:
 
 ```bash
 uv run llmtracefx --trace trace.json --gpu-type GB10 --no-claude
 ```
 
 `DGX-SPARK` is accepted as an alias. The profile uses the GB10's 128 GB
-coherent unified memory and 273 GB/s memory bandwidth.
+coherent unified memory and 273 GB/s memory bandwidth from the
+[NVIDIA DGX Spark hardware guide](https://docs.nvidia.com/dgx/dgx-spark/hardware.html).
+It does not capture a CUDA trace by itself.
 
 ### 2. FastAPI Server
 
@@ -350,7 +365,7 @@ curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/analyze-trac
 
 ```bash
 export CLAUDE_API_KEY="your_claude_api_key"
-export DEFAULT_GPU_TYPE="A10G"  # or H100, A100
+export DEFAULT_GPU_TYPE="A10G"  # A10G, A100, H100, GB10, or MLX
 export ENABLE_CLAUDE="true"
 export DASHBOARD_PORT="8000"
 ```
@@ -367,7 +382,7 @@ export DASHBOARD_PORT="8000"
 ```
 🔍 Analyzing trace: sample
 📊 Using sample trace data
-🔧 Analyzing GPU performance (GPU: A10G)
+🔧 Analyzing GPU performance (NVIDIA A10G)
 📈 Analysis complete:
    Total tokens: 5
    Total latency: 120.5ms
@@ -390,6 +405,7 @@ Base URL: `https://siddhant-k-code--llmtracefx-web-app.modal.run`
 ```bash
 POST /upload-trace          # Upload trace file
 POST /analyze-trace         # Analyze trace data
+GET  /hardware              # List hardware profiles
 GET  /analysis/{id}         # Get analysis summary
 GET  /token/{id}/{token}    # Get token details
 GET  /explain/{id}/{token}  # Get Claude explanation
@@ -439,10 +455,8 @@ print(f"Performance score: {response.json()['avg_performance_score']:.1f}/100")
 #### **Upload Trace File**
 ```bash
 # Upload your vLLM trace file
-curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/upload-trace" \
-     -F "file=@your_trace.json" \
-     -F "gpu_type=A10G" \
-     -F "enable_claude=true"
+curl -X POST "https://siddhant-k-code--llmtracefx-web-app.modal.run/upload-trace?gpu_type=A10G&enable_claude=true" \
+     -F "file=@your_trace.json"
 ```
 
 #### **Local Development**
@@ -513,8 +527,10 @@ dashboard = requests.get(f'http://localhost:8000/dashboard/{analysis_id}')
 
 Measured values can be supplied in operation metadata using `stall_pct`,
 `launch_delay_ms`, `memory_latency_ms`, `occupancy_pct`, `cache_hit_rate`, and
-`compute_utilization`. Missing fields use deterministic estimates, and each
-report labels the metrics as `measured`, `mixed`, or `estimated`.
+`compute_utilization`. Missing fields use deterministic estimates. A report is
+`measured` only when every operation supplies all six metrics; otherwise it is
+labelled `mixed` or `estimated`. MLX recorder timings and memory snapshots are
+measured, but the six analyzer metrics remain estimated unless you add them.
 
 ### Supported Hardware
 - **A10G**: 24GB VRAM, 600 GB/s bandwidth
@@ -617,7 +633,11 @@ python -m llmtracefx.main --create-sample
 ### Run Tests
 
 ```bash
-python -m llmtracefx.main --trace test_traces/sample_vllm_trace.json
+uv sync --extra dev --extra test
+uv run pytest
+uv run ruff check llmtracefx/hardware.py \
+  llmtracefx/profiler/mlx_tracer.py \
+  llmtracefx/profiler/gpu_analyzer.py tests
 ```
 
 ## 📄 License

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ ssh -L 8080:localhost:8080 -L 8501:localhost:8501 \
 - **Interactive visualizations** with flame graphs and dashboards
 - **Modal.com deployment** with GPU acceleration
 - **Multiple input formats** (vLLM, generic trace logs)
+- **Apple Silicon and NVIDIA GB10 profiles** with an optional MLX recorder
 
 ## 📦 Installation
 
@@ -216,6 +217,9 @@ uv sync
 
 # Or install in development mode with optional dependencies
 uv sync --extra dev --extra test
+
+# Apple Silicon only: install the optional MLX recorder dependency
+uv sync --extra mlx
 ```
 
 ### Using pip
@@ -249,6 +253,43 @@ python -m llmtracefx.main --trace sample
 python -m llmtracefx.main --trace your_trace.json --gpu-type A10G
 python -m llmtracefx.main --trace sample --no-claude
 ```
+
+### Apple Silicon with MLX
+
+`MLXTraceRecorder` evaluates and synchronizes lazy MLX work, records real
+per-operation durations, and writes JSON that the existing CLI can read.
+
+```bash
+uv sync --extra mlx
+uv run python examples/mlx_trace.py
+uv run llmtracefx --trace mlx_trace.json --gpu-type MLX --no-claude
+```
+
+Use the recorder around token generation in your own model:
+
+```python
+from llmtracefx.profiler import MLXTraceRecorder
+
+with MLXTraceRecorder("mlx_trace.json") as trace:
+    with trace.token(0, "Hello"):
+        logits = trace.measure("model_forward", model, input_ids)
+        next_token = trace.measure("sample", sample, logits)
+```
+
+For a native Xcode GPU capture of the same region, pass
+`metal_capture_path="mlx_trace.gputrace"` and run with
+`MTL_CAPTURE_ENABLED=1`. The `.gputrace` path must not already exist.
+
+### NVIDIA GB10 / DGX Spark
+
+Use the `GB10` profile with an existing LLMTraceFX, vLLM, or event trace:
+
+```bash
+uv run llmtracefx --trace trace.json --gpu-type GB10 --no-claude
+```
+
+`DGX-SPARK` is accepted as an alias. The profile uses the GB10's 128 GB
+coherent unified memory and 273 GB/s memory bandwidth.
 
 ### 2. FastAPI Server
 
@@ -466,14 +507,21 @@ dashboard = requests.get(f'http://localhost:8000/dashboard/{analysis_id}')
 ### GPU Metrics
 - **Stall Percentage**: Memory-bound bottlenecks
 - **Launch Delay**: Kernel launch overhead
-- **SM Occupancy**: Streaming multiprocessor utilization
+- **Occupancy**: SM occupancy on CUDA and GPU occupancy on Metal
 - **Cache Hit Rate**: Memory access efficiency
 - **Compute Utilization**: GPU computational usage
 
-### Supported GPUs
+Measured values can be supplied in operation metadata using `stall_pct`,
+`launch_delay_ms`, `memory_latency_ms`, `occupancy_pct`, `cache_hit_rate`, and
+`compute_utilization`. Missing fields use deterministic estimates, and each
+report labels the metrics as `measured`, `mixed`, or `estimated`.
+
+### Supported Hardware
 - **A10G**: 24GB VRAM, 600 GB/s bandwidth
 - **H100**: 80GB VRAM, 3350 GB/s bandwidth
 - **A100**: 80GB VRAM, 1935 GB/s bandwidth
+- **GB10 / DGX Spark**: 128GB coherent unified memory, 273 GB/s bandwidth
+- **MLX / Apple Silicon**: Metal backend with runtime device metadata
 
 ## 🤖 Claude Integration
 

--- a/examples/mlx_trace.py
+++ b/examples/mlx_trace.py
@@ -1,0 +1,18 @@
+"""Create a small LLMTraceFX trace from real MLX work on Apple Silicon."""
+
+import mlx.core as mx
+
+from llmtracefx.profiler import MLXTraceRecorder
+
+left = mx.random.uniform(shape=(1024, 1024))
+right = mx.random.uniform(shape=(1024, 1024))
+mx.eval(left, right)
+
+with MLXTraceRecorder("mlx_trace.json") as trace:
+    for token_id, token_text in enumerate(("Hello", "MLX")):
+        with trace.token(token_id, token_text):
+            result = trace.measure("matmul", mx.matmul, left, right)
+            trace.measure("softmax", mx.softmax, result, axis=-1)
+
+print("Wrote mlx_trace.json")
+print("Analyze it with: llmtracefx --trace mlx_trace.json --gpu-type MLX --no-claude")

--- a/examples/mlx_trace.py
+++ b/examples/mlx_trace.py
@@ -1,18 +1,26 @@
 """Create a small LLMTraceFX trace from real MLX work on Apple Silicon."""
 
+import argparse
+from pathlib import Path
+
 import mlx.core as mx
 
 from llmtracefx.profiler import MLXTraceRecorder
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--output", type=Path, default=Path("mlx_trace.json"))
+parser.add_argument("--metal-capture", type=Path)
+args = parser.parse_args()
 
 left = mx.random.uniform(shape=(1024, 1024))
 right = mx.random.uniform(shape=(1024, 1024))
 mx.eval(left, right)
 
-with MLXTraceRecorder("mlx_trace.json") as trace:
+with MLXTraceRecorder(args.output, metal_capture_path=args.metal_capture) as trace:
     for token_id, token_text in enumerate(("Hello", "MLX")):
         with trace.token(token_id, token_text):
             result = trace.measure("matmul", mx.matmul, left, right)
             trace.measure("softmax", mx.softmax, result, axis=-1)
 
-print("Wrote mlx_trace.json")
-print("Analyze it with: llmtracefx --trace mlx_trace.json --gpu-type MLX --no-claude")
+print(f"Wrote {args.output}")
+print(f"Analyze it with: llmtracefx --trace {args.output} --gpu-type MLX --no-claude")

--- a/llmtracefx/__init__.py
+++ b/llmtracefx/__init__.py
@@ -1,0 +1,1 @@
+"""LLMTraceFX package."""

--- a/llmtracefx/api/serve.py
+++ b/llmtracefx/api/serve.py
@@ -173,6 +173,7 @@ async def upload_trace(
         try:
             # Parse trace file
             tokens = parser.parse_trace_file(tmp_path)
+            _require_tokens(tokens)
             
             # Analyze tokens
             analyzer_instance = GPUAnalyzer(gpu_type)
@@ -279,6 +280,7 @@ async def analyze_trace(
         # CPU fallback processing (original code)
         # Parse trace data
         tokens = parser.parse_trace_data(request.trace_data)
+        _require_tokens(tokens)
         
         # Analyze tokens
         analyzer_instance = GPUAnalyzer(gpu_type)
@@ -484,6 +486,13 @@ def _validate_hardware(gpu_type: str) -> str:
         return normalize_hardware_name(gpu_type)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _require_tokens(tokens: list[Any]) -> None:
+    if not tokens:
+        raise HTTPException(
+            status_code=400, detail="Trace does not contain any tokens"
+        )
 
 
 async def generate_claude_explanations(analysis_id: str, analyses: List[TokenAnalysis]):

--- a/llmtracefx/api/serve.py
+++ b/llmtracefx/api/serve.py
@@ -14,6 +14,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+from ..hardware import hardware_profiles, normalize_hardware_name
 from ..profiler.trace_parser import TraceParser
 from ..profiler.gpu_analyzer import GPUAnalyzer, TokenAnalysis
 from ..explainer.claude import ClaudeExplainer
@@ -53,7 +54,7 @@ class TokenDetailResponse(BaseModel):
 app = FastAPI(
     title="LLMTraceFX API",
     description="GPU-level LLM inference profiler",
-    version="1.0.0"
+    version="1.1.0"
 )
 
 # Add CORS middleware
@@ -100,6 +101,11 @@ async def root():
         <p>GPU-level LLM inference profiler</p>
         
         <h2>Available Endpoints:</h2>
+
+        <div class="endpoint">
+            <span class="method">GET</span> /hardware
+            <br>List supported CUDA and Metal hardware profiles
+        </div>
         
         <div class="endpoint">
             <span class="method">POST</span> /upload-trace
@@ -140,6 +146,12 @@ async def root():
     """
 
 
+@app.get("/hardware")
+async def list_hardware():
+    """List supported hardware profiles."""
+    return {"hardware": hardware_profiles()}
+
+
 @app.post("/upload-trace", response_model=AnalysisResponse)
 async def upload_trace(
     file: UploadFile = File(...),
@@ -149,6 +161,7 @@ async def upload_trace(
 ):
     """Upload and analyze trace file"""
     try:
+        gpu_type = _validate_hardware(gpu_type)
         # Read uploaded file
         content = await file.read()
         
@@ -196,6 +209,8 @@ async def upload_trace(
             # Clean up temp file
             os.unlink(tmp_path)
             
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error processing trace: {str(e)}")
 
@@ -207,6 +222,7 @@ async def analyze_trace(
 ):
     """Analyze trace data directly - uses GPU when available"""
     try:
+        gpu_type = _validate_hardware(request.gpu_type)
         # Check if we should use Modal GPU functions
         try:
             # Try to import Modal and get the GPU function
@@ -219,7 +235,7 @@ async def analyze_trace(
                 # Call the GPU function remotely
                 gpu_result = modal_app.analyze_trace_modal.remote(
                     trace_data=request.trace_data,
-                    gpu_type=request.gpu_type,
+                    gpu_type=gpu_type,
                     enable_claude=request.enable_claude
                 )
                 
@@ -265,7 +281,7 @@ async def analyze_trace(
         tokens = parser.parse_trace_data(request.trace_data)
         
         # Analyze tokens
-        analyzer_instance = GPUAnalyzer(request.gpu_type)
+        analyzer_instance = GPUAnalyzer(gpu_type)
         analyses = analyzer_instance.analyze_sequence(tokens)
         
         # Generate analysis ID
@@ -295,6 +311,8 @@ async def analyze_trace(
             status="completed" if not request.enable_claude else "processing_explanations"
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error analyzing trace: {str(e)}")
 
@@ -376,7 +394,10 @@ async def get_token_detail(analysis_id: str, token_id: int):
             "memory_latency_ms": token_analysis.gpu_metrics.memory_latency_ms,
             "sm_occupancy_pct": token_analysis.gpu_metrics.sm_occupancy_pct,
             "cache_hit_rate": token_analysis.gpu_metrics.cache_hit_rate,
-            "compute_utilization": token_analysis.gpu_metrics.compute_utilization
+            "memory_bandwidth_gb_s": token_analysis.gpu_metrics.memory_bandwidth_gb_s,
+            "compute_utilization": token_analysis.gpu_metrics.compute_utilization,
+            "occupancy_label": token_analysis.gpu_metrics.occupancy_label,
+            "metrics_source": token_analysis.gpu_metrics.metrics_source
         },
         claude_explanation=claude_explanation
     )
@@ -456,6 +477,13 @@ async def get_flame_graph(analysis_id: str):
 async def health_check():
     """Health check endpoint"""
     return {"status": "healthy", "analyses_count": len(analyses_store)}
+
+
+def _validate_hardware(gpu_type: str) -> str:
+    try:
+        return normalize_hardware_name(gpu_type)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 async def generate_claude_explanations(analysis_id: str, analyses: List[TokenAnalysis]):

--- a/llmtracefx/explainer/claude.py
+++ b/llmtracefx/explainer/claude.py
@@ -70,9 +70,10 @@ GPU METRICS:
 - Stall Percentage: {metrics.stall_pct:.1f}%
 - Launch Delay: {metrics.launch_delay_ms:.1f}ms
 - Memory Latency: {metrics.memory_latency_ms:.1f}ms
-- SM Occupancy: {metrics.sm_occupancy_pct:.1f}%
+- {metrics.occupancy_label}: {metrics.sm_occupancy_pct:.1f}%
 - Cache Hit Rate: {metrics.cache_hit_rate:.1f}%
 - Compute Utilization: {metrics.compute_utilization:.1f}%
+- Metrics Source: {metrics.metrics_source}
 
 DETECTED BOTTLENECK: {analysis.bottleneck_type}
 OPTIMIZATION FLAGS: {', '.join(analysis.optimization_flags)}

--- a/llmtracefx/hardware.py
+++ b/llmtracefx/hardware.py
@@ -1,0 +1,111 @@
+"""Hardware profiles supported by LLMTraceFX."""
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    """Static details used to interpret a trace for a target accelerator."""
+
+    name: str
+    display_name: str
+    vendor: str
+    backend: str
+    memory_bandwidth_gb_s: float | None
+    memory_size_gb: float | None
+    compute_units: int | None
+    unified_memory: bool = False
+    occupancy_label: str = "SM occupancy"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+_PROFILES = {
+    "A10G": HardwareProfile(
+        name="A10G",
+        display_name="NVIDIA A10G",
+        vendor="NVIDIA",
+        backend="CUDA",
+        memory_bandwidth_gb_s=600,
+        memory_size_gb=24,
+        compute_units=80,
+    ),
+    "A100": HardwareProfile(
+        name="A100",
+        display_name="NVIDIA A100 80GB",
+        vendor="NVIDIA",
+        backend="CUDA",
+        memory_bandwidth_gb_s=1935,
+        memory_size_gb=80,
+        compute_units=108,
+    ),
+    "H100": HardwareProfile(
+        name="H100",
+        display_name="NVIDIA H100 80GB",
+        vendor="NVIDIA",
+        backend="CUDA",
+        memory_bandwidth_gb_s=3350,
+        memory_size_gb=80,
+        compute_units=132,
+    ),
+    "GB10": HardwareProfile(
+        # https://docs.nvidia.com/dgx/dgx-spark/hardware.html
+        name="GB10",
+        display_name="NVIDIA GB10 / DGX Spark",
+        vendor="NVIDIA",
+        backend="CUDA",
+        memory_bandwidth_gb_s=273,
+        memory_size_gb=128,
+        compute_units=None,
+        unified_memory=True,
+    ),
+    "MLX": HardwareProfile(
+        name="MLX",
+        display_name="Apple Silicon (MLX / Metal)",
+        vendor="Apple",
+        backend="Metal",
+        memory_bandwidth_gb_s=None,
+        memory_size_gb=None,
+        compute_units=None,
+        unified_memory=True,
+        occupancy_label="GPU occupancy",
+    ),
+}
+
+_ALIASES = {
+    "APPLE_SILICON": "MLX",
+    "DGX_SPARK": "GB10",
+    "METAL": "MLX",
+}
+
+
+def _clean_name(name: str) -> str:
+    return name.strip().upper().replace("-", "_").replace(" ", "_")
+
+
+def normalize_hardware_name(name: str) -> str:
+    """Normalize a hardware name or raise a useful error."""
+    cleaned = _clean_name(name)
+    canonical = _ALIASES.get(cleaned, cleaned)
+    if canonical not in _PROFILES:
+        choices = ", ".join(supported_hardware())
+        raise ValueError(f"Unsupported hardware '{name}'. Choose one of: {choices}")
+    return canonical
+
+
+def get_hardware_profile(name: str) -> HardwareProfile:
+    """Return a hardware profile, accepting common aliases."""
+    return _PROFILES[normalize_hardware_name(name)]
+
+
+def supported_hardware() -> list[str]:
+    """Return canonical hardware names in CLI display order."""
+    return list(_PROFILES)
+
+
+def hardware_profiles() -> list[dict[str, Any]]:
+    """Return all profiles for API clients and user interfaces."""
+    return [profile.to_dict() for profile in _PROFILES.values()]

--- a/llmtracefx/main.py
+++ b/llmtracefx/main.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from .hardware import normalize_hardware_name, supported_hardware
 from .profiler.trace_parser import TraceParser
 from .profiler.gpu_analyzer import GPUAnalyzer
 from .explainer.claude import ClaudeExplainer
@@ -66,7 +67,7 @@ async def analyze_trace(trace_file: str, gpu_type: str = "A10G", enable_claude: 
     
     # Create output directory
     output_path = Path(output_dir)
-    output_path.mkdir(exist_ok=True)
+    output_path.mkdir(parents=True, exist_ok=True)
     
     # Parse trace
     parser = TraceParser()
@@ -85,9 +86,13 @@ async def analyze_trace(trace_file: str, gpu_type: str = "A10G", enable_claude: 
         print(f"❌ Error parsing trace: {e}")
         return
     
+    if not tokens:
+        print("❌ Trace does not contain any tokens")
+        return
+
     # Analyze GPU performance
-    print(f"🔧 Analyzing GPU performance (GPU: {gpu_type})")
     analyzer = GPUAnalyzer(gpu_type)
+    print(f"🔧 Analyzing GPU performance ({analyzer.hardware.display_name})")
     analyses = analyzer.analyze_sequence(tokens)
     
     # Calculate summary stats
@@ -157,7 +162,7 @@ async def analyze_trace(trace_file: str, gpu_type: str = "A10G", enable_claude: 
         f.write("=" * 50 + "\n\n")
         
         f.write(f"Trace File: {trace_file}\n")
-        f.write(f"GPU Type: {gpu_type}\n")
+        f.write(f"Hardware: {analyzer.hardware.display_name}\n")
         f.write(f"Analysis Time: {total_latency:.1f}ms\n")
         f.write(f"Average Performance Score: {avg_performance:.1f}/100\n\n")
         
@@ -190,8 +195,9 @@ async def analyze_trace(trace_file: str, gpu_type: str = "A10G", enable_claude: 
             metrics = analysis.gpu_metrics
             f.write(f"    Stall %: {metrics.stall_pct:.1f}%\n")
             f.write(f"    Launch Delay: {metrics.launch_delay_ms:.1f}ms\n")
-            f.write(f"    SM Occupancy: {metrics.sm_occupancy_pct:.1f}%\n")
+            f.write(f"    {metrics.occupancy_label}: {metrics.sm_occupancy_pct:.1f}%\n")
             f.write(f"    Cache Hit Rate: {metrics.cache_hit_rate:.1f}%\n")
+            f.write(f"    Metrics Source: {metrics.metrics_source}\n")
             
             # Include Claude explanation if available
             if enable_claude and analysis.token_id in explanations:
@@ -221,6 +227,12 @@ Examples:
   
   # Analyze with specific GPU type
   python -m llmtracefx.main --trace sample --gpu-type H100
+
+  # Analyze on NVIDIA GB10 / DGX Spark
+  python -m llmtracefx.main --trace trace.json --gpu-type GB10
+
+  # Analyze a trace recorded with MLXTraceRecorder
+  python -m llmtracefx.main --trace mlx_trace.json --gpu-type MLX
   
   # Analyze without Claude explanations
   python -m llmtracefx.main --trace sample --no-claude
@@ -236,10 +248,10 @@ Examples:
     
     parser.add_argument(
         "--gpu-type",
-        type=str,
+        type=normalize_hardware_name,
         default="A10G",
-        choices=["A10G", "H100", "A100"],
-        help="GPU type for analysis"
+        choices=supported_hardware(),
+        help="Target hardware for analysis"
     )
     
     parser.add_argument(

--- a/llmtracefx/modal_app.py
+++ b/llmtracefx/modal_app.py
@@ -153,7 +153,9 @@ def explain_token_modal(token_analysis_data: dict):
             sm_occupancy_pct=token_analysis_data["gpu_metrics"]["sm_occupancy_pct"],
             cache_hit_rate=token_analysis_data["gpu_metrics"]["cache_hit_rate"],
             memory_bandwidth_gb_s=token_analysis_data["gpu_metrics"]["memory_bandwidth_gb_s"],
-            compute_utilization=token_analysis_data["gpu_metrics"]["compute_utilization"]
+            compute_utilization=token_analysis_data["gpu_metrics"]["compute_utilization"],
+            occupancy_label=token_analysis_data["gpu_metrics"].get("occupancy_label", "SM occupancy"),
+            metrics_source=token_analysis_data["gpu_metrics"].get("metrics_source", "estimated")
         )
         
         analysis = TokenAnalysis(

--- a/llmtracefx/profiler/__init__.py
+++ b/llmtracefx/profiler/__init__.py
@@ -1,1 +1,5 @@
+"""Profiling helpers exposed by LLMTraceFX."""
 
+from .mlx_tracer import MLXTraceRecorder
+
+__all__ = ["MLXTraceRecorder"]

--- a/llmtracefx/profiler/gpu_analyzer.py
+++ b/llmtracefx/profiler/gpu_analyzer.py
@@ -1,314 +1,334 @@
-"""
-GPU performance analyzer for kernel timing and bottleneck detection
-"""
-import random
-from typing import Dict, List, Any, Optional
+"""GPU performance analysis for token-level inference traces."""
+
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any, TypedDict
+
+from llmtracefx.hardware import HardwareProfile, get_hardware_profile
+
 from .trace_parser import Operation, TokenTrace
+
+
+class OperationModel(TypedDict):
+    stall_range: tuple[float, float]
+    memory_bound: bool
 
 
 @dataclass
 class GPUMetrics:
-    """GPU performance metrics for an operation"""
+    """GPU metrics for an operation or token."""
+
     stall_pct: float
     launch_delay_ms: float
     memory_latency_ms: float
     sm_occupancy_pct: float
     cache_hit_rate: float
-    memory_bandwidth_gb_s: float
+    memory_bandwidth_gb_s: float | None
     compute_utilization: float
+    occupancy_label: str = "SM occupancy"
+    metrics_source: str = "estimated"
 
 
 @dataclass
 class TokenAnalysis:
-    """Complete analysis for a token"""
+    """Complete analysis for a token."""
+
     token_id: int
     token_text: str
     total_latency_ms: float
-    operations: List[Operation]
+    operations: list[Operation]
     gpu_metrics: GPUMetrics
     bottleneck_type: str
-    optimization_flags: List[str]
-    performance_score: float  # 0-100, higher is better
+    optimization_flags: list[str]
+    performance_score: float
 
 
 class GPUAnalyzer:
-    """Analyze GPU performance and identify bottlenecks"""
-    
+    """Analyze token traces for CUDA or Metal hardware profiles.
+
+    Operation metadata can provide measured values using ``stall_pct``,
+    ``launch_delay_ms``, ``memory_latency_ms``, ``occupancy_pct`` (or
+    ``sm_occupancy_pct``), ``cache_hit_rate``, and ``compute_utilization``.
+    Missing values are filled with deterministic operation-level estimates.
+    """
+
     def __init__(self, gpu_type: str = "A10G"):
-        self.gpu_type = gpu_type
-        self.gpu_specs = self._get_gpu_specs(gpu_type)
-        
-        # Performance models for different operations
-        self.op_models = {
-            "rmsnorm": {"base_time": 2.0, "stall_range": (10, 25), "memory_bound": True},
-            "layernorm": {"base_time": 2.2, "stall_range": (10, 25), "memory_bound": True},
-            "linear": {"base_time": 8.0, "stall_range": (15, 35), "memory_bound": False},
-            "matmul": {"base_time": 12.0, "stall_range": (20, 45), "memory_bound": False},
-            "softmax": {"base_time": 3.0, "stall_range": (5, 20), "memory_bound": True},
-            "kvload": {"base_time": 9.0, "stall_range": (30, 60), "memory_bound": True},
-            "kvstore": {"base_time": 7.0, "stall_range": (25, 50), "memory_bound": True},
-            "attention": {"base_time": 15.0, "stall_range": (20, 40), "memory_bound": False},
-            "activation": {"base_time": 1.5, "stall_range": (5, 15), "memory_bound": True},
-            "embedding": {"base_time": 5.0, "stall_range": (15, 30), "memory_bound": True}
+        self.hardware: HardwareProfile = get_hardware_profile(gpu_type)
+        self.gpu_type = self.hardware.name
+        # Keep the existing attribute available for callers that inspect it.
+        self.gpu_specs = self.hardware.to_dict()
+
+        self.op_models: dict[str, OperationModel] = {
+            "rmsnorm": {"stall_range": (10, 25), "memory_bound": True},
+            "layernorm": {"stall_range": (10, 25), "memory_bound": True},
+            "linear": {"stall_range": (15, 35), "memory_bound": False},
+            "matmul": {"stall_range": (20, 45), "memory_bound": False},
+            "softmax": {"stall_range": (5, 20), "memory_bound": True},
+            "kvload": {"stall_range": (30, 60), "memory_bound": True},
+            "kvstore": {"stall_range": (25, 50), "memory_bound": True},
+            "attention": {"stall_range": (20, 40), "memory_bound": False},
+            "activation": {"stall_range": (5, 15), "memory_bound": True},
+            "embedding": {"stall_range": (15, 30), "memory_bound": True},
         }
-    
-    def _get_gpu_specs(self, gpu_type: str) -> Dict[str, Any]:
-        """Get GPU specifications"""
-        specs = {
-            "A10G": {
-                "memory_bandwidth_gb_s": 600,
-                "compute_units": 80,
-                "base_clock_mhz": 1695,
-                "memory_size_gb": 24,
-                "l2_cache_mb": 6
-            },
-            "H100": {
-                "memory_bandwidth_gb_s": 3350,
-                "compute_units": 132,
-                "base_clock_mhz": 1980,
-                "memory_size_gb": 80,
-                "l2_cache_mb": 50
-            },
-            "A100": {
-                "memory_bandwidth_gb_s": 1935,
-                "compute_units": 108,
-                "base_clock_mhz": 1410,
-                "memory_size_gb": 80,
-                "l2_cache_mb": 40
-            }
-        }
-        return specs.get(gpu_type, specs["A10G"])
-    
+
+    def _get_gpu_specs(self, gpu_type: str) -> dict[str, Any]:
+        """Return validated hardware specifications for compatibility."""
+        return get_hardware_profile(gpu_type).to_dict()
+
     def analyze_token(self, token_trace: TokenTrace) -> TokenAnalysis:
-        """Analyze a single token's performance"""
-        # Analyze each operation
-        analyzed_ops = []
-        total_stall_time = 0
-        total_memory_time = 0
-        
-        for op in token_trace.operations:
-            gpu_metrics = self._analyze_operation(op)
-            analyzed_ops.append(op)
-            
-            total_stall_time += op.duration * (gpu_metrics.stall_pct / 100)
-            total_memory_time += gpu_metrics.memory_latency_ms
-        
-        # Calculate aggregate metrics
-        avg_stall_pct = (total_stall_time / token_trace.total_latency) * 100 if token_trace.total_latency > 0 else 0
-        avg_launch_delay = sum(self._get_launch_delay(op) for op in analyzed_ops) / len(analyzed_ops)
-        avg_sm_occupancy = sum(self._get_sm_occupancy(op) for op in analyzed_ops) / len(analyzed_ops)
-        avg_cache_hit = sum(self._get_cache_hit_rate(op) for op in analyzed_ops) / len(analyzed_ops)
-        
+        """Analyze one token's operations."""
+        operations = token_trace.operations
+        if not operations:
+            metrics = GPUMetrics(
+                stall_pct=0,
+                launch_delay_ms=0,
+                memory_latency_ms=0,
+                sm_occupancy_pct=0,
+                cache_hit_rate=0,
+                memory_bandwidth_gb_s=self.hardware.memory_bandwidth_gb_s,
+                compute_utilization=0,
+                occupancy_label=self.hardware.occupancy_label,
+                metrics_source="unavailable",
+            )
+            return TokenAnalysis(
+                token_id=token_trace.token_id,
+                token_text=token_trace.token_text,
+                total_latency_ms=token_trace.total_latency,
+                operations=[],
+                gpu_metrics=metrics,
+                bottleneck_type="no_operations",
+                optimization_flags=[],
+                performance_score=0,
+            )
+
+        operation_metrics = [self._analyze_operation(op) for op in operations]
+        total_duration = sum(max(op.duration, 0) for op in operations)
+
+        def weighted_average(values: list[float]) -> float:
+            if total_duration == 0:
+                return sum(values) / len(values)
+            return (
+                sum(
+                    value * max(op.duration, 0)
+                    for op, value in zip(operations, values, strict=True)
+                )
+                / total_duration
+            )
+
+        sources = {metrics.metrics_source for metrics in operation_metrics}
+        if sources == {"measured"}:
+            metrics_source = "measured"
+        elif sources == {"estimated"}:
+            metrics_source = "estimated"
+        else:
+            metrics_source = "mixed"
+
         aggregate_metrics = GPUMetrics(
-            stall_pct=avg_stall_pct,
-            launch_delay_ms=avg_launch_delay,
-            memory_latency_ms=total_memory_time,
-            sm_occupancy_pct=avg_sm_occupancy,
-            cache_hit_rate=avg_cache_hit,
-            memory_bandwidth_gb_s=self.gpu_specs["memory_bandwidth_gb_s"],
-            compute_utilization=self._calculate_compute_utilization(analyzed_ops)
+            stall_pct=weighted_average(
+                [metrics.stall_pct for metrics in operation_metrics]
+            ),
+            launch_delay_ms=sum(
+                metrics.launch_delay_ms for metrics in operation_metrics
+            )
+            / len(operation_metrics),
+            memory_latency_ms=sum(
+                metrics.memory_latency_ms for metrics in operation_metrics
+            ),
+            sm_occupancy_pct=weighted_average(
+                [metrics.sm_occupancy_pct for metrics in operation_metrics]
+            ),
+            cache_hit_rate=weighted_average(
+                [metrics.cache_hit_rate for metrics in operation_metrics]
+            ),
+            memory_bandwidth_gb_s=self.hardware.memory_bandwidth_gb_s,
+            compute_utilization=weighted_average(
+                [metrics.compute_utilization for metrics in operation_metrics]
+            ),
+            occupancy_label=self.hardware.occupancy_label,
+            metrics_source=metrics_source,
         )
-        
-        # Identify bottleneck
-        bottleneck = self._identify_bottleneck(aggregate_metrics, analyzed_ops)
-        
-        # Generate optimization flags
-        optimization_flags = self._generate_optimization_flags(aggregate_metrics, analyzed_ops)
-        
-        # Calculate performance score
-        performance_score = self._calculate_performance_score(aggregate_metrics, token_trace.total_latency)
-        
+
         return TokenAnalysis(
             token_id=token_trace.token_id,
             token_text=token_trace.token_text,
             total_latency_ms=token_trace.total_latency,
-            operations=analyzed_ops,
+            operations=operations,
             gpu_metrics=aggregate_metrics,
-            bottleneck_type=bottleneck,
-            optimization_flags=optimization_flags,
-            performance_score=performance_score
+            bottleneck_type=self._identify_bottleneck(aggregate_metrics, operations),
+            optimization_flags=self._generate_optimization_flags(
+                aggregate_metrics, operations
+            ),
+            performance_score=self._calculate_performance_score(
+                aggregate_metrics, token_trace.total_latency
+            ),
         )
-    
+
     def _analyze_operation(self, op: Operation) -> GPUMetrics:
-        """Analyze a single operation's GPU performance"""
+        """Use measured metadata when present and estimate missing metrics."""
         model = self.op_models.get(op.name, self.op_models["linear"])
-        
-        # Simulate stall percentage based on operation type
-        stall_pct = random.uniform(*model["stall_range"])
-        
-        # Simulate realistic metrics
-        launch_delay = self._get_launch_delay(op)
-        memory_latency = self._get_memory_latency(op)
-        sm_occupancy = self._get_sm_occupancy(op)
-        cache_hit_rate = self._get_cache_hit_rate(op)
-        compute_util = self._get_compute_utilization(op)
-        
+        stall_min, stall_max = model["stall_range"]
+
+        values: list[tuple[float, bool]] = [
+            self._metadata_value(op, ("stall_pct",), (stall_min + stall_max) / 2),
+            self._metadata_value(op, ("launch_delay_ms",), self._get_launch_delay(op)),
+            self._metadata_value(
+                op, ("memory_latency_ms",), self._get_memory_latency(op)
+            ),
+            self._metadata_value(
+                op,
+                ("occupancy_pct", "sm_occupancy_pct"),
+                self._get_sm_occupancy(op),
+            ),
+            self._metadata_value(op, ("cache_hit_rate",), self._get_cache_hit_rate(op)),
+            self._metadata_value(
+                op,
+                ("compute_utilization",),
+                self._get_compute_utilization(op),
+            ),
+        ]
+        measured_count = sum(measured for _, measured in values)
+        if measured_count == len(values):
+            source = "measured"
+        elif measured_count == 0:
+            source = "estimated"
+        else:
+            source = "mixed"
+
         return GPUMetrics(
-            stall_pct=stall_pct,
-            launch_delay_ms=launch_delay,
-            memory_latency_ms=memory_latency,
-            sm_occupancy_pct=sm_occupancy,
-            cache_hit_rate=cache_hit_rate,
-            memory_bandwidth_gb_s=self.gpu_specs["memory_bandwidth_gb_s"],
-            compute_utilization=compute_util
+            stall_pct=self._clamp(values[0][0]),
+            launch_delay_ms=max(0, values[1][0]),
+            memory_latency_ms=max(0, values[2][0]),
+            sm_occupancy_pct=self._clamp(values[3][0]),
+            cache_hit_rate=self._clamp(values[4][0]),
+            memory_bandwidth_gb_s=self.hardware.memory_bandwidth_gb_s,
+            compute_utilization=self._clamp(values[5][0]),
+            occupancy_label=self.hardware.occupancy_label,
+            metrics_source=source,
         )
-    
+
+    @staticmethod
+    def _metadata_value(
+        op: Operation, keys: Sequence[str], default: float
+    ) -> tuple[float, bool]:
+        for key in keys:
+            if key in op.metadata:
+                try:
+                    return float(op.metadata[key]), True
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"Operation '{op.name}' metadata '{key}' must be numeric"
+                    ) from exc
+        return float(default), False
+
+    @staticmethod
+    def _clamp(value: float, minimum: float = 0, maximum: float = 100) -> float:
+        return max(minimum, min(maximum, value))
+
     def _get_launch_delay(self, op: Operation) -> float:
-        """Simulate kernel launch delay"""
-        base_delay = 0.1  # 0.1ms base launch overhead
-        
-        # Longer operations have slightly higher launch overhead
-        size_factor = min(op.duration / 10.0, 2.0)
-        return base_delay + (size_factor * random.uniform(0.05, 0.3))
-    
+        """Estimate launch overhead deterministically from operation duration."""
+        size_factor = min(max(op.duration, 0) / 10.0, 2.0)
+        return 0.1 + (size_factor * 0.175)
+
     def _get_memory_latency(self, op: Operation) -> float:
-        """Simulate memory access latency"""
+        """Estimate the memory component of operation latency."""
         model = self.op_models.get(op.name, self.op_models["linear"])
-        
-        if model["memory_bound"]:
-            # Memory-bound operations have higher memory latency
-            return op.duration * random.uniform(0.3, 0.6)
-        else:
-            # Compute-bound operations have lower memory latency
-            return op.duration * random.uniform(0.1, 0.3)
-    
+        factor = 0.45 if model["memory_bound"] else 0.2
+        return max(op.duration, 0) * factor
+
     def _get_sm_occupancy(self, op: Operation) -> float:
-        """Simulate SM occupancy percentage"""
+        """Estimate accelerator occupancy from operation type."""
         model = self.op_models.get(op.name, self.op_models["linear"])
-        
-        if model["memory_bound"]:
-            # Memory-bound ops typically have lower occupancy
-            return random.uniform(40, 70)
-        else:
-            # Compute-bound ops can achieve higher occupancy
-            return random.uniform(60, 90)
-    
+        return 55.0 if model["memory_bound"] else 75.0
+
     def _get_cache_hit_rate(self, op: Operation) -> float:
-        """Simulate cache hit rate"""
-        # KV operations typically have good cache locality
-        if "kv" in op.name:
-            return random.uniform(80, 95)
-        # Other operations vary more
-        return random.uniform(60, 85)
-    
+        """Estimate cache hit rate from operation type."""
+        return 87.5 if "kv" in op.name else 72.5
+
     def _get_compute_utilization(self, op: Operation) -> float:
-        """Simulate compute utilization"""
+        """Estimate compute utilization from operation type."""
         model = self.op_models.get(op.name, self.op_models["linear"])
-        
-        if model["memory_bound"]:
-            return random.uniform(30, 60)
-        else:
-            return random.uniform(70, 95)
-    
-    def _calculate_compute_utilization(self, ops: List[Operation]) -> float:
-        """Calculate average compute utilization"""
+        return 45.0 if model["memory_bound"] else 82.5
+
+    def _calculate_compute_utilization(self, ops: list[Operation]) -> float:
+        """Calculate average estimated compute utilization."""
         if not ops:
             return 0.0
-        
-        total_util = sum(self._get_compute_utilization(op) for op in ops)
-        return total_util / len(ops)
-    
-    def _identify_bottleneck(self, metrics: GPUMetrics, ops: List[Operation]) -> str:
-        """Identify the primary bottleneck type"""
+        return sum(self._get_compute_utilization(op) for op in ops) / len(ops)
+
+    def _identify_bottleneck(self, metrics: GPUMetrics, ops: list[Operation]) -> str:
         if metrics.stall_pct > 40:
             return "memory_stall"
-        elif metrics.launch_delay_ms > 2.0:
+        if metrics.launch_delay_ms > 2.0:
             return "launch_overhead"
-        elif metrics.sm_occupancy_pct < 50:
+        if metrics.sm_occupancy_pct < 50:
             return "low_occupancy"
-        elif metrics.cache_hit_rate < 70:
+        if metrics.cache_hit_rate < 70:
             return "cache_miss"
-        elif metrics.compute_utilization < 60:
+        if metrics.compute_utilization < 60:
             return "compute_underutilization"
-        else:
-            return "optimal"
-    
-    def _generate_optimization_flags(self, metrics: GPUMetrics, ops: List[Operation]) -> List[str]:
-        """Generate optimization suggestions"""
+        return "optimal"
+
+    def _generate_optimization_flags(
+        self, metrics: GPUMetrics, ops: list[Operation]
+    ) -> list[str]:
         flags = []
-        
         if metrics.stall_pct > 35:
             flags.append("high_memory_stall")
-        
         if metrics.launch_delay_ms > 1.5:
             flags.append("kernel_fusion_candidate")
-        
         if metrics.sm_occupancy_pct < 60:
             flags.append("increase_occupancy")
-        
         if metrics.cache_hit_rate < 75:
             flags.append("improve_data_locality")
-        
         if metrics.compute_utilization < 70:
             flags.append("underutilized_compute")
-        
-        # Check for fusion opportunities
         if len(ops) > 3:
             flags.append("multi_kernel_fusion")
-        
-        # Check for specific patterns
+
         op_names = [op.name for op in ops]
         if "rmsnorm" in op_names and "linear" in op_names:
             flags.append("norm_linear_fusion")
-        
         if "kvload" in op_names and "attention" in op_names:
             flags.append("attention_optimization")
-        
         return flags
-    
-    def _calculate_performance_score(self, metrics: GPUMetrics, total_latency: float) -> float:
-        """Calculate overall performance score (0-100)"""
+
+    def _calculate_performance_score(
+        self, metrics: GPUMetrics, total_latency: float
+    ) -> float:
         score = 100.0
-        
-        # Penalize high stall percentage
         score -= metrics.stall_pct * 0.8
-        
-        # Penalize low occupancy
         score -= max(0, (80 - metrics.sm_occupancy_pct) * 0.5)
-        
-        # Penalize low cache hit rate
         score -= max(0, (85 - metrics.cache_hit_rate) * 0.3)
-        
-        # Penalize low compute utilization
         score -= max(0, (80 - metrics.compute_utilization) * 0.4)
-        
-        # Penalize high launch delay
         score -= min(metrics.launch_delay_ms * 10, 20)
-        
         return max(0, min(100, score))
-    
-    def analyze_sequence(self, tokens: List[TokenTrace]) -> List[TokenAnalysis]:
-        """Analyze a sequence of tokens"""
+
+    def analyze_sequence(self, tokens: list[TokenTrace]) -> list[TokenAnalysis]:
+        """Analyze a sequence of tokens."""
         return [self.analyze_token(token) for token in tokens]
-    
-    def get_aggregate_stats(self, analyses: List[TokenAnalysis]) -> Dict[str, Any]:
-        """Get aggregate statistics across all tokens"""
+
+    def get_aggregate_stats(self, analyses: list[TokenAnalysis]) -> dict[str, Any]:
+        """Get aggregate statistics across tokens."""
         if not analyses:
             return {}
-        
-        avg_latency = sum(a.total_latency_ms for a in analyses) / len(analyses)
-        avg_stall_pct = sum(a.gpu_metrics.stall_pct for a in analyses) / len(analyses)
-        avg_performance = sum(a.performance_score for a in analyses) / len(analyses)
-        
-        bottleneck_counts = {}
+
+        bottleneck_counts: dict[str, int] = {}
+        flag_counts: dict[str, int] = {}
         for analysis in analyses:
-            bottleneck_counts[analysis.bottleneck_type] = bottleneck_counts.get(analysis.bottleneck_type, 0) + 1
-        
-        all_flags = []
-        for analysis in analyses:
-            all_flags.extend(analysis.optimization_flags)
-        
-        flag_counts = {}
-        for flag in all_flags:
-            flag_counts[flag] = flag_counts.get(flag, 0) + 1
-        
+            bottleneck_counts[analysis.bottleneck_type] = (
+                bottleneck_counts.get(analysis.bottleneck_type, 0) + 1
+            )
+            for flag in analysis.optimization_flags:
+                flag_counts[flag] = flag_counts.get(flag, 0) + 1
+
         return {
             "total_tokens": len(analyses),
-            "avg_latency_ms": avg_latency,
-            "avg_stall_pct": avg_stall_pct,
-            "avg_performance_score": avg_performance,
+            "avg_latency_ms": sum(a.total_latency_ms for a in analyses) / len(analyses),
+            "avg_stall_pct": sum(a.gpu_metrics.stall_pct for a in analyses)
+            / len(analyses),
+            "avg_performance_score": sum(a.performance_score for a in analyses)
+            / len(analyses),
             "bottleneck_distribution": bottleneck_counts,
             "optimization_flags": flag_counts,
-            "total_latency_ms": sum(a.total_latency_ms for a in analyses)
+            "total_latency_ms": sum(a.total_latency_ms for a in analyses),
         }

--- a/llmtracefx/profiler/gpu_analyzer.py
+++ b/llmtracefx/profiler/gpu_analyzer.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import isfinite
 from typing import Any, TypedDict
 
 from llmtracefx.hardware import HardwareProfile, get_hardware_profile
@@ -213,11 +214,16 @@ class GPUAnalyzer:
         for key in keys:
             if key in op.metadata:
                 try:
-                    return float(op.metadata[key]), True
+                    value = float(op.metadata[key])
                 except (TypeError, ValueError) as exc:
                     raise ValueError(
                         f"Operation '{op.name}' metadata '{key}' must be numeric"
                     ) from exc
+                if not isfinite(value):
+                    raise ValueError(
+                        f"Operation '{op.name}' metadata '{key}' must be finite"
+                    )
+                return value, True
         return float(default), False
 
     @staticmethod

--- a/llmtracefx/profiler/mlx_tracer.py
+++ b/llmtracefx/profiler/mlx_tracer.py
@@ -31,7 +31,7 @@ class MLXTraceRecorder:
         self.metal_capture_path = (
             Path(metal_capture_path) if metal_capture_path is not None else None
         )
-        self._mlx = mlx_module or self._load_mlx()
+        self._mlx = mlx_module if mlx_module is not None else self._load_mlx()
         self._clock_ns = clock_ns
         self._started_ns: int | None = None
         self._active_token: dict[str, Any] | None = None
@@ -57,7 +57,11 @@ class MLXTraceRecorder:
                     f"Metal capture path already exists: {self.metal_capture_path}"
                 )
             self.metal_capture_path.parent.mkdir(parents=True, exist_ok=True)
-            self._metal_api().start_capture(str(self.metal_capture_path))
+            metal = self._metal_api()
+            is_available = getattr(metal, "is_available", None)
+            if is_available is not None and not is_available():
+                raise RuntimeError("Metal capture requires an available Metal backend")
+            metal.start_capture(str(self.metal_capture_path))
             self._metal_capture_active = True
         return self
 
@@ -166,15 +170,8 @@ class MLXTraceRecorder:
         )
 
     def _evaluate(self, result: Any) -> None:
-        if isinstance(result, dict):
-            values = list(result.values())
-            if values:
-                self._mlx.eval(*values)
-            return
-        if isinstance(result, (list, tuple)):
-            if result:
-                self._mlx.eval(*result)
-            return
+        # mx.eval accepts an arbitrarily nested list, tuple, or dict of arrays.
+        # Passing the tree intact also lets MLX ignore non-array leaves.
         self._mlx.eval(result)
 
     def _synchronize(self) -> None:
@@ -192,7 +189,7 @@ class MLXTraceRecorder:
         return self._json_safe_dict(device_info()) if device_info else {}
 
     def _memory_snapshot(self) -> dict[str, int]:
-        snapshot = {}
+        snapshot: dict[str, int] = {}
         for function_name, output_name in (
             ("get_active_memory", "active_memory_bytes"),
             ("get_peak_memory", "peak_memory_bytes"),

--- a/llmtracefx/profiler/mlx_tracer.py
+++ b/llmtracefx/profiler/mlx_tracer.py
@@ -1,0 +1,234 @@
+"""Small, optional MLX tracer that writes LLMTraceFX-compatible JSON."""
+
+import json
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+PathLike = str | Path
+
+
+class MLXTraceRecorder:
+    """Record synchronized MLX operations at token granularity.
+
+    MLX evaluates arrays lazily. :meth:`measure` evaluates the returned arrays
+    and synchronizes the device so the recorded duration includes GPU work.
+    The optional Metal capture is useful for inspecting the same region in
+    Xcode while the JSON output can be analyzed directly by LLMTraceFX.
+    """
+
+    def __init__(
+        self,
+        output_path: PathLike,
+        *,
+        metal_capture_path: PathLike | None = None,
+        mlx_module: Any | None = None,
+        clock_ns: Callable[[], int] = time.perf_counter_ns,
+    ):
+        self.output_path = Path(output_path)
+        self.metal_capture_path = (
+            Path(metal_capture_path) if metal_capture_path is not None else None
+        )
+        self._mlx = mlx_module or self._load_mlx()
+        self._clock_ns = clock_ns
+        self._started_ns: int | None = None
+        self._active_token: dict[str, Any] | None = None
+        self._tokens: list[dict[str, Any]] = []
+        self._metal_capture_active = False
+
+    @staticmethod
+    def _load_mlx() -> Any:
+        try:
+            import mlx.core as mx  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "MLX tracing requires MLX. On Apple Silicon run "
+                "`uv sync --extra mlx` or `pip install mlx`."
+            ) from exc
+        return mx
+
+    def __enter__(self) -> "MLXTraceRecorder":
+        self._started_ns = self._clock_ns()
+        if self.metal_capture_path is not None:
+            if self.metal_capture_path.exists():
+                raise FileExistsError(
+                    f"Metal capture path already exists: {self.metal_capture_path}"
+                )
+            self.metal_capture_path.parent.mkdir(parents=True, exist_ok=True)
+            self._metal_api().start_capture(str(self.metal_capture_path))
+            self._metal_capture_active = True
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self._metal_capture_active:
+            self._metal_api().stop_capture()
+            self._metal_capture_active = False
+        if exc_type is None:
+            self.write()
+
+    @contextmanager
+    def token(self, token_id: int, token_text: str = "") -> Iterator[None]:
+        """Group measured operations under one generated token."""
+        self._ensure_started()
+        if self._active_token is not None:
+            raise RuntimeError("Nested token traces are not supported")
+
+        token = {
+            "id": token_id,
+            "text": token_text,
+            "operations": [],
+        }
+        self._active_token = token
+        try:
+            yield
+        finally:
+            self._tokens.append(token)
+            self._active_token = None
+
+    @contextmanager
+    def operation(
+        self, name: str, *, metadata: dict[str, Any] | None = None
+    ) -> Iterator[None]:
+        """Time a block after synchronizing pending MLX work.
+
+        Call ``mx.eval(...)`` inside the block when it creates lazy arrays, or
+        use :meth:`measure`, which evaluates returned arrays automatically.
+        """
+        self._ensure_active_token()
+        self._synchronize()
+        started_ns = self._clock_ns()
+        try:
+            yield
+        finally:
+            self._synchronize()
+            ended_ns = self._clock_ns()
+            self._record_operation(name, started_ns, ended_ns, metadata)
+
+    def measure(
+        self,
+        name: str,
+        function: Callable[..., Any],
+        *args: Any,
+        evaluate: bool = True,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run, evaluate, synchronize, and record one MLX operation."""
+        self._ensure_active_token()
+        self._synchronize()
+        started_ns = self._clock_ns()
+        result = function(*args, **kwargs)
+        if evaluate:
+            self._evaluate(result)
+        self._synchronize()
+        ended_ns = self._clock_ns()
+        self._record_operation(name, started_ns, ended_ns, metadata)
+        return result
+
+    def write(self) -> Path:
+        """Write the current trace and return its path."""
+        if self._active_token is not None:
+            raise RuntimeError("Finish the active token before writing the trace")
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "format": "llmtracefx.mlx.v1",
+            "framework": "mlx",
+            "hardware": "MLX",
+            "device": self._device_info(),
+            "time_unit": "ms",
+            "tokens": self._tokens,
+        }
+        self.output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return self.output_path
+
+    def _record_operation(
+        self,
+        name: str,
+        started_ns: int,
+        ended_ns: int,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        token = self._ensure_active_token()
+        operation_metadata = dict(metadata or {})
+        operation_metadata.update(self._memory_snapshot())
+        operation_metadata.setdefault("backend", "metal")
+
+        origin_ns = self._started_ns if self._started_ns is not None else started_ns
+        token["operations"].append(
+            {
+                "name": name,
+                "start_time": (started_ns - origin_ns) / 1_000_000,
+                "duration": max(0, ended_ns - started_ns) / 1_000_000,
+                "metadata": operation_metadata,
+            }
+        )
+
+    def _evaluate(self, result: Any) -> None:
+        if isinstance(result, dict):
+            values = list(result.values())
+            if values:
+                self._mlx.eval(*values)
+            return
+        if isinstance(result, (list, tuple)):
+            if result:
+                self._mlx.eval(*result)
+            return
+        self._mlx.eval(result)
+
+    def _synchronize(self) -> None:
+        synchronize = getattr(self._mlx, "synchronize", None)
+        if synchronize is None:
+            raise RuntimeError("This MLX version does not expose mx.synchronize()")
+        synchronize()
+
+    def _device_info(self) -> dict[str, Any]:
+        device_info = getattr(self._mlx, "device_info", None)
+        if device_info is not None:
+            return self._json_safe_dict(device_info())
+        metal = self._metal_api()
+        device_info = getattr(metal, "device_info", None)
+        return self._json_safe_dict(device_info()) if device_info else {}
+
+    def _memory_snapshot(self) -> dict[str, int]:
+        snapshot = {}
+        for function_name, output_name in (
+            ("get_active_memory", "active_memory_bytes"),
+            ("get_peak_memory", "peak_memory_bytes"),
+            ("get_cache_memory", "cache_memory_bytes"),
+        ):
+            function = getattr(self._mlx, function_name, None)
+            if function is not None:
+                snapshot[output_name] = int(function())
+        return snapshot
+
+    def _metal_api(self) -> Any:
+        metal = getattr(self._mlx, "metal", None)
+        if metal is None:
+            raise RuntimeError(
+                "The active MLX build does not provide the Metal backend"
+            )
+        return metal
+
+    def _ensure_started(self) -> None:
+        if self._started_ns is None:
+            self._started_ns = self._clock_ns()
+
+    def _ensure_active_token(self) -> dict[str, Any]:
+        self._ensure_started()
+        if self._active_token is None:
+            raise RuntimeError("Start a token trace with `with trace.token(...)`")
+        return self._active_token
+
+    @staticmethod
+    def _json_safe_dict(value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+        safe = {}
+        for key, item in value.items():
+            if isinstance(item, (str, int, float, bool)) or item is None:
+                safe[str(key)] = item
+            else:
+                safe[str(key)] = str(item)
+        return safe

--- a/llmtracefx/profiler/trace_parser.py
+++ b/llmtracefx/profiler/trace_parser.py
@@ -3,7 +3,7 @@ Trace parser for LLM inference logs (vLLM format)
 """
 import json
 from typing import Dict, List, Any, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -13,14 +13,8 @@ class Operation:
     name: str
     start_time: float
     duration: float
-    dependencies: List[str] = None
-    metadata: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        if self.dependencies is None:
-            self.dependencies = []
-        if self.metadata is None:
-            self.metadata = {}
+    dependencies: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -37,7 +31,7 @@ class TokenTrace:
 class TraceParser:
     """Parse vLLM trace logs into token-level operations"""
     
-    def __init__(self):
+    def __init__(self) -> None:
         self.known_ops = {
             "rmsnorm", "layernorm", "linear", "matmul", "softmax", 
             "kvload", "kvstore", "attention", "activation", "embedding"
@@ -68,9 +62,9 @@ class TraceParser:
             token_text = token_data.get("text", "")
             
             operations = []
-            total_latency = 0
+            total_latency = 0.0
             start_time = float('inf')
-            end_time = 0
+            end_time = 0.0
             
             for op_data in token_data.get("operations", []):
                 op = Operation(
@@ -182,8 +176,8 @@ class TraceParser:
         total_latency = sum(token.total_latency for token in tokens)
         avg_latency = total_latency / len(tokens)
         
-        op_counts = {}
-        op_times = {}
+        op_counts: Dict[str, int] = {}
+        op_times: Dict[str, float] = {}
         
         for token in tokens:
             for op in token.operations:

--- a/llmtracefx/realtime_dashboard.py
+++ b/llmtracefx/realtime_dashboard.py
@@ -17,6 +17,8 @@ import logging
 from typing import Dict, List, Any, Optional
 from datetime import datetime, timedelta
 
+from llmtracefx.hardware import supported_hardware
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -660,7 +662,7 @@ def main():
     # GPU Type selection
     gpu_type = st.sidebar.selectbox(
         "GPU Type",
-        ["A10G", "H100", "A100"],
+        supported_hardware(),
         index=0
     )
     

--- a/llmtracefx/visualize/flame.py
+++ b/llmtracefx/visualize/flame.py
@@ -203,7 +203,7 @@ class FlameGraphGenerator:
         metrics = analysis.gpu_metrics
         
         categories = [
-            'SM Occupancy %',
+            f'{metrics.occupancy_label} %',
             'Cache Hit Rate %', 
             'Compute Utilization %',
             'Memory Efficiency %',
@@ -434,7 +434,10 @@ class FlameGraphGenerator:
                     "memory_latency_ms": analysis.gpu_metrics.memory_latency_ms,
                     "sm_occupancy_pct": analysis.gpu_metrics.sm_occupancy_pct,
                     "cache_hit_rate": analysis.gpu_metrics.cache_hit_rate,
-                    "compute_utilization": analysis.gpu_metrics.compute_utilization
+                    "memory_bandwidth_gb_s": analysis.gpu_metrics.memory_bandwidth_gb_s,
+                    "compute_utilization": analysis.gpu_metrics.compute_utilization,
+                    "occupancy_label": analysis.gpu_metrics.occupancy_label,
+                    "metrics_source": analysis.gpu_metrics.metrics_source
                 }
             })
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "GPU-level LLM inference profiler with AI-powered explanations"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "GPL-3.0-only"
 authors = [
     {name = "LLMTraceFX Team", email = "info@llmtracefx.com"},
 ]
@@ -16,7 +16,6 @@ keywords = ["llm", "gpu", "profiler", "inference", "performance", "claude"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -47,6 +46,7 @@ dev = [
     "flake8>=6.0.0",
     "mypy>=1.5.0",
     "pre-commit>=3.3.0",
+    "ruff>=0.12.0",
 ]
 
 test = [
@@ -67,10 +67,9 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/your-org/llmtracefx"
-Documentation = "https://llmtracefx.readthedocs.io"
-Repository = "https://github.com/your-org/llmtracefx"
-Issues = "https://github.com/your-org/llmtracefx/issues"
+Homepage = "https://github.com/Siddhant-K-code/LLMTraceFX"
+Repository = "https://github.com/Siddhant-K-code/LLMTraceFX"
+Issues = "https://github.com/Siddhant-K-code/LLMTraceFX/issues"
 
 [project.scripts]
 llmtracefx = "llmtracefx.main:main"
@@ -190,6 +189,8 @@ exclude_lines = [
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -205,6 +206,6 @@ ignore = [
     "C901",  # too complex
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/*" = ["B011"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "llmtracefx"
 version = "1.0.0"
 description = "GPU-level LLM inference profiler with AI-powered explanations"
-readme = "llmtracefx/README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
@@ -54,6 +54,10 @@ test = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
     "httpx>=0.24.0",
+]
+
+mlx = [
+    "mlx>=0.25.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 
 docs = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from llmtracefx.api.serve import app
+
+
+def test_hardware_endpoint_lists_gb10_and_mlx():
+    response = TestClient(app).get("/hardware")
+
+    assert response.status_code == 200
+    names = [item["name"] for item in response.json()["hardware"]]
+    assert "GB10" in names
+    assert "MLX" in names
+
+
+def test_analysis_rejects_unknown_hardware_before_processing():
+    response = TestClient(app).post(
+        "/analyze-trace",
+        json={"trace_data": {"tokens": []}, "gpu_type": "unknown"},
+    )
+
+    assert response.status_code == 400
+    assert "Choose one of" in response.json()["detail"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,6 @@
+import json
+import sys
+
 from fastapi.testclient import TestClient
 
 from llmtracefx.api.serve import app
@@ -12,6 +15,15 @@ def test_hardware_endpoint_lists_gb10_and_mlx():
     assert "MLX" in names
 
 
+def test_hardware_endpoint_exposes_backend_and_memory_model():
+    response = TestClient(app).get("/hardware")
+
+    profiles = {item["name"]: item for item in response.json()["hardware"]}
+    assert profiles["GB10"]["backend"] == "CUDA"
+    assert profiles["GB10"]["unified_memory"] is True
+    assert profiles["MLX"]["backend"] == "Metal"
+
+
 def test_analysis_rejects_unknown_hardware_before_processing():
     response = TestClient(app).post(
         "/analyze-trace",
@@ -20,3 +32,67 @@ def test_analysis_rejects_unknown_hardware_before_processing():
 
     assert response.status_code == 400
     assert "Choose one of" in response.json()["detail"]
+
+
+def test_analysis_accepts_apple_silicon_alias_and_exports_metrics(monkeypatch):
+    monkeypatch.setitem(sys.modules, "modal", None)
+    client = TestClient(app)
+    response = client.post(
+        "/analyze-trace",
+        json={
+            "trace_data": {
+                "tokens": [
+                    {
+                        "id": 3,
+                        "text": "hello",
+                        "operations": [
+                            {"name": "matmul", "start_time": 0, "duration": 2.5}
+                        ],
+                    }
+                ]
+            },
+            "gpu_type": "apple-silicon",
+            "enable_claude": False,
+        },
+    )
+
+    assert response.status_code == 200
+    analysis_id = response.json()["analysis_id"]
+    token = client.get(f"/token/{analysis_id}/3")
+    exported = client.get(f"/export/{analysis_id}")
+    assert token.status_code == 200
+    assert token.json()["gpu_metrics"]["occupancy_label"] == "GPU occupancy"
+    assert token.json()["gpu_metrics"]["metrics_source"] == "estimated"
+    assert exported.status_code == 200
+    assert exported.json()[0]["gpu_metrics"]["memory_bandwidth_gb_s"] is None
+
+
+def test_analysis_rejects_empty_trace(monkeypatch):
+    monkeypatch.setitem(sys.modules, "modal", None)
+    response = TestClient(app).post(
+        "/analyze-trace",
+        json={
+            "trace_data": {"tokens": []},
+            "gpu_type": "MLX",
+            "enable_claude": False,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Trace does not contain any tokens"
+
+
+def test_upload_rejects_empty_trace():
+    response = TestClient(app).post(
+        "/upload-trace?gpu_type=GB10&enable_claude=false",
+        files={
+            "file": (
+                "trace.json",
+                json.dumps({"tokens": []}),
+                "application/json",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Trace does not contain any tokens"

--- a/tests/test_gpu_analyzer.py
+++ b/tests/test_gpu_analyzer.py
@@ -1,0 +1,68 @@
+import pytest
+
+from llmtracefx.profiler.gpu_analyzer import GPUAnalyzer
+from llmtracefx.profiler.trace_parser import Operation, TokenTrace
+
+
+def make_token(metadata=None):
+    operation = Operation(
+        name="matmul",
+        start_time=0,
+        duration=10,
+        metadata=metadata or {},
+    )
+    return TokenTrace(
+        token_id=1,
+        token_text="test",
+        total_latency=10,
+        operations=[operation],
+        start_time=0,
+        end_time=10,
+    )
+
+
+def test_gb10_analysis_is_deterministic():
+    analyzer = GPUAnalyzer("DGX-SPARK")
+
+    first = analyzer.analyze_token(make_token())
+    second = analyzer.analyze_token(make_token())
+
+    assert analyzer.gpu_type == "GB10"
+    assert first.gpu_metrics == second.gpu_metrics
+    assert first.performance_score == second.performance_score
+    assert first.gpu_metrics.memory_bandwidth_gb_s == 273
+    assert first.gpu_metrics.metrics_source == "estimated"
+
+
+def test_measured_operation_metadata_overrides_estimates():
+    metadata = {
+        "stall_pct": 12,
+        "launch_delay_ms": 0.2,
+        "memory_latency_ms": 1.5,
+        "occupancy_pct": 88,
+        "cache_hit_rate": 91,
+        "compute_utilization": 84,
+    }
+
+    analysis = GPUAnalyzer("MLX").analyze_token(make_token(metadata))
+
+    assert analysis.gpu_metrics.stall_pct == 12
+    assert analysis.gpu_metrics.launch_delay_ms == 0.2
+    assert analysis.gpu_metrics.memory_latency_ms == 1.5
+    assert analysis.gpu_metrics.sm_occupancy_pct == 88
+    assert analysis.gpu_metrics.cache_hit_rate == 91
+    assert analysis.gpu_metrics.compute_utilization == 84
+    assert analysis.gpu_metrics.occupancy_label == "GPU occupancy"
+    assert analysis.gpu_metrics.metrics_source == "measured"
+
+
+def test_partial_metadata_is_marked_mixed():
+    analysis = GPUAnalyzer("MLX").analyze_token(make_token({"stall_pct": 15}))
+
+    assert analysis.gpu_metrics.stall_pct == 15
+    assert analysis.gpu_metrics.metrics_source == "mixed"
+
+
+def test_non_numeric_metadata_is_rejected():
+    with pytest.raises(ValueError, match="must be numeric"):
+        GPUAnalyzer("GB10").analyze_token(make_token({"stall_pct": "high"}))

--- a/tests/test_gpu_analyzer.py
+++ b/tests/test_gpu_analyzer.py
@@ -66,3 +66,59 @@ def test_partial_metadata_is_marked_mixed():
 def test_non_numeric_metadata_is_rejected():
     with pytest.raises(ValueError, match="must be numeric"):
         GPUAnalyzer("GB10").analyze_token(make_token({"stall_pct": "high"}))
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_metadata_is_rejected(value):
+    with pytest.raises(ValueError, match="must be finite"):
+        GPUAnalyzer("MLX").analyze_token(make_token({"stall_pct": value}))
+
+
+def test_percentage_metadata_is_clamped_to_valid_range():
+    analysis = GPUAnalyzer("MLX").analyze_token(
+        make_token({"occupancy_pct": 110, "cache_hit_rate": -2})
+    )
+
+    assert analysis.gpu_metrics.sm_occupancy_pct == 100
+    assert analysis.gpu_metrics.cache_hit_rate == 0
+    assert analysis.gpu_metrics.metrics_source == "mixed"
+
+
+def test_empty_token_has_explicit_unavailable_analysis():
+    token = TokenTrace(
+        token_id=2,
+        token_text="",
+        total_latency=0,
+        operations=[],
+        start_time=0,
+        end_time=0,
+    )
+
+    analysis = GPUAnalyzer("GB10").analyze_token(token)
+
+    assert analysis.bottleneck_type == "no_operations"
+    assert analysis.performance_score == 0
+    assert analysis.gpu_metrics.metrics_source == "unavailable"
+
+
+def test_aggregate_metrics_are_duration_weighted():
+    operations = [
+        Operation(
+            name="matmul",
+            start_time=0,
+            duration=9,
+            metadata={"stall_pct": 10},
+        ),
+        Operation(
+            name="softmax",
+            start_time=9,
+            duration=1,
+            metadata={"stall_pct": 90},
+        ),
+    ]
+    token = TokenTrace(1, "test", 10, operations, 0, 10)
+
+    analysis = GPUAnalyzer("GB10").analyze_token(token)
+
+    assert analysis.gpu_metrics.stall_pct == pytest.approx(18)
+    assert analysis.gpu_metrics.metrics_source == "mixed"

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,38 @@
+import pytest
+
+from llmtracefx.hardware import (
+    get_hardware_profile,
+    normalize_hardware_name,
+    supported_hardware,
+)
+
+
+def test_gb10_profile_uses_dgx_spark_specs():
+    profile = get_hardware_profile("GB10")
+
+    assert profile.backend == "CUDA"
+    assert profile.memory_size_gb == 128
+    assert profile.memory_bandwidth_gb_s == 273
+    assert profile.unified_memory is True
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("dgx-spark", "GB10"),
+        ("apple silicon", "MLX"),
+        ("metal", "MLX"),
+        ("h100", "H100"),
+    ],
+)
+def test_hardware_aliases(alias, expected):
+    assert normalize_hardware_name(alias) == expected
+
+
+def test_unknown_hardware_has_actionable_error():
+    with pytest.raises(ValueError, match="Choose one of: A10G, A100, H100, GB10, MLX"):
+        get_hardware_profile("unknown")
+
+
+def test_supported_hardware_includes_new_profiles():
+    assert supported_hardware() == ["A10G", "A100", "H100", "GB10", "MLX"]

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -2,6 +2,7 @@ import pytest
 
 from llmtracefx.hardware import (
     get_hardware_profile,
+    hardware_profiles,
     normalize_hardware_name,
     supported_hardware,
 )
@@ -36,3 +37,21 @@ def test_unknown_hardware_has_actionable_error():
 
 def test_supported_hardware_includes_new_profiles():
     assert supported_hardware() == ["A10G", "A100", "H100", "GB10", "MLX"]
+
+
+def test_hardware_profiles_are_json_ready_and_complete():
+    profiles = hardware_profiles()
+
+    assert [profile["name"] for profile in profiles] == supported_hardware()
+    assert all(profile["backend"] in {"CUDA", "Metal"} for profile in profiles)
+    assert next(profile for profile in profiles if profile["name"] == "MLX") == {
+        "name": "MLX",
+        "display_name": "Apple Silicon (MLX / Metal)",
+        "vendor": "Apple",
+        "backend": "Metal",
+        "memory_bandwidth_gb_s": None,
+        "memory_size_gb": None,
+        "compute_units": None,
+        "unified_memory": True,
+        "occupancy_label": "GPU occupancy",
+    }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,90 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from llmtracefx.profiler.gpu_analyzer import GPUAnalyzer
+from llmtracefx.profiler.trace_parser import TraceParser
+from llmtracefx.visualize.flame import FlameGraphGenerator
+
+
+def mlx_trace_payload():
+    return {
+        "format": "llmtracefx.mlx.v1",
+        "framework": "mlx",
+        "hardware": "MLX",
+        "device": {"device_name": "Test Apple GPU"},
+        "time_unit": "ms",
+        "tokens": [
+            {
+                "id": 0,
+                "text": "hello",
+                "operations": [
+                    {
+                        "name": "model_forward",
+                        "start_time": 0,
+                        "duration": 2.5,
+                        "metadata": {
+                            "backend": "metal",
+                            "active_memory_bytes": 1024,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_mlx_trace_parser_analyzer_and_visualizer_pipeline():
+    tokens = TraceParser().parse_trace_data(mlx_trace_payload())
+    analyses = GPUAnalyzer("MLX").analyze_sequence(tokens)
+    visualizer = FlameGraphGenerator()
+
+    exported = json.loads(visualizer.export_data_json(analyses))
+    dashboard = visualizer.generate_comprehensive_dashboard(analyses)
+
+    assert exported[0]["total_latency_ms"] == 2.5
+    assert exported[0]["gpu_metrics"]["occupancy_label"] == "GPU occupancy"
+    assert exported[0]["gpu_metrics"]["metrics_source"] == "estimated"
+    assert "GPU occupancy" in dashboard
+
+
+@pytest.mark.parametrize(
+    ("hardware", "display_name", "occupancy_label"),
+    [
+        ("apple-silicon", "Apple Silicon (MLX / Metal)", "GPU occupancy"),
+        ("DGX-SPARK", "NVIDIA GB10 / DGX Spark", "SM occupancy"),
+    ],
+)
+def test_cli_analyzes_new_hardware_aliases(
+    tmp_path, hardware, display_name, occupancy_label
+):
+    trace_path = tmp_path / "mlx_trace.json"
+    output_dir = tmp_path / "nested" / "report"
+    trace_path.write_text(json.dumps(mlx_trace_payload()), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "llmtracefx.main",
+            "--trace",
+            str(trace_path),
+            "--gpu-type",
+            hardware,
+            "--no-claude",
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = (output_dir / "report.txt").read_text(encoding="utf-8")
+    exported = json.loads((output_dir / "analysis_data.json").read_text())
+    assert display_name in report
+    assert "Metrics Source: estimated" in report
+    assert exported[0]["gpu_metrics"]["occupancy_label"] == occupancy_label

--- a/tests/test_mlx_tracer.py
+++ b/tests/test_mlx_tracer.py
@@ -1,0 +1,124 @@
+import json
+
+import pytest
+
+from llmtracefx.profiler import MLXTraceRecorder
+from llmtracefx.profiler.trace_parser import TraceParser
+
+
+class FakeClock:
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
+
+
+class FakeMetal:
+    def __init__(self):
+        self.started = None
+        self.stopped = False
+
+    def start_capture(self, path):
+        self.started = path
+
+    def stop_capture(self):
+        self.stopped = True
+
+
+class FakeMLX:
+    def __init__(self):
+        self.eval_calls = []
+        self.synchronize_calls = 0
+        self.metal = FakeMetal()
+
+    def eval(self, *values):
+        self.eval_calls.append(values)
+
+    def synchronize(self):
+        self.synchronize_calls += 1
+
+    def device_info(self):
+        return {
+            "device_name": "Fake M4 Max",
+            "architecture": "applegpu_g16s",
+            "memory_size": 64 * 1024**3,
+        }
+
+    def get_active_memory(self):
+        return 1024
+
+    def get_peak_memory(self):
+        return 2048
+
+    def get_cache_memory(self):
+        return 512
+
+
+def test_mlx_recorder_writes_parseable_trace(tmp_path):
+    output_path = tmp_path / "mlx_trace.json"
+    fake_mlx = FakeMLX()
+    result = object()
+    clock = FakeClock(0, 1_000_000, 4_000_000)
+
+    with MLXTraceRecorder(output_path, mlx_module=fake_mlx, clock_ns=clock) as trace:
+        with trace.token(7, "hello"):
+            returned = trace.measure("matmul", lambda: result)
+
+    payload = json.loads(output_path.read_text())
+    operation = payload["tokens"][0]["operations"][0]
+
+    assert returned is result
+    assert payload["format"] == "llmtracefx.mlx.v1"
+    assert payload["hardware"] == "MLX"
+    assert payload["device"]["device_name"] == "Fake M4 Max"
+    assert operation["start_time"] == 1.0
+    assert operation["duration"] == 3.0
+    assert operation["metadata"]["active_memory_bytes"] == 1024
+    assert fake_mlx.eval_calls == [(result,)]
+    assert fake_mlx.synchronize_calls == 2
+
+    tokens = TraceParser().parse_trace_file(str(output_path))
+    assert tokens[0].token_id == 7
+    assert tokens[0].operations[0].name == "matmul"
+    assert tokens[0].total_latency == 3.0
+
+
+def test_optional_native_metal_capture_uses_same_region(tmp_path):
+    output_path = tmp_path / "mlx_trace.json"
+    capture_path = tmp_path / "mlx_trace.gputrace"
+    fake_mlx = FakeMLX()
+    clock = FakeClock(0, 1_000_000, 2_000_000)
+
+    with MLXTraceRecorder(
+        output_path,
+        metal_capture_path=capture_path,
+        mlx_module=fake_mlx,
+        clock_ns=clock,
+    ) as trace:
+        with trace.token(0):
+            trace.measure("softmax", lambda: object())
+
+    assert fake_mlx.metal.started == str(capture_path)
+    assert fake_mlx.metal.stopped is True
+
+
+def test_measure_requires_an_active_token(tmp_path):
+    recorder = MLXTraceRecorder(tmp_path / "trace.json", mlx_module=FakeMLX())
+
+    with pytest.raises(RuntimeError, match="Start a token trace"):
+        recorder.measure("matmul", lambda: object())
+
+
+def test_native_capture_refuses_to_overwrite_existing_trace(tmp_path):
+    capture_path = tmp_path / "existing.gputrace"
+    capture_path.mkdir()
+    recorder = MLXTraceRecorder(
+        tmp_path / "trace.json",
+        metal_capture_path=capture_path,
+        mlx_module=FakeMLX(),
+    )
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        with recorder:
+            pass

--- a/tests/test_mlx_tracer.py
+++ b/tests/test_mlx_tracer.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 
 import pytest
@@ -15,15 +16,22 @@ class FakeClock:
 
 
 class FakeMetal:
-    def __init__(self):
+    def __init__(self, available=True):
+        self.available = available
         self.started = None
         self.stopped = False
+
+    def is_available(self):
+        return self.available
 
     def start_capture(self, path):
         self.started = path
 
     def stop_capture(self):
         self.stopped = True
+
+    def device_info(self):
+        return {"architecture": "fake-metal"}
 
 
 class FakeMLX:
@@ -103,6 +111,49 @@ def test_optional_native_metal_capture_uses_same_region(tmp_path):
     assert fake_mlx.metal.stopped is True
 
 
+def test_measure_passes_nested_array_tree_to_mlx_eval(tmp_path):
+    fake_mlx = FakeMLX()
+    nested_result = {"logits": [object()], "cache": (object(),)}
+    clock = FakeClock(0, 1_000_000, 2_000_000)
+
+    with MLXTraceRecorder(
+        tmp_path / "trace.json", mlx_module=fake_mlx, clock_ns=clock
+    ) as trace:
+        with trace.token(0):
+            trace.measure("model_forward", lambda: nested_result)
+
+    assert fake_mlx.eval_calls == [(nested_result,)]
+
+
+def test_operation_context_records_manually_evaluated_work(tmp_path):
+    fake_mlx = FakeMLX()
+    clock = FakeClock(0, 1_000_000, 5_000_000)
+    output_path = tmp_path / "trace.json"
+
+    with MLXTraceRecorder(output_path, mlx_module=fake_mlx, clock_ns=clock) as trace:
+        with trace.token(0):
+            with trace.operation("compiled_step", metadata={"batch_size": 1}):
+                fake_mlx.eval(object())
+
+    operation = json.loads(output_path.read_text())["tokens"][0]["operations"][0]
+    assert operation["duration"] == 4.0
+    assert operation["metadata"]["batch_size"] == 1
+    assert fake_mlx.synchronize_calls == 2
+
+
+def test_measure_can_skip_evaluation_for_already_eager_work(tmp_path):
+    fake_mlx = FakeMLX()
+    clock = FakeClock(0, 1_000_000, 2_000_000)
+
+    with MLXTraceRecorder(
+        tmp_path / "trace.json", mlx_module=fake_mlx, clock_ns=clock
+    ) as trace:
+        with trace.token(0):
+            trace.measure("host_step", lambda: object(), evaluate=False)
+
+    assert fake_mlx.eval_calls == []
+
+
 def test_measure_requires_an_active_token(tmp_path):
     recorder = MLXTraceRecorder(tmp_path / "trace.json", mlx_module=FakeMLX())
 
@@ -122,3 +173,92 @@ def test_native_capture_refuses_to_overwrite_existing_trace(tmp_path):
     with pytest.raises(FileExistsError, match="already exists"):
         with recorder:
             pass
+
+
+def test_native_capture_requires_available_metal_backend(tmp_path):
+    fake_mlx = FakeMLX()
+    fake_mlx.metal = FakeMetal(available=False)
+    recorder = MLXTraceRecorder(
+        tmp_path / "trace.json",
+        metal_capture_path=tmp_path / "trace.gputrace",
+        mlx_module=fake_mlx,
+    )
+
+    with pytest.raises(RuntimeError, match="available Metal backend"):
+        with recorder:
+            pass
+
+
+def test_exception_stops_native_capture_without_writing_json(tmp_path):
+    fake_mlx = FakeMLX()
+    output_path = tmp_path / "trace.json"
+    recorder = MLXTraceRecorder(
+        output_path,
+        metal_capture_path=tmp_path / "trace.gputrace",
+        mlx_module=fake_mlx,
+    )
+
+    with pytest.raises(RuntimeError, match="model failed"):
+        with recorder:
+            raise RuntimeError("model failed")
+
+    assert fake_mlx.metal.stopped is True
+    assert not output_path.exists()
+
+
+def test_missing_synchronize_has_actionable_error(tmp_path):
+    fake_mlx = FakeMLX()
+    fake_mlx.synchronize = None
+    recorder = MLXTraceRecorder(tmp_path / "trace.json", mlx_module=fake_mlx)
+
+    with recorder.token(0):
+        with pytest.raises(RuntimeError, match="mx.synchronize"):
+            recorder.measure("matmul", lambda: object())
+
+
+def test_nested_tokens_are_rejected_without_corrupting_outer_token(tmp_path):
+    fake_mlx = FakeMLX()
+    output_path = tmp_path / "trace.json"
+    recorder = MLXTraceRecorder(output_path, mlx_module=fake_mlx)
+
+    with recorder.token(0):
+        with pytest.raises(RuntimeError, match="Nested token"):
+            with recorder.token(1):
+                pass
+
+    recorder.write()
+    payload = json.loads(output_path.read_text())
+    assert [token["id"] for token in payload["tokens"]] == [0]
+
+
+def test_write_rejects_an_active_token(tmp_path):
+    recorder = MLXTraceRecorder(tmp_path / "trace.json", mlx_module=FakeMLX())
+
+    with recorder.token(0):
+        with pytest.raises(RuntimeError, match="Finish the active token"):
+            recorder.write()
+
+
+def test_device_info_falls_back_to_legacy_metal_api(tmp_path):
+    fake_mlx = FakeMLX()
+    fake_mlx.device_info = None
+    output_path = tmp_path / "trace.json"
+
+    MLXTraceRecorder(output_path, mlx_module=fake_mlx).write()
+
+    payload = json.loads(output_path.read_text())
+    assert payload["device"] == {"architecture": "fake-metal"}
+
+
+def test_missing_mlx_dependency_has_install_instructions(tmp_path, monkeypatch):
+    real_import = builtins.__import__
+
+    def block_mlx(name, *args, **kwargs):
+        if name == "mlx.core":
+            raise ImportError("MLX is unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_mlx)
+
+    with pytest.raises(RuntimeError, match="uv sync --extra mlx"):
+        MLXTraceRecorder(tmp_path / "trace.json")

--- a/uv.lock
+++ b/uv.lock
@@ -835,6 +835,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -875,6 +876,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "streamlit", specifier = ">=1.28.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
@@ -2303,6 +2305,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/a6/33b1fc0c9f7dcfcfc4a4353daa6308b3ece22496ceece348b3e7a7559a09/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2abe21d8ba64cded53a2a677e149ceb76dcf44284202d737178afe7ba540c1eb", size = 559439, upload-time = "2025-07-01T15:56:48.549Z" },
     { url = "https://files.pythonhosted.org/packages/71/2d/ceb3f9c12f8cfa56d34995097f6cd99da1325642c60d1b6680dd9df03ed8/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:4feb7511c29f8442cbbc28149a92093d32e815a28aa2c50d333826ad2a20fdf0", size = 588380, upload-time = "2025-07-01T15:56:50.086Z" },
     { url = "https://files.pythonhosted.org/packages/c8/ed/9de62c2150ca8e2e5858acf3f4f4d0d180a38feef9fdab4078bea63d8dba/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e99685fc95d386da368013e7fb4269dd39c30d99f812a8372d62f244f662709c", size = 555334, upload-time = "2025-07-01T15:56:51.703Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -431,7 +431,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -841,6 +841,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+mlx = [
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+]
 test = [
     { name = "httpx" },
     { name = "pytest" },
@@ -859,6 +862,7 @@ requires-dist = [
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.25.0" },
     { name = "modal", specifier = ">=0.57.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "numpy", specifier = ">=1.25.2" },
@@ -874,7 +878,7 @@ requires-dist = [
     { name = "streamlit", specifier = ">=1.28.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev", "test", "docs"]
+provides-extras = ["dev", "test", "mlx", "docs"]
 
 [[package]]
 name = "markdown"
@@ -1100,6 +1104,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ed/b886f8c714fd7cccc39b79646b627dbea84cd95c46be43459ef46852caf0/mkdocstrings_python-1.16.12.tar.gz", hash = "sha256:9b9eaa066e0024342d433e332a41095c4e429937024945fea511afe58f63175d", size = 206065, upload-time = "2025-06-03T12:52:49.276Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/dd/a24ee3de56954bfafb6ede7cd63c2413bb842cc48eb45e41c43a05a33074/mkdocstrings_python-1.16.12-py3-none-any.whl", hash = "sha256:22ded3a63b3d823d57457a70ff9860d5a4de9e8b1e482876fc9baabaf6f5f374", size = 124287, upload-time = "2025-06-03T12:52:47.819Z" },
+]
+
+[[package]]
+name = "mlx"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/38/a034159df4d21ef7b5721225a2c46092e20a2c627724f57be3e89fa7dbce/mlx-0.32.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:c6feb17e32160b70c7634aab925cf3f8c5c7bebbf99f227c48450478e1008af2", size = 562899, upload-time = "2026-07-07T17:55:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/054d26695279155b590a95330440b592bd9c2dfe9cf450812b18ac598962/mlx-0.32.0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:73303259f2bda7fb4a0c782a7299e0e28a2890b9b6fbfc4b635fb8032208ec7e", size = 562898, upload-time = "2026-07-07T17:55:26.995Z" },
+    { url = "https://files.pythonhosted.org/packages/16/06/9f74a23e8d3931a87e0fa24044fe178656d69852ca20493b50e7da2326c3/mlx-0.32.0-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:8637003c6eb089443d149fdb483f5d7a7846d6cc43d112148d7aa07cf1356c04", size = 562871, upload-time = "2026-07-07T17:55:28.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c7/cb62301b01dbccd66b256cab0c98fc29e7533dd76aa599fe44c1bb1f4168/mlx-0.32.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:72c605368d145c756877057d7e3c54f169c9899fe1f83232bfb3a6342561e234", size = 562792, upload-time = "2026-07-07T17:55:35.24Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/c2eba5bb18c94a9fe1b5d6599f18ba2ef5de2d8b42439716d9241ab196c4/mlx-0.32.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0a0e38a409b9cae29647ec9e75ce9747b224ce7e5d91adbfad7eac37b6118ffd", size = 562792, upload-time = "2026-07-07T17:55:36.876Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/43/5b481bfb8f1234153fd8fef9dcacfe34860b0934eb507c0eb811ba599afe/mlx-0.32.0-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:2a180cd39ac68b397b85cc4658d0b8e0ab58166c2549fc9ab2ca5f99d15ef0c3", size = 562776, upload-time = "2026-07-07T17:55:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/5d1f1cb1b073c39c822e0c0be1e68f4ced6fd32ab15cf8bb1f448028842c/mlx-0.32.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5f778001562ccce26cf6e5be1050d2afc78e2902bad206201ab9f5a6d0f886a", size = 558890, upload-time = "2026-07-07T17:55:46.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/01/02110ceacf4efd00ec172f60b4cd42c8b1509ac50ffa65a6a77d723133aa/mlx-0.32.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:8dfb577faa4dc413cfd0d6eb78f230d3b3b6169df4473e84408abdeb21346e9d", size = 558856, upload-time = "2026-07-07T17:55:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/be/ddc888d4a20c7602da06ad1a244f495010c6c7d2457f6253e8fa3c99ceea/mlx-0.32.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:abb786ee1e9638759be82583222fc7d09c5650ef90ad2b7c5da7d1931a8676dc", size = 558795, upload-time = "2026-07-07T17:55:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b9/4f0ae7785fdb3fa7e44434908d832cbc7a9a1e096d046ac6fe953812c52c/mlx-0.32.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:deb284f3a5cd0c3e87bed80c2bee9dcbf946bdad44d75592f6fb784da878c1c0", size = 558799, upload-time = "2026-07-07T17:55:56.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/7bc999ce5d09dfac8961dcda4ed47e173fca2857492f34599b237380f20d/mlx-0.32.0-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4192a2d02014a13a6a1030bf13dfb4e4fe05ec3ffa47678ee37da29111e25cb1", size = 558786, upload-time = "2026-07-07T17:55:58.272Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/5e49c183f9024f86dc1f038866ccd743aaec1fe412a7e7dc76fec9271f48/mlx-0.32.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2ee79b1f8c2c2a329afc95ece7dce0be798d43f3de771a6370d2b9f9702bbd9a", size = 561387, upload-time = "2026-07-07T17:56:05.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/33/e3d7f7a18331523762e9968b6716e81514649af81ffd9ba4364e3df95823/mlx-0.32.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e0db558267bb2d13fac4f85674456adbe0f085c570b9219e03d4e95fdc11c4d0", size = 561389, upload-time = "2026-07-07T17:56:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/58/bd847d3fed65296573a4bb3399adde6934c0a718813b5636000d7d1b4063/mlx-0.32.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:23e83c8e74a23156696e9f9905d16a17b7d27b5a596c1bc0f720a98df1c5aadf", size = 561392, upload-time = "2026-07-07T17:56:08.237Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add validated NVIDIA GB10 / DGX Spark and Apple MLX / Metal hardware profiles across the CLI, API, and dashboard
- add an optional `MLXTraceRecorder` with synchronized timings, allocator snapshots, nested result evaluation, and optional Xcode `.gputrace` capture
- use measured operation metadata when available and label deterministic fallbacks as `measured`, `mixed`, or `estimated`
- reject invalid hardware, non-finite metric metadata, unavailable Metal capture, and empty API traces with actionable errors
- document copy-paste MLX capture/analysis and GB10 analysis workflows, including what is measured versus estimated
- correct package metadata and include Ruff in the documented development setup

## Usage

```bash
uv run llmtracefx --trace trace.json --gpu-type DGX-SPARK --no-claude

uv sync --extra mlx
uv run python examples/mlx_trace.py
uv run llmtracefx --trace mlx_trace.json --gpu-type MLX --no-claude

MTL_CAPTURE_ENABLED=1 uv run python examples/mlx_trace.py \
  --metal-capture mlx_trace.gputrace
```

## Verification

- 41 tests pass on Python 3.10, 3.11, and 3.12
- recorder → parser → analyzer → dashboard/export/CLI/API integration coverage
- MLX recorder: 97% coverage; hardware profiles: 100%
- Ruff, Black, and targeted MyPy checks pass
- lockfile and installed dependency checks pass
- wheel and source distribution build without metadata warnings
- clean-wheel CLI and import smoke tests pass
- MLX 0.25 API compatibility checked against source; current API checked against official MLX documentation

The MLX path is thoroughly tested with a fake backend on Linux. A final smoke test on physical Apple Silicon is still needed before marking this ready.

Closes #1