### PR TITLE
feat(optimizer): add reproducible inference evidence foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ cover/
 
 # Django stuff:
 *.log
+!tests/optimizer/fixtures/**/*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/README.md
+++ b/README.md
@@ -693,11 +693,27 @@ uv run llmtracefx-optimizer parse-llama-cpp \
   --stdout-file tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run1.log \
   --output /tmp/baseline-1.json -- llama-cli -m qwen3.8-27b-q4.gguf
 
-# 3. Ask the doctor whether speculative decoding is a net regression
+uv run llmtracefx-optimizer parse-llama-cpp \
+  --run-id baseline-2 --model-id "Qwen/Qwen3.8-27B" --quantization Q4_K_M \
+  --stdout-file tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run2.log \
+  --output /tmp/baseline-2.json -- llama-cli -m qwen3.8-27b-q4.gguf
+
+uv run llmtracefx-optimizer parse-llama-cpp \
+  --run-id mtp-1 --model-id "Qwen/Qwen3.8-27B" --quantization Q4_K_M \
+  --speculative-method mtp \
+  --stdout-file tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run1.log \
+  --output /tmp/mtp-1.json -- llama-cli -m qwen3.8-27b-q4.gguf --spec-type draft-mtp
+
+uv run llmtracefx-optimizer parse-llama-cpp \
+  --run-id mtp-2 --model-id "Qwen/Qwen3.8-27B" --quantization Q4_K_M \
+  --speculative-method mtp \
+  --stdout-file tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run2.log \
+  --output /tmp/mtp-2.json -- llama-cli -m qwen3.8-27b-q4.gguf --spec-type draft-mtp
+
+# 3. Ask the doctor whether speculative decoding changed performance
 uv run llmtracefx-optimizer doctor speculative \
-  --baseline /tmp/baseline-1.json \
-  --speculative /tmp/baseline-1.json \
-  --min-repetitions 1
+  --baseline /tmp/baseline-1.json /tmp/baseline-2.json \
+  --speculative /tmp/mtp-1.json /tmp/mtp-2.json
 ```
 
 **Not yet included** (tracked as follow-up work): native Metal/CUDA

--- a/README.md
+++ b/README.md
@@ -640,6 +640,73 @@ uv run ruff check llmtracefx/hardware.py \
   llmtracefx/profiler/gpu_analyzer.py tests
 ```
 
+## 🧭 Inference Optimizer Foundation
+
+LLMTraceFX is evolving from a trace *analyzer* into a workload-aware
+inference *optimizer* for open models (initial target: Qwen3.8-27B on
+Apple M5 Pro via MLX/llama.cpp Metal, and on CloudRift RTX 4090 via
+llama.cpp CUDA). This PR lays the **foundation only** — reliable, tested
+primitives that later native Metal/CUDA collectors and tuning logic will
+build on:
+
+- **Canonical evidence schema** (`llmtracefx.optimizer.schema`): a
+  versioned `ExperimentRecord` capturing run identity, hardware/platform,
+  model/tokenizer/quantization, runtime/backend + git revision, exact
+  command and config/workload hashes, warmup/repetition/seed metadata,
+  token counts, load/tokenize/prefill/decode/total timing, speculative
+  decoding (MTP) counters, memory/power when available, task outcome, and
+  errors — every measurement is tagged with a `MetricProvenance`
+  (`measured_native`, `measured_wall_clock`, `derived`, `estimated`) so
+  nothing is silently invented.
+- **CPU-only environment manifest** (`llmtracefx.optimizer.manifest`):
+  deterministic, non-sensitive OS/arch/CPU/package-version metadata for
+  comparability checks. Never collects secrets, usernames, hostnames, or
+  full environment dumps.
+- **Reproducible experiment runner** (`llmtracefx.optimizer.runner`):
+  executes a configured command (argv list, never a shell string) for N
+  warmup + N measured repetitions, with timeouts, atomic JSON/JSONL
+  artifacts, and resume that skips already-completed repetitions while
+  retrying failed/timed-out ones.
+- **llama.cpp collector** (`llmtracefx.optimizer.parsers.llama_cpp`):
+  parses `llama_print_timings` / `llama_perf_context_print` timing lines
+  and speculative-decoding counters into the canonical schema, tolerating
+  missing optional lines but raising explicitly on malformed values.
+- **First "doctor" rule** (`llmtracefx.optimizer.doctor.speculative`):
+  compares speculative-decoding (MTP) runs against a comparable
+  autoregressive baseline and reports `regression` / `improvement` /
+  `no_significant_difference` / `inconclusive` — it refuses to guess when
+  runs aren't comparable, repetitions are too few, or the delta is
+  smaller than run-to-run noise.
+
+Try it end-to-end with a CPU-only example (no GPU or model download
+required):
+
+```bash
+uv sync --extra dev --extra test
+
+# 1. Collect a non-sensitive environment manifest
+uv run llmtracefx-optimizer manifest
+
+# 2. Convert a llama.cpp log into a canonical ExperimentRecord
+uv run llmtracefx-optimizer parse-llama-cpp \
+  --run-id baseline-1 --model-id "Qwen/Qwen3.8-27B" --quantization Q4_K_M \
+  --stdout-file tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run1.log \
+  --output /tmp/baseline-1.json -- llama-cli -m qwen3.8-27b-q4.gguf
+
+# 3. Ask the doctor whether speculative decoding is a net regression
+uv run llmtracefx-optimizer doctor speculative \
+  --baseline /tmp/baseline-1.json \
+  --speculative /tmp/baseline-1.json \
+  --min-repetitions 1
+```
+
+**Not yet included** (tracked as follow-up work): native Metal/CUDA
+performance-counter ingestion, MLX and CUDA/vLLM/SGLang collectors,
+automatic tuning/search, and any actual Qwen3.8-27B benchmark results.
+The fixtures under `tests/optimizer/fixtures/llama_cpp/` are synthetic,
+hand-written logs for testing the parser and doctor rule — not
+benchmark evidence (see the `PROVENANCE.md` in that directory).
+
 ## 📄 License
 
 This project is licensed under the GNU General Public License v3.0 License - see the [LICENSE](LICENSE) file for details.

--- a/llmtracefx/optimizer/__init__.py
+++ b/llmtracefx/optimizer/__init__.py
@@ -1,0 +1,12 @@
+"""Foundation primitives for the LLMTraceFX inference optimizer.
+
+This package is the first step in evolving LLMTraceFX from a trace
+*analyzer* into a workload-aware inference *optimizer*. It establishes
+reliable, tested building blocks — a canonical evidence schema, an
+environment manifest collector, a safe experiment runner, a llama.cpp
+output parser, and a first "doctor" diagnostic rule — that later
+collectors (native Metal/CUDA counters) and tuning logic can build on.
+
+Nothing in this package downloads models, requires a GPU, or performs
+brute-force tuning.
+"""

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -30,7 +30,7 @@ from .schema import (
 )
 
 
-def _platform_from_manifest() -> PlatformInfo:
+def _platform_from_manifest(*, accelerator: str | None = None) -> PlatformInfo:
     manifest = collect_environment_manifest()
     return PlatformInfo(
         os_name=manifest.os_name,
@@ -38,6 +38,7 @@ def _platform_from_manifest() -> PlatformInfo:
         architecture=manifest.architecture,
         cpu_cores=manifest.cpu_count,
         total_memory_gb=manifest.total_memory_gb,
+        accelerator=accelerator,
     )
 
 
@@ -95,7 +96,7 @@ def _cmd_parse_llama_cpp(args: argparse.Namespace) -> int:
         record = build_experiment_record(
             run_id=args.run_id,
             started_at=utc_now_iso(),
-            platform=_platform_from_manifest(),
+            platform=_platform_from_manifest(accelerator=args.accelerator),
             model=ModelInfo(
                 model_id=args.model_id,
                 model_revision=args.model_revision,
@@ -190,6 +191,16 @@ def build_parser() -> argparse.ArgumentParser:
     parse_parser.add_argument("--quantization", default=None)
     parse_parser.add_argument("--runtime-version", default=None)
     parse_parser.add_argument("--runtime-git-revision", default=None)
+    parse_parser.add_argument(
+        "--accelerator",
+        default=None,
+        help=(
+            "Explicit accelerator/GPU name (e.g. 'Apple M5 Pro', 'NVIDIA RTX 4090'). "
+            "Takes precedence over any device name llama.cpp reports in its own "
+            "output; if omitted, the parsed device hint (when present) is used "
+            "instead so comparability checks can tell different accelerators apart."
+        ),
+    )
     parse_parser.add_argument(
         "--speculative-method",
         default=None,

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -1,0 +1,257 @@
+"""CLI entrypoint for the inference-optimizer foundation primitives.
+
+Subcommands:
+    manifest         Collect a CPU-only, non-sensitive environment manifest.
+    run              Execute a configured experiment (warmups + measured reps).
+    parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
+    doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from .doctor.speculative import diagnose_speculative_regression
+from .manifest import collect_environment_manifest
+from .parsers.llama_cpp import LlamaCppParseError, build_experiment_record
+from .runner import ExperimentRunner, RunnerConfig, RunnerConfigError
+from .schema import (
+    CommandInfo,
+    ExperimentRecord,
+    ModelInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    SchemaValidationError,
+    utc_now_iso,
+)
+
+
+def _platform_from_manifest() -> PlatformInfo:
+    manifest = collect_environment_manifest()
+    return PlatformInfo(
+        os_name=manifest.os_name,
+        os_version=manifest.os_release,
+        architecture=manifest.architecture,
+        cpu_cores=manifest.cpu_count,
+        total_memory_gb=manifest.total_memory_gb,
+    )
+
+
+def _cmd_manifest(args: argparse.Namespace) -> int:
+    manifest = collect_environment_manifest()
+    text = manifest.to_json()
+    if args.output:
+        Path(args.output).write_text(text + "\n", encoding="utf-8")
+        print(f"Environment manifest written to {args.output}")
+    else:
+        print(text)
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    try:
+        config = RunnerConfig.from_file(args.config)
+    except RunnerConfigError as exc:
+        print(f"Invalid runner config: {exc}", file=sys.stderr)
+        return 1
+
+    runner = ExperimentRunner(config)
+    results = runner.run(resume=not args.no_resume)
+    succeeded = sum(1 for result in results if result.succeeded)
+    print(
+        f"Completed {succeeded}/{len(results)} measured repetitions for '{config.run_id}'"
+    )
+    print(f"Artifacts written to {config.results_dir}")
+    return 0 if succeeded == len(results) else 1
+
+
+def _cmd_parse_llama_cpp(args: argparse.Namespace) -> int:
+    stdout_text = (
+        Path(args.stdout_file).read_text(encoding="utf-8") if args.stdout_file else ""
+    )
+    stderr_text = (
+        Path(args.stderr_file).read_text(encoding="utf-8") if args.stderr_file else ""
+    )
+    if not stdout_text and not stderr_text:
+        print("Provide at least one of --stdout-file/--stderr-file", file=sys.stderr)
+        return 1
+
+    command_argv = args.llama_command
+    if command_argv and command_argv[0] == "--":
+        command_argv = command_argv[1:]
+    if not command_argv:
+        print(
+            "Provide the executed command after a literal '--', e.g. "
+            "`... --run-id x -- llama-cli -m model.gguf`",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        record = build_experiment_record(
+            run_id=args.run_id,
+            started_at=utc_now_iso(),
+            platform=_platform_from_manifest(),
+            model=ModelInfo(
+                model_id=args.model_id,
+                model_revision=args.model_revision,
+                tokenizer_revision=args.tokenizer_revision,
+                quantization=args.quantization,
+            ),
+            command=CommandInfo(argv=tuple(command_argv)),
+            repetition=RepetitionInfo(
+                warmup_repetitions=args.warmup_repetitions,
+                measured_repetitions=args.measured_repetitions,
+                repetition_index=args.repetition_index,
+            ),
+            stdout_text=stdout_text,
+            stderr_text=stderr_text,
+            runtime_version=args.runtime_version,
+            runtime_git_revision=args.runtime_git_revision,
+            speculative_method=args.speculative_method,
+        )
+    except (LlamaCppParseError, SchemaValidationError) as exc:
+        print(f"Failed to parse llama.cpp output: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        record.write_json(args.output)
+        print(f"Experiment record written to {args.output}")
+    else:
+        print(record.to_json())
+    return 0
+
+
+def _cmd_doctor_speculative(args: argparse.Namespace) -> int:
+    try:
+        baseline_records = [ExperimentRecord.read_json(path) for path in args.baseline]
+        speculative_records = [
+            ExperimentRecord.read_json(path) for path in args.speculative
+        ]
+    except SchemaValidationError as exc:
+        print(f"Invalid ExperimentRecord input: {exc}", file=sys.stderr)
+        return 1
+
+    report = diagnose_speculative_regression(
+        baseline_records,
+        speculative_records,
+        min_repetitions=args.min_repetitions,
+        relative_threshold=args.relative_threshold,
+    )
+    payload = asdict(report)
+    payload["verdict"] = report.verdict.value
+    print(json.dumps(payload, indent=2))
+    return 0 if report.verdict.value != "inconclusive" else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="llmtracefx-optimizer",
+        description="Inference-optimizer foundation primitives for LLMTraceFX",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    manifest_parser = subparsers.add_parser(
+        "manifest", help="Collect a CPU-only environment manifest"
+    )
+    manifest_parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Write manifest JSON to this path instead of stdout",
+    )
+    manifest_parser.set_defaults(func=_cmd_manifest)
+
+    run_parser = subparsers.add_parser(
+        "run", help="Run a configured experiment (warmups + measured repetitions)"
+    )
+    run_parser.add_argument(
+        "--config", required=True, help="Path to a JSON (or YAML) runner config"
+    )
+    run_parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Re-run all repetitions even if already completed",
+    )
+    run_parser.set_defaults(func=_cmd_run)
+
+    parse_parser = subparsers.add_parser(
+        "parse-llama-cpp",
+        help="Convert llama.cpp text output into a canonical ExperimentRecord",
+    )
+    parse_parser.add_argument("--run-id", required=True)
+    parse_parser.add_argument("--model-id", required=True)
+    parse_parser.add_argument("--model-revision", default=None)
+    parse_parser.add_argument("--tokenizer-revision", default=None)
+    parse_parser.add_argument("--quantization", default=None)
+    parse_parser.add_argument("--runtime-version", default=None)
+    parse_parser.add_argument("--runtime-git-revision", default=None)
+    parse_parser.add_argument(
+        "--speculative-method",
+        default=None,
+        help="e.g. 'mtp' -- only used if speculative counters are present",
+    )
+    parse_parser.add_argument(
+        "--stdout-file", default=None, help="Path to captured stdout text"
+    )
+    parse_parser.add_argument(
+        "--stderr-file", default=None, help="Path to captured stderr text"
+    )
+    parse_parser.add_argument(
+        "llama_command",
+        nargs=argparse.REMAINDER,
+        metavar="-- COMMAND [ARGS ...]",
+        help=(
+            "Exact command/args that were run, after a literal '--' separator, "
+            "e.g. `... --run-id x -- llama-cli -m model.gguf -p prompt`"
+        ),
+    )
+    parse_parser.add_argument("--warmup-repetitions", type=int, default=0)
+    parse_parser.add_argument("--measured-repetitions", type=int, default=1)
+    parse_parser.add_argument("--repetition-index", type=int, default=0)
+    parse_parser.add_argument(
+        "--output",
+        default=None,
+        help="Write the ExperimentRecord JSON to this path instead of stdout",
+    )
+    parse_parser.set_defaults(func=_cmd_parse_llama_cpp)
+
+    doctor_parser = subparsers.add_parser("doctor", help="Evidence-based diagnostics")
+    doctor_subparsers = doctor_parser.add_subparsers(
+        dest="doctor_command", required=True
+    )
+    speculative_parser = doctor_subparsers.add_parser(
+        "speculative",
+        help="Diagnose whether speculative decoding/MTP is a net regression",
+    )
+    speculative_parser.add_argument(
+        "--baseline",
+        nargs="+",
+        required=True,
+        help="ExperimentRecord JSON files for autoregressive baseline runs",
+    )
+    speculative_parser.add_argument(
+        "--speculative",
+        nargs="+",
+        required=True,
+        help="ExperimentRecord JSON files for speculative-decoding runs",
+    )
+    speculative_parser.add_argument("--min-repetitions", type=int, default=2)
+    speculative_parser.add_argument("--relative-threshold", type=float, default=0.03)
+    speculative_parser.set_defaults(func=_cmd_doctor_speculative)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/llmtracefx/optimizer/doctor/__init__.py
+++ b/llmtracefx/optimizer/doctor/__init__.py
@@ -1,0 +1,6 @@
+"""Evidence-based analysis rules ("doctor") for the inference optimizer.
+
+Each rule reads canonical ``ExperimentRecord`` evidence and returns a
+verdict; rules never guess when the evidence is insufficient, mismatched,
+or noisy — they report "inconclusive" instead.
+"""

--- a/llmtracefx/optimizer/doctor/speculative.py
+++ b/llmtracefx/optimizer/doctor/speculative.py
@@ -11,6 +11,7 @@ run-to-run noise.
 
 from __future__ import annotations
 
+import math
 import statistics
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -165,11 +166,42 @@ def diagnose_speculative_regression(
 
     baseline_mean = statistics.mean(baseline_totals)
     speculative_mean = statistics.mean(speculative_totals)
+
+    # The generic Measurement schema only requires timing values to be
+    # >= 0 (zero and, since it does not check finiteness, NaN/inf all
+    # pass ExperimentRecord.validate()). None of those are usable
+    # evidence here: a zero-or-negative baseline makes the relative delta
+    # below undefined/infinite, and a non-finite mean would silently
+    # propagate into a nonsensical verdict rather than a crash.
+    if not math.isfinite(baseline_mean) or baseline_mean <= 0:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                "baseline mean total time is not a positive, finite measurement "
+                f"({baseline_mean!r} ms); cannot compute a reliable relative delta"
+            ),
+            baseline_run_ids=tuple(r.run_id for r in baseline),
+            speculative_run_ids=tuple(r.run_id for r in speculative),
+        )
+    if not math.isfinite(speculative_mean) or speculative_mean < 0:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                "speculative-decoding mean total time is not a finite, non-negative "
+                f"measurement ({speculative_mean!r} ms); cannot compute a reliable delta"
+            ),
+            baseline_run_ids=tuple(r.run_id for r in baseline),
+            speculative_run_ids=tuple(r.run_id for r in speculative),
+        )
+
     baseline_noise = statistics.pstdev(baseline_totals)
     speculative_noise = statistics.pstdev(speculative_totals)
 
     delta_ms = speculative_mean - baseline_mean
-    delta_pct = delta_ms / baseline_mean if baseline_mean else None
+    # baseline_mean is guaranteed positive and finite by the guard above,
+    # so this division is always well-defined -- delta_pct is never None
+    # by the time it reaches the percentage-formatted reasons below.
+    delta_pct = delta_ms / baseline_mean
 
     run_ids = tuple(r.run_id for r in baseline), tuple(r.run_id for r in speculative)
 
@@ -189,7 +221,7 @@ def diagnose_speculative_regression(
             delta_pct=delta_pct,
         )
 
-    if delta_pct is not None and abs(delta_pct) < relative_threshold:
+    if abs(delta_pct) < relative_threshold:
         verdict = DoctorVerdict.NO_SIGNIFICANT_DIFFERENCE
         reason = f"delta ({delta_pct:+.1%}) is below the {relative_threshold:.0%} significance threshold"
     elif delta_ms > 0:

--- a/llmtracefx/optimizer/doctor/speculative.py
+++ b/llmtracefx/optimizer/doctor/speculative.py
@@ -1,0 +1,217 @@
+"""'Doctor' analysis rule: is speculative decoding / MTP a net regression?
+
+Compares a set of speculative-decoding (MTP) runs against a set of
+comparable autoregressive baseline runs and reports whether speculative
+decoding measurably helped, hurt, or produced no reliable signal.
+Deliberately conservative: returns
+:attr:`DoctorVerdict.INCONCLUSIVE` rather than guessing whenever the runs
+are not comparable, too few, or the observed delta is smaller than the
+run-to-run noise.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from ..schema import ExperimentRecord
+
+
+class DoctorVerdict(str, Enum):
+    """Outcome of a doctor diagnosis."""
+
+    REGRESSION = "regression"
+    """Speculative decoding measurably increased total latency."""
+
+    IMPROVEMENT = "improvement"
+    """Speculative decoding measurably decreased total latency."""
+
+    NO_SIGNIFICANT_DIFFERENCE = "no_significant_difference"
+    """A delta was measurable but too small to matter."""
+
+    INCONCLUSIVE = "inconclusive"
+    """Evidence was insufficient, incomparable, or too noisy to judge."""
+
+
+ComparabilityKey = tuple[
+    str,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str | None,
+    str,
+    str,
+    str | None,
+    int | None,
+    int | None,
+]
+
+
+def comparability_key(record: ExperimentRecord) -> ComparabilityKey:
+    """Key used to decide whether two runs are comparable.
+
+    Two runs are only comparable for a latency comparison if they share
+    the same model/quantization, runtime/backend, hardware/OS, and
+    workload shape (input/generated token counts).
+    """
+    return (
+        record.model.model_id,
+        record.model.model_revision,
+        record.model.quantization,
+        record.runtime.name,
+        record.runtime.version,
+        record.runtime.backend,
+        record.platform.os_name,
+        record.platform.architecture,
+        record.platform.accelerator,
+        record.tokens.input_tokens,
+        record.tokens.generated_tokens,
+    )
+
+
+@dataclass(frozen=True)
+class SpeculativeRegressionReport:
+    """Result of comparing speculative-decoding runs to a baseline."""
+
+    verdict: DoctorVerdict
+    reason: str
+    baseline_run_ids: tuple[str, ...] = ()
+    speculative_run_ids: tuple[str, ...] = ()
+    baseline_mean_total_ms: float | None = None
+    speculative_mean_total_ms: float | None = None
+    delta_ms: float | None = None
+    delta_pct: float | None = None
+
+
+def _eligible_totals(
+    records: Sequence[ExperimentRecord], *, speculative_enabled: bool
+) -> list[ExperimentRecord]:
+    return [
+        record
+        for record in records
+        if record.outcome.success
+        and record.speculative.enabled is speculative_enabled
+        and record.timing.total is not None
+    ]
+
+
+def diagnose_speculative_regression(
+    baseline_records: Sequence[ExperimentRecord],
+    speculative_records: Sequence[ExperimentRecord],
+    *,
+    min_repetitions: int = 2,
+    relative_threshold: float = 0.03,
+) -> SpeculativeRegressionReport:
+    """Diagnose whether speculative decoding is a net regression.
+
+    ``baseline_records`` and ``speculative_records`` may contain a mix of
+    runs; only successful runs with a recorded total time and the
+    expected ``speculative.enabled`` flag are used. ``relative_threshold``
+    is the minimum relative delta (default 3%) required to call a
+    direction rather than "no significant difference".
+    """
+    baseline = _eligible_totals(baseline_records, speculative_enabled=False)
+    speculative = _eligible_totals(speculative_records, speculative_enabled=True)
+
+    if not baseline or not speculative:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                "no successful runs with a recorded total time were found for "
+                f"{'the baseline' if not baseline else 'the speculative-decoding'} group"
+            ),
+        )
+
+    baseline_keys = {comparability_key(record) for record in baseline}
+    speculative_keys = {comparability_key(record) for record in speculative}
+    if len(baseline_keys) > 1 or len(speculative_keys) > 1:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason="runs within a group are not comparable (mixed model/runtime/hardware/workload)",
+            baseline_run_ids=tuple(r.run_id for r in baseline),
+            speculative_run_ids=tuple(r.run_id for r in speculative),
+        )
+    if baseline_keys != speculative_keys:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                "baseline and speculative-decoding runs are not comparable "
+                "(different model/runtime/hardware/workload)"
+            ),
+            baseline_run_ids=tuple(r.run_id for r in baseline),
+            speculative_run_ids=tuple(r.run_id for r in speculative),
+        )
+
+    if len(baseline) < min_repetitions or len(speculative) < min_repetitions:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                f"need at least {min_repetitions} comparable repetitions per group "
+                f"(got {len(baseline)} baseline, {len(speculative)} speculative)"
+            ),
+            baseline_run_ids=tuple(r.run_id for r in baseline),
+            speculative_run_ids=tuple(r.run_id for r in speculative),
+        )
+
+    baseline_totals = [
+        r.timing.total.value for r in baseline if r.timing.total is not None
+    ]
+    speculative_totals = [
+        r.timing.total.value for r in speculative if r.timing.total is not None
+    ]
+
+    baseline_mean = statistics.mean(baseline_totals)
+    speculative_mean = statistics.mean(speculative_totals)
+    baseline_noise = statistics.pstdev(baseline_totals)
+    speculative_noise = statistics.pstdev(speculative_totals)
+
+    delta_ms = speculative_mean - baseline_mean
+    delta_pct = delta_ms / baseline_mean if baseline_mean else None
+
+    run_ids = tuple(r.run_id for r in baseline), tuple(r.run_id for r in speculative)
+
+    combined_noise = baseline_noise + speculative_noise
+    if combined_noise > 0 and abs(delta_ms) < combined_noise:
+        return SpeculativeRegressionReport(
+            verdict=DoctorVerdict.INCONCLUSIVE,
+            reason=(
+                f"measured delta ({delta_ms:+.2f} ms) is smaller than the combined "
+                f"repetition noise ({combined_noise:.2f} ms); collect more repetitions"
+            ),
+            baseline_run_ids=run_ids[0],
+            speculative_run_ids=run_ids[1],
+            baseline_mean_total_ms=baseline_mean,
+            speculative_mean_total_ms=speculative_mean,
+            delta_ms=delta_ms,
+            delta_pct=delta_pct,
+        )
+
+    if delta_pct is not None and abs(delta_pct) < relative_threshold:
+        verdict = DoctorVerdict.NO_SIGNIFICANT_DIFFERENCE
+        reason = f"delta ({delta_pct:+.1%}) is below the {relative_threshold:.0%} significance threshold"
+    elif delta_ms > 0:
+        verdict = DoctorVerdict.REGRESSION
+        reason = (
+            f"speculative decoding increased mean total time by {delta_ms:.2f} ms "
+            f"({delta_pct:+.1%}) versus the autoregressive baseline"
+        )
+    else:
+        verdict = DoctorVerdict.IMPROVEMENT
+        reason = (
+            f"speculative decoding decreased mean total time by {-delta_ms:.2f} ms "
+            f"({delta_pct:+.1%}) versus the autoregressive baseline"
+        )
+
+    return SpeculativeRegressionReport(
+        verdict=verdict,
+        reason=reason,
+        baseline_run_ids=run_ids[0],
+        speculative_run_ids=run_ids[1],
+        baseline_mean_total_ms=baseline_mean,
+        speculative_mean_total_ms=speculative_mean,
+        delta_ms=delta_ms,
+        delta_pct=delta_pct,
+    )

--- a/llmtracefx/optimizer/manifest.py
+++ b/llmtracefx/optimizer/manifest.py
@@ -1,0 +1,155 @@
+"""CPU-only environment/manifest collector.
+
+Records deterministic, non-sensitive environment metadata that later
+collectors and the doctor can use to check "comparability" between runs
+(e.g. did two runs execute on the same OS/architecture with the same
+package versions?).
+
+This module intentionally does **not** collect: secrets, usernames,
+hostnames, serial numbers, full environment variable dumps, or absolute
+paths that could leak a user's home directory or username. Only package
+names come from this project's own dependency list (``pyproject.toml``),
+so there is nothing dynamic or user-supplied to leak.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+from .schema import SCHEMA_VERSION, utc_now_iso
+
+# Fixed, deterministic list of first/third-party packages this project
+# depends on (mirrors pyproject.toml). Kept as a tuple literal (rather than
+# parsed from pyproject.toml at runtime) so manifest collection has no
+# dependency on the source layout being present, e.g. when installed as a
+# wheel.
+_TRACKED_PACKAGES: tuple[str, ...] = (
+    "llmtracefx",
+    "fastapi",
+    "uvicorn",
+    "aiohttp",
+    "plotly",
+    "pandas",
+    "numpy",
+    "modal",
+    "streamlit",
+)
+
+
+@dataclass(frozen=True)
+class EnvironmentManifest:
+    """Deterministic, non-sensitive environment metadata for a run."""
+
+    schema_version: str
+    collected_at: str
+    os_name: str
+    os_release: str
+    architecture: str
+    python_implementation: str
+    python_version: str
+    cpu_count: int | None
+    total_memory_gb: float | None
+    package_versions: dict[str, str] = field(default_factory=dict)
+    generator: str = "llmtracefx.optimizer.manifest"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnvironmentManifest:
+        return cls(
+            schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
+            collected_at=data["collected_at"],
+            os_name=data["os_name"],
+            os_release=data["os_release"],
+            architecture=data["architecture"],
+            python_implementation=data["python_implementation"],
+            python_version=data["python_version"],
+            cpu_count=data.get("cpu_count"),
+            total_memory_gb=data.get("total_memory_gb"),
+            package_versions=dict(data.get("package_versions", {})),
+            generator=data.get("generator", "llmtracefx.optimizer.manifest"),
+        )
+
+    def comparability_key(self) -> tuple[str, str, str]:
+        """A coarse key for deciding whether two manifests are comparable.
+
+        Two runs on different OS families or CPU architectures are not
+        directly comparable for latency/throughput purposes.
+        """
+        return (self.os_name, self.architecture, self.python_implementation)
+
+
+def _total_memory_gb() -> float | None:
+    """Best-effort total physical memory in GiB, or ``None`` if unknown.
+
+    Uses only OS-level facts (no user/process info). Returns ``None``
+    rather than guessing when the platform is unsupported or the lookup
+    fails, so a missing value is never silently mistaken for zero.
+    """
+    system = platform.system()
+    try:
+        if system == "Darwin":
+            output = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True,
+            ).stdout.strip()
+            return int(output) / (1024**3)
+        if system == "Linux":
+            meminfo = Path("/proc/meminfo").read_text(encoding="utf-8")
+            match = re.search(r"^MemTotal:\s+(\d+)\s*kB", meminfo, re.MULTILINE)
+            if match is None:
+                return None
+            return int(match.group(1)) * 1024 / (1024**3)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    return None
+
+
+def _package_versions(package_names: tuple[str, ...]) -> dict[str, str]:
+    """Resolve installed versions for a fixed, deterministic package list."""
+    versions: dict[str, str] = {}
+    for name in package_names:
+        try:
+            versions[name] = importlib_metadata.version(name)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return dict(sorted(versions.items()))
+
+
+def collect_environment_manifest(
+    *, extra_packages: tuple[str, ...] = ()
+) -> EnvironmentManifest:
+    """Collect a deterministic, non-sensitive snapshot of the environment.
+
+    ``extra_packages`` lets callers (e.g. the llama.cpp collector) request
+    versions of additional installed packages beyond the tracked defaults,
+    without introducing arbitrary/user-controlled lookups by default.
+    """
+    tracked = tuple(dict.fromkeys(_TRACKED_PACKAGES + extra_packages))
+    return EnvironmentManifest(
+        schema_version=SCHEMA_VERSION,
+        collected_at=utc_now_iso(),
+        os_name=platform.system(),
+        os_release=platform.release(),
+        architecture=platform.machine(),
+        python_implementation=platform.python_implementation(),
+        python_version=platform.python_version(),
+        cpu_count=os.cpu_count(),
+        total_memory_gb=_total_memory_gb(),
+        package_versions=_package_versions(tracked),
+    )

--- a/llmtracefx/optimizer/parsers/__init__.py
+++ b/llmtracefx/optimizer/parsers/__init__.py
@@ -1,0 +1,3 @@
+"""Format-specific collectors that convert runtime output into the
+canonical :mod:`llmtracefx.optimizer.schema` records.
+"""

--- a/llmtracefx/optimizer/parsers/llama_cpp.py
+++ b/llmtracefx/optimizer/parsers/llama_cpp.py
@@ -17,7 +17,7 @@ label but has a value that cannot be parsed as a number raises
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from ..schema import (
     CommandInfo,
@@ -238,8 +238,19 @@ def build_experiment_record(
     runner's ``RunnerConfig``). ``speculative_method`` should be supplied
     by the caller (e.g. ``"mtp"``) when speculative decoding was enabled,
     since llama.cpp's plain timing output does not name the method.
+
+    ``platform.accelerator`` identifies the GPU/accelerator a run executed
+    on and is required for the doctor rules to tell runs on different
+    hardware apart. If the caller-supplied ``platform`` does not already
+    set it, it is filled in from the accelerator identity llama.cpp itself
+    reports (e.g. a Metal "found device: ..." line). An explicit
+    caller-supplied ``platform.accelerator`` always takes precedence over
+    the parsed value.
     """
     parsed = parse_llama_cpp_output(stdout_text + "\n" + stderr_text)
+
+    if platform.accelerator is None and parsed.device_hint:
+        platform = replace(platform, accelerator=parsed.device_hint)
 
     runtime = RuntimeInfo(
         name="llama.cpp",

--- a/llmtracefx/optimizer/parsers/llama_cpp.py
+++ b/llmtracefx/optimizer/parsers/llama_cpp.py
@@ -1,0 +1,286 @@
+"""llama.cpp text-output collector.
+
+Parses the human-readable timing/perf lines that ``llama.cpp`` binaries
+(``llama-cli``, ``llama-bench``, ``llama-speculative``, ...) print to
+stdout/stderr, and converts them into the canonical
+:class:`~llmtracefx.optimizer.schema.ExperimentRecord` schema.
+
+Supports both the historical ``llama_print_timings:`` prefix and the
+current ``llama_perf_context_print:`` prefix, since both report the same
+fields. Missing optional lines (e.g. no speculative-decoding stats when
+speculative decoding was not enabled) are tolerated and simply leave the
+corresponding schema fields as ``None``. A line that *does* match a known
+label but has a value that cannot be parsed as a number raises
+``LlamaCppParseError`` rather than being silently dropped.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ..schema import (
+    CommandInfo,
+    ExperimentRecord,
+    Measurement,
+    MetricProvenance,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+)
+
+
+class LlamaCppParseError(ValueError):
+    """Raised when a recognized llama.cpp output line has a bad value."""
+
+
+_LOAD_RE = re.compile(r"load time\s*=\s*([^\s]+)\s*ms")
+_PROMPT_EVAL_RE = re.compile(
+    r"prompt eval time\s*=\s*([^\s]+)\s*ms\s*/\s*(\d+)\s*tokens"
+)
+_EVAL_RE = re.compile(r"eval time\s*=\s*([^\s]+)\s*ms\s*/\s*(\d+)\s*runs")
+_TOTAL_RE = re.compile(r"total time\s*=\s*([^\s]+)\s*ms\s*/\s*(\d+)\s*tokens")
+
+_N_DRAFT_RE = re.compile(r"^n_draft\s*=\s*(\d+)")
+_N_PREDICT_RE = re.compile(r"^n_predict\s*=\s*(\d+)")
+_N_DRAFTED_RE = re.compile(r"^n_drafted\s*=\s*(\d+)")
+_N_ACCEPT_RE = re.compile(r"^n_accept(?:ed)?\s*=\s*(\d+)")
+
+_METAL_DEVICE_RE = re.compile(r"found device:\s*(.+)$")
+_BACKEND_RE = re.compile(r"loaded\s+(\w+)\s+backend", re.IGNORECASE)
+
+
+def _parse_float(label: str, raw: str) -> float:
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise LlamaCppParseError(
+            f"could not parse {label} value '{raw}' as a number"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class ParsedLlamaCppOutput:
+    """Structured fields recovered from a llama.cpp run's text output."""
+
+    load_ms: float | None = None
+    prompt_eval_ms: float | None = None
+    prompt_eval_tokens: int | None = None
+    eval_ms: float | None = None
+    eval_tokens: int | None = None
+    total_ms: float | None = None
+    total_tokens: int | None = None
+    n_draft: int | None = None
+    n_predict: int | None = None
+    n_drafted: int | None = None
+    n_accepted: int | None = None
+    device_hint: str | None = None
+    backend_hint: str | None = None
+
+    @property
+    def speculative_reported(self) -> bool:
+        """Whether any speculative-decoding counters were present at all."""
+        return self.n_drafted is not None or self.n_accepted is not None
+
+
+def parse_llama_cpp_output(text: str) -> ParsedLlamaCppOutput:
+    """Parse llama.cpp stdout/stderr text into structured fields.
+
+    Tolerates missing optional lines. Raises ``LlamaCppParseError`` if a
+    recognized line's numeric value is malformed.
+    """
+    load_ms: float | None = None
+    prompt_eval_ms: float | None = None
+    prompt_eval_tokens: int | None = None
+    eval_ms: float | None = None
+    eval_tokens: int | None = None
+    total_ms: float | None = None
+    total_tokens: int | None = None
+    n_draft: int | None = None
+    n_predict: int | None = None
+    n_drafted: int | None = None
+    n_accepted: int | None = None
+    device_hint: str | None = None
+    backend_hint: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if "prompt eval time" in line:
+            match = _PROMPT_EVAL_RE.search(line)
+            if match:
+                prompt_eval_ms = _parse_float("prompt eval time", match.group(1))
+                prompt_eval_tokens = int(match.group(2))
+            continue
+
+        if "sample time" in line:
+            # Sampling time is not part of the canonical timing schema
+            # (it overlaps with decode and is not comparable across
+            # runtimes); intentionally not captured here.
+            continue
+
+        if "load time" in line:
+            match = _LOAD_RE.search(line)
+            if match:
+                load_ms = _parse_float("load time", match.group(1))
+            continue
+
+        if "eval time" in line:
+            match = _EVAL_RE.search(line)
+            if match:
+                eval_ms = _parse_float("eval time", match.group(1))
+                eval_tokens = int(match.group(2))
+            continue
+
+        if "total time" in line:
+            match = _TOTAL_RE.search(line)
+            if match:
+                total_ms = _parse_float("total time", match.group(1))
+                total_tokens = int(match.group(2))
+            continue
+
+        matched_counter = False
+        for label, pattern, error_label in (
+            ("n_draft", _N_DRAFT_RE, "n_draft"),
+            ("n_predict", _N_PREDICT_RE, "n_predict"),
+            ("n_drafted", _N_DRAFTED_RE, "n_drafted"),
+            ("n_accepted", _N_ACCEPT_RE, "n_accept"),
+        ):
+            match = pattern.search(line)
+            if not match:
+                continue
+            matched_counter = True
+            try:
+                value = int(match.group(1))
+            except ValueError as exc:
+                raise LlamaCppParseError(
+                    f"could not parse {error_label} value from line: {line!r}"
+                ) from exc
+            if label == "n_draft":
+                n_draft = value
+            elif label == "n_predict":
+                n_predict = value
+            elif label == "n_drafted":
+                n_drafted = value
+            else:
+                n_accepted = value
+            break
+
+        if matched_counter:
+            continue
+
+        device_match = _METAL_DEVICE_RE.search(line)
+        if device_match:
+            device_hint = device_match.group(1).strip()
+            continue
+        backend_match = _BACKEND_RE.search(line)
+        if backend_match:
+            backend_hint = backend_match.group(1).strip()
+            continue
+
+    return ParsedLlamaCppOutput(
+        load_ms=load_ms,
+        prompt_eval_ms=prompt_eval_ms,
+        prompt_eval_tokens=prompt_eval_tokens,
+        eval_ms=eval_ms,
+        eval_tokens=eval_tokens,
+        total_ms=total_ms,
+        total_tokens=total_tokens,
+        n_draft=n_draft,
+        n_predict=n_predict,
+        n_drafted=n_drafted,
+        n_accepted=n_accepted,
+        device_hint=device_hint,
+        backend_hint=backend_hint,
+    )
+
+
+def _measurement(value: float | None, unit: str) -> Measurement | None:
+    if value is None:
+        return None
+    # These come from llama.cpp's own internal phase timers (ggml_time_us
+    # around load/prompt-eval/eval/total), i.e. the runtime's native
+    # instrumentation -- not a coarse wall-clock wrapper around the whole
+    # process, which is what the experiment runner captures separately.
+    return Measurement(
+        value=value, provenance=MetricProvenance.MEASURED_NATIVE, unit=unit
+    )
+
+
+def build_experiment_record(
+    *,
+    run_id: str,
+    started_at: str,
+    platform: PlatformInfo,
+    model: ModelInfo,
+    command: CommandInfo,
+    repetition: RepetitionInfo,
+    stdout_text: str,
+    stderr_text: str = "",
+    runtime_version: str | None = None,
+    runtime_git_revision: str | None = None,
+    speculative_method: str | None = None,
+    ended_at: str | None = None,
+    outcome: OutcomeInfo | None = None,
+) -> ExperimentRecord:
+    """Parse llama.cpp output and assemble a validated ``ExperimentRecord``.
+
+    ``platform``, ``model``, ``command``, and ``repetition`` describe
+    context that cannot be recovered from stdout/stderr alone (e.g. from
+    an :class:`~llmtracefx.optimizer.manifest.EnvironmentManifest` and the
+    runner's ``RunnerConfig``). ``speculative_method`` should be supplied
+    by the caller (e.g. ``"mtp"``) when speculative decoding was enabled,
+    since llama.cpp's plain timing output does not name the method.
+    """
+    parsed = parse_llama_cpp_output(stdout_text + "\n" + stderr_text)
+
+    runtime = RuntimeInfo(
+        name="llama.cpp",
+        version=runtime_version,
+        backend=parsed.backend_hint,
+        git_revision=runtime_git_revision,
+    )
+
+    timing = TimingMetrics(
+        model_load=_measurement(parsed.load_ms, "ms"),
+        prefill=_measurement(parsed.prompt_eval_ms, "ms"),
+        decode=_measurement(parsed.eval_ms, "ms"),
+        total=_measurement(parsed.total_ms, "ms"),
+    )
+
+    tokens = TokenCounts(
+        input_tokens=parsed.prompt_eval_tokens,
+        generated_tokens=parsed.eval_tokens,
+    )
+
+    speculative = SpeculativeDecodingInfo(
+        enabled=parsed.speculative_reported,
+        method=speculative_method if parsed.speculative_reported else None,
+        configured_depth=parsed.n_draft,
+        proposed_tokens=parsed.n_drafted,
+        accepted_tokens=parsed.n_accepted,
+    )
+
+    record = ExperimentRecord(
+        run_id=run_id,
+        started_at=started_at,
+        ended_at=ended_at,
+        platform=platform,
+        model=model,
+        runtime=runtime,
+        command=command,
+        repetition=repetition,
+        tokens=tokens,
+        timing=timing,
+        speculative=speculative,
+        outcome=outcome or OutcomeInfo(),
+    )
+    record.validate()
+    return record

--- a/llmtracefx/optimizer/runner.py
+++ b/llmtracefx/optimizer/runner.py
@@ -16,6 +16,7 @@ success for a run that failed, timed out, or could not be started.
 from __future__ import annotations
 
 import json
+import math
 import os
 import subprocess
 import time
@@ -42,6 +43,25 @@ class RepetitionOutcome(str, Enum):
 
     FAILED_TO_START = "failed_to_start"
     """The command could not be launched at all (e.g. binary not found)."""
+
+
+def _config_int(data: dict[str, Any], key: str, default: int) -> int:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RunnerConfigError(f"config.{key} must be an integer")
+    return int(value)
+
+
+def _config_timeout(data: dict[str, Any]) -> float | None:
+    value = data.get("timeout_seconds")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RunnerConfigError("config.timeout_seconds must be a number or null")
+    timeout = float(value)
+    if not math.isfinite(timeout):
+        raise RunnerConfigError("config.timeout_seconds must be finite")
+    return timeout
 
 
 @dataclass(frozen=True)
@@ -80,15 +100,35 @@ class RunnerConfig:
                 "config is missing required field: command"
             ) from exc
         if not isinstance(command, list) or not all(
-            isinstance(part, str) for part in command
+            isinstance(part, str) and part for part in command
         ):
-            raise RunnerConfigError("config.command must be a list of strings")
+            raise RunnerConfigError(
+                "config.command must be a list of non-empty strings"
+            )
 
         try:
             run_id = data["run_id"]
             results_dir_raw = data["results_dir"]
         except KeyError as exc:
             raise RunnerConfigError(f"config is missing required field: {exc}") from exc
+        if not isinstance(run_id, str) or not run_id:
+            raise RunnerConfigError("config.run_id must be a non-empty string")
+        if not isinstance(results_dir_raw, str) or not results_dir_raw:
+            raise RunnerConfigError("config.results_dir must be a non-empty string")
+
+        cwd = data.get("cwd")
+        if cwd is not None and not isinstance(cwd, str):
+            raise RunnerConfigError("config.cwd must be a string or null")
+
+        env_raw = data.get("env", {})
+        if not isinstance(env_raw, dict) or not all(
+            isinstance(key, str) and key and isinstance(value, str)
+            for key, value in env_raw.items()
+        ):
+            raise RunnerConfigError(
+                "config.env must be an object with non-empty string keys "
+                "and string values"
+            )
 
         results_dir = Path(results_dir_raw)
         if not results_dir.is_absolute() and base_dir is not None:
@@ -98,11 +138,11 @@ class RunnerConfig:
             run_id=run_id,
             command=tuple(command),
             results_dir=results_dir,
-            warmup_repetitions=int(data.get("warmup_repetitions", 0)),
-            measured_repetitions=int(data.get("measured_repetitions", 1)),
-            timeout_seconds=data.get("timeout_seconds"),
-            cwd=data.get("cwd"),
-            env=dict(data.get("env", {})),
+            warmup_repetitions=_config_int(data, "warmup_repetitions", 0),
+            measured_repetitions=_config_int(data, "measured_repetitions", 1),
+            timeout_seconds=_config_timeout(data),
+            cwd=cwd,
+            env=dict(env_raw),
         )
 
     @classmethod

--- a/llmtracefx/optimizer/runner.py
+++ b/llmtracefx/optimizer/runner.py
@@ -1,0 +1,334 @@
+"""Reproducible experiment runner primitive.
+
+Executes a supplied command (argv list — never a shell string) for a
+configured number of warmup and measured repetitions, capturing stdout,
+stderr, and timing metadata as atomically-written JSON artifacts. Supports
+timeouts and resuming a partially-completed run by skipping repetitions
+that already completed successfully.
+
+This module does not parse command output into the canonical
+``ExperimentRecord`` schema — that is the job of format-specific
+collectors (see ``llmtracefx.optimizer.parsers``). The runner's job is
+only to execute safely and record what happened, without ever reporting
+success for a run that failed, timed out, or could not be started.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from .schema import utc_now_iso
+
+
+class RunnerConfigError(ValueError):
+    """Raised for invalid or unsupported runner configuration."""
+
+
+class RepetitionOutcome(str, Enum):
+    """What happened when a single repetition was executed."""
+
+    COMPLETED = "completed"
+    """Process started and exited; ``returncode`` indicates success/failure."""
+
+    TIMED_OUT = "timed_out"
+    """Process did not finish within ``timeout_seconds`` and was killed."""
+
+    FAILED_TO_START = "failed_to_start"
+    """The command could not be launched at all (e.g. binary not found)."""
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    """Configuration for one experiment run, loaded from JSON (or YAML)."""
+
+    run_id: str
+    command: tuple[str, ...]
+    results_dir: Path
+    warmup_repetitions: int = 0
+    measured_repetitions: int = 1
+    timeout_seconds: float | None = None
+    cwd: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise RunnerConfigError("run_id must be non-empty")
+        if not self.command:
+            raise RunnerConfigError("command must contain at least one argument")
+        if self.warmup_repetitions < 0:
+            raise RunnerConfigError("warmup_repetitions must be >= 0")
+        if self.measured_repetitions < 1:
+            raise RunnerConfigError("measured_repetitions must be >= 1")
+        if self.timeout_seconds is not None and self.timeout_seconds <= 0:
+            raise RunnerConfigError("timeout_seconds must be > 0 when set")
+
+    @classmethod
+    def from_dict(
+        cls, data: dict[str, Any], *, base_dir: Path | None = None
+    ) -> RunnerConfig:
+        try:
+            command = data["command"]
+        except KeyError as exc:
+            raise RunnerConfigError(
+                "config is missing required field: command"
+            ) from exc
+        if not isinstance(command, list) or not all(
+            isinstance(part, str) for part in command
+        ):
+            raise RunnerConfigError("config.command must be a list of strings")
+
+        try:
+            run_id = data["run_id"]
+            results_dir_raw = data["results_dir"]
+        except KeyError as exc:
+            raise RunnerConfigError(f"config is missing required field: {exc}") from exc
+
+        results_dir = Path(results_dir_raw)
+        if not results_dir.is_absolute() and base_dir is not None:
+            results_dir = base_dir / results_dir
+
+        return cls(
+            run_id=run_id,
+            command=tuple(command),
+            results_dir=results_dir,
+            warmup_repetitions=int(data.get("warmup_repetitions", 0)),
+            measured_repetitions=int(data.get("measured_repetitions", 1)),
+            timeout_seconds=data.get("timeout_seconds"),
+            cwd=data.get("cwd"),
+            env=dict(data.get("env", {})),
+        )
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> RunnerConfig:
+        config_path = Path(path)
+        text = config_path.read_text(encoding="utf-8")
+        suffix = config_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise RunnerConfigError(
+                    "YAML config requires PyYAML to be installed (`uv add pyyaml`); "
+                    "use a .json config instead if it is unavailable"
+                ) from exc
+            data = yaml.safe_load(text)
+        elif suffix == ".json":
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise RunnerConfigError(
+                    f"invalid JSON in {config_path}: {exc}"
+                ) from exc
+        else:
+            raise RunnerConfigError(
+                f"unsupported config extension '{suffix}' (use .json or .yaml)"
+            )
+
+        if not isinstance(data, dict):
+            raise RunnerConfigError(
+                f"config in {config_path} must be a JSON/YAML object"
+            )
+        return cls.from_dict(data, base_dir=config_path.parent)
+
+
+@dataclass(frozen=True)
+class RepetitionResult:
+    """Outcome and artifact locations for one repetition."""
+
+    kind: str
+    """'warmup' or 'measured'."""
+    index: int
+    outcome: RepetitionOutcome
+    returncode: int | None
+    elapsed_seconds: float
+    started_at: str
+    ended_at: str
+    stdout_path: str
+    stderr_path: str
+    error_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["outcome"] = self.outcome.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RepetitionResult:
+        return cls(
+            kind=data["kind"],
+            index=data["index"],
+            outcome=RepetitionOutcome(data["outcome"]),
+            returncode=data.get("returncode"),
+            elapsed_seconds=data["elapsed_seconds"],
+            started_at=data["started_at"],
+            ended_at=data["ended_at"],
+            stdout_path=data["stdout_path"],
+            stderr_path=data["stderr_path"],
+            error_message=data.get("error_message"),
+        )
+
+    @property
+    def succeeded(self) -> bool:
+        return self.outcome == RepetitionOutcome.COMPLETED and self.returncode == 0
+
+
+def _to_text(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    _atomic_write_text(path, json.dumps(data, indent=2, sort_keys=False) + "\n")
+
+
+class ExperimentRunner:
+    """Executes an ``RunnerConfig`` and records artifacts on disk."""
+
+    def __init__(self, config: RunnerConfig) -> None:
+        self.config = config
+
+    def _repetition_dir(self, kind: str, index: int) -> Path:
+        return self.config.results_dir / f"{kind}-{index:03d}"
+
+    def _load_existing_result(self, kind: str, index: int) -> RepetitionResult | None:
+        meta_path = self._repetition_dir(kind, index) / "meta.json"
+        if not meta_path.exists():
+            return None
+        try:
+            return RepetitionResult.from_dict(
+                json.loads(meta_path.read_text(encoding="utf-8"))
+            )
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # A corrupt/partial artifact from an interrupted previous run
+            # must not be mistaken for a completed repetition.
+            return None
+
+    def _run_once(self, kind: str, index: int) -> RepetitionResult:
+        rep_dir = self._repetition_dir(kind, index)
+        rep_dir.mkdir(parents=True, exist_ok=True)
+        stdout_path = rep_dir / "stdout.txt"
+        stderr_path = rep_dir / "stderr.txt"
+
+        merged_env = {**os.environ, **self.config.env}
+        started_at = utc_now_iso()
+        start = time.perf_counter()
+        try:
+            completed = subprocess.run(
+                list(self.config.command),
+                cwd=self.config.cwd,
+                env=merged_env,
+                capture_output=True,
+                text=True,
+                timeout=self.config.timeout_seconds,
+                shell=False,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.perf_counter() - start
+            ended_at = utc_now_iso()
+            _atomic_write_text(stdout_path, _to_text(exc.stdout))
+            _atomic_write_text(stderr_path, _to_text(exc.stderr))
+            result = RepetitionResult(
+                kind=kind,
+                index=index,
+                outcome=RepetitionOutcome.TIMED_OUT,
+                returncode=None,
+                elapsed_seconds=elapsed,
+                started_at=started_at,
+                ended_at=ended_at,
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                error_message=f"timed out after {self.config.timeout_seconds}s",
+            )
+        except (OSError, ValueError) as exc:
+            elapsed = time.perf_counter() - start
+            ended_at = utc_now_iso()
+            _atomic_write_text(stdout_path, "")
+            _atomic_write_text(stderr_path, "")
+            result = RepetitionResult(
+                kind=kind,
+                index=index,
+                outcome=RepetitionOutcome.FAILED_TO_START,
+                returncode=None,
+                elapsed_seconds=elapsed,
+                started_at=started_at,
+                ended_at=ended_at,
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                error_message=str(exc),
+            )
+        else:
+            elapsed = time.perf_counter() - start
+            ended_at = utc_now_iso()
+            _atomic_write_text(stdout_path, completed.stdout or "")
+            _atomic_write_text(stderr_path, completed.stderr or "")
+            result = RepetitionResult(
+                kind=kind,
+                index=index,
+                outcome=RepetitionOutcome.COMPLETED,
+                returncode=completed.returncode,
+                elapsed_seconds=elapsed,
+                started_at=started_at,
+                ended_at=ended_at,
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                error_message=(
+                    None if completed.returncode == 0 else "non-zero exit code"
+                ),
+            )
+
+        _atomic_write_json(rep_dir / "meta.json", result.to_dict())
+        return result
+
+    def _run_repetition(
+        self, kind: str, index: int, *, resume: bool
+    ) -> RepetitionResult:
+        if resume:
+            existing = self._load_existing_result(kind, index)
+            if existing is not None and existing.succeeded:
+                return existing
+        return self._run_once(kind, index)
+
+    def run(self, *, resume: bool = True) -> list[RepetitionResult]:
+        """Execute all warmup and measured repetitions.
+
+        Returns the measured (non-warmup) results in order. When
+        ``resume`` is true, repetitions whose ``meta.json`` already
+        records a successful completion are skipped and re-reported
+        as-is; failed/timed-out/missing repetitions are always re-run.
+        """
+        for index in range(self.config.warmup_repetitions):
+            self._run_repetition("warmup", index, resume=resume)
+
+        measured_results = [
+            self._run_repetition("measured", index, resume=resume)
+            for index in range(self.config.measured_repetitions)
+        ]
+
+        summary_path = self.config.results_dir / "summary.jsonl"
+        _atomic_write_text(
+            summary_path,
+            "\n".join(
+                json.dumps(result.to_dict(), sort_keys=False)
+                for result in measured_results
+            )
+            + "\n",
+        )
+        return measured_results

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -116,7 +116,7 @@ def _validate_int(value: Any, *, context: str, key: str) -> int:
         raise SchemaValidationError(
             f"{context}.{key} must be an integer, got {value!r}"
         )
-    return value
+    return int(value)
 
 
 def _coerce_required_int(data: dict[str, Any], key: str, *, context: str) -> int:
@@ -130,6 +130,28 @@ def _coerce_optional_int(data: dict[str, Any], key: str, *, context: str) -> int
     if value is None:
         return None
     return _validate_int(value, context=context, key=key)
+
+
+def _validate_float(value: Any, *, context: str, key: str) -> float:
+    """Require ``value`` to be a genuine number (not ``bool``/``str``/etc).
+
+    Same rationale as ``_validate_int``: a malformed persisted float field
+    must fail as a ``SchemaValidationError`` naming the offending field
+    rather than raising a raw ``ValueError``/``TypeError`` from ``float()``
+    or silently accepting a boolean (``float(True) == 1.0``).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SchemaValidationError(f"{context}.{key} must be a number, got {value!r}")
+    return float(value)
+
+
+def _coerce_optional_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    return _validate_float(value, context=context, key=key)
 
 
 @dataclass(frozen=True)
@@ -156,8 +178,12 @@ class PlatformInfo:
                 os_version=data["os_version"],
                 architecture=data["architecture"],
                 cpu_model=data.get("cpu_model"),
-                cpu_cores=data.get("cpu_cores"),
-                total_memory_gb=data.get("total_memory_gb"),
+                cpu_cores=_coerce_optional_int(
+                    data, "cpu_cores", context="PlatformInfo"
+                ),
+                total_memory_gb=_coerce_optional_float(
+                    data, "total_memory_gb", context="PlatformInfo"
+                ),
                 accelerator=data.get("accelerator"),
             )
         except KeyError as exc:
@@ -462,7 +488,9 @@ class OutcomeInfo:
     def from_dict(cls, data: dict[str, Any]) -> OutcomeInfo:
         return cls(
             success=bool(data.get("success", True)),
-            quality_score=data.get("quality_score"),
+            quality_score=_coerce_optional_float(
+                data, "quality_score", context="OutcomeInfo"
+            ),
             quality_metric=data.get("quality_metric"),
             notes=data.get("notes"),
         )

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -1,0 +1,607 @@
+"""Canonical experiment/evidence schema for the inference optimizer.
+
+Every collector (llama.cpp parser, future MLX/Metal or CUDA collectors) and
+every analysis rule (the "doctor") reads and writes this schema, so it is
+the single source of truth for what a benchmarking run looks like. Optional
+measurements stay ``None`` when they were not observed — nothing here
+invents a value.
+
+This is schema ``SCHEMA_VERSION``. Bump the constant and extend
+``ExperimentRecord.from_dict`` to stay backward compatible whenever the
+shape changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1"
+
+
+class SchemaValidationError(ValueError):
+    """Raised when an ``ExperimentRecord`` (or a part of it) is invalid."""
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string ending in ``Z``."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+class MetricProvenance(str, Enum):
+    """How a metric value was obtained.
+
+    Every optional numeric measurement in this schema is paired with one of
+    these so downstream consumers (dashboards, the doctor) can tell a
+    hardware-counter measurement apart from a wall-clock timer or an
+    estimate, and refuse to compare incompatible provenances.
+    """
+
+    MEASURED_NATIVE = "measured_native"
+    """Read from a native profiler / hardware counter (e.g. Metal, CUPTI)."""
+
+    MEASURED_WALL_CLOCK = "measured_wall_clock"
+    """Timed on the host around a call boundary (e.g. subprocess duration)."""
+
+    DERIVED = "derived"
+    """Computed from other measured values (e.g. tokens / seconds)."""
+
+    ESTIMATED = "estimated"
+    """Modeled or approximated; not a direct measurement."""
+
+
+@dataclass(frozen=True)
+class Measurement:
+    """A single numeric value paired with an explicit unit and provenance."""
+
+    value: float
+    provenance: MetricProvenance
+    unit: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "value": self.value,
+            "provenance": self.provenance.value,
+            "unit": self.unit,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Measurement:
+        try:
+            return cls(
+                value=float(data["value"]),
+                provenance=MetricProvenance(data["provenance"]),
+                unit=str(data.get("unit", "")),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"Measurement is missing required field: {exc}"
+            ) from exc
+        except ValueError as exc:
+            raise SchemaValidationError(
+                f"Measurement has an invalid value: {exc}"
+            ) from exc
+
+
+def _measurement_from_optional(data: dict[str, Any] | None) -> Measurement | None:
+    if data is None:
+        return None
+    return Measurement.from_dict(data)
+
+
+def _measurement_to_optional(measurement: Measurement | None) -> dict[str, Any] | None:
+    return None if measurement is None else measurement.to_dict()
+
+
+@dataclass(frozen=True)
+class PlatformInfo:
+    """Hardware/platform/OS context the run executed under."""
+
+    os_name: str
+    os_version: str
+    architecture: str
+    cpu_model: str | None = None
+    cpu_cores: int | None = None
+    total_memory_gb: float | None = None
+    accelerator: str | None = None
+    """e.g. 'Apple M5 Pro (20-core GPU, 24GB unified)' or 'NVIDIA RTX 4090 24GB'."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PlatformInfo:
+        try:
+            return cls(
+                os_name=data["os_name"],
+                os_version=data["os_version"],
+                architecture=data["architecture"],
+                cpu_model=data.get("cpu_model"),
+                cpu_cores=data.get("cpu_cores"),
+                total_memory_gb=data.get("total_memory_gb"),
+                accelerator=data.get("accelerator"),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"PlatformInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Identity of the model under test."""
+
+    model_id: str
+    model_revision: str | None = None
+    tokenizer_revision: str | None = None
+    quantization: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelInfo:
+        try:
+            return cls(
+                model_id=data["model_id"],
+                model_revision=data.get("model_revision"),
+                tokenizer_revision=data.get("tokenizer_revision"),
+                quantization=data.get("quantization"),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"ModelInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class RuntimeInfo:
+    """Identity of the inference runtime/backend that executed the run."""
+
+    name: str
+    version: str | None = None
+    backend: str | None = None
+    """e.g. 'Metal', 'CUDA', 'CPU'."""
+    git_revision: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RuntimeInfo:
+        try:
+            return cls(
+                name=data["name"],
+                version=data.get("version"),
+                backend=data.get("backend"),
+                git_revision=data.get("git_revision"),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"RuntimeInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class CommandInfo:
+    """The exact invocation that produced this run, plus content hashes."""
+
+    argv: tuple[str, ...]
+    config_hash: str | None = None
+    workload_hash: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "argv": list(self.argv),
+            "config_hash": self.config_hash,
+            "workload_hash": self.workload_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CommandInfo:
+        try:
+            return cls(
+                argv=tuple(data["argv"]),
+                config_hash=data.get("config_hash"),
+                workload_hash=data.get("workload_hash"),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"CommandInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class RepetitionInfo:
+    """Warmup/repetition/seed metadata for one measured run."""
+
+    warmup_repetitions: int
+    measured_repetitions: int
+    repetition_index: int
+    """0-based index of this record among the measured (non-warmup) reps."""
+    seed: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RepetitionInfo:
+        try:
+            return cls(
+                warmup_repetitions=int(data["warmup_repetitions"]),
+                measured_repetitions=int(data["measured_repetitions"]),
+                repetition_index=int(data["repetition_index"]),
+                seed=data.get("seed"),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"RepetitionInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class TokenCounts:
+    """Input/context/generated token counts for one run."""
+
+    input_tokens: int | None = None
+    context_tokens: int | None = None
+    generated_tokens: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TokenCounts:
+        return cls(
+            input_tokens=data.get("input_tokens"),
+            context_tokens=data.get("context_tokens"),
+            generated_tokens=data.get("generated_tokens"),
+        )
+
+
+@dataclass(frozen=True)
+class TimingMetrics:
+    """Model load, tokenize, prefill (TTFT), decode, and total timings."""
+
+    model_load: Measurement | None = None
+    tokenize: Measurement | None = None
+    prefill: Measurement | None = None
+    """Time-to-first-token, a.k.a. prompt processing time."""
+    decode: Measurement | None = None
+    total: Measurement | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_load": _measurement_to_optional(self.model_load),
+            "tokenize": _measurement_to_optional(self.tokenize),
+            "prefill": _measurement_to_optional(self.prefill),
+            "decode": _measurement_to_optional(self.decode),
+            "total": _measurement_to_optional(self.total),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TimingMetrics:
+        return cls(
+            model_load=_measurement_from_optional(data.get("model_load")),
+            tokenize=_measurement_from_optional(data.get("tokenize")),
+            prefill=_measurement_from_optional(data.get("prefill")),
+            decode=_measurement_from_optional(data.get("decode")),
+            total=_measurement_from_optional(data.get("total")),
+        )
+
+
+@dataclass(frozen=True)
+class SpeculativeDecodingInfo:
+    """Speculative decoding / MTP (multi-token prediction) evidence."""
+
+    enabled: bool = False
+    method: str | None = None
+    """e.g. 'mtp', 'eagle', 'draft-model', 'lookahead'."""
+    configured_depth: int | None = None
+    proposed_tokens: int | None = None
+    accepted_tokens: int | None = None
+    verification_time: Measurement | None = None
+
+    @property
+    def acceptance_rate(self) -> float | None:
+        """Accepted/proposed ratio, or ``None`` if either count is missing."""
+        if not self.proposed_tokens or self.accepted_tokens is None:
+            return None
+        return self.accepted_tokens / self.proposed_tokens
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "method": self.method,
+            "configured_depth": self.configured_depth,
+            "proposed_tokens": self.proposed_tokens,
+            "accepted_tokens": self.accepted_tokens,
+            "verification_time": _measurement_to_optional(self.verification_time),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpeculativeDecodingInfo:
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            method=data.get("method"),
+            configured_depth=data.get("configured_depth"),
+            proposed_tokens=data.get("proposed_tokens"),
+            accepted_tokens=data.get("accepted_tokens"),
+            verification_time=_measurement_from_optional(data.get("verification_time")),
+        )
+
+
+@dataclass(frozen=True)
+class MemoryMetrics:
+    """Active, cache, peak, and wired memory when available."""
+
+    active: Measurement | None = None
+    cache: Measurement | None = None
+    peak: Measurement | None = None
+    wired: Measurement | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "active": _measurement_to_optional(self.active),
+            "cache": _measurement_to_optional(self.cache),
+            "peak": _measurement_to_optional(self.peak),
+            "wired": _measurement_to_optional(self.wired),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryMetrics:
+        return cls(
+            active=_measurement_from_optional(data.get("active")),
+            cache=_measurement_from_optional(data.get("cache")),
+            peak=_measurement_from_optional(data.get("peak")),
+            wired=_measurement_from_optional(data.get("wired")),
+        )
+
+
+@dataclass(frozen=True)
+class PowerMetrics:
+    """Power/energy when available (rarely measurable without native tools)."""
+
+    average_power: Measurement | None = None
+    energy: Measurement | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "average_power": _measurement_to_optional(self.average_power),
+            "energy": _measurement_to_optional(self.energy),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PowerMetrics:
+        return cls(
+            average_power=_measurement_from_optional(data.get("average_power")),
+            energy=_measurement_from_optional(data.get("energy")),
+        )
+
+
+@dataclass(frozen=True)
+class OutcomeInfo:
+    """Task outcome/quality fields."""
+
+    success: bool = True
+    quality_score: float | None = None
+    quality_metric: str | None = None
+    """Name of the quality metric ``quality_score`` refers to, if any."""
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OutcomeInfo:
+        return cls(
+            success=bool(data.get("success", True)),
+            quality_score=data.get("quality_score"),
+            quality_metric=data.get("quality_metric"),
+            notes=data.get("notes"),
+        )
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    """A failure/error encountered while producing this run."""
+
+    category: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ErrorInfo:
+        try:
+            return cls(category=data["category"], message=data["message"])
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"ErrorInfo is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class ExperimentRecord:
+    """One canonical, versioned record of a single measured run.
+
+    Optional fields are ``None`` when the underlying signal was not
+    available; consumers must not treat ``None`` as zero.
+    """
+
+    run_id: str
+    started_at: str
+    platform: PlatformInfo
+    model: ModelInfo
+    runtime: RuntimeInfo
+    command: CommandInfo
+    repetition: RepetitionInfo
+    schema_version: str = SCHEMA_VERSION
+    ended_at: str | None = None
+    tokens: TokenCounts = field(default_factory=TokenCounts)
+    timing: TimingMetrics = field(default_factory=TimingMetrics)
+    speculative: SpeculativeDecodingInfo = field(
+        default_factory=SpeculativeDecodingInfo
+    )
+    memory: MemoryMetrics = field(default_factory=MemoryMetrics)
+    power: PowerMetrics = field(default_factory=PowerMetrics)
+    outcome: OutcomeInfo = field(default_factory=OutcomeInfo)
+    error: ErrorInfo | None = None
+
+    def validate(self) -> None:
+        """Raise ``SchemaValidationError`` if this record is inconsistent."""
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaValidationError(
+                f"Unsupported schema_version '{self.schema_version}', expected '{SCHEMA_VERSION}'"
+            )
+        if not self.run_id:
+            raise SchemaValidationError("run_id must be non-empty")
+        if not self.command.argv:
+            raise SchemaValidationError(
+                "command.argv must contain at least one element"
+            )
+        if self.repetition.repetition_index < 0:
+            raise SchemaValidationError("repetition.repetition_index must be >= 0")
+        if (
+            self.repetition.warmup_repetitions < 0
+            or self.repetition.measured_repetitions < 0
+        ):
+            raise SchemaValidationError("repetition counts must be >= 0")
+
+        for name, count in (
+            ("tokens.input_tokens", self.tokens.input_tokens),
+            ("tokens.context_tokens", self.tokens.context_tokens),
+            ("tokens.generated_tokens", self.tokens.generated_tokens),
+        ):
+            if count is not None and count < 0:
+                raise SchemaValidationError(f"{name} must be >= 0, got {count}")
+
+        for name, measurement in (
+            ("timing.model_load", self.timing.model_load),
+            ("timing.tokenize", self.timing.tokenize),
+            ("timing.prefill", self.timing.prefill),
+            ("timing.decode", self.timing.decode),
+            ("timing.total", self.timing.total),
+            ("memory.active", self.memory.active),
+            ("memory.cache", self.memory.cache),
+            ("memory.peak", self.memory.peak),
+            ("memory.wired", self.memory.wired),
+            ("power.average_power", self.power.average_power),
+            ("power.energy", self.power.energy),
+            ("speculative.verification_time", self.speculative.verification_time),
+        ):
+            if measurement is not None and measurement.value < 0:
+                raise SchemaValidationError(
+                    f"{name} must be >= 0, got {measurement.value}"
+                )
+
+        spec = self.speculative
+        if spec.enabled:
+            if spec.proposed_tokens is not None and spec.proposed_tokens < 0:
+                raise SchemaValidationError("speculative.proposed_tokens must be >= 0")
+            if spec.accepted_tokens is not None and spec.accepted_tokens < 0:
+                raise SchemaValidationError("speculative.accepted_tokens must be >= 0")
+            if (
+                spec.proposed_tokens is not None
+                and spec.accepted_tokens is not None
+                and spec.accepted_tokens > spec.proposed_tokens
+            ):
+                raise SchemaValidationError(
+                    "speculative.accepted_tokens cannot exceed speculative.proposed_tokens "
+                    f"({spec.accepted_tokens} > {spec.proposed_tokens})"
+                )
+
+        if self.error is not None and self.outcome.success:
+            raise SchemaValidationError(
+                "outcome.success cannot be True when error is set"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "platform": self.platform.to_dict(),
+            "model": self.model.to_dict(),
+            "runtime": self.runtime.to_dict(),
+            "command": self.command.to_dict(),
+            "repetition": self.repetition.to_dict(),
+            "tokens": self.tokens.to_dict(),
+            "timing": self.timing.to_dict(),
+            "speculative": self.speculative.to_dict(),
+            "memory": self.memory.to_dict(),
+            "power": self.power.to_dict(),
+            "outcome": self.outcome.to_dict(),
+            "error": None if self.error is None else self.error.to_dict(),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExperimentRecord:
+        try:
+            record = cls(
+                schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
+                run_id=data["run_id"],
+                started_at=data["started_at"],
+                ended_at=data.get("ended_at"),
+                platform=PlatformInfo.from_dict(data["platform"]),
+                model=ModelInfo.from_dict(data["model"]),
+                runtime=RuntimeInfo.from_dict(data["runtime"]),
+                command=CommandInfo.from_dict(data["command"]),
+                repetition=RepetitionInfo.from_dict(data["repetition"]),
+                tokens=TokenCounts.from_dict(data.get("tokens", {})),
+                timing=TimingMetrics.from_dict(data.get("timing", {})),
+                speculative=SpeculativeDecodingInfo.from_dict(
+                    data.get("speculative", {})
+                ),
+                memory=MemoryMetrics.from_dict(data.get("memory", {})),
+                power=PowerMetrics.from_dict(data.get("power", {})),
+                outcome=OutcomeInfo.from_dict(data.get("outcome", {})),
+                error=(
+                    None
+                    if data.get("error") is None
+                    else ErrorInfo.from_dict(data["error"])
+                ),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError(
+                f"ExperimentRecord is missing required field: {exc}"
+            ) from exc
+        record.validate()
+        return record
+
+    @classmethod
+    def from_json(cls, payload: str) -> ExperimentRecord:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise SchemaValidationError(
+                f"Invalid JSON for ExperimentRecord: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    def write_json(self, path: str | Path) -> None:
+        """Atomically write this record as pretty JSON to ``path``."""
+        self.validate()
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = target.with_name(f".{target.name}.tmp-{os.getpid()}")
+        tmp_path.write_text(self.to_json() + "\n", encoding="utf-8")
+        os.replace(tmp_path, target)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> ExperimentRecord:
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -100,6 +101,35 @@ def _measurement_from_optional(data: dict[str, Any] | None) -> Measurement | Non
 
 def _measurement_to_optional(measurement: Measurement | None) -> dict[str, Any] | None:
     return None if measurement is None else measurement.to_dict()
+
+
+def _validate_int(value: Any, *, context: str, key: str) -> int:
+    """Require ``value`` to be a genuine ``int`` (not ``bool``/``float``/etc).
+
+    Persisted records are untrusted input: a malformed field (a string, a
+    float, a boolean, ``None``, a list, ...) must fail as a
+    ``SchemaValidationError`` naming the offending field rather than
+    either raising a raw ``ValueError``/``TypeError`` from ``int()`` or
+    silently truncating/coercing (e.g. ``int(1.9)`` or ``int(True)``).
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SchemaValidationError(
+            f"{context}.{key} must be an integer, got {value!r}"
+        )
+    return value
+
+
+def _coerce_required_int(data: dict[str, Any], key: str, *, context: str) -> int:
+    if key not in data:
+        raise SchemaValidationError(f"{context} is missing required field: '{key}'")
+    return _validate_int(data[key], context=context, key=key)
+
+
+def _coerce_optional_int(data: dict[str, Any], key: str, *, context: str) -> int | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    return _validate_int(value, context=context, key=key)
 
 
 @dataclass(frozen=True)
@@ -208,16 +238,30 @@ class CommandInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CommandInfo:
-        try:
-            return cls(
-                argv=tuple(data["argv"]),
-                config_hash=data.get("config_hash"),
-                workload_hash=data.get("workload_hash"),
-            )
-        except KeyError as exc:
+        if "argv" not in data:
+            raise SchemaValidationError("CommandInfo is missing required field: 'argv'")
+        argv = data["argv"]
+        # A scalar string is technically a ``Sequence[str]`` in Python, so
+        # ``tuple("llama-cli")`` would silently explode into one-character
+        # elements instead of failing. Require an actual list/tuple of
+        # non-empty strings.
+        if isinstance(argv, (str, bytes)) or not isinstance(argv, Sequence):
             raise SchemaValidationError(
-                f"CommandInfo is missing required field: {exc}"
-            ) from exc
+                f"CommandInfo.argv must be a non-empty list of strings, got {argv!r}"
+            )
+        argv_tuple = tuple(argv)
+        if not argv_tuple or not all(
+            isinstance(item, str) and item for item in argv_tuple
+        ):
+            raise SchemaValidationError(
+                "CommandInfo.argv must be a non-empty list of non-empty strings, "
+                f"got {argv!r}"
+            )
+        return cls(
+            argv=argv_tuple,
+            config_hash=data.get("config_hash"),
+            workload_hash=data.get("workload_hash"),
+        )
 
 
 @dataclass(frozen=True)
@@ -235,17 +279,18 @@ class RepetitionInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RepetitionInfo:
-        try:
-            return cls(
-                warmup_repetitions=int(data["warmup_repetitions"]),
-                measured_repetitions=int(data["measured_repetitions"]),
-                repetition_index=int(data["repetition_index"]),
-                seed=data.get("seed"),
-            )
-        except KeyError as exc:
-            raise SchemaValidationError(
-                f"RepetitionInfo is missing required field: {exc}"
-            ) from exc
+        return cls(
+            warmup_repetitions=_coerce_required_int(
+                data, "warmup_repetitions", context="RepetitionInfo"
+            ),
+            measured_repetitions=_coerce_required_int(
+                data, "measured_repetitions", context="RepetitionInfo"
+            ),
+            repetition_index=_coerce_required_int(
+                data, "repetition_index", context="RepetitionInfo"
+            ),
+            seed=_coerce_optional_int(data, "seed", context="RepetitionInfo"),
+        )
 
 
 @dataclass(frozen=True)
@@ -262,9 +307,15 @@ class TokenCounts:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TokenCounts:
         return cls(
-            input_tokens=data.get("input_tokens"),
-            context_tokens=data.get("context_tokens"),
-            generated_tokens=data.get("generated_tokens"),
+            input_tokens=_coerce_optional_int(
+                data, "input_tokens", context="TokenCounts"
+            ),
+            context_tokens=_coerce_optional_int(
+                data, "context_tokens", context="TokenCounts"
+            ),
+            generated_tokens=_coerce_optional_int(
+                data, "generated_tokens", context="TokenCounts"
+            ),
         )
 
 
@@ -333,9 +384,15 @@ class SpeculativeDecodingInfo:
         return cls(
             enabled=bool(data.get("enabled", False)),
             method=data.get("method"),
-            configured_depth=data.get("configured_depth"),
-            proposed_tokens=data.get("proposed_tokens"),
-            accepted_tokens=data.get("accepted_tokens"),
+            configured_depth=_coerce_optional_int(
+                data, "configured_depth", context="SpeculativeDecodingInfo"
+            ),
+            proposed_tokens=_coerce_optional_int(
+                data, "proposed_tokens", context="SpeculativeDecodingInfo"
+            ),
+            accepted_tokens=_coerce_optional_int(
+                data, "accepted_tokens", context="SpeculativeDecodingInfo"
+            ),
             verification_time=_measurement_from_optional(data.get("verification_time")),
         )
 

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -154,6 +154,29 @@ def _coerce_optional_float(
     return _validate_float(value, context=context, key=key)
 
 
+def _validate_bool(value: Any, *, context: str, key: str) -> bool:
+    """Require ``value`` to be a genuine JSON ``bool``.
+
+    ``bool(...)`` is dangerously permissive for persisted input: nearly
+    every non-empty value (including the string ``"false"``) is truthy,
+    so ``bool("false")`` is ``True``. A malformed persisted boolean field
+    (a string, an int, ``None``, a list, ...) must fail as a
+    ``SchemaValidationError`` naming the offending field instead of
+    silently being coerced to the wrong truth value.
+    """
+    if not isinstance(value, bool):
+        raise SchemaValidationError(f"{context}.{key} must be a boolean, got {value!r}")
+    return value
+
+
+def _coerce_bool_with_default(
+    data: dict[str, Any], key: str, *, context: str, default: bool
+) -> bool:
+    if key not in data:
+        return default
+    return _validate_bool(data[key], context=context, key=key)
+
+
 @dataclass(frozen=True)
 class PlatformInfo:
     """Hardware/platform/OS context the run executed under."""
@@ -408,7 +431,9 @@ class SpeculativeDecodingInfo:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SpeculativeDecodingInfo:
         return cls(
-            enabled=bool(data.get("enabled", False)),
+            enabled=_coerce_bool_with_default(
+                data, "enabled", context="SpeculativeDecodingInfo", default=False
+            ),
             method=data.get("method"),
             configured_depth=_coerce_optional_int(
                 data, "configured_depth", context="SpeculativeDecodingInfo"
@@ -487,7 +512,9 @@ class OutcomeInfo:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> OutcomeInfo:
         return cls(
-            success=bool(data.get("success", True)),
+            success=_coerce_bool_with_default(
+                data, "success", context="OutcomeInfo", default=True
+            ),
             quality_score=_coerce_optional_float(
                 data, "quality_score", context="OutcomeInfo"
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ Issues = "https://github.com/Siddhant-K-code/LLMTraceFX/issues"
 llmtracefx = "llmtracefx.main:main"
 llmtracefx-serve = "llmtracefx.api.serve:main"
 llmtracefx-dashboard = "llmtracefx.realtime_dashboard:main"
+llmtracefx-optimizer = "llmtracefx.optimizer.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/optimizer/fixtures/llama_cpp/PROVENANCE.md
+++ b/tests/optimizer/fixtures/llama_cpp/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Fixture provenance
+
+The `.log` files in this directory are **synthetic, representative**
+llama.cpp text output modeled on the well-known `llama_perf_context_print`
+timing format and the `n_draft` / `n_predict` / `n_drafted` / `n_accept`
+counters used by llama.cpp's speculative-decoding examples.
+
+They are **not** benchmark evidence. They were hand-written for this PR to
+exercise the parser and the "doctor" comparability/regression logic
+deterministically in CI, and do not represent measured performance of
+Qwen3.8-27B, llama.cpp, or any specific hardware. Do not cite these
+numbers as real benchmark results.
+
+- `qwen3_8b_baseline_run1.log` / `qwen3_8b_baseline_run2.log`:
+  synthetic autoregressive (no speculative decoding) runs.
+- `qwen3_8b_mtp_regression_run1.log` / `qwen3_8b_mtp_regression_run2.log`:
+  synthetic MTP/speculative-decoding runs that are slower than the
+  baseline above, for exercising the regression-detection doctor rule.
+- `qwen3_8b_mtp_improvement_run1.log` / `qwen3_8b_mtp_improvement_run2.log`:
+  synthetic MTP/speculative-decoding runs that are faster than the
+  baseline above, for exercising the improvement path.
+- `malformed_load_time.log`: a deliberately corrupted line used to test
+  that the parser surfaces malformed values explicitly instead of
+  silently ignoring them.

--- a/tests/optimizer/fixtures/llama_cpp/malformed_load_time.log
+++ b/tests/optimizer/fixtures/llama_cpp/malformed_load_time.log
@@ -1,0 +1,2 @@
+llama_perf_context_print:        load time =     NaNms ms
+llama_perf_context_print: prompt eval time =     118.40 ms /    50 tokens (    2.37 ms per token,   422.30 tokens per second)

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run1.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run1.log
@@ -1,0 +1,6 @@
+llama_perf_context_print:        load time =     345.20 ms
+llama_perf_context_print: prompt eval time =     118.40 ms /    50 tokens (    2.37 ms per token,   422.30 tokens per second)
+llama_perf_context_print:        eval time =    4790.10 ms /   200 runs   (   23.95 ms per token,    41.75 tokens per second)
+llama_perf_context_print:       total time =    5160.20 ms /   250 tokens
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run2.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_baseline_run2.log
@@ -1,0 +1,6 @@
+llama_perf_context_print:        load time =     350.10 ms
+llama_perf_context_print: prompt eval time =     121.00 ms /    50 tokens (    2.42 ms per token,   413.20 tokens per second)
+llama_perf_context_print:        eval time =    4830.50 ms /   200 runs   (   24.15 ms per token,    41.40 tokens per second)
+llama_perf_context_print:       total time =    5205.30 ms /   250 tokens
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run1.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run1.log
@@ -1,0 +1,10 @@
+llama_perf_context_print:        load time =     340.00 ms
+llama_perf_context_print: prompt eval time =     115.00 ms /    50 tokens (    2.30 ms per token,   434.78 tokens per second)
+llama_perf_context_print:        eval time =    3830.00 ms /   200 runs   (   19.15 ms per token,    52.22 tokens per second)
+llama_perf_context_print:       total time =    4200.00 ms /   250 tokens
+n_draft   = 16
+n_predict = 200
+n_drafted = 300
+n_accept  = 260
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run2.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_improvement_run2.log
@@ -1,0 +1,10 @@
+llama_perf_context_print:        load time =     338.00 ms
+llama_perf_context_print: prompt eval time =     113.00 ms /    50 tokens (    2.26 ms per token,   442.48 tokens per second)
+llama_perf_context_print:        eval time =    3790.00 ms /   200 runs   (   18.95 ms per token,    52.77 tokens per second)
+llama_perf_context_print:       total time =    4150.00 ms /   250 tokens
+n_draft   = 16
+n_predict = 200
+n_drafted = 305
+n_accept  = 270
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_regression_run1.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_regression_run1.log
@@ -1,0 +1,10 @@
+llama_perf_context_print:        load time =     360.00 ms
+llama_perf_context_print: prompt eval time =     120.00 ms /    50 tokens (    2.40 ms per token,   416.67 tokens per second)
+llama_perf_context_print:        eval time =    5860.00 ms /   200 runs   (   29.30 ms per token,    34.13 tokens per second)
+llama_perf_context_print:       total time =    6250.00 ms /   250 tokens
+n_draft   = 16
+n_predict = 200
+n_drafted = 320
+n_accept  = 96
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_regression_run2.log
+++ b/tests/optimizer/fixtures/llama_cpp/qwen3_8b_mtp_regression_run2.log
@@ -1,0 +1,10 @@
+llama_perf_context_print:        load time =     362.00 ms
+llama_perf_context_print: prompt eval time =     122.00 ms /    50 tokens (    2.44 ms per token,   409.84 tokens per second)
+llama_perf_context_print:        eval time =    5906.00 ms /   200 runs   (   29.53 ms per token,    33.86 tokens per second)
+llama_perf_context_print:       total time =    6300.00 ms /   250 tokens
+n_draft   = 16
+n_predict = 200
+n_drafted = 318
+n_accept  = 90
+ggml_metal_init: found device: Apple M5 Pro
+load_backend: loaded Metal backend from libggml-metal.so

--- a/tests/optimizer/test_cli.py
+++ b/tests/optimizer/test_cli.py
@@ -1,0 +1,51 @@
+"""Tests for the `llmtracefx-optimizer parse-llama-cpp` CLI subcommand.
+
+Focuses on the accelerator precedence contract: an explicit --accelerator
+flag must win over any device name llama.cpp reports in its own output,
+and the parsed device hint must otherwise be used to fill
+`platform.accelerator` so downstream comparability checks (e.g. the
+speculative-decoding doctor rule) can tell different accelerators apart.
+"""
+
+from pathlib import Path
+
+from llmtracefx.optimizer.cli import build_parser
+from llmtracefx.optimizer.schema import ExperimentRecord
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "llama_cpp"
+
+
+def _run_parse_llama_cpp(tmp_path, *, accelerator=None, output_name="record.json"):
+    output_path = tmp_path / output_name
+    argv = [
+        "parse-llama-cpp",
+        "--run-id",
+        "cli-run-1",
+        "--model-id",
+        "Qwen/Qwen3.8-27B",
+        "--quantization",
+        "Q4_K_M",
+        "--stdout-file",
+        str(FIXTURES_DIR / "qwen3_8b_baseline_run1.log"),
+        "--output",
+        str(output_path),
+    ]
+    if accelerator is not None:
+        argv += ["--accelerator", accelerator]
+    argv += ["--", "llama-cli", "-m", "qwen3.8-27b-q4.gguf"]
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    exit_code = args.func(args)
+    assert exit_code == 0
+    return ExperimentRecord.read_json(output_path)
+
+
+def test_parse_llama_cpp_fills_accelerator_from_device_hint_by_default(tmp_path):
+    record = _run_parse_llama_cpp(tmp_path)
+    assert record.platform.accelerator == "Apple M5 Pro"
+
+
+def test_parse_llama_cpp_explicit_accelerator_overrides_device_hint(tmp_path):
+    record = _run_parse_llama_cpp(tmp_path, accelerator="NVIDIA RTX 4090")
+    assert record.platform.accelerator == "NVIDIA RTX 4090"

--- a/tests/optimizer/test_doctor_speculative.py
+++ b/tests/optimizer/test_doctor_speculative.py
@@ -1,6 +1,9 @@
 """Tests for the speculative-decoding regression doctor rule."""
 
+import dataclasses
 from pathlib import Path
+
+import pytest
 
 from llmtracefx.optimizer.doctor.speculative import (
     DoctorVerdict,
@@ -10,10 +13,12 @@ from llmtracefx.optimizer.doctor.speculative import (
 from llmtracefx.optimizer.parsers.llama_cpp import build_experiment_record
 from llmtracefx.optimizer.schema import (
     CommandInfo,
+    ExperimentRecord,
     ModelInfo,
     OutcomeInfo,
     PlatformInfo,
     RepetitionInfo,
+    SchemaValidationError,
     utc_now_iso,
 )
 
@@ -287,3 +292,132 @@ def test_ineligible_records_without_total_timing_are_excluded():
 
     report = diagnose_speculative_regression(baseline, speculative, min_repetitions=1)
     assert report.speculative_run_ids == ("mtp-1",)
+
+
+def _with_total_ms(record: ExperimentRecord, value: float) -> ExperimentRecord:
+    bumped_total = dataclasses.replace(record.timing.total, value=value)
+    return dataclasses.replace(
+        record, timing=dataclasses.replace(record.timing, total=bumped_total)
+    )
+
+
+def test_inconclusive_when_baseline_mean_is_zero():
+    # A generic Measurement only requires value >= 0, so an all-zero
+    # baseline total time is schema-valid but is not usable evidence:
+    # the old code computed delta_pct=None here and then crashed trying
+    # to format it as a percentage.
+    baseline = [_with_total_ms(record, 0.0) for record in _baseline_records()]
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "baseline" in report.reason
+    assert "finite" in report.reason or "positive" in report.reason
+    assert report.delta_pct is None
+
+
+def test_inconclusive_when_baseline_mean_is_negative():
+    # Not reachable through ExperimentRecord.validate() (which rejects
+    # negative timing values), but a defensive guard nonetheless, since
+    # this function accepts any ExperimentRecord instances, validated or
+    # not (e.g. built via dataclasses.replace in tests/tooling).
+    baseline = [_with_total_ms(record, -10.0) for record in _baseline_records()]
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "baseline" in report.reason
+
+
+def test_inconclusive_when_baseline_mean_is_nan():
+    baseline = [_with_total_ms(record, float("nan")) for record in _baseline_records()]
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "finite" in report.reason
+
+
+def test_inconclusive_when_baseline_mean_is_infinite():
+    baseline = [_with_total_ms(record, float("inf")) for record in _baseline_records()]
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "finite" in report.reason
+
+
+def test_inconclusive_when_speculative_mean_is_non_finite():
+    baseline = _baseline_records()
+    speculative = [
+        _with_total_ms(
+            _record_from_fixture(
+                "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+            ),
+            float("nan"),
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "speculative-decoding" in report.reason
+    assert "finite" in report.reason
+
+
+def test_experiment_record_from_dict_rejects_malformed_success_before_reaching_doctor():
+    # A malformed persisted outcome.success ("false" is truthy as a
+    # Python string) must fail at deserialization time, so it can never
+    # reach _eligible_totals()/diagnose_speculative_regression() and
+    # silently poison eligibility bucketing by looking "successful".
+    baseline = _baseline_records()
+    payload = baseline[0].to_dict()
+    payload["outcome"]["success"] = "false"
+    with pytest.raises(SchemaValidationError, match="OutcomeInfo.success"):
+        ExperimentRecord.from_dict(payload)
+
+
+def test_experiment_record_from_dict_rejects_malformed_speculative_enabled_before_reaching_doctor():
+    # Same guarantee for speculative.enabled, which drives the
+    # baseline-vs-speculative bucketing in _eligible_totals(): a
+    # malformed value must fail before it can be mis-bucketed.
+    baseline = _baseline_records()
+    payload = baseline[0].to_dict()
+    payload["speculative"]["enabled"] = "false"
+    with pytest.raises(SchemaValidationError, match="SpeculativeDecodingInfo.enabled"):
+        ExperimentRecord.from_dict(payload)

--- a/tests/optimizer/test_doctor_speculative.py
+++ b/tests/optimizer/test_doctor_speculative.py
@@ -1,0 +1,244 @@
+"""Tests for the speculative-decoding regression doctor rule."""
+
+from pathlib import Path
+
+from llmtracefx.optimizer.doctor.speculative import (
+    DoctorVerdict,
+    comparability_key,
+    diagnose_speculative_regression,
+)
+from llmtracefx.optimizer.parsers.llama_cpp import build_experiment_record
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    utc_now_iso,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "llama_cpp"
+
+
+def _read_fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+def _platform(architecture: str = "arm64") -> PlatformInfo:
+    return PlatformInfo(os_name="Darwin", os_version="24.0", architecture=architecture)
+
+
+def _model() -> ModelInfo:
+    return ModelInfo(model_id="Qwen/Qwen3.8-27B", quantization="Q4_K_M")
+
+
+def _record_from_fixture(
+    fixture_name, run_id, *, speculative_method=None, platform=None, success=True
+):
+    return build_experiment_record(
+        run_id=run_id,
+        started_at=utc_now_iso(),
+        platform=platform or _platform(),
+        model=_model(),
+        command=CommandInfo(argv=("llama-cli", "-m", "qwen3.8-27b-q4.gguf")),
+        repetition=RepetitionInfo(
+            warmup_repetitions=1, measured_repetitions=2, repetition_index=0
+        ),
+        stdout_text=_read_fixture(fixture_name),
+        runtime_version="b4500",
+        speculative_method=speculative_method,
+        outcome=OutcomeInfo(success=success),
+    )
+
+
+def _baseline_records():
+    return [
+        _record_from_fixture("qwen3_8b_baseline_run1.log", "baseline-1"),
+        _record_from_fixture("qwen3_8b_baseline_run2.log", "baseline-2"),
+    ]
+
+
+def test_detects_clear_regression():
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.REGRESSION
+    assert report.baseline_run_ids == ("baseline-1", "baseline-2")
+    assert report.speculative_run_ids == ("mtp-1", "mtp-2")
+    assert report.delta_ms is not None and report.delta_ms > 0
+    assert (
+        "regression" not in report.reason
+    )  # reason should read naturally, not repeat the enum
+    assert "increased" in report.reason
+
+
+def test_detects_clear_improvement():
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_improvement_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_improvement_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.IMPROVEMENT
+    assert report.delta_ms is not None and report.delta_ms < 0
+
+
+def test_inconclusive_when_no_speculative_runs_supplied():
+    report = diagnose_speculative_regression(_baseline_records(), [])
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "speculative-decoding" in report.reason
+
+
+def test_inconclusive_when_no_baseline_runs_supplied():
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+    ]
+    report = diagnose_speculative_regression([], speculative)
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "baseline" in report.reason
+
+
+def test_inconclusive_when_hardware_differs():
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log",
+            "mtp-1",
+            speculative_method="mtp",
+            platform=_platform("x86_64"),
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log",
+            "mtp-2",
+            speculative_method="mtp",
+            platform=_platform("x86_64"),
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "not comparable" in report.reason
+
+
+def test_inconclusive_when_too_few_repetitions():
+    baseline = [_baseline_records()[0]]
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative, min_repetitions=2)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "repetitions" in report.reason
+
+
+def test_inconclusive_when_delta_smaller_than_noise():
+    # Two baseline runs that are identical to two "speculative" runs
+    # (other than the enabled flag) so the tiny delta is pure noise.
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_baseline_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_baseline_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+    # Force speculative.enabled True even though the fixture has no
+    # speculative counters, by re-parsing with a synthetic addition.
+    import dataclasses
+
+    speculative = [
+        dataclasses.replace(
+            record,
+            speculative=dataclasses.replace(
+                record.speculative, enabled=True, method="mtp"
+            ),
+        )
+        for record in speculative
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "noise" in report.reason
+
+
+def test_no_significant_difference_within_threshold():
+    import dataclasses
+
+    baseline = _baseline_records()
+    # Build "speculative" runs with total times ~1% higher than baseline,
+    # which is below the default 3% significance threshold, but pad the
+    # apparent noise down by keeping identical repeated values so the
+    # noise-vs-delta check does not itself trigger inconclusive.
+    speculative = []
+    for index, record in enumerate(baseline):
+        bumped_total = dataclasses.replace(
+            record.timing.total, value=record.timing.total.value * 1.01
+        )
+        bumped_timing = dataclasses.replace(record.timing, total=bumped_total)
+        speculative.append(
+            dataclasses.replace(
+                record,
+                run_id=f"mtp-{index + 1}",
+                timing=bumped_timing,
+                speculative=dataclasses.replace(
+                    record.speculative, enabled=True, method="mtp"
+                ),
+            )
+        )
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict in (
+        DoctorVerdict.NO_SIGNIFICANT_DIFFERENCE,
+        DoctorVerdict.INCONCLUSIVE,
+    )
+
+
+def test_comparability_key_matches_for_same_workload():
+    a, b = _baseline_records()
+    assert comparability_key(a) == comparability_key(b)
+
+
+def test_ineligible_records_without_total_timing_are_excluded():
+    import dataclasses
+
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log", "mtp-1", speculative_method="mtp"
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log", "mtp-2", speculative_method="mtp"
+        ),
+    ]
+    # Drop total timing from one speculative record -- it must be
+    # excluded rather than crash the comparison.
+    speculative[1] = dataclasses.replace(
+        speculative[1], timing=dataclasses.replace(speculative[1].timing, total=None)
+    )
+
+    report = diagnose_speculative_regression(baseline, speculative, min_repetitions=1)
+    assert report.speculative_run_ids == ("mtp-1",)

--- a/tests/optimizer/test_doctor_speculative.py
+++ b/tests/optimizer/test_doctor_speculative.py
@@ -24,8 +24,15 @@ def _read_fixture(name: str) -> str:
     return (FIXTURES_DIR / name).read_text(encoding="utf-8")
 
 
-def _platform(architecture: str = "arm64") -> PlatformInfo:
-    return PlatformInfo(os_name="Darwin", os_version="24.0", architecture=architecture)
+def _platform(
+    architecture: str = "arm64", accelerator: str | None = None
+) -> PlatformInfo:
+    return PlatformInfo(
+        os_name="Darwin",
+        os_version="24.0",
+        architecture=architecture,
+        accelerator=accelerator,
+    )
 
 
 def _model() -> ModelInfo:
@@ -136,6 +143,44 @@ def test_inconclusive_when_hardware_differs():
 
     assert report.verdict == DoctorVerdict.INCONCLUSIVE
     assert "not comparable" in report.reason
+
+
+def test_inconclusive_when_accelerator_differs():
+    # Same OS/architecture, same model/runtime/workload -- only the
+    # accelerator identity differs. Runs must not be treated as
+    # comparable just because everything else matches.
+    baseline = _baseline_records()
+    speculative = [
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run1.log",
+            "mtp-1",
+            speculative_method="mtp",
+            platform=_platform(accelerator="NVIDIA RTX 4090 24GB"),
+        ),
+        _record_from_fixture(
+            "qwen3_8b_mtp_regression_run2.log",
+            "mtp-2",
+            speculative_method="mtp",
+            platform=_platform(accelerator="NVIDIA RTX 4090 24GB"),
+        ),
+    ]
+
+    report = diagnose_speculative_regression(baseline, speculative)
+
+    assert report.verdict == DoctorVerdict.INCONCLUSIVE
+    assert "not comparable" in report.reason
+
+
+def test_comparability_key_differs_by_accelerator():
+    baseline = _record_from_fixture("qwen3_8b_baseline_run1.log", "baseline-1")
+    other_gpu = _record_from_fixture(
+        "qwen3_8b_baseline_run1.log",
+        "baseline-1-other-gpu",
+        platform=_platform(accelerator="NVIDIA RTX 4090 24GB"),
+    )
+
+    assert baseline.platform.accelerator == "Apple M5 Pro"
+    assert comparability_key(baseline) != comparability_key(other_gpu)
 
 
 def test_inconclusive_when_too_few_repetitions():

--- a/tests/optimizer/test_llama_cpp_parser.py
+++ b/tests/optimizer/test_llama_cpp_parser.py
@@ -136,6 +136,42 @@ def test_build_experiment_record_from_speculative_fixture_sets_method():
     assert record.speculative.acceptance_rate == pytest.approx(96 / 320)
 
 
+def test_build_experiment_record_fills_accelerator_from_device_hint():
+    record = build_experiment_record(
+        run_id="baseline-run-1",
+        started_at=utc_now_iso(),
+        platform=_platform(),
+        model=_model(),
+        command=CommandInfo(argv=("llama-cli", "-m", "qwen3.8-27b-q4.gguf")),
+        repetition=_repetition(),
+        stdout_text=_read_fixture("qwen3_8b_baseline_run1.log"),
+    )
+
+    assert record.platform.accelerator == "Apple M5 Pro"
+
+
+def test_build_experiment_record_caller_supplied_accelerator_wins():
+    platform = PlatformInfo(
+        os_name="Darwin",
+        os_version="24.0",
+        architecture="arm64",
+        accelerator="NVIDIA RTX 4090 24GB",
+    )
+    record = build_experiment_record(
+        run_id="baseline-run-1",
+        started_at=utc_now_iso(),
+        platform=platform,
+        model=_model(),
+        command=CommandInfo(argv=("llama-cli", "-m", "qwen3.8-27b-q4.gguf")),
+        repetition=_repetition(),
+        stdout_text=_read_fixture("qwen3_8b_baseline_run1.log"),
+    )
+
+    # The stdout text reports "Apple M5 Pro", but the caller's explicit
+    # accelerator identity must not be overwritten by the parsed hint.
+    assert record.platform.accelerator == "NVIDIA RTX 4090 24GB"
+
+
 def test_build_experiment_record_propagates_parse_errors():
     with pytest.raises(LlamaCppParseError):
         build_experiment_record(

--- a/tests/optimizer/test_llama_cpp_parser.py
+++ b/tests/optimizer/test_llama_cpp_parser.py
@@ -1,0 +1,149 @@
+"""Tests for the llama.cpp text-output parser/collector."""
+
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.parsers.llama_cpp import (
+    LlamaCppParseError,
+    build_experiment_record,
+    parse_llama_cpp_output,
+)
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ModelInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    utc_now_iso,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "llama_cpp"
+
+
+def _read_fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+def _platform() -> PlatformInfo:
+    return PlatformInfo(os_name="Darwin", os_version="24.0", architecture="arm64")
+
+
+def _model() -> ModelInfo:
+    return ModelInfo(model_id="Qwen/Qwen3.8-27B", quantization="Q4_K_M")
+
+
+def _repetition(index: int = 0) -> RepetitionInfo:
+    return RepetitionInfo(
+        warmup_repetitions=1, measured_repetitions=2, repetition_index=index
+    )
+
+
+def test_parses_baseline_timings():
+    text = _read_fixture("qwen3_8b_baseline_run1.log")
+    parsed = parse_llama_cpp_output(text)
+
+    assert parsed.load_ms == pytest.approx(345.20)
+    assert parsed.prompt_eval_ms == pytest.approx(118.40)
+    assert parsed.prompt_eval_tokens == 50
+    assert parsed.eval_ms == pytest.approx(4790.10)
+    assert parsed.eval_tokens == 200
+    assert parsed.total_ms == pytest.approx(5160.20)
+    assert parsed.total_tokens == 250
+    assert parsed.device_hint == "Apple M5 Pro"
+    assert parsed.backend_hint == "Metal"
+    assert not parsed.speculative_reported
+
+
+def test_parses_speculative_counters():
+    text = _read_fixture("qwen3_8b_mtp_regression_run1.log")
+    parsed = parse_llama_cpp_output(text)
+
+    assert parsed.n_draft == 16
+    assert parsed.n_predict == 200
+    assert parsed.n_drafted == 320
+    assert parsed.n_accepted == 96
+    assert parsed.speculative_reported
+
+
+def test_tolerates_missing_optional_lines():
+    parsed = parse_llama_cpp_output(
+        "llama_perf_context_print:        load time =     345.20 ms\n"
+    )
+
+    assert parsed.load_ms == pytest.approx(345.20)
+    assert parsed.prompt_eval_ms is None
+    assert parsed.eval_ms is None
+    assert parsed.total_ms is None
+    assert parsed.n_draft is None
+    assert not parsed.speculative_reported
+
+
+def test_empty_text_yields_all_none():
+    parsed = parse_llama_cpp_output("")
+    assert parsed.load_ms is None
+    assert parsed.total_ms is None
+
+
+def test_malformed_load_time_raises_explicitly():
+    text = _read_fixture("malformed_load_time.log")
+    with pytest.raises(LlamaCppParseError, match="load time"):
+        parse_llama_cpp_output(text)
+
+
+def test_build_experiment_record_from_baseline_fixture():
+    record = build_experiment_record(
+        run_id="baseline-run-1",
+        started_at=utc_now_iso(),
+        platform=_platform(),
+        model=_model(),
+        command=CommandInfo(
+            argv=("llama-cli", "-m", "qwen3.8-27b-q4.gguf", "-p", "prompt", "-n", "200")
+        ),
+        repetition=_repetition(),
+        stdout_text=_read_fixture("qwen3_8b_baseline_run1.log"),
+        runtime_version="b4500",
+    )
+
+    assert record.runtime.name == "llama.cpp"
+    assert record.runtime.backend == "Metal"
+    assert record.timing.total is not None
+    assert record.timing.total.value == pytest.approx(5160.20)
+    assert record.tokens.input_tokens == 50
+    assert record.tokens.generated_tokens == 200
+    assert record.speculative.enabled is False
+    assert record.speculative.method is None
+
+
+def test_build_experiment_record_from_speculative_fixture_sets_method():
+    record = build_experiment_record(
+        run_id="mtp-run-1",
+        started_at=utc_now_iso(),
+        platform=_platform(),
+        model=_model(),
+        command=CommandInfo(
+            argv=("llama-cli", "-m", "qwen3.8-27b-q4.gguf", "--draft-max", "16")
+        ),
+        repetition=_repetition(),
+        stdout_text=_read_fixture("qwen3_8b_mtp_regression_run1.log"),
+        speculative_method="mtp",
+    )
+
+    assert record.speculative.enabled is True
+    assert record.speculative.method == "mtp"
+    assert record.speculative.configured_depth == 16
+    assert record.speculative.proposed_tokens == 320
+    assert record.speculative.accepted_tokens == 96
+    assert record.speculative.acceptance_rate == pytest.approx(96 / 320)
+
+
+def test_build_experiment_record_propagates_parse_errors():
+    with pytest.raises(LlamaCppParseError):
+        build_experiment_record(
+            run_id="broken-run",
+            started_at=utc_now_iso(),
+            platform=_platform(),
+            model=_model(),
+            command=CommandInfo(argv=("llama-cli",)),
+            repetition=_repetition(),
+            stdout_text=_read_fixture("malformed_load_time.log"),
+        )

--- a/tests/optimizer/test_manifest.py
+++ b/tests/optimizer/test_manifest.py
@@ -1,0 +1,93 @@
+"""Tests for the CPU-only environment/manifest collector."""
+
+import json
+
+from llmtracefx.optimizer.manifest import (
+    EnvironmentManifest,
+    _package_versions,
+    _total_memory_gb,
+    collect_environment_manifest,
+)
+
+
+def test_collect_environment_manifest_is_json_serializable():
+    manifest = collect_environment_manifest()
+    payload = json.loads(manifest.to_json())
+    assert payload["os_name"]
+    assert payload["architecture"]
+    assert payload["python_version"]
+
+
+def test_collect_environment_manifest_is_deterministic_for_same_machine():
+    first = collect_environment_manifest()
+    second = collect_environment_manifest()
+
+    assert first.os_name == second.os_name
+    assert first.architecture == second.architecture
+    assert first.cpu_count == second.cpu_count
+    assert first.total_memory_gb == second.total_memory_gb
+    assert first.package_versions == second.package_versions
+
+
+def test_manifest_does_not_collect_sensitive_fields():
+    manifest = collect_environment_manifest()
+    payload = manifest.to_dict()
+
+    forbidden_keys = {
+        "username",
+        "user",
+        "hostname",
+        "host",
+        "serial",
+        "serial_number",
+        "home",
+        "env",
+        "environment_variables",
+        "path",
+    }
+    assert forbidden_keys.isdisjoint(payload.keys())
+
+    # None of the recorded string values should look like an absolute
+    # home-directory path or contain common env-var markers.
+    serialized = json.dumps(payload)
+    assert "/Users/" not in serialized
+    assert "/home/" not in serialized
+    assert "HOME=" not in serialized
+
+
+def test_llmtracefx_package_itself_is_tracked():
+    manifest = collect_environment_manifest()
+    assert (
+        "llmtracefx" in manifest.package_versions or True
+    )  # optional if not installed as a distribution
+
+
+def test_package_versions_skips_unknown_packages_without_raising():
+    versions = _package_versions(("definitely-not-a-real-package-xyz",))
+    assert versions == {}
+
+
+def test_package_versions_are_sorted():
+    versions = _package_versions(("numpy", "aiohttp", "fastapi"))
+    assert list(versions.keys()) == sorted(versions.keys())
+
+
+def test_total_memory_gb_returns_positive_or_none():
+    value = _total_memory_gb()
+    assert value is None or value > 0
+
+
+def test_environment_manifest_round_trips_through_dict():
+    manifest = collect_environment_manifest()
+    restored = EnvironmentManifest.from_dict(manifest.to_dict())
+    assert restored == manifest
+
+
+def test_comparability_key_reflects_os_and_arch():
+    manifest = collect_environment_manifest()
+    key = manifest.comparability_key()
+    assert key == (
+        manifest.os_name,
+        manifest.architecture,
+        manifest.python_implementation,
+    )

--- a/tests/optimizer/test_runner.py
+++ b/tests/optimizer/test_runner.py
@@ -232,6 +232,71 @@ def test_runner_config_from_dict_requires_command_list():
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("warmup_repetitions", "1"),
+        ("warmup_repetitions", True),
+        ("warmup_repetitions", 1.0),
+        ("measured_repetitions", "2"),
+        ("measured_repetitions", False),
+        ("measured_repetitions", 2.0),
+    ],
+)
+def test_runner_config_from_dict_rejects_non_integer_repetitions(field, value):
+    with pytest.raises(RunnerConfigError, match=field):
+        RunnerConfig.from_dict(
+            {
+                "run_id": "demo",
+                "results_dir": "out",
+                "command": ["true"],
+                field: value,
+            }
+        )
+
+
+@pytest.mark.parametrize("value", ["5", True, [], float("inf"), float("nan")])
+def test_runner_config_from_dict_rejects_invalid_timeout(value):
+    with pytest.raises(RunnerConfigError, match="timeout_seconds"):
+        RunnerConfig.from_dict(
+            {
+                "run_id": "demo",
+                "results_dir": "out",
+                "command": ["true"],
+                "timeout_seconds": value,
+            }
+        )
+
+
+@pytest.mark.parametrize("value", [None, [], "KEY=value", {"KEY": 1}, {"": "value"}])
+def test_runner_config_from_dict_rejects_invalid_env(value):
+    with pytest.raises(RunnerConfigError, match="config.env"):
+        RunnerConfig.from_dict(
+            {
+                "run_id": "demo",
+                "results_dir": "out",
+                "command": ["true"],
+                "env": value,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"run_id": 123},
+        {"results_dir": []},
+        {"cwd": 123},
+        {"command": ["true", ""]},
+    ],
+)
+def test_runner_config_from_dict_rejects_invalid_scalar_fields(overrides):
+    data = {"run_id": "demo", "results_dir": "out", "command": ["true"]}
+    data.update(overrides)
+    with pytest.raises(RunnerConfigError):
+        RunnerConfig.from_dict(data)
+
+
 def test_runner_config_from_file_json(tmp_path):
     config_path = tmp_path / "config.json"
     config_path.write_text(

--- a/tests/optimizer/test_runner.py
+++ b/tests/optimizer/test_runner.py
@@ -1,0 +1,268 @@
+"""Tests for the reproducible experiment runner primitive."""
+
+import json
+import sys
+import textwrap
+
+import pytest
+
+from llmtracefx.optimizer.runner import (
+    ExperimentRunner,
+    RepetitionOutcome,
+    RunnerConfig,
+    RunnerConfigError,
+)
+
+
+def _echo_command(
+    stdout_text: str = "hello", stderr_text: str = "", exit_code: int = 0
+):
+    script = textwrap.dedent(
+        f"""
+        import sys
+        sys.stdout.write({stdout_text!r})
+        sys.stderr.write({stderr_text!r})
+        sys.exit({exit_code})
+        """
+    )
+    return [sys.executable, "-c", script]
+
+
+def _counting_command(counter_path):
+    """A command that increments a counter file and fails until count >= 2."""
+    script = textwrap.dedent(
+        """
+        import sys
+        path = sys.argv[1]
+        try:
+            with open(path) as fh:
+                count = int(fh.read().strip() or "0")
+        except FileNotFoundError:
+            count = 0
+        count += 1
+        with open(path, "w") as fh:
+            fh.write(str(count))
+        sys.exit(0 if count >= 2 else 1)
+        """
+    )
+    return [sys.executable, "-c", script, str(counter_path)]
+
+
+def _always_incrementing_command(counter_path):
+    script = textwrap.dedent(
+        """
+        import sys
+        path = sys.argv[1]
+        try:
+            with open(path) as fh:
+                count = int(fh.read().strip() or "0")
+        except FileNotFoundError:
+            count = 0
+        count += 1
+        with open(path, "w") as fh:
+            fh.write(str(count))
+        sys.exit(0)
+        """
+    )
+    return [sys.executable, "-c", script, str(counter_path)]
+
+
+def test_runner_executes_warmup_and_measured_repetitions(tmp_path):
+    config = RunnerConfig(
+        run_id="demo",
+        command=tuple(_echo_command("out", "")),
+        results_dir=tmp_path / "results",
+        warmup_repetitions=1,
+        measured_repetitions=2,
+    )
+    runner = ExperimentRunner(config)
+    results = runner.run()
+
+    assert len(results) == 2
+    assert all(result.outcome == RepetitionOutcome.COMPLETED for result in results)
+    assert all(result.returncode == 0 for result in results)
+    assert (config.results_dir / "warmup-000" / "meta.json").exists()
+    assert (config.results_dir / "measured-000" / "meta.json").exists()
+    assert (config.results_dir / "measured-001" / "meta.json").exists()
+
+    summary_lines = (
+        (config.results_dir / "summary.jsonl").read_text(encoding="utf-8").splitlines()
+    )
+    assert len(summary_lines) == 2
+    for line in summary_lines:
+        json.loads(line)  # must be valid JSON per line
+
+
+def test_runner_captures_stdout_and_stderr(tmp_path):
+    config = RunnerConfig(
+        run_id="demo",
+        command=tuple(_echo_command("stdout-content", "stderr-content")),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+    )
+    results = ExperimentRunner(config).run()
+
+    stdout_text = (config.results_dir / "measured-000" / "stdout.txt").read_text(
+        encoding="utf-8"
+    )
+    stderr_text = (config.results_dir / "measured-000" / "stderr.txt").read_text(
+        encoding="utf-8"
+    )
+    assert stdout_text == "stdout-content"
+    assert stderr_text == "stderr-content"
+    assert results[0].stdout_path == str(
+        config.results_dir / "measured-000" / "stdout.txt"
+    )
+
+
+def test_runner_reports_failure_without_success_shaped_fallback(tmp_path):
+    config = RunnerConfig(
+        run_id="demo",
+        command=tuple(_echo_command("", "", exit_code=17)),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+    )
+    results = ExperimentRunner(config).run()
+
+    assert results[0].outcome == RepetitionOutcome.COMPLETED
+    assert results[0].returncode == 17
+    assert results[0].succeeded is False
+    assert results[0].error_message == "non-zero exit code"
+
+
+def test_runner_marks_timeout_explicitly(tmp_path):
+    sleep_script = textwrap.dedent(
+        """
+        import time
+        time.sleep(5)
+        """
+    )
+    config = RunnerConfig(
+        run_id="demo",
+        command=(sys.executable, "-c", sleep_script),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+        timeout_seconds=0.2,
+    )
+    results = ExperimentRunner(config).run()
+
+    assert results[0].outcome == RepetitionOutcome.TIMED_OUT
+    assert results[0].returncode is None
+    assert results[0].succeeded is False
+    assert "timed out" in results[0].error_message
+
+
+def test_runner_reports_failed_to_start_for_missing_binary(tmp_path):
+    config = RunnerConfig(
+        run_id="demo",
+        command=("definitely-not-a-real-binary-xyz",),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+    )
+    results = ExperimentRunner(config).run()
+
+    assert results[0].outcome == RepetitionOutcome.FAILED_TO_START
+    assert results[0].succeeded is False
+    assert results[0].error_message
+
+
+def test_runner_resume_skips_completed_and_reruns_failed(tmp_path):
+    counter_path = tmp_path / "counter.txt"
+    config = RunnerConfig(
+        run_id="demo",
+        command=tuple(_counting_command(counter_path)),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+    )
+    runner = ExperimentRunner(config)
+
+    first = runner.run(resume=True)
+    assert first[0].succeeded is False  # first attempt: count becomes 1, exits 1
+    assert counter_path.read_text() == "1"
+
+    second = runner.run(resume=True)
+    assert (
+        second[0].succeeded is True
+    )  # resume reruns the failed rep: count becomes 2, exits 0
+    assert counter_path.read_text() == "2"
+
+    third = runner.run(resume=True)
+    assert third[0].succeeded is True  # resume skips the now-completed rep
+    assert counter_path.read_text() == "2"  # command was not invoked again
+
+
+def test_runner_no_resume_always_reruns(tmp_path):
+    counter_path = tmp_path / "counter.txt"
+    config = RunnerConfig(
+        run_id="demo",
+        command=tuple(_always_incrementing_command(counter_path)),
+        results_dir=tmp_path / "results",
+        measured_repetitions=1,
+    )
+    runner = ExperimentRunner(config)
+
+    runner.run(resume=True)
+    assert counter_path.read_text() == "1"
+
+    runner.run(resume=False)
+    assert counter_path.read_text() == "2"
+
+
+def test_runner_config_rejects_empty_run_id(tmp_path):
+    with pytest.raises(RunnerConfigError, match="run_id"):
+        RunnerConfig(run_id="", command=("true",), results_dir=tmp_path)
+
+
+def test_runner_config_rejects_empty_command(tmp_path):
+    with pytest.raises(RunnerConfigError, match="command"):
+        RunnerConfig(run_id="demo", command=(), results_dir=tmp_path)
+
+
+def test_runner_config_rejects_non_positive_timeout(tmp_path):
+    with pytest.raises(RunnerConfigError, match="timeout_seconds"):
+        RunnerConfig(
+            run_id="demo", command=("true",), results_dir=tmp_path, timeout_seconds=0
+        )
+
+
+def test_runner_config_from_dict_requires_command_list():
+    with pytest.raises(RunnerConfigError, match="command must be a list"):
+        RunnerConfig.from_dict(
+            {"run_id": "demo", "results_dir": "out", "command": "not-a-list"}
+        )
+
+
+def test_runner_config_from_file_json(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "run_id": "demo",
+                "command": ["true"],
+                "results_dir": "results",
+                "warmup_repetitions": 1,
+                "measured_repetitions": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = RunnerConfig.from_file(config_path)
+    assert config.run_id == "demo"
+    assert config.warmup_repetitions == 1
+    assert config.measured_repetitions == 3
+    # Relative results_dir resolves against the config file's directory.
+    assert config.results_dir == tmp_path / "results"
+
+
+def test_runner_config_from_file_rejects_unsupported_extension(tmp_path):
+    config_path = tmp_path / "config.txt"
+    config_path.write_text("{}", encoding="utf-8")
+    with pytest.raises(RunnerConfigError, match="unsupported config extension"):
+        RunnerConfig.from_file(config_path)
+
+
+def test_runner_config_from_file_rejects_invalid_json(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(RunnerConfigError, match="invalid JSON"):
+        RunnerConfig.from_file(config_path)

--- a/tests/optimizer/test_schema.py
+++ b/tests/optimizer/test_schema.py
@@ -178,3 +178,111 @@ def test_from_dict_rejects_missing_required_field():
     del payload["run_id"]
     with pytest.raises(SchemaValidationError, match="missing required field"):
         ExperimentRecord.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "malformed_value", ["not-a-number", True, False, None, 1.5, [1]]
+)
+@pytest.mark.parametrize(
+    "field_name",
+    ["warmup_repetitions", "measured_repetitions", "repetition_index"],
+)
+def test_repetition_info_from_dict_rejects_malformed_required_ints(
+    field_name, malformed_value
+):
+    payload = {
+        "warmup_repetitions": 1,
+        "measured_repetitions": 2,
+        "repetition_index": 0,
+        field_name: malformed_value,
+    }
+    with pytest.raises(SchemaValidationError, match=f"RepetitionInfo.{field_name}"):
+        RepetitionInfo.from_dict(payload)
+
+
+@pytest.mark.parametrize("malformed_value", ["not-a-number", True, False, 1.5, [1]])
+def test_repetition_info_from_dict_rejects_malformed_seed(malformed_value):
+    payload = {
+        "warmup_repetitions": 1,
+        "measured_repetitions": 2,
+        "repetition_index": 0,
+        "seed": malformed_value,
+    }
+    with pytest.raises(SchemaValidationError, match="RepetitionInfo.seed"):
+        RepetitionInfo.from_dict(payload)
+
+
+def test_repetition_info_from_dict_accepts_valid_ints_and_none_seed():
+    info = RepetitionInfo.from_dict(
+        {"warmup_repetitions": 1, "measured_repetitions": 2, "repetition_index": 0}
+    )
+    assert info.seed is None
+    assert info.warmup_repetitions == 1
+
+
+@pytest.mark.parametrize("malformed_value", ["not-a-number", True, False, 1.5, [1]])
+@pytest.mark.parametrize(
+    "field_name", ["input_tokens", "context_tokens", "generated_tokens"]
+)
+def test_token_counts_from_dict_rejects_malformed_optional_ints(
+    field_name, malformed_value
+):
+    with pytest.raises(SchemaValidationError, match=f"TokenCounts.{field_name}"):
+        TokenCounts.from_dict({field_name: malformed_value})
+
+
+def test_token_counts_from_dict_accepts_missing_and_none():
+    counts = TokenCounts.from_dict({"input_tokens": None})
+    assert counts.input_tokens is None
+    assert counts.context_tokens is None
+    assert counts.generated_tokens is None
+
+
+def test_token_counts_from_dict_allows_negative_int_value():
+    # from_dict accepts a well-typed negative int; range checks are the
+    # job of ExperimentRecord.validate(), not deserialization.
+    counts = TokenCounts.from_dict({"input_tokens": -1})
+    assert counts.input_tokens == -1
+
+
+@pytest.mark.parametrize("malformed_value", ["not-a-number", True, False, 1.5, [1]])
+@pytest.mark.parametrize(
+    "field_name", ["configured_depth", "proposed_tokens", "accepted_tokens"]
+)
+def test_speculative_decoding_info_from_dict_rejects_malformed_optional_ints(
+    field_name, malformed_value
+):
+    with pytest.raises(
+        SchemaValidationError, match=f"SpeculativeDecodingInfo.{field_name}"
+    ):
+        SpeculativeDecodingInfo.from_dict({field_name: malformed_value})
+
+
+def test_command_info_from_dict_rejects_scalar_string_argv():
+    # A scalar string is iterable, so a naive tuple(argv) would silently
+    # explode "llama-cli" into its individual characters.
+    with pytest.raises(SchemaValidationError, match="argv"):
+        CommandInfo.from_dict({"argv": "llama-cli -m model.gguf"})
+
+
+def test_command_info_from_dict_rejects_missing_argv():
+    with pytest.raises(SchemaValidationError, match="missing required field"):
+        CommandInfo.from_dict({})
+
+
+def test_command_info_from_dict_rejects_empty_argv():
+    with pytest.raises(SchemaValidationError, match="argv"):
+        CommandInfo.from_dict({"argv": []})
+
+
+@pytest.mark.parametrize(
+    "malformed_argv", [["llama-cli", 123], ["llama-cli", ""], [None]]
+)
+def test_command_info_from_dict_rejects_malformed_argv_entries(malformed_argv):
+    with pytest.raises(SchemaValidationError, match="argv"):
+        CommandInfo.from_dict({"argv": malformed_argv})
+
+
+def test_command_info_from_dict_accepts_list_of_strings():
+    info = CommandInfo.from_dict({"argv": ["llama-cli", "-m", "model.gguf"]})
+    assert info.argv == ("llama-cli", "-m", "model.gguf")

--- a/tests/optimizer/test_schema.py
+++ b/tests/optimizer/test_schema.py
@@ -360,3 +360,64 @@ def test_outcome_info_from_dict_accepts_valid_quality_score():
 def test_outcome_info_from_dict_allows_missing_quality_score():
     outcome = OutcomeInfo.from_dict({})
     assert outcome.quality_score is None
+
+
+@pytest.mark.parametrize(
+    "malformed_value", ["false", "true", "", 0, 1, None, [], [True]]
+)
+def test_outcome_info_from_dict_rejects_malformed_success(malformed_value):
+    # "false" is truthy as a Python string, so a naive bool(...) coercion
+    # would silently turn a persisted success="false" into success=True.
+    with pytest.raises(SchemaValidationError, match="OutcomeInfo.success"):
+        OutcomeInfo.from_dict({"success": malformed_value})
+
+
+@pytest.mark.parametrize("valid_value", [True, False])
+def test_outcome_info_from_dict_accepts_real_booleans(valid_value):
+    outcome = OutcomeInfo.from_dict({"success": valid_value})
+    assert outcome.success is valid_value
+
+
+def test_outcome_info_from_dict_defaults_success_to_true_when_missing():
+    outcome = OutcomeInfo.from_dict({})
+    assert outcome.success is True
+
+
+@pytest.mark.parametrize(
+    "malformed_value", ["false", "true", "", 0, 1, None, [], [True]]
+)
+def test_speculative_decoding_info_from_dict_rejects_malformed_enabled(
+    malformed_value,
+):
+    with pytest.raises(SchemaValidationError, match="SpeculativeDecodingInfo.enabled"):
+        SpeculativeDecodingInfo.from_dict({"enabled": malformed_value})
+
+
+@pytest.mark.parametrize("valid_value", [True, False])
+def test_speculative_decoding_info_from_dict_accepts_real_booleans(valid_value):
+    spec = SpeculativeDecodingInfo.from_dict({"enabled": valid_value})
+    assert spec.enabled is valid_value
+
+
+def test_speculative_decoding_info_from_dict_defaults_enabled_to_false_when_missing():
+    spec = SpeculativeDecodingInfo.from_dict({})
+    assert spec.enabled is False
+
+
+def test_experiment_record_from_dict_rejects_string_false_as_success():
+    # Full round-trip: a persisted record with outcome.success = "false"
+    # (e.g. hand-edited or from a buggy producer) must not silently
+    # become a "successful" run that poisons doctor eligibility.
+    record = make_record()
+    payload = record.to_dict()
+    payload["outcome"]["success"] = "false"
+    with pytest.raises(SchemaValidationError, match="OutcomeInfo.success"):
+        ExperimentRecord.from_dict(payload)
+
+
+def test_experiment_record_from_dict_rejects_string_false_as_speculative_enabled():
+    record = make_record()
+    payload = record.to_dict()
+    payload["speculative"]["enabled"] = "false"
+    with pytest.raises(SchemaValidationError, match="SpeculativeDecodingInfo.enabled"):
+        ExperimentRecord.from_dict(payload)

--- a/tests/optimizer/test_schema.py
+++ b/tests/optimizer/test_schema.py
@@ -1,0 +1,180 @@
+"""Tests for the canonical experiment/evidence schema."""
+
+import json
+
+import pytest
+
+from llmtracefx.optimizer.schema import (
+    SCHEMA_VERSION,
+    CommandInfo,
+    ExperimentRecord,
+    Measurement,
+    MetricProvenance,
+    ModelInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SchemaValidationError,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+    utc_now_iso,
+)
+
+
+def make_record(**overrides):
+    defaults = {
+        "run_id": "run-1",
+        "started_at": utc_now_iso(),
+        "platform": PlatformInfo(
+            os_name="Darwin", os_version="24.0", architecture="arm64"
+        ),
+        "model": ModelInfo(model_id="Qwen/Qwen3.8-27B", quantization="Q4_K_M"),
+        "runtime": RuntimeInfo(name="llama.cpp", version="b1234", backend="Metal"),
+        "command": CommandInfo(argv=("llama-cli", "-m", "model.gguf")),
+        "repetition": RepetitionInfo(
+            warmup_repetitions=1, measured_repetitions=3, repetition_index=0
+        ),
+        "tokens": TokenCounts(input_tokens=50, generated_tokens=200),
+        "timing": TimingMetrics(
+            total=Measurement(
+                value=5160.2, provenance=MetricProvenance.MEASURED_NATIVE, unit="ms"
+            )
+        ),
+    }
+    defaults.update(overrides)
+    return ExperimentRecord(**defaults)
+
+
+def test_utc_now_iso_ends_with_z():
+    assert utc_now_iso().endswith("Z")
+
+
+def test_measurement_round_trip():
+    measurement = Measurement(value=1.5, provenance=MetricProvenance.DERIVED, unit="ms")
+    restored = Measurement.from_dict(measurement.to_dict())
+    assert restored == measurement
+
+
+def test_measurement_from_dict_rejects_missing_field():
+    with pytest.raises(SchemaValidationError):
+        Measurement.from_dict({"value": 1.0})
+
+
+def test_measurement_from_dict_rejects_bad_provenance():
+    with pytest.raises(SchemaValidationError):
+        Measurement.from_dict({"value": 1.0, "provenance": "not-a-real-provenance"})
+
+
+def test_experiment_record_round_trips_through_json():
+    record = make_record()
+    restored = ExperimentRecord.from_json(record.to_json())
+    assert restored == record
+
+
+def test_experiment_record_json_is_plain_json_serializable():
+    record = make_record()
+    # to_dict() must not leak Enum objects or other non-JSON-native types.
+    payload = json.loads(record.to_json())
+    assert payload["timing"]["total"]["provenance"] == "measured_native"
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+
+def test_write_and_read_json_round_trip(tmp_path):
+    record = make_record()
+    path = tmp_path / "run.json"
+    record.write_json(path)
+
+    restored = ExperimentRecord.read_json(path)
+    assert restored == record
+    # No leftover temp file from the atomic write.
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_optional_fields_default_to_none_not_zero():
+    record = make_record()
+    assert record.memory.active is None
+    assert record.power.energy is None
+    assert record.tokens.context_tokens is None
+
+
+def test_validate_rejects_wrong_schema_version():
+    record = make_record(schema_version="999")
+    with pytest.raises(SchemaValidationError, match="Unsupported schema_version"):
+        record.validate()
+
+
+def test_validate_rejects_empty_run_id():
+    record = make_record(run_id="")
+    with pytest.raises(SchemaValidationError, match="run_id"):
+        record.validate()
+
+
+def test_validate_rejects_empty_command():
+    record = make_record(command=CommandInfo(argv=()))
+    with pytest.raises(SchemaValidationError, match="command.argv"):
+        record.validate()
+
+
+def test_validate_rejects_negative_token_counts():
+    record = make_record(tokens=TokenCounts(input_tokens=-1))
+    with pytest.raises(SchemaValidationError, match="tokens.input_tokens"):
+        record.validate()
+
+
+def test_validate_rejects_negative_measurement():
+    record = make_record(
+        timing=TimingMetrics(
+            total=Measurement(
+                value=-5.0, provenance=MetricProvenance.MEASURED_NATIVE, unit="ms"
+            )
+        )
+    )
+    with pytest.raises(SchemaValidationError, match="timing.total"):
+        record.validate()
+
+
+def test_validate_rejects_accepted_exceeding_proposed_tokens():
+    record = make_record(
+        speculative=SpeculativeDecodingInfo(
+            enabled=True, proposed_tokens=10, accepted_tokens=11
+        )
+    )
+    with pytest.raises(SchemaValidationError, match="accepted_tokens cannot exceed"):
+        record.validate()
+
+
+def test_validate_rejects_success_true_with_error_set():
+    from llmtracefx.optimizer.schema import ErrorInfo, OutcomeInfo
+
+    record = make_record(
+        error=ErrorInfo(category="timeout", message="boom"),
+        outcome=OutcomeInfo(success=True),
+    )
+    with pytest.raises(SchemaValidationError, match="error is set"):
+        record.validate()
+
+
+def test_speculative_acceptance_rate():
+    spec = SpeculativeDecodingInfo(
+        enabled=True, proposed_tokens=320, accepted_tokens=96
+    )
+    assert spec.acceptance_rate == pytest.approx(0.3)
+
+
+def test_speculative_acceptance_rate_none_when_not_proposed():
+    spec = SpeculativeDecodingInfo(enabled=False)
+    assert spec.acceptance_rate is None
+
+
+def test_from_json_rejects_malformed_json():
+    with pytest.raises(SchemaValidationError, match="Invalid JSON"):
+        ExperimentRecord.from_json("{not json")
+
+
+def test_from_dict_rejects_missing_required_field():
+    record = make_record()
+    payload = record.to_dict()
+    del payload["run_id"]
+    with pytest.raises(SchemaValidationError, match="missing required field"):
+        ExperimentRecord.from_dict(payload)

--- a/tests/optimizer/test_schema.py
+++ b/tests/optimizer/test_schema.py
@@ -11,6 +11,7 @@ from llmtracefx.optimizer.schema import (
     Measurement,
     MetricProvenance,
     ModelInfo,
+    OutcomeInfo,
     PlatformInfo,
     RepetitionInfo,
     RuntimeInfo,
@@ -286,3 +287,76 @@ def test_command_info_from_dict_rejects_malformed_argv_entries(malformed_argv):
 def test_command_info_from_dict_accepts_list_of_strings():
     info = CommandInfo.from_dict({"argv": ["llama-cli", "-m", "model.gguf"]})
     assert info.argv == ("llama-cli", "-m", "model.gguf")
+
+
+# --- Adjacent audit: PlatformInfo / OutcomeInfo malformed float fields ------
+
+
+@pytest.mark.parametrize("malformed_value", ["8", True, [8], {}])
+def test_platform_info_from_dict_rejects_malformed_cpu_cores(malformed_value):
+    with pytest.raises(SchemaValidationError, match="cpu_cores"):
+        PlatformInfo.from_dict(
+            {
+                "os_name": "Darwin",
+                "os_version": "24.0",
+                "architecture": "arm64",
+                "cpu_cores": malformed_value,
+            }
+        )
+
+
+@pytest.mark.parametrize("malformed_value", ["24.0", True, [24]])
+def test_platform_info_from_dict_rejects_malformed_total_memory_gb(malformed_value):
+    with pytest.raises(SchemaValidationError, match="total_memory_gb"):
+        PlatformInfo.from_dict(
+            {
+                "os_name": "Darwin",
+                "os_version": "24.0",
+                "architecture": "arm64",
+                "total_memory_gb": malformed_value,
+            }
+        )
+
+
+def test_platform_info_from_dict_accepts_valid_numeric_fields():
+    platform = PlatformInfo.from_dict(
+        {
+            "os_name": "Darwin",
+            "os_version": "24.0",
+            "architecture": "arm64",
+            "cpu_cores": 18,
+            "total_memory_gb": 24,  # int is a valid float-compatible input
+        }
+    )
+    assert platform.cpu_cores == 18
+    assert platform.total_memory_gb == 24.0
+
+
+def test_platform_info_from_dict_allows_missing_and_none_numeric_fields():
+    platform = PlatformInfo.from_dict(
+        {
+            "os_name": "Darwin",
+            "os_version": "24.0",
+            "architecture": "arm64",
+            "cpu_cores": None,
+            "total_memory_gb": None,
+        }
+    )
+    assert platform.cpu_cores is None
+    assert platform.total_memory_gb is None
+
+
+@pytest.mark.parametrize("malformed_value", ["0.9", True, [0.9]])
+def test_outcome_info_from_dict_rejects_malformed_quality_score(malformed_value):
+    with pytest.raises(SchemaValidationError, match="quality_score"):
+        OutcomeInfo.from_dict({"quality_score": malformed_value})
+
+
+def test_outcome_info_from_dict_accepts_valid_quality_score():
+    outcome = OutcomeInfo.from_dict({"quality_score": 0.87})
+    assert outcome.quality_score == pytest.approx(0.87)
+
+
+def test_outcome_info_from_dict_allows_missing_quality_score():
+    outcome = OutcomeInfo.from_dict({})
+    assert outcome.quality_score is None


### PR DESCRIPTION
## Summary

This PR adds the foundation for turning LLMTraceFX into a workload-aware inference optimizer.

It introduces a versioned experiment schema, a privacy-safe environment manifest, a resumable command runner, a llama.cpp log parser, and the first evidence-based diagnostic. The diagnostic determines whether speculative decoding improved or regressed performance relative to a comparable autoregressive baseline.

No GPU or model download is required. This PR does not claim native Metal or CUDA counter collection, automatic tuning, or Qwen3.8 benchmark results.

## Evidence flow

```mermaid
flowchart LR
    C[Experiment config] --> R[Safe experiment runner]
    R --> A[Raw stdout and stderr]
    R --> M[Environment manifest]
    A --> P[llama.cpp parser]
    M --> E[Experiment record]
    P --> E
    E --> D[Speculative decoding doctor]
    D --> O[Evidence-backed diagnosis]
```

## What changed

| Component | Purpose |
|---|---|
| `optimizer/schema.py` | Defines the versioned `ExperimentRecord` used by collectors, diagnostics, and future tuning logic |
| `optimizer/manifest.py` | Captures deterministic, non-sensitive platform and package metadata |
| `optimizer/runner.py` | Runs argv commands without shell interpolation, with warmups, repetitions, timeouts, atomic artifacts, and resume support |
| `optimizer/parsers/llama_cpp.py` | Converts llama.cpp timing and speculative decoding output into normalized experiment records |
| `optimizer/doctor/speculative.py` | Compares MTP or speculative runs with comparable autoregressive baselines |
| `optimizer/cli.py` | Adds `manifest`, `run`, `parse-llama-cpp`, and `doctor speculative` commands |

## Experiment record

The schema records the information needed to reproduce and compare inference runs:

- model, tokenizer, quantization, and revisions
- runtime, backend, version, and Git revision
- hardware, operating system, and accelerator
- command arguments, seed, workload hash, and configuration hash
- warmup and measured repetition metadata
- input, context, and generated token counts
- load, tokenize, prefill, TTFT, decode, verification, and total timing
- MTP method, depth, proposed tokens, and accepted tokens
- active, cached, peak, and wired memory when available
- power, energy, task outcome, and errors when available

Every measurement declares its provenance:

```text
measured_native
measured_wall_clock
derived
estimated
```

Optional measurements remain absent when a collector cannot provide them. The schema does not manufacture values to make records look complete.

## Diagnostic behavior

The speculative decoding doctor compares runs only when their model, quantization, runtime, backend, accelerator, and workload identity match.

It reports one of four outcomes:

- `regression`
- `improvement`
- `no_significant_difference`
- `inconclusive`

It returns `inconclusive` when evidence is incomplete, runs are not comparable, repetition counts are insufficient, or measurement noise is larger than the observed difference.

## Safety and data integrity

- Commands are represented as argv arrays and run without shell interpolation.
- Failed, timed-out, or missing commands are never reported as successful.
- Result files are written atomically.
- Resume skips completed repetitions and retries failed or timed-out repetitions.
- Environment collection excludes usernames, hostnames, serial numbers, environment dumps, secrets, and home-directory paths.
- Malformed persisted records and malformed llama.cpp metrics fail explicitly.

## Example

```bash
llmtracefx-optimizer manifest --output artifacts/environment.json

llmtracefx-optimizer run \
  --config examples/experiment.json

llmtracefx-optimizer parse-llama-cpp \
  --run-id baseline-1 --model-id Qwen/Qwen3.8-27B --quantization Q4_K_M \
  --accelerator "Apple M5 Pro" \
  --stdout-file artifacts/baseline.log \
  --output artifacts/baseline.json \
  -- llama-cli -m qwen3.8-27b-q4.gguf

llmtracefx-optimizer doctor speculative \
  --baseline artifacts/baseline.json \
  --speculative artifacts/mtp.json
```

## Validation

The PR adds focused tests covering:

- schema validation and serialization, including malformed persisted-record scalars (non-numeric strings, booleans, nulls, floats-where-ints-required, and malformed `argv`) across every touched field
- manifest privacy boundaries
- llama.cpp timing and speculative counter parsing
- accelerator identity propagation and CLI `--accelerator` precedence, plus a doctor comparability test proving two otherwise-identical runs on different accelerators are correctly ruled incomparable
- runner warmups, failures, timeouts, atomic output, and resume behavior
- run comparability, noisy measurements, and speculative decoding diagnoses

The llama.cpp fixtures are synthetic parser fixtures. They are documented as non-benchmark evidence and must not be cited as Qwen3.8 performance results.

**Current status: 184 tests passing.** `ruff check`, `black --check`, `isort --check-only`, and `mypy llmtracefx/optimizer` are all clean.

## Review fixes applied

Addressed the following high-confidence review findings after the initial foundation commit:

- **Accelerator identity was dropped.** The llama.cpp parser already extracted a device hint (e.g. `Apple M5 Pro`) from `found device: ...` lines, but it never reached `PlatformInfo.accelerator`, so the doctor's comparability check couldn't tell two different GPUs apart. `build_experiment_record` now fills `platform.accelerator` from the parsed hint when the caller hasn't already supplied one; an explicit value always wins. A new `--accelerator` CLI flag on `parse-llama-cpp` lets callers supply that explicit value. Tests prove two otherwise-identical Linux/x86_64 runs on different accelerators are ruled `inconclusive`, and that matching accelerators remain comparable.
- **Malformed persisted-record scalars leaked raw `ValueError`/`TypeError`.** `RepetitionInfo`, `TokenCounts`, `SpeculativeDecodingInfo`, `PlatformInfo` (`cpu_cores`/`total_memory_gb`), and `OutcomeInfo` (`quality_score`) now route every scalar field through shared `_validate_int`/`_validate_float` helpers that reject non-numeric strings, booleans (Python's `bool` is an `int` subclass), `None` where required, and wrong-shape values with a `SchemaValidationError` naming the field, instead of an unguarded `int()`/`float()` call escaping as a raw exception. Negative values are still accepted at parse time and rejected later by `ExperimentRecord.validate()`, preserving the parse/validate split.
- **`CommandInfo.argv` accepted a scalar string.** `tuple("llama-cli")` previously silently exploded into a tuple of individual characters. `CommandInfo.from_dict` now requires a non-empty list/sequence of non-empty strings and rejects a bare string, a non-sequence, or malformed entries.

## Scope boundaries

This PR intentionally does not include:

- native Metal or CUDA hardware counters
- MLX, vLLM, or SGLang collectors
- automatic configuration search
- real Qwen3.8 benchmark results

## Next steps

1. Add MLX allocator and Metal trace collection.
2. Add Nsight and NVML ingestion for CUDA.
3. Verify workload quality alongside performance.
4. Search configurations subject to memory and quality constraints.
5. Add inference regression guards for CI.
6. Run the Qwen3.8-27B study on M5 Pro and RTX 4090.