### PR TITLE
feat(optimizer): add MLX-LM inference collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,9 +716,46 @@ uv run llmtracefx-optimizer doctor speculative \
   --speculative /tmp/mtp-1.json /tmp/mtp-2.json
 ```
 
+### Collect an MLX-LM run on Apple Silicon
+
+Install the optional MLX runtime dependencies, then point the collector at an
+existing local MLX model directory:
+
+```bash
+uv sync --extra mlx
+
+uv run llmtracefx-optimizer collect-mlx \
+  --run-id local-smoke-1 \
+  --model-path "$HOME/.cache/huggingface/hub/models--mlx-community--Llama-3.2-3B-Instruct-4bit/snapshots/<revision>" \
+  --model-id mlx-community/Llama-3.2-3B-Instruct-4bit \
+  --model-revision <revision> \
+  --quantization mlx-affine-4bit \
+  --prompt-file examples/optimizer/mlx-smoke-prompt.txt \
+  --max-tokens 64 \
+  --output-dir artifacts/local-smoke-1
+```
+
+The model directory must already exist. `collect-mlx` never downloads or
+converts model weights. It writes:
+
+- `record.json`: the canonical experiment record
+- `response.txt`: generated output
+- `environment.json`: non-sensitive package and platform metadata
+
+The collector records host wall-clock timing around model load, tokenization,
+time to first token, decode, and total execution. MLX allocator values are
+recorded as native measurements. The normal path synchronizes at phase
+boundaries only and does not force evaluation per layer or per token.
+
+An optional existing MLX-LM draft model can be supplied with
+`--draft-model-path`. Accepted draft tokens are counted from MLX-LM's
+`from_draft` signal. MLX-LM does not expose the number of proposed tokens or
+verification time through this API, so those fields remain absent. This is
+generic draft-model speculation, not native Qwen3.8 MTP.
+
 **Not yet included** (tracked as follow-up work): native Metal/CUDA
-performance-counter ingestion, MLX and CUDA/vLLM/SGLang collectors,
-automatic tuning/search, and any actual Qwen3.8-27B benchmark results.
+performance-counter ingestion, native Qwen3.8 MTP collection, CUDA/vLLM/SGLang
+collectors, automatic tuning/search, and any actual Qwen3.8-27B benchmark results.
 The fixtures under `tests/optimizer/fixtures/llama_cpp/` are synthetic,
 hand-written logs for testing the parser and doctor rule — not
 benchmark evidence (see the `PROVENANCE.md` in that directory).

--- a/examples/optimizer/mlx-smoke-prompt.txt
+++ b/examples/optimizer/mlx-smoke-prompt.txt
@@ -1,0 +1,1 @@
+Explain in two sentences why speculative decoding can reduce generation latency.

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -3,6 +3,7 @@
 Subcommands:
     manifest         Collect a CPU-only, non-sensitive environment manifest.
     run              Execute a configured experiment (warmups + measured reps).
+    collect-mlx      Run one local MLX-LM inference and record normalized evidence.
     parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
     doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
 """
@@ -15,6 +16,12 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+from .collectors.mlx import (
+    MLXCollectionConfig,
+    MLXCollectorError,
+    MLXLMRuntime,
+    collect_mlx,
+)
 from .doctor.speculative import diagnose_speculative_regression
 from .manifest import collect_environment_manifest
 from .parsers.llama_cpp import LlamaCppParseError, build_experiment_record
@@ -68,6 +75,69 @@ def _cmd_run(args: argparse.Namespace) -> int:
     )
     print(f"Artifacts written to {config.results_dir}")
     return 0 if succeeded == len(results) else 1
+
+
+def _collect_mlx_argv(args: argparse.Namespace) -> tuple[str, ...]:
+    invocation = getattr(args, "_invocation", None)
+    if invocation is not None:
+        return tuple(invocation)
+    return (
+        "llmtracefx-optimizer",
+        "collect-mlx",
+        "--run-id",
+        args.run_id,
+        "--model-path",
+        args.model_path,
+        "--model-id",
+        args.model_id,
+        "--prompt-file",
+        args.prompt_file,
+        "--output-dir",
+        args.output_dir,
+        "--max-tokens",
+        str(args.max_tokens),
+        "--seed",
+        str(args.seed),
+    )
+
+
+def _cmd_collect_mlx(args: argparse.Namespace) -> int:
+    try:
+        prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+        config = MLXCollectionConfig(
+            run_id=args.run_id,
+            model_path=Path(args.model_path),
+            model_id=args.model_id,
+            prompt=prompt,
+            output_dir=Path(args.output_dir),
+            command_argv=_collect_mlx_argv(args),
+            max_tokens=args.max_tokens,
+            seed=args.seed,
+            model_revision=args.model_revision,
+            tokenizer_revision=args.tokenizer_revision,
+            quantization=args.quantization,
+            accelerator=args.accelerator,
+            draft_model_path=(
+                Path(args.draft_model_path) if args.draft_model_path else None
+            ),
+            num_draft_tokens=args.num_draft_tokens,
+        )
+        result = collect_mlx(config, runtime=MLXLMRuntime())
+    except (OSError, UnicodeError, MLXCollectorError) as exc:
+        print(f"Failed to collect MLX evidence: {exc}", file=sys.stderr)
+        return 1
+
+    record_path = config.output_dir / "record.json"
+    print(f"MLX experiment record written to {record_path}")
+    if result.record.outcome.success:
+        return 0
+    error_message = (
+        result.record.error.message
+        if result.record.error is not None
+        else "unknown runtime failure"
+    )
+    print(f"MLX inference failed: {error_message}", file=sys.stderr)
+    return 1
 
 
 def _cmd_parse_llama_cpp(args: argparse.Namespace) -> int:
@@ -180,6 +250,44 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_parser.set_defaults(func=_cmd_run)
 
+    collect_mlx_parser = subparsers.add_parser(
+        "collect-mlx",
+        help="Run one local MLX-LM inference and record normalized evidence",
+    )
+    collect_mlx_parser.add_argument("--run-id", required=True)
+    collect_mlx_parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Existing local MLX model directory; models are never downloaded",
+    )
+    collect_mlx_parser.add_argument("--model-id", required=True)
+    collect_mlx_parser.add_argument("--model-revision", default=None)
+    collect_mlx_parser.add_argument("--tokenizer-revision", default=None)
+    collect_mlx_parser.add_argument("--quantization", default=None)
+    collect_mlx_parser.add_argument(
+        "--prompt-file",
+        required=True,
+        help="UTF-8 prompt file; prompt contents are hashed but not copied into the record",
+    )
+    collect_mlx_parser.add_argument("--output-dir", required=True)
+    collect_mlx_parser.add_argument("--max-tokens", type=int, default=128)
+    collect_mlx_parser.add_argument("--seed", type=int, default=0)
+    collect_mlx_parser.add_argument(
+        "--accelerator",
+        default=None,
+        help="Explicit accelerator name; otherwise MLX device_info is used",
+    )
+    collect_mlx_parser.add_argument(
+        "--draft-model-path",
+        default=None,
+        help=(
+            "Optional existing local MLX-LM draft model. This enables generic "
+            "draft-model speculation, not native Qwen MTP."
+        ),
+    )
+    collect_mlx_parser.add_argument("--num-draft-tokens", type=int, default=2)
+    collect_mlx_parser.set_defaults(func=_cmd_collect_mlx)
+
     parse_parser = subparsers.add_parser(
         "parse-llama-cpp",
         help="Convert llama.cpp text output into a canonical ExperimentRecord",
@@ -260,7 +368,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
-    args = parser.parse_args(argv)
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    args = parser.parse_args(raw_argv)
+    args._invocation = (parser.prog, *raw_argv)
     sys.exit(args.func(args))
 
 

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -81,7 +81,8 @@ def _collect_mlx_argv(args: argparse.Namespace) -> tuple[str, ...]:
     invocation = getattr(args, "_invocation", None)
     if invocation is not None:
         return tuple(invocation)
-    return (
+
+    reconstructed = [
         "llmtracefx-optimizer",
         "collect-mlx",
         "--run-id",
@@ -98,7 +99,19 @@ def _collect_mlx_argv(args: argparse.Namespace) -> tuple[str, ...]:
         str(args.max_tokens),
         "--seed",
         str(args.seed),
-    )
+        "--num-draft-tokens",
+        str(args.num_draft_tokens),
+    ]
+    for flag, value in (
+        ("--model-revision", args.model_revision),
+        ("--tokenizer-revision", args.tokenizer_revision),
+        ("--quantization", args.quantization),
+        ("--accelerator", args.accelerator),
+        ("--draft-model-path", args.draft_model_path),
+    ):
+        if value is not None:
+            reconstructed.extend((flag, value))
+    return tuple(reconstructed)
 
 
 def _cmd_collect_mlx(args: argparse.Namespace) -> int:

--- a/llmtracefx/optimizer/collectors/__init__.py
+++ b/llmtracefx/optimizer/collectors/__init__.py
@@ -1,0 +1,17 @@
+"""Runtime collectors that emit canonical inference optimizer evidence."""
+
+from .mlx import (
+    MLXCollectionConfig,
+    MLXCollectionResult,
+    MLXCollectorError,
+    MLXLMRuntime,
+    collect_mlx,
+)
+
+__all__ = [
+    "MLXCollectionConfig",
+    "MLXCollectionResult",
+    "MLXCollectorError",
+    "MLXLMRuntime",
+    "collect_mlx",
+]

--- a/llmtracefx/optimizer/collectors/mlx.py
+++ b/llmtracefx/optimizer/collectors/mlx.py
@@ -402,7 +402,7 @@ def collect_mlx(
         runtime.synchronize()
         generation_ended = clock()
         memory = runtime.memory_snapshot()
-    except (RuntimeError, ValueError, OSError, MemoryError) as exc:
+    except (KeyError, RuntimeError, ValueError, OSError, MemoryError) as exc:
         generation_ended = clock()
         error = ErrorInfo(category=type(exc).__name__, message=str(exc))
 

--- a/llmtracefx/optimizer/collectors/mlx.py
+++ b/llmtracefx/optimizer/collectors/mlx.py
@@ -1,0 +1,476 @@
+"""Collect normalized evidence from one MLX-LM inference run.
+
+The normal collection path synchronizes MLX only at phase boundaries. It does
+not force evaluation per layer or per token, which would materially change the
+workload being measured. Native Metal performance counters are outside this
+collector's scope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any, Protocol
+
+from ...profiler.mlx_tracer import mlx_memory_snapshot
+from ..manifest import collect_environment_manifest
+from ..schema import (
+    CommandInfo,
+    ErrorInfo,
+    ExperimentRecord,
+    Measurement,
+    MemoryMetrics,
+    MetricProvenance,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+    utc_now_iso,
+)
+
+
+class MLXCollectorError(RuntimeError):
+    """Raised when MLX collection cannot be configured or started."""
+
+
+@dataclass(frozen=True)
+class MLXMemorySnapshot:
+    """Allocator values exposed by MLX, in bytes."""
+
+    active_bytes: int | None = None
+    cache_bytes: int | None = None
+    peak_bytes: int | None = None
+
+
+class MLXGenerationResponse(Protocol):
+    """Subset of ``mlx_lm.GenerationResponse`` consumed by the collector."""
+
+    text: str
+    from_draft: bool
+    prompt_tokens: int
+    generation_tokens: int
+
+
+class MLXRuntime(Protocol):
+    """Injectable MLX-LM boundary used by the collector and its tests."""
+
+    @property
+    def mlx_version(self) -> str | None: ...
+
+    @property
+    def mlx_lm_version(self) -> str | None: ...
+
+    def load_model(self, path: Path) -> tuple[Any, Any]: ...
+
+    def encode(self, tokenizer: Any, prompt: str) -> list[int]: ...
+
+    def seed(self, seed: int) -> None: ...
+
+    def synchronize(self) -> None: ...
+
+    def reset_peak_memory(self) -> None: ...
+
+    def memory_snapshot(self) -> MLXMemorySnapshot: ...
+
+    def accelerator_name(self) -> str | None: ...
+
+    def stream_generate(
+        self,
+        model: Any,
+        tokenizer: Any,
+        prompt_tokens: list[int],
+        *,
+        max_tokens: int,
+        draft_model: Any | None,
+        num_draft_tokens: int,
+    ) -> Iterator[MLXGenerationResponse]: ...
+
+
+def _installed_version(distribution: str) -> str | None:
+    try:
+        return importlib_metadata.version(distribution)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+class MLXLMRuntime:
+    """Production adapter for MLX-LM on Apple Silicon."""
+
+    def __init__(self) -> None:
+        if platform.system() != "Darwin" or platform.machine() != "arm64":
+            raise MLXCollectorError(
+                "MLX collection requires Apple Silicon running macOS"
+            )
+        try:
+            import mlx.core as mx  # type: ignore[import-not-found]
+            from mlx_lm import load, stream_generate
+        except ImportError as exc:
+            raise MLXCollectorError(
+                "MLX collection requires the optional runtime dependencies. "
+                "Install them with `uv sync --extra mlx` or "
+                "`pip install 'llmtracefx[mlx]'`."
+            ) from exc
+
+        self._mx = mx
+        self._load = load
+        self._stream_generate = stream_generate
+
+    @property
+    def mlx_version(self) -> str | None:
+        return _installed_version("mlx")
+
+    @property
+    def mlx_lm_version(self) -> str | None:
+        return _installed_version("mlx-lm")
+
+    def load_model(self, path: Path) -> tuple[Any, Any]:
+        loaded = self._load(str(path), lazy=False, return_config=False)
+        if len(loaded) != 2:
+            raise MLXCollectorError("mlx_lm.load returned an unexpected result shape")
+        return loaded[0], loaded[1]
+
+    def encode(self, tokenizer: Any, prompt: str) -> list[int]:
+        bos_token = getattr(tokenizer, "bos_token", None)
+        add_special_tokens = bos_token is None or not prompt.startswith(bos_token)
+        encoded = tokenizer.encode(prompt, add_special_tokens=add_special_tokens)
+        return [int(token) for token in encoded]
+
+    def seed(self, seed: int) -> None:
+        self._mx.random.seed(seed)
+
+    def synchronize(self) -> None:
+        synchronize = getattr(self._mx, "synchronize", None)
+        if synchronize is None:
+            raise MLXCollectorError(
+                "This MLX version does not expose mx.synchronize(), which "
+                "phase-boundary timing depends on for correctness"
+            )
+        synchronize()
+
+    def reset_peak_memory(self) -> None:
+        reset = getattr(self._mx, "reset_peak_memory", None)
+        if reset is not None:
+            reset()
+
+    def memory_snapshot(self) -> MLXMemorySnapshot:
+        snapshot = mlx_memory_snapshot(self._mx)
+        return MLXMemorySnapshot(
+            active_bytes=snapshot.get("active_memory_bytes"),
+            cache_bytes=snapshot.get("cache_memory_bytes"),
+            peak_bytes=snapshot.get("peak_memory_bytes"),
+        )
+
+    def accelerator_name(self) -> str | None:
+        device_info_fn = getattr(self._mx, "device_info", None)
+        if device_info_fn is None:
+            metal = getattr(self._mx, "metal", None)
+            device_info_fn = (
+                getattr(metal, "device_info", None) if metal is not None else None
+            )
+        if device_info_fn is None:
+            return None
+        device_info = device_info_fn()
+        if not isinstance(device_info, dict):
+            return None
+        for key in ("device_name", "architecture"):
+            value = device_info.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def stream_generate(
+        self,
+        model: Any,
+        tokenizer: Any,
+        prompt_tokens: list[int],
+        *,
+        max_tokens: int,
+        draft_model: Any | None,
+        num_draft_tokens: int,
+    ) -> Iterator[MLXGenerationResponse]:
+        kwargs: dict[str, Any] = {"max_tokens": max_tokens}
+        if draft_model is not None:
+            kwargs["draft_model"] = draft_model
+            kwargs["num_draft_tokens"] = num_draft_tokens
+        return self._stream_generate(model, tokenizer, prompt_tokens, **kwargs)
+
+
+@dataclass(frozen=True)
+class MLXCollectionConfig:
+    """Inputs and reproducibility metadata for one local MLX-LM run."""
+
+    run_id: str
+    model_path: Path
+    model_id: str
+    prompt: str
+    output_dir: Path
+    command_argv: tuple[str, ...]
+    max_tokens: int = 128
+    seed: int = 0
+    model_revision: str | None = None
+    tokenizer_revision: str | None = None
+    quantization: str | None = None
+    accelerator: str | None = None
+    draft_model_path: Path | None = None
+    num_draft_tokens: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise MLXCollectorError("run_id must be non-empty")
+        if not self.model_id:
+            raise MLXCollectorError("model_id must be non-empty")
+        if not self.model_path.exists():
+            raise MLXCollectorError(
+                f"model_path does not exist: {self.model_path}. "
+                "Download or convert the model separately before collection."
+            )
+        if self.draft_model_path is not None and not self.draft_model_path.exists():
+            raise MLXCollectorError(
+                f"draft_model_path does not exist: {self.draft_model_path}"
+            )
+        if not self.command_argv or not all(self.command_argv):
+            raise MLXCollectorError(
+                "command_argv must contain non-empty argument strings"
+            )
+        if (
+            isinstance(self.max_tokens, bool)
+            or not isinstance(self.max_tokens, int)
+            or self.max_tokens < 1
+        ):
+            raise MLXCollectorError("max_tokens must be a positive integer")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise MLXCollectorError("seed must be an integer")
+        if (
+            isinstance(self.num_draft_tokens, bool)
+            or not isinstance(self.num_draft_tokens, int)
+            or self.num_draft_tokens < 1
+        ):
+            raise MLXCollectorError("num_draft_tokens must be a positive integer")
+
+
+@dataclass(frozen=True)
+class MLXCollectionResult:
+    """Canonical record plus the generated response text."""
+
+    record: ExperimentRecord
+    response_text: str
+
+
+def _sha256_text(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _config_hash(config: MLXCollectionConfig) -> str:
+    payload = {
+        "model_id": config.model_id,
+        "model_revision": config.model_revision,
+        "tokenizer_revision": config.tokenizer_revision,
+        "quantization": config.quantization,
+        "max_tokens": config.max_tokens,
+        "seed": config.seed,
+        "draft_enabled": config.draft_model_path is not None,
+        "num_draft_tokens": config.num_draft_tokens,
+    }
+    return _sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _milliseconds(started: float | None, ended: float | None) -> Measurement | None:
+    if started is None or ended is None:
+        return None
+    return Measurement(
+        value=max(0.0, ended - started) * 1000,
+        provenance=MetricProvenance.MEASURED_WALL_CLOCK,
+        unit="ms",
+    )
+
+
+def _bytes_measurement(value: int | None) -> Measurement | None:
+    if value is None:
+        return None
+    return Measurement(
+        value=float(value),
+        provenance=MetricProvenance.MEASURED_NATIVE,
+        unit="bytes",
+    )
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _record_platform(
+    runtime: MLXRuntime, accelerator_override: str | None
+) -> PlatformInfo:
+    manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm"))
+    accelerator = accelerator_override or runtime.accelerator_name()
+    return PlatformInfo(
+        os_name=manifest.os_name,
+        os_version=manifest.os_release,
+        architecture=manifest.architecture,
+        cpu_cores=manifest.cpu_count,
+        total_memory_gb=manifest.total_memory_gb,
+        accelerator=accelerator,
+    )
+
+
+def collect_mlx(
+    config: MLXCollectionConfig,
+    *,
+    runtime: MLXRuntime,
+    clock: Callable[[], float] = time.perf_counter,
+) -> MLXCollectionResult:
+    """Run one MLX-LM generation and persist normalized evidence.
+
+    Runtime failures are represented as failed experiment records. Invalid
+    collector configuration and artifact write failures remain explicit
+    exceptions.
+    """
+
+    started_at = utc_now_iso()
+    total_started = clock()
+    load_started: float | None = None
+    load_ended: float | None = None
+    tokenize_started: float | None = None
+    tokenize_ended: float | None = None
+    generation_started: float | None = None
+    first_token_at: float | None = None
+    generation_ended: float | None = None
+    prompt_tokens: list[int] = []
+    generated_tokens = 0
+    accepted_draft_tokens = 0
+    response_parts: list[str] = []
+    memory = MLXMemorySnapshot()
+    error: ErrorInfo | None = None
+
+    try:
+        load_started = clock()
+        model, tokenizer = runtime.load_model(config.model_path)
+        draft_model = (
+            runtime.load_model(config.draft_model_path)[0]
+            if config.draft_model_path is not None
+            else None
+        )
+        runtime.synchronize()
+        load_ended = clock()
+
+        runtime.reset_peak_memory()
+        tokenize_started = clock()
+        prompt_tokens = runtime.encode(tokenizer, config.prompt)
+        tokenize_ended = clock()
+        runtime.seed(config.seed)
+        runtime.synchronize()
+
+        generation_started = clock()
+        previous_generation_tokens = 0
+        for response in runtime.stream_generate(
+            model,
+            tokenizer,
+            prompt_tokens,
+            max_tokens=config.max_tokens,
+            draft_model=draft_model,
+            num_draft_tokens=config.num_draft_tokens,
+        ):
+            observed_at = clock()
+            if first_token_at is None:
+                first_token_at = observed_at
+            response_parts.append(response.text)
+            if response.generation_tokens > previous_generation_tokens:
+                if response.from_draft:
+                    accepted_draft_tokens += 1
+                previous_generation_tokens = response.generation_tokens
+            generated_tokens = max(generated_tokens, response.generation_tokens)
+
+        runtime.synchronize()
+        generation_ended = clock()
+        memory = runtime.memory_snapshot()
+    except (RuntimeError, ValueError, OSError, MemoryError) as exc:
+        generation_ended = clock()
+        error = ErrorInfo(category=type(exc).__name__, message=str(exc))
+
+    total_ended = clock()
+    record = ExperimentRecord(
+        run_id=config.run_id,
+        started_at=started_at,
+        ended_at=utc_now_iso(),
+        platform=_record_platform(runtime, config.accelerator),
+        model=ModelInfo(
+            model_id=config.model_id,
+            model_revision=config.model_revision,
+            tokenizer_revision=config.tokenizer_revision,
+            quantization=config.quantization,
+        ),
+        runtime=RuntimeInfo(
+            name="mlx-lm",
+            version=runtime.mlx_lm_version,
+            backend="Metal",
+            git_revision=None,
+        ),
+        command=CommandInfo(
+            argv=config.command_argv,
+            config_hash=_config_hash(config),
+            workload_hash=_sha256_text(config.prompt),
+        ),
+        repetition=RepetitionInfo(
+            warmup_repetitions=0,
+            measured_repetitions=1,
+            repetition_index=0,
+            seed=config.seed,
+        ),
+        tokens=TokenCounts(
+            input_tokens=len(prompt_tokens) if prompt_tokens else None,
+            context_tokens=len(prompt_tokens) if prompt_tokens else None,
+            generated_tokens=generated_tokens or None,
+        ),
+        timing=TimingMetrics(
+            model_load=_milliseconds(load_started, load_ended),
+            tokenize=_milliseconds(tokenize_started, tokenize_ended),
+            prefill=_milliseconds(generation_started, first_token_at),
+            decode=_milliseconds(first_token_at, generation_ended),
+            total=_milliseconds(total_started, total_ended),
+        ),
+        speculative=SpeculativeDecodingInfo(
+            enabled=config.draft_model_path is not None,
+            method=("draft-model" if config.draft_model_path is not None else None),
+            configured_depth=(
+                config.num_draft_tokens if config.draft_model_path is not None else None
+            ),
+            proposed_tokens=None,
+            accepted_tokens=(
+                accepted_draft_tokens if config.draft_model_path is not None else None
+            ),
+            verification_time=None,
+        ),
+        memory=MemoryMetrics(
+            active=_bytes_measurement(memory.active_bytes),
+            cache=_bytes_measurement(memory.cache_bytes),
+            peak=_bytes_measurement(memory.peak_bytes),
+            wired=None,
+        ),
+        outcome=OutcomeInfo(success=error is None),
+        error=error,
+    )
+    record.validate()
+
+    response_text = "".join(response_parts)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    record.write_json(config.output_dir / "record.json")
+    _atomic_write_text(config.output_dir / "response.txt", response_text)
+    manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm"))
+    _atomic_write_text(
+        config.output_dir / "environment.json", manifest.to_json() + "\n"
+    )
+    return MLXCollectionResult(record=record, response_text=response_text)

--- a/llmtracefx/optimizer/collectors/mlx.py
+++ b/llmtracefx/optimizer/collectors/mlx.py
@@ -60,6 +60,7 @@ class MLXGenerationResponse(Protocol):
     from_draft: bool
     prompt_tokens: int
     generation_tokens: int
+    finish_reason: str | None
 
 
 class MLXRuntime(Protocol):
@@ -388,11 +389,15 @@ def collect_mlx(
             if first_token_at is None:
                 first_token_at = observed_at
             response_parts.append(response.text)
-            if response.generation_tokens > previous_generation_tokens:
+            is_eos_summary = response.finish_reason == "stop"
+            if (
+                response.generation_tokens > previous_generation_tokens
+                and not is_eos_summary
+            ):
                 if response.from_draft:
                     accepted_draft_tokens += 1
                 previous_generation_tokens = response.generation_tokens
-            generated_tokens = max(generated_tokens, response.generation_tokens)
+                generated_tokens = response.generation_tokens
 
         runtime.synchronize()
         generation_ended = clock()

--- a/llmtracefx/profiler/__init__.py
+++ b/llmtracefx/profiler/__init__.py
@@ -1,5 +1,5 @@
 """Profiling helpers exposed by LLMTraceFX."""
 
-from .mlx_tracer import MLXTraceRecorder
+from .mlx_tracer import MLXTraceRecorder, mlx_memory_snapshot
 
-__all__ = ["MLXTraceRecorder"]
+__all__ = ["MLXTraceRecorder", "mlx_memory_snapshot"]

--- a/llmtracefx/profiler/mlx_tracer.py
+++ b/llmtracefx/profiler/mlx_tracer.py
@@ -10,6 +10,28 @@ from typing import Any
 PathLike = str | Path
 
 
+def mlx_memory_snapshot(mlx_module: Any) -> dict[str, int]:
+    """Best-effort MLX allocator memory snapshot for an ``mx``-like module.
+
+    Reads whichever of ``get_active_memory``/``get_peak_memory``/
+    ``get_cache_memory`` the installed MLX build exposes and omits the
+    rest, rather than guessing a value for an unavailable counter. Shared
+    by :class:`MLXTraceRecorder` and the ``llmtracefx.optimizer``
+    MLX collector so both report identical key names for the same
+    underlying allocator counters.
+    """
+    snapshot: dict[str, int] = {}
+    for function_name, output_name in (
+        ("get_active_memory", "active_memory_bytes"),
+        ("get_peak_memory", "peak_memory_bytes"),
+        ("get_cache_memory", "cache_memory_bytes"),
+    ):
+        function = getattr(mlx_module, function_name, None)
+        if function is not None:
+            snapshot[output_name] = int(function())
+    return snapshot
+
+
 class MLXTraceRecorder:
     """Record synchronized MLX operations at token granularity.
 
@@ -189,16 +211,7 @@ class MLXTraceRecorder:
         return self._json_safe_dict(device_info()) if device_info else {}
 
     def _memory_snapshot(self) -> dict[str, int]:
-        snapshot: dict[str, int] = {}
-        for function_name, output_name in (
-            ("get_active_memory", "active_memory_bytes"),
-            ("get_peak_memory", "peak_memory_bytes"),
-            ("get_cache_memory", "cache_memory_bytes"),
-        ):
-            function = getattr(self._mlx, function_name, None)
-            if function is not None:
-                snapshot[output_name] = int(function())
-        return snapshot
+        return mlx_memory_snapshot(self._mlx)
 
     def _metal_api(self) -> Any:
         metal = getattr(self._mlx, "metal", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
 
 mlx = [
     "mlx>=0.25.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.31.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 
 docs = [

--- a/tests/optimizer/test_mlx_collector.py
+++ b/tests/optimizer/test_mlx_collector.py
@@ -36,6 +36,7 @@ class FakeResponse:
     from_draft: bool
     prompt_tokens: int
     generation_tokens: int
+    finish_reason: str | None = None
 
 
 class FakeRuntime:
@@ -207,6 +208,40 @@ def test_collect_mlx_records_generic_draft_acceptance_without_inventing_proposal
     assert record.speculative.accepted_tokens == 1
     assert record.speculative.proposed_tokens is None
     assert record.speculative.verification_time is None
+
+
+def test_eos_summary_does_not_inflate_generated_or_accepted_tokens(tmp_path):
+    draft_path = tmp_path / "draft"
+    draft_path.mkdir()
+    runtime = FakeRuntime()
+    runtime.responses = [
+        FakeResponse("hello", False, 3, 1),
+        FakeResponse(" world", True, 3, 2),
+        FakeResponse("", True, 3, 3, finish_reason="stop"),
+    ]
+
+    result = collect_mlx(
+        make_config(tmp_path, draft_model_path=draft_path),
+        runtime=runtime,
+        clock=StepClock(),
+    )
+
+    assert result.response_text == "hello world"
+    assert result.record.tokens.generated_tokens == 2
+    assert result.record.speculative.accepted_tokens == 1
+
+
+def test_length_summary_counts_the_final_generated_token(tmp_path):
+    runtime = FakeRuntime()
+    runtime.responses = [
+        FakeResponse("hello", False, 3, 1),
+        FakeResponse(" world", False, 3, 2, finish_reason="length"),
+    ]
+
+    result = collect_mlx(make_config(tmp_path), runtime=runtime, clock=StepClock())
+
+    assert result.response_text == "hello world"
+    assert result.record.tokens.generated_tokens == 2
 
 
 def test_collect_mlx_leaves_unavailable_allocator_metrics_absent(tmp_path):

--- a/tests/optimizer/test_mlx_collector.py
+++ b/tests/optimizer/test_mlx_collector.py
@@ -1,0 +1,278 @@
+"""Tests for normalized MLX-LM experiment collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from llmtracefx.optimizer.collectors.mlx import (
+    MLXCollectionConfig,
+    MLXCollectorError,
+    MLXLMRuntime,
+    MLXMemorySnapshot,
+    collect_mlx,
+)
+from llmtracefx.optimizer.schema import (
+    ExperimentRecord,
+    MetricProvenance,
+)
+
+
+class StepClock:
+    def __init__(self, step: float = 0.01):
+        self.value = 0.0
+        self.step = step
+
+    def __call__(self):
+        current = self.value
+        self.value += self.step
+        return current
+
+
+@dataclass
+class FakeResponse:
+    text: str
+    from_draft: bool
+    prompt_tokens: int
+    generation_tokens: int
+
+
+class FakeRuntime:
+    mlx_version = "0.32.0"
+    mlx_lm_version = "0.31.3"
+
+    def __init__(self):
+        self.load_calls = []
+        self.synchronize_calls = 0
+        self.reset_peak_calls = 0
+        self.seed_calls = []
+        self.generate_calls = []
+        self.responses = [
+            FakeResponse("hello", False, 3, 1),
+            FakeResponse(" world", True, 3, 2),
+        ]
+        self.snapshot = MLXMemorySnapshot(
+            active_bytes=1024,
+            cache_bytes=256,
+            peak_bytes=2048,
+        )
+
+    def load_model(self, path):
+        self.load_calls.append(path)
+        return object(), FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        assert isinstance(tokenizer, FakeTokenizer)
+        assert prompt == "test prompt"
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        self.seed_calls.append(seed)
+
+    def synchronize(self):
+        self.synchronize_calls += 1
+
+    def reset_peak_memory(self):
+        self.reset_peak_calls += 1
+
+    def memory_snapshot(self):
+        return self.snapshot
+
+    def accelerator_name(self):
+        return "Apple M5 Pro"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        self.generate_calls.append(
+            {
+                "prompt_tokens": prompt_tokens,
+                "max_tokens": max_tokens,
+                "draft_model": draft_model,
+                "num_draft_tokens": num_draft_tokens,
+            }
+        )
+        yield from self.responses
+
+
+class FakeTokenizer:
+    bos_token = None
+
+
+class FailingRuntime(FakeRuntime):
+    def load_model(self, path):
+        raise RuntimeError("model load failed")
+
+
+def make_config(tmp_path, **overrides):
+    model_path = tmp_path / "model"
+    model_path.mkdir(exist_ok=True)
+    values = {
+        "run_id": "mlx-run-1",
+        "model_path": model_path,
+        "model_id": "local/test-model",
+        "prompt": "test prompt",
+        "output_dir": tmp_path / "artifacts",
+        "command_argv": (
+            "llmtracefx-optimizer",
+            "collect-mlx",
+            "--model-path",
+            str(model_path),
+        ),
+        "max_tokens": 16,
+        "seed": 7,
+        "quantization": "4bit",
+    }
+    values.update(overrides)
+    return MLXCollectionConfig(**values)
+
+
+def test_collect_mlx_writes_normalized_record_and_response(tmp_path):
+    runtime = FakeRuntime()
+    result = collect_mlx(
+        make_config(tmp_path),
+        runtime=runtime,
+        clock=StepClock(),
+    )
+
+    record = result.record
+    assert record.outcome.success is True
+    assert record.platform.accelerator == "Apple M5 Pro"
+    assert record.runtime.name == "mlx-lm"
+    assert record.runtime.version == "0.31.3"
+    assert record.runtime.backend == "Metal"
+    assert record.tokens.input_tokens == 3
+    assert record.tokens.context_tokens == 3
+    assert record.tokens.generated_tokens == 2
+    assert record.command.workload_hash.startswith("sha256:")
+    assert record.command.config_hash.startswith("sha256:")
+    assert record.timing.prefill.provenance == MetricProvenance.MEASURED_WALL_CLOCK
+    assert record.timing.decode.provenance == MetricProvenance.MEASURED_WALL_CLOCK
+    assert record.memory.active.value == 1024
+    assert record.memory.active.provenance == MetricProvenance.MEASURED_NATIVE
+    assert record.memory.cache.value == 256
+    assert record.memory.peak.value == 2048
+    assert record.memory.wired is None
+    assert record.speculative.enabled is False
+    assert result.response_text == "hello world"
+
+    persisted = ExperimentRecord.read_json(tmp_path / "artifacts" / "record.json")
+    assert persisted == record
+    assert (tmp_path / "artifacts" / "response.txt").read_text() == "hello world"
+    assert (tmp_path / "artifacts" / "environment.json").exists()
+    assert runtime.seed_calls == [7]
+    assert runtime.reset_peak_calls == 1
+
+
+def test_normal_collection_synchronizes_only_at_phase_boundaries(tmp_path):
+    runtime = FakeRuntime()
+    runtime.responses = [
+        FakeResponse(str(index), False, 3, index + 1) for index in range(20)
+    ]
+
+    collect_mlx(make_config(tmp_path), runtime=runtime, clock=StepClock())
+
+    assert runtime.synchronize_calls == 3
+
+
+def test_collect_mlx_records_generic_draft_acceptance_without_inventing_proposals(
+    tmp_path,
+):
+    draft_path = tmp_path / "draft"
+    draft_path.mkdir()
+    runtime = FakeRuntime()
+
+    record = collect_mlx(
+        make_config(
+            tmp_path,
+            draft_model_path=draft_path,
+            num_draft_tokens=4,
+        ),
+        runtime=runtime,
+        clock=StepClock(),
+    ).record
+
+    assert runtime.load_calls == [tmp_path / "model", draft_path]
+    assert record.speculative.enabled is True
+    assert record.speculative.method == "draft-model"
+    assert record.speculative.configured_depth == 4
+    assert record.speculative.accepted_tokens == 1
+    assert record.speculative.proposed_tokens is None
+    assert record.speculative.verification_time is None
+
+
+def test_collect_mlx_leaves_unavailable_allocator_metrics_absent(tmp_path):
+    runtime = FakeRuntime()
+    runtime.snapshot = MLXMemorySnapshot()
+
+    record = collect_mlx(
+        make_config(tmp_path), runtime=runtime, clock=StepClock()
+    ).record
+
+    assert record.memory.active is None
+    assert record.memory.cache is None
+    assert record.memory.peak is None
+
+
+def test_explicit_accelerator_overrides_runtime_detection(tmp_path):
+    record = collect_mlx(
+        make_config(tmp_path, accelerator="Test accelerator"),
+        runtime=FakeRuntime(),
+        clock=StepClock(),
+    ).record
+
+    assert record.platform.accelerator == "Test accelerator"
+
+
+def test_runtime_failure_is_persisted_without_success_fallback(tmp_path):
+    result = collect_mlx(
+        make_config(tmp_path),
+        runtime=FailingRuntime(),
+        clock=StepClock(),
+    )
+
+    assert result.record.outcome.success is False
+    assert result.record.error.category == "RuntimeError"
+    assert result.record.error.message == "model load failed"
+    assert result.record.timing.total is not None
+    assert result.record.timing.model_load is None
+    persisted = ExperimentRecord.read_json(tmp_path / "artifacts" / "record.json")
+    assert persisted.outcome.success is False
+
+
+def test_missing_model_path_is_rejected_without_downloading(tmp_path):
+    with pytest.raises(MLXCollectorError, match="Download or convert"):
+        make_config(tmp_path, model_path=tmp_path / "missing")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"max_tokens": True},
+        {"max_tokens": 1.5},
+        {"max_tokens": 0},
+        {"seed": False},
+        {"seed": "0"},
+        {"num_draft_tokens": True},
+        {"num_draft_tokens": 0},
+    ],
+)
+def test_collection_config_rejects_malformed_numeric_values(tmp_path, overrides):
+    with pytest.raises(MLXCollectorError):
+        make_config(tmp_path, **overrides)
+
+
+def test_runtime_rejects_non_apple_platform_before_import(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+
+    with pytest.raises(MLXCollectorError, match="Apple Silicon"):
+        MLXLMRuntime()

--- a/tests/optimizer/test_mlx_collector.py
+++ b/tests/optimizer/test_mlx_collector.py
@@ -113,6 +113,11 @@ class FailingRuntime(FakeRuntime):
         raise RuntimeError("model load failed")
 
 
+class MalformedModelRuntime(FakeRuntime):
+    def load_model(self, path):
+        raise KeyError("model_type")
+
+
 def make_config(tmp_path, **overrides):
     model_path = tmp_path / "model"
     model_path.mkdir(exist_ok=True)
@@ -281,6 +286,20 @@ def test_runtime_failure_is_persisted_without_success_fallback(tmp_path):
     assert result.record.timing.model_load is None
     persisted = ExperimentRecord.read_json(tmp_path / "artifacts" / "record.json")
     assert persisted.outcome.success is False
+
+
+def test_malformed_local_model_is_persisted_without_traceback(tmp_path):
+    result = collect_mlx(
+        make_config(tmp_path),
+        runtime=MalformedModelRuntime(),
+        clock=StepClock(),
+    )
+
+    assert result.record.outcome.success is False
+    assert result.record.error.category == "KeyError"
+    assert "model_type" in result.record.error.message
+    persisted = ExperimentRecord.read_json(tmp_path / "artifacts" / "record.json")
+    assert persisted.error.category == "KeyError"
 
 
 def test_missing_model_path_is_rejected_without_downloading(tmp_path):

--- a/tests/optimizer/test_mlx_collector_cli.py
+++ b/tests/optimizer/test_mlx_collector_cli.py
@@ -1,0 +1,120 @@
+"""CLI tests for local MLX evidence collection."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from llmtracefx.optimizer import cli
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.schema import ExperimentRecord
+
+
+@dataclass
+class FakeResponse:
+    text: str = "ok"
+    from_draft: bool = False
+    prompt_tokens: int = 2
+    generation_tokens: int = 1
+
+
+class FakeTokenizer:
+    bos_token = None
+
+
+class FakeRuntime:
+    mlx_version = "0.32.0"
+    mlx_lm_version = "0.31.3"
+
+    def __init__(self):
+        self.snapshot = MLXMemorySnapshot()
+
+    def load_model(self, path):
+        return object(), FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        return [1, 2]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return self.snapshot
+
+    def accelerator_name(self):
+        return "Apple M5 Pro"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        yield FakeResponse()
+
+
+def test_collect_mlx_cli_uses_local_paths_and_writes_evidence(tmp_path, monkeypatch):
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("test prompt", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    runtime = FakeRuntime()
+    runtime.snapshot = MLXMemorySnapshot(active_bytes=42)
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: runtime)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "collect-mlx",
+            "--run-id",
+            "cli-mlx-1",
+            "--model-path",
+            str(model_path),
+            "--model-id",
+            "local/test-model",
+            "--prompt-file",
+            str(prompt_path),
+            "--output-dir",
+            str(output_dir),
+            "--quantization",
+            "4bit",
+        ]
+    )
+
+    assert args.func(args) == 0
+    record = ExperimentRecord.read_json(output_dir / "record.json")
+    assert record.run_id == "cli-mlx-1"
+    assert record.model.quantization == "4bit"
+    assert record.memory.active.value == 42
+    assert Path(record.command.argv[0]).name == "llmtracefx-optimizer"
+
+
+def test_collect_mlx_cli_reports_missing_prompt_without_traceback(tmp_path, capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "collect-mlx",
+            "--run-id",
+            "cli-mlx-1",
+            "--model-path",
+            str(tmp_path / "model"),
+            "--model-id",
+            "local/test-model",
+            "--prompt-file",
+            str(tmp_path / "missing.txt"),
+            "--output-dir",
+            str(tmp_path / "artifacts"),
+        ]
+    )
+
+    assert args.func(args) == 1
+    assert "Failed to collect MLX evidence" in capsys.readouterr().err

--- a/tests/optimizer/test_mlx_collector_cli.py
+++ b/tests/optimizer/test_mlx_collector_cli.py
@@ -14,6 +14,7 @@ class FakeResponse:
     from_draft: bool = False
     prompt_tokens: int = 2
     generation_tokens: int = 1
+    finish_reason: str | None = None
 
 
 class FakeTokenizer:
@@ -96,6 +97,66 @@ def test_collect_mlx_cli_uses_local_paths_and_writes_evidence(tmp_path, monkeypa
     assert record.model.quantization == "4bit"
     assert record.memory.active.value == 42
     assert Path(record.command.argv[0]).name == "llmtracefx-optimizer"
+
+
+def test_collect_mlx_cli_fallback_records_all_reproducibility_flags(
+    tmp_path, monkeypatch
+):
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    draft_path = tmp_path / "draft"
+    draft_path.mkdir()
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("test prompt", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.setattr(cli, "MLXLMRuntime", FakeRuntime)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "collect-mlx",
+            "--run-id",
+            "cli-mlx-2",
+            "--model-path",
+            str(model_path),
+            "--model-id",
+            "local/test-model",
+            "--model-revision",
+            "model-sha",
+            "--tokenizer-revision",
+            "tokenizer-sha",
+            "--quantization",
+            "4bit",
+            "--accelerator",
+            "Apple M5 Pro",
+            "--draft-model-path",
+            str(draft_path),
+            "--num-draft-tokens",
+            "4",
+            "--prompt-file",
+            str(prompt_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert args.func(args) == 0
+    argv = ExperimentRecord.read_json(output_dir / "record.json").command.argv
+    for expected in (
+        "--model-revision",
+        "model-sha",
+        "--tokenizer-revision",
+        "tokenizer-sha",
+        "--quantization",
+        "4bit",
+        "--accelerator",
+        "Apple M5 Pro",
+        "--draft-model-path",
+        str(draft_path),
+        "--num-draft-tokens",
+        "4",
+    ):
+        assert expected in argv
 
 
 def test_collect_mlx_cli_reports_missing_prompt_without_traceback(tmp_path, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -570,6 +570,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -653,6 +662,16 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+]
+
+[[package]]
 name = "hpack"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -723,6 +742,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
 ]
 
 [[package]]
@@ -844,6 +883,7 @@ docs = [
 ]
 mlx = [
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 test = [
     { name = "httpx" },
@@ -864,6 +904,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.25.0" },
+    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.31.0" },
     { name = "modal", specifier = ">=0.57.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "numpy", specifier = ">=1.25.2" },
@@ -1131,6 +1172,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/90/5e49c183f9024f86dc1f038866ccd743aaec1fe412a7e7dc76fec9271f48/mlx-0.32.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2ee79b1f8c2c2a329afc95ece7dce0be798d43f3de771a6370d2b9f9702bbd9a", size = 561387, upload-time = "2026-07-07T17:56:05.177Z" },
     { url = "https://files.pythonhosted.org/packages/dc/33/e3d7f7a18331523762e9968b6716e81514649af81ffd9ba4364e3df95823/mlx-0.32.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e0db558267bb2d13fac4f85674456adbe0f085c570b9219e03d4e95fdc11c4d0", size = 561389, upload-time = "2026-07-07T17:56:06.743Z" },
     { url = "https://files.pythonhosted.org/packages/c2/58/bd847d3fed65296573a4bb3399adde6934c0a718813b5636000d7d1b4063/mlx-0.32.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:23e83c8e74a23156696e9f9905d16a17b7d27b5a596c1bc0f720a98df1c5aadf", size = 561392, upload-time = "2026-07-07T17:56:08.237Z" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
 ]
 
 [[package]]
@@ -2153,6 +2213,28 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/13/bbf7d9d1887fe4a3693527c6caa232c197ea9da91f1212e9672eff60329d/regex-2026.7.19-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:555497390743af1a65045fa4527782d10ff5b88970359412baa4a1e628fe393b", size = 494009, upload-time = "2026-07-19T00:16:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/cefe4f051302ca298d3f3e79ed6dbd933ac84485b9515acdd6a52d70cef7/regex-2026.7.19-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ebee1ee89c39c953baac6924fcde08c5bb427c4057510862f9d7c7bdb3d8665", size = 290633, upload-time = "2026-07-19T00:16:17.182Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cef4de2bac939280b68d32adc659478845238a8274f2f79c465063f590ad/regex-2026.7.19-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac777001cdfc28b72477d93c8564bb7583081ea8fb45cdca3d568e0a4f87183c", size = 494012, upload-time = "2026-07-19T00:16:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/2360c41d8080a3d9ec7e5c90fad6eab3b50192869d10e9a5609e48c8177b/regex-2026.7.19-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90c633e7e8d6bf4e992b8b36ce69e018f834b641dd6de8cea6d78c06ffa119c5", size = 290615, upload-time = "2026-07-19T00:16:43.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2333,6 +2415,37 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/33/ea3cb3839607eb175da835244a798f797f478c5ddf0e8ecdf57ea85a4c70/sentencepiece-0.2.2.tar.gz", hash = "sha256:3d2b5e824b5622038dc7b490897efe05ebbbb9e7350fc142f3ecc8789ef9bdf6", size = 8218435, upload-time = "2026-07-12T08:39:34.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/1b/e6c69e4c2026ed575d68dda2847a404468ca7b5fa684bb0b19f71d82d29d/sentencepiece-0.2.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bc7b0b1da20f856bfac5f84b2673fe534b167e41980b27442ca8f78c2b7eb77e", size = 2180607, upload-time = "2026-07-12T08:38:01.018Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/3d43a75dd5a22503ca5074d0d37707cabb2e4a71b4bc6e6c61be3643cc7a/sentencepiece-0.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f1f61592e7cabd45d49ce8cc0ef42ca655c091e037153754fb3fa59725b5914", size = 1345667, upload-time = "2026-07-12T08:38:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/f23a2efaa0210b883574001b88fa64e499f798f0848a0b610fb9b384d162/sentencepiece-0.2.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:69e9dc8078e128286ed3b975e37c837ba96e215a50c3ef9f3f8b7ab9e5a832a0", size = 2184255, upload-time = "2026-07-12T08:38:14.855Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/92/3a6ea4a2c6dd9e7062698a5a33534ca0e20844883338ae9c6b9c122c1a9f/sentencepiece-0.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:443ac618c7a2a1377cf5c82581fbb849591d14e656d5e5a3e4682d4e36a34e4e", size = 1346997, upload-time = "2026-07-12T08:38:18.499Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/13/7a562289c8d5b49ebdf3f9c1e8ab67cf14a8743b1d90c8f406bfdec36b72/sentencepiece-0.2.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1edb10e520e4bddf74d85b0f5ae74cc2d60c2b448885080bfb618bc2b3a49f6b", size = 2188384, upload-time = "2026-07-12T08:38:28.486Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/44/caa9cab5f261a019e2808bc5046152775dc57352ba9cbae7525e9e7a1ed4/sentencepiece-0.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:38111ed1f79268f399c505028023d5eaaf0ab4e5eafceb709468b0d3323e7838", size = 1347176, upload-time = "2026-07-12T08:38:32.211Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/b3b05095c174d6e80d37d5ddc2f57c2c56237333e7bbd6079cf3243c2a8a/sentencepiece-0.2.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:77c3ce990b23441e5ecfa5bce181fd6f408b564aeb6d7e1d1e7de9c5612501c8", size = 2188346, upload-time = "2026-07-12T08:38:41.089Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/f9ea1a6844b4fa5dfe2312095cd866a1f724cd0905054ab9d5991778ba50/sentencepiece-0.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:201a8e0f55501a76e08dbf2c54bc45f4642b379271e89c667d517bfbc2191f2a", size = 1347267, upload-time = "2026-07-12T08:38:44.389Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9c/dfc82846460e7a712310f5613f23d8b553cabb4e2e648663c11d8382af56/sentencepiece-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:72b7825b331b1b7e7c45be2e674b3e3c65af608fa376bad2d851b20aaf0cdc78", size = 2223080, upload-time = "2026-07-12T08:38:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5a/16d51d05360be4cee3ebfe4837c184054c4eed16cabaeb3b039524e9a000/sentencepiece-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ab3f1ae98970b5590e2209341522718900ba19bcc2c207ffaa6bd417ad960c5", size = 1361138, upload-time = "2026-07-12T08:38:58.808Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/f5df63edb6bcb46c1343cfa5d9192d73a4eb61af2e800d9402efff387523/sentencepiece-0.2.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c62bd361cec1f5b556eb8210264ecfff37486cd990c3386cc00310f26c54090a", size = 2190240, upload-time = "2026-07-12T08:39:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/823954c9c90e74eba09fb96752dc37a5555df00d69866cb9406d1725dc7e/sentencepiece-0.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:79bac5a251f23a7341e28fda9ce0d5319edf45328239ce037c0682936f137906", size = 1348056, upload-time = "2026-07-12T08:39:11.744Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c4/7afe8c2315b76e46818851a057e50a378a0382aa00b970a1fa444181b6f6/sentencepiece-0.2.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d254c98ca6387655400b3959c33c83efd807f5edeb608e3aca45800ceaa77151", size = 2223281, upload-time = "2026-07-12T08:39:20.978Z" },
+    { url = "https://files.pythonhosted.org/packages/78/52/ffe402b13bce1889228a98dc6cd86ae8afac1112362236be3468be784441/sentencepiece-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7fc14c1585139fa6b68775e616a6b90cf622ebf219f9558c0aeaf5d253ee6c9b", size = 1361736, upload-time = "2026-07-12T08:39:24.602Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2445,6 +2558,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2509,6 +2634,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/18/e3f902a1d21f14035b5bc6246a8c0f51e0eef562ace3a2cea403c1fb7021/tornado-6.5.1-cp39-abi3-win32.whl", hash = "sha256:e0a36e1bc684dca10b1aa75a31df8bdfed656831489bc1e6a6ebed05dc1ec365", size = 444396, upload-time = "2025-05-22T18:15:34.205Z" },
     { url = "https://files.pythonhosted.org/packages/7b/09/6526e32bf1049ee7de3bebba81572673b19a2a8541f795d887e92af1a8bc/tornado-6.5.1-cp39-abi3-win_amd64.whl", hash = "sha256:908e7d64567cecd4c2b458075589a775063453aeb1d2a1853eedb806922f568b", size = 444840, upload-time = "2025-05-22T18:15:36.1Z" },
     { url = "https://files.pythonhosted.org/packages/55/a7/535c44c7bea4578e48281d83c615219f3ab19e6abc67625ef637c73987be/tornado-6.5.1-cp39-abi3-win_arm64.whl", hash = "sha256:02420a0eb7bf617257b9935e2b754d1b63897525d8a289c9d65690d580b4dcf7", size = 443596, upload-time = "2025-05-22T18:15:37.433Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "python_version < '0'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2e/ba418680ab901dae269360bb8642485eae04f1af91ee2ebb8bd6f3607305/transformers-5.16.1.tar.gz", hash = "sha256:17b0eac726ddc55e84ac58946063e0c6d37fd000c456b581f050ea0f4e822869", size = 9650542, upload-time = "2026-08-26T14:48:58.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/4d/ee3728674c0bbc637bb4af88ccf0be697f92e4e90b55f5dc110c44d61b61/transformers-5.16.1-py3-none-any.whl", hash = "sha256:2f2d5b98a5ad3718713653734298fa620754ed683702a635ebb587df3ed29c7e", size = 12080592, upload-time = "2026-08-26T14:48:55.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `llmtracefx-optimizer collect-mlx`, the first hardware-facing collector for the inference optimizer.

The command runs one inference against an existing local MLX-LM model and writes a canonical `ExperimentRecord`. It captures reproducibility metadata, phase timing, MLX allocator values, generated output, and generic draft-model attribution without downloading model weights or claiming access to native Metal hardware counters.

## Data flow

```mermaid
flowchart LR
    CLI[collect-mlx] --> C[Validated collection config]
    C --> R[MLX runtime adapter]
    R --> G[MLX-LM generation]
    G --> E[Canonical experiment record]
    E --> A[record.json]
    G --> O[response.txt]
    R --> M[environment.json]
```

## Collected evidence

| Area | Evidence |
|---|---|
| Model | ID, model revision, tokenizer revision, quantization, local model path invocation |
| Runtime | MLX-LM version, MLX package version, Metal backend, accelerator identity |
| Workload | Prompt SHA-256, configuration SHA-256, exact command arguments |
| Tokens | Input, context, generated, and accepted draft token counts |
| Timing | Model load, tokenization, TTFT, decode, and total wall-clock time |
| Memory | MLX active, cache, and peak allocator bytes |
| Outcome | Success or an explicit structured runtime error |

Timing measurements use `measured_wall_clock` provenance. MLX allocator values use `measured_native` provenance. Missing runtime metrics remain absent rather than being estimated.

## Runtime behavior

- The model and optional draft model must already exist as local directories.
- Collection never passes an unresolved model ID to `mlx_lm.load`, preventing implicit Hugging Face downloads.
- MLX is synchronized only after model load, before generation, and after generation.
- The normal path does not force evaluation per layer or per token.
- Accelerator detection uses `mx.device_info()` unless explicitly overridden.
- Runtime failures, including malformed local model metadata, produce failed experiment records instead of uncaught tracebacks.

## Speculative decoding

An existing MLX-LM draft model can be supplied with `--draft-model-path` and `--num-draft-tokens`.

Accepted tokens are counted from MLX-LM's `from_draft` signal. Proposed token count and verification time remain absent because the public streaming API does not expose them.

The collector distinguishes MLX-LM's terminal response behavior:

- EOS summary responses are not counted as generated or accepted draft tokens.
- Length-terminated summary responses are counted because they represent the final generated token.

This is generic draft-model speculation. Native Qwen3.8 MTP collection remains separate future work.

## Example

```bash
uv sync --extra mlx

uv run llmtracefx-optimizer collect-mlx \
  --run-id local-smoke-1 \
  --model-path /path/to/existing/mlx-model \
  --model-id mlx-community/Llama-3.2-3B-Instruct-4bit \
  --model-revision pinned-revision \
  --quantization mlx-affine-4bit \
  --prompt-file examples/optimizer/mlx-smoke-prompt.txt \
  --max-tokens 64 \
  --output-dir artifacts/local-smoke-1
```

Artifacts:

```text
artifacts/local-smoke-1/
  record.json
  response.txt
  environment.json
```

## Design

`MLXRuntime` defines the injectable runtime boundary. `MLXLMRuntime` provides the production adapter, while tests use a fake runtime and do not require Apple hardware or MLX imports.

The existing `MLXTraceRecorder` now shares its allocator snapshot helper with the collector. Its token-level tracing behavior remains unchanged.

## Validation

- 256 tests pass
- Ruff passes for the changed optimizer and MLX tracer surfaces
- Black and isort checks pass for the changed surfaces
- mypy passes for the changed collector and tracer modules

Tests cover normalized record creation, metric provenance, optional metric absence, allocator capture, accelerator precedence, phase synchronization, runtime failures, malformed local model metadata, local-path enforcement, CLI behavior, generic draft attribution, EOS accounting, and length-terminated accounting.

## Scope boundaries

This PR does not add:

- native Metal System Trace or hardware counters
- native Qwen3.8 MTP collection
- CUDA, Nsight, NVML, vLLM, or SGLang collectors
- automatic configuration search
- real Qwen3.8 benchmark results