### PR TITLE
feat(optimizer): add Qwen MTP capability checks and workload matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,19 @@ build on:
   `no_significant_difference` / `inconclusive` — it refuses to guess when
   runs aren't comparable, repetitions are too few, or the delta is
   smaller than run-to-run noise.
+- **Native Qwen MTP capability detection**
+  (`llmtracefx.optimizer.collectors.native_mtp`): checks, against verified
+  upstream mlx-lm/mlx-vlm source, whether this environment can produce
+  trustworthy native multi-token-prediction evidence for a checkpoint's
+  architecture family, validates target/sidecar checkpoint compatibility,
+  and records an explicit unsupported result rather than mislabeling
+  generic draft-model speculation as native MTP.
+- **Deterministic workload matrix** (`llmtracefx.optimizer.workloads`): a
+  pinned, versioned catalog of code-completion, structured-JSON, and
+  prose-reasoning workloads with deterministic evaluators, materialized to
+  2K/8K/16K context tiers with documented, hashed padding, and a dry-run
+  matrix generator that plans (never executes) `collect-mlx`/`native-mtp`
+  commands across decode modes.
 
 Try it end-to-end with a CPU-only example (no GPU or model download
 required):
@@ -753,12 +766,109 @@ An optional existing MLX-LM draft model can be supplied with
 verification time through this API, so those fields remain absent. This is
 generic draft-model speculation, not native Qwen3.8 MTP.
 
-**Not yet included** (tracked as follow-up work): native Metal/CUDA
-performance-counter ingestion, native Qwen3.8 MTP collection, CUDA/vLLM/SGLang
-collectors, automatic tuning/search, and any actual Qwen3.8-27B benchmark results.
-The fixtures under `tests/optimizer/fixtures/llama_cpp/` are synthetic,
-hand-written logs for testing the parser and doctor rule — not
-benchmark evidence (see the `PROVENANCE.md` in that directory).
+### Native Qwen MTP: capability report and honest evidence collection
+
+Native multi-token-prediction (MTP) is architecturally different from the
+generic draft-model speculation above: the *same* model predicts several
+tokens ahead using its own MTP heads, instead of a smaller external draft
+model proposing tokens for the target to verify. Before adding an
+`llmtracefx-optimizer native-mtp collect` run, verify this project can
+actually trust what it would report:
+
+```bash
+uv run llmtracefx-optimizer native-mtp capability-report \
+  --target-model-path /path/to/local/qwen-checkpoint
+```
+
+This inspects the checkpoint's `config.json` model family and checks it
+against verified upstream facts (exit code `0` if a trustworthy native-MTP
+path exists, `3` if not, `1` on error):
+
+- **mlx-lm** (the runtime `collect-mlx` wraps) strips multi-token-prediction
+  weights during model loading for every family that ships them
+  (`qwen3_next`, `qwen3_5`, `qwen3_5_moe`, and others -- see
+  `llmtracefx.optimizer.collectors.native_mtp` for the full, referenced
+  list). There is no code path in mlx-lm that loads or invokes an MTP head.
+- **mlx-vlm** has an experimental, git-main-only `mlx_vlm.speculative.drafters`
+  module for a narrow set of families (e.g. `qwen4_exp`), dispatched through
+  the same `draft_model` request path as generic speculative decoding. It is
+  not a stable release, and this project cannot reliably distinguish its
+  metrics from generic draft-model speculation from the generation response
+  alone -- only checkpoint provenance does, and that is a best-effort,
+  metadata-only check.
+
+Given that, `native-mtp collect` never fabricates native-MTP evidence. It
+validates the target/sidecar checkpoints are locally present and
+architecturally compatible (`hidden_size`/`vocab_size` match, failing
+clearly otherwise), runs the same capability check, and:
+
+```bash
+uv run llmtracefx-optimizer native-mtp collect \
+  --run-id native-mtp-smoke-1 \
+  --target-model-path /path/to/local/qwen-target \
+  --mtp-sidecar-path /path/to/local/qwen-mtp-sidecar \
+  --model-id "Qwen/Qwen3.8-27B" \
+  --prompt-file examples/optimizer/mlx-smoke-prompt.txt \
+  --output-dir artifacts/native-mtp-smoke-1
+```
+
+writes an explicit, honest `record.json` (`outcome.success = false`,
+`error.category = "NativeMTPUnsupported"`, `speculative.enabled = false`)
+plus a standalone `capability_report.json`, rather than silently running
+generic draft-model speculation and mislabeling it as MTP. The collector's
+capable code path (`speculative.method = "native-mtp"`, recording only
+whatever proposed/accepted/depth fields a runtime actually exposes) is fully
+implemented and tested against a fake runtime so it is ready to wrap a
+genuinely stable, metrics-differentiated API if one is published upstream --
+no production adapter claims that today.
+
+### Deterministic code/JSON/reasoning workload matrix
+
+`llmtracefx.optimizer.workloads` pins a small, versioned, redistributable
+catalog of three workload categories -- code completion, constrained
+structured JSON, and prose/reasoning -- and a deterministic evaluator for
+each (exact unit-test pass/fail, exact required-field/type match, and exact
+expected-answer pattern match; no LLM-as-judge). Generate the full matrix for
+a target model without loading or downloading anything:
+
+```bash
+uv run llmtracefx-optimizer workloads generate-matrix \
+  --model-id "Qwen/Qwen3.8-27B" \
+  --model-family qwen3_next \
+  --output-dir artifacts/qwen3.8-matrix
+```
+
+This materializes each workload's prompt toward the 2K/8K/16K context tiers
+using a documented, deterministic filler-padding scheme (the base task prompt
+is always preserved verbatim and never truncated), hashes the fully
+materialized prompt, and writes:
+
+- `manifest.json`: every (workload, context tier, decode mode) combination,
+  each with its prompt hash, whether it is `runnable`, and -- for MTP rows
+  the capability report marks unsupported -- an explicit
+  `unsupported_reason` instead of a silently-omitted row.
+- `prompts/<workload>-<tier>.txt`: the exact materialized prompt text.
+- `configs/<run_id>.json`: a ready-to-use config for the PR #3 runner
+  (`llmtracefx-optimizer run --config ...`), wrapping the exact
+  `collect-mlx`/`native-mtp collect` invocation for that row.
+
+Evaluate a captured response against one workload's deterministic checker:
+
+```bash
+uv run llmtracefx-optimizer workloads evaluate \
+  --workload-id structured-json-profile-extraction \
+  --response-file /tmp/response.txt
+```
+
+**Not yet included** (tracked as a follow-up PR): a genuinely capable
+native-MTP runtime adapter (none exists upstream today), native Metal/CUDA
+performance-counter ingestion, CUDA/vLLM/SGLang collectors, automatic
+tuning/search, and any actual Qwen3.8-27B benchmark results -- everything in
+this section was verified against fake runtimes and small local checkpoints,
+never a real Qwen3.8-27B run. The fixtures under
+`tests/optimizer/fixtures/llama_cpp/` are synthetic, hand-written logs for
+testing the parser and doctor rule — not benchmark evidence (see the
+`PROVENANCE.md` in that directory).
 
 ## 📄 License
 

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -4,8 +4,10 @@ Subcommands:
     manifest         Collect a CPU-only, non-sensitive environment manifest.
     run              Execute a configured experiment (warmups + measured reps).
     collect-mlx      Run one local MLX-LM inference and record normalized evidence.
+    native-mtp       Native Qwen MTP capability report / evidence collection.
     parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
     doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
+    workloads        Generate a deterministic code/JSON/reasoning workload matrix.
 """
 
 from __future__ import annotations
@@ -22,6 +24,12 @@ from .collectors.mlx import (
     MLXLMRuntime,
     collect_mlx,
 )
+from .collectors.native_mtp import (
+    NativeMTPCollectionConfig,
+    NativeMTPCollectorError,
+    capability_report_for_target,
+    collect_native_mtp,
+)
 from .doctor.speculative import diagnose_speculative_regression
 from .manifest import collect_environment_manifest
 from .parsers.llama_cpp import LlamaCppParseError, build_experiment_record
@@ -35,6 +43,10 @@ from .schema import (
     SchemaValidationError,
     utc_now_iso,
 )
+from .workloads.catalog import WORKLOADS, workload_by_id
+from .workloads.evaluators import evaluate_workload
+from .workloads.matrix import generate_matrix, write_matrix
+from .workloads.schema import ContextTier, WorkloadSchemaError
 
 
 def _platform_from_manifest(*, accelerator: str | None = None) -> PlatformInfo:
@@ -153,6 +165,104 @@ def _cmd_collect_mlx(args: argparse.Namespace) -> int:
     return 1
 
 
+def _cmd_native_mtp_capability_report(args: argparse.Namespace) -> int:
+    try:
+        report = capability_report_for_target(Path(args.target_model_path))
+    except NativeMTPCollectorError as exc:
+        print(f"Failed to determine native-MTP capability: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        report.write_json(args.output)
+        print(f"Native-MTP capability report written to {args.output}")
+    else:
+        print(report.to_json())
+    return 0 if report.supported else 3
+
+
+def _native_mtp_collect_argv(args: argparse.Namespace) -> tuple[str, ...]:
+    invocation = getattr(args, "_invocation", None)
+    if invocation is not None:
+        return tuple(invocation)
+
+    reconstructed = [
+        "llmtracefx-optimizer",
+        "native-mtp",
+        "collect",
+        "--run-id",
+        args.run_id,
+        "--target-model-path",
+        args.target_model_path,
+        "--mtp-sidecar-path",
+        args.mtp_sidecar_path,
+        "--model-id",
+        args.model_id,
+        "--prompt-file",
+        args.prompt_file,
+        "--output-dir",
+        args.output_dir,
+        "--max-tokens",
+        str(args.max_tokens),
+        "--seed",
+        str(args.seed),
+        "--configured-depth",
+        str(args.configured_depth),
+    ]
+    for flag, value in (
+        ("--model-revision", args.model_revision),
+        ("--tokenizer-revision", args.tokenizer_revision),
+        ("--quantization", args.quantization),
+        ("--accelerator", args.accelerator),
+    ):
+        if value is not None:
+            reconstructed.extend((flag, value))
+    return tuple(reconstructed)
+
+
+def _cmd_native_mtp_collect(args: argparse.Namespace) -> int:
+    try:
+        prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+        config = NativeMTPCollectionConfig(
+            run_id=args.run_id,
+            target_model_path=Path(args.target_model_path),
+            mtp_sidecar_path=Path(args.mtp_sidecar_path),
+            model_id=args.model_id,
+            prompt=prompt,
+            output_dir=Path(args.output_dir),
+            command_argv=_native_mtp_collect_argv(args),
+            max_tokens=args.max_tokens,
+            seed=args.seed,
+            configured_depth=args.configured_depth,
+            model_revision=args.model_revision,
+            tokenizer_revision=args.tokenizer_revision,
+            quantization=args.quantization,
+            accelerator=args.accelerator,
+        )
+        result = collect_native_mtp(config, runtime=None)
+    except (OSError, UnicodeError, NativeMTPCollectorError) as exc:
+        print(f"Failed to collect native-MTP evidence: {exc}", file=sys.stderr)
+        return 1
+
+    record_path = config.output_dir / "record.json"
+    print(f"Native-MTP experiment record written to {record_path}")
+    if result.record.outcome.success:
+        return 0
+    error_message = (
+        result.record.error.message
+        if result.record.error is not None
+        else "unknown failure"
+    )
+    print(
+        f"Native-MTP collection did not run (capability unsupported): {error_message}",
+        file=sys.stderr,
+    )
+    print(
+        f"See {config.output_dir / 'capability_report.json'} for details",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def _cmd_parse_llama_cpp(args: argparse.Namespace) -> int:
     stdout_text = (
         Path(args.stdout_file).read_text(encoding="utf-8") if args.stdout_file else ""
@@ -232,6 +342,66 @@ def _cmd_doctor_speculative(args: argparse.Namespace) -> int:
     return 0 if report.verdict.value != "inconclusive" else 2
 
 
+def _cmd_workloads_list(args: argparse.Namespace) -> int:
+    for workload in WORKLOADS:
+        print(f"{workload.workload_id}\t{workload.category.value}\tv{workload.version}")
+    return 0
+
+
+def _cmd_workloads_generate_matrix(args: argparse.Namespace) -> int:
+    context_tiers = (
+        tuple(ContextTier(value) for value in args.context_tiers)
+        if args.context_tiers
+        else tuple(ContextTier)
+    )
+    manifest = generate_matrix(
+        model_id=args.model_id,
+        model_family=args.model_family,
+        output_dir=args.output_dir,
+        target_model_path=args.target_model_path,
+        mtp_sidecar_path=args.mtp_sidecar_path,
+        context_tiers=context_tiers,
+        max_tokens=args.max_tokens,
+    )
+    write_matrix(manifest)
+
+    runnable = sum(1 for entry in manifest.entries if entry.runnable)
+    print(
+        f"Wrote {len(manifest.entries)} planned matrix entries "
+        f"({runnable} runnable) to {args.output_dir}/manifest.json. "
+        "No model was loaded or downloaded."
+    )
+    return 0
+
+
+def _cmd_workloads_evaluate(args: argparse.Namespace) -> int:
+    try:
+        workload = workload_by_id(args.workload_id)
+    except KeyError as exc:
+        print(f"Unknown workload: {exc}", file=sys.stderr)
+        return 1
+
+    response_text = Path(args.response_file).read_text(encoding="utf-8")
+    try:
+        outcome = evaluate_workload(workload, response_text)
+    except WorkloadSchemaError as exc:
+        print(f"Failed to evaluate workload: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "success": outcome.success,
+                "quality_score": outcome.quality_score,
+                "quality_metric": outcome.quality_metric,
+                "notes": outcome.notes,
+            },
+            indent=2,
+        )
+    )
+    return 0 if outcome.success else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llmtracefx-optimizer",
@@ -300,6 +470,72 @@ def build_parser() -> argparse.ArgumentParser:
     )
     collect_mlx_parser.add_argument("--num-draft-tokens", type=int, default=2)
     collect_mlx_parser.set_defaults(func=_cmd_collect_mlx)
+
+    native_mtp_parser = subparsers.add_parser(
+        "native-mtp",
+        help="Native Qwen MTP capability report / evidence collection",
+    )
+    native_mtp_subparsers = native_mtp_parser.add_subparsers(
+        dest="native_mtp_command", required=True
+    )
+
+    capability_parser = native_mtp_subparsers.add_parser(
+        "capability-report",
+        help=(
+            "Report whether this environment can produce trustworthy "
+            "native-MTP evidence for a local checkpoint's architecture "
+            "family (exit 0 if supported, 3 if not, 1 on error)"
+        ),
+    )
+    capability_parser.add_argument(
+        "--target-model-path",
+        required=True,
+        help="Existing local target checkpoint directory containing config.json",
+    )
+    capability_parser.add_argument(
+        "--output",
+        default=None,
+        help="Write the capability report JSON to this path instead of stdout",
+    )
+    capability_parser.set_defaults(func=_cmd_native_mtp_capability_report)
+
+    native_mtp_collect_parser = native_mtp_subparsers.add_parser(
+        "collect",
+        help=(
+            "Validate a target/sidecar checkpoint pair and either collect "
+            "native-MTP evidence or record an explicit unsupported result"
+        ),
+    )
+    native_mtp_collect_parser.add_argument("--run-id", required=True)
+    native_mtp_collect_parser.add_argument(
+        "--target-model-path",
+        required=True,
+        help="Existing local target MLX checkpoint; never downloaded",
+    )
+    native_mtp_collect_parser.add_argument(
+        "--mtp-sidecar-path",
+        required=True,
+        help="Existing local MTP sidecar/drafter checkpoint; never downloaded",
+    )
+    native_mtp_collect_parser.add_argument("--model-id", required=True)
+    native_mtp_collect_parser.add_argument("--model-revision", default=None)
+    native_mtp_collect_parser.add_argument("--tokenizer-revision", default=None)
+    native_mtp_collect_parser.add_argument("--quantization", default=None)
+    native_mtp_collect_parser.add_argument(
+        "--prompt-file",
+        required=True,
+        help="UTF-8 prompt file; prompt contents are hashed but not copied into the record",
+    )
+    native_mtp_collect_parser.add_argument("--output-dir", required=True)
+    native_mtp_collect_parser.add_argument("--max-tokens", type=int, default=128)
+    native_mtp_collect_parser.add_argument("--seed", type=int, default=0)
+    native_mtp_collect_parser.add_argument("--configured-depth", type=int, default=2)
+    native_mtp_collect_parser.add_argument(
+        "--accelerator",
+        default=None,
+        help="Explicit accelerator name; otherwise left unset",
+    )
+    native_mtp_collect_parser.set_defaults(func=_cmd_native_mtp_collect)
 
     parse_parser = subparsers.add_parser(
         "parse-llama-cpp",
@@ -375,6 +611,67 @@ def build_parser() -> argparse.ArgumentParser:
     speculative_parser.add_argument("--min-repetitions", type=int, default=2)
     speculative_parser.add_argument("--relative-threshold", type=float, default=0.03)
     speculative_parser.set_defaults(func=_cmd_doctor_speculative)
+
+    workloads_parser = subparsers.add_parser(
+        "workloads",
+        help="Deterministic code/JSON/reasoning workload matrix and evaluators",
+    )
+    workloads_subparsers = workloads_parser.add_subparsers(
+        dest="workloads_command", required=True
+    )
+
+    list_parser = workloads_subparsers.add_parser(
+        "list", help="List the pinned workload catalog"
+    )
+    list_parser.set_defaults(func=_cmd_workloads_list)
+
+    matrix_parser = workloads_subparsers.add_parser(
+        "generate-matrix",
+        help=(
+            "Materialize the deterministic (workload, context tier, decode "
+            "mode) matrix, prompts, and planned commands. Dry-run only: "
+            "never loads a model or downloads weights."
+        ),
+    )
+    matrix_parser.add_argument("--model-id", required=True)
+    matrix_parser.add_argument(
+        "--model-family",
+        required=True,
+        help=(
+            "Architecture family (e.g. 'qwen3_next'), used to determine "
+            "which native-MTP rows are runnable via capability detection"
+        ),
+    )
+    matrix_parser.add_argument("--output-dir", required=True)
+    matrix_parser.add_argument(
+        "--target-model-path",
+        default=None,
+        help="Existing local target checkpoint path for the planned commands",
+    )
+    matrix_parser.add_argument(
+        "--mtp-sidecar-path",
+        default=None,
+        help="Existing local MTP sidecar checkpoint path for the planned commands",
+    )
+    matrix_parser.add_argument(
+        "--context-tiers",
+        nargs="+",
+        choices=[tier.value for tier in ContextTier],
+        default=None,
+        help="Subset of context tiers to plan for (default: all)",
+    )
+    matrix_parser.add_argument("--max-tokens", type=int, default=128)
+    matrix_parser.set_defaults(func=_cmd_workloads_generate_matrix)
+
+    evaluate_parser = workloads_subparsers.add_parser(
+        "evaluate",
+        help="Run the deterministic evaluator for one workload against a response",
+    )
+    evaluate_parser.add_argument("--workload-id", required=True)
+    evaluate_parser.add_argument(
+        "--response-file", required=True, help="Path to the model's response text"
+    )
+    evaluate_parser.set_defaults(func=_cmd_workloads_evaluate)
 
     return parser
 

--- a/llmtracefx/optimizer/collectors/_shared.py
+++ b/llmtracefx/optimizer/collectors/_shared.py
@@ -1,0 +1,67 @@
+"""Helpers shared by the MLX-LM and native-MTP collectors.
+
+Kept separate from ``collectors.mlx`` so new collectors extend the same
+primitives (hashing, atomic writes, wall-clock/byte measurements, platform
+recording) instead of duplicating them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Any
+
+from ..manifest import collect_environment_manifest
+from ..schema import Measurement, MetricProvenance, PlatformInfo
+
+
+def sha256_text(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def milliseconds(started: float | None, ended: float | None) -> Measurement | None:
+    if started is None or ended is None:
+        return None
+    return Measurement(
+        value=max(0.0, ended - started) * 1000,
+        provenance=MetricProvenance.MEASURED_WALL_CLOCK,
+        unit="ms",
+    )
+
+
+def bytes_measurement(value: int | None) -> Measurement | None:
+    if value is None:
+        return None
+    return Measurement(
+        value=float(value),
+        provenance=MetricProvenance.MEASURED_NATIVE,
+        unit="bytes",
+    )
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def record_platform(
+    *, accelerator: str | None, extra_packages: tuple[str, ...] = ("mlx", "mlx-lm")
+) -> PlatformInfo:
+    manifest = collect_environment_manifest(extra_packages=extra_packages)
+    return PlatformInfo(
+        os_name=manifest.os_name,
+        os_version=manifest.os_release,
+        architecture=manifest.architecture,
+        cpu_cores=manifest.cpu_count,
+        total_memory_gb=manifest.total_memory_gb,
+        accelerator=accelerator,
+    )
+
+
+def config_hash(payload: dict[str, Any]) -> str:
+    import json
+
+    return sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":")))

--- a/llmtracefx/optimizer/collectors/mlx.py
+++ b/llmtracefx/optimizer/collectors/mlx.py
@@ -8,9 +8,6 @@ collector's scope.
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
 import platform
 import time
 from collections.abc import Callable, Iterator
@@ -25,18 +22,23 @@ from ..schema import (
     CommandInfo,
     ErrorInfo,
     ExperimentRecord,
-    Measurement,
     MemoryMetrics,
-    MetricProvenance,
     ModelInfo,
     OutcomeInfo,
-    PlatformInfo,
     RepetitionInfo,
     RuntimeInfo,
     SpeculativeDecodingInfo,
     TimingMetrics,
     TokenCounts,
     utc_now_iso,
+)
+from ._shared import (
+    atomic_write_text,
+    bytes_measurement,
+    config_hash,
+    milliseconds,
+    record_platform,
+    sha256_text,
 )
 
 
@@ -268,10 +270,6 @@ class MLXCollectionResult:
     response_text: str
 
 
-def _sha256_text(value: str) -> str:
-    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
-
-
 def _config_hash(config: MLXCollectionConfig) -> str:
     payload = {
         "model_id": config.model_id,
@@ -283,49 +281,7 @@ def _config_hash(config: MLXCollectionConfig) -> str:
         "draft_enabled": config.draft_model_path is not None,
         "num_draft_tokens": config.num_draft_tokens,
     }
-    return _sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":")))
-
-
-def _milliseconds(started: float | None, ended: float | None) -> Measurement | None:
-    if started is None or ended is None:
-        return None
-    return Measurement(
-        value=max(0.0, ended - started) * 1000,
-        provenance=MetricProvenance.MEASURED_WALL_CLOCK,
-        unit="ms",
-    )
-
-
-def _bytes_measurement(value: int | None) -> Measurement | None:
-    if value is None:
-        return None
-    return Measurement(
-        value=float(value),
-        provenance=MetricProvenance.MEASURED_NATIVE,
-        unit="bytes",
-    )
-
-
-def _atomic_write_text(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
-    temporary.write_text(content, encoding="utf-8")
-    os.replace(temporary, path)
-
-
-def _record_platform(
-    runtime: MLXRuntime, accelerator_override: str | None
-) -> PlatformInfo:
-    manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm"))
-    accelerator = accelerator_override or runtime.accelerator_name()
-    return PlatformInfo(
-        os_name=manifest.os_name,
-        os_version=manifest.os_release,
-        architecture=manifest.architecture,
-        cpu_cores=manifest.cpu_count,
-        total_memory_gb=manifest.total_memory_gb,
-        accelerator=accelerator,
-    )
+    return config_hash(payload)
 
 
 def collect_mlx(
@@ -411,7 +367,9 @@ def collect_mlx(
         run_id=config.run_id,
         started_at=started_at,
         ended_at=utc_now_iso(),
-        platform=_record_platform(runtime, config.accelerator),
+        platform=record_platform(
+            accelerator=config.accelerator or runtime.accelerator_name()
+        ),
         model=ModelInfo(
             model_id=config.model_id,
             model_revision=config.model_revision,
@@ -427,7 +385,7 @@ def collect_mlx(
         command=CommandInfo(
             argv=config.command_argv,
             config_hash=_config_hash(config),
-            workload_hash=_sha256_text(config.prompt),
+            workload_hash=sha256_text(config.prompt),
         ),
         repetition=RepetitionInfo(
             warmup_repetitions=0,
@@ -441,11 +399,11 @@ def collect_mlx(
             generated_tokens=generated_tokens or None,
         ),
         timing=TimingMetrics(
-            model_load=_milliseconds(load_started, load_ended),
-            tokenize=_milliseconds(tokenize_started, tokenize_ended),
-            prefill=_milliseconds(generation_started, first_token_at),
-            decode=_milliseconds(first_token_at, generation_ended),
-            total=_milliseconds(total_started, total_ended),
+            model_load=milliseconds(load_started, load_ended),
+            tokenize=milliseconds(tokenize_started, tokenize_ended),
+            prefill=milliseconds(generation_started, first_token_at),
+            decode=milliseconds(first_token_at, generation_ended),
+            total=milliseconds(total_started, total_ended),
         ),
         speculative=SpeculativeDecodingInfo(
             enabled=config.draft_model_path is not None,
@@ -460,9 +418,9 @@ def collect_mlx(
             verification_time=None,
         ),
         memory=MemoryMetrics(
-            active=_bytes_measurement(memory.active_bytes),
-            cache=_bytes_measurement(memory.cache_bytes),
-            peak=_bytes_measurement(memory.peak_bytes),
+            active=bytes_measurement(memory.active_bytes),
+            cache=bytes_measurement(memory.cache_bytes),
+            peak=bytes_measurement(memory.peak_bytes),
             wired=None,
         ),
         outcome=OutcomeInfo(success=error is None),
@@ -473,9 +431,7 @@ def collect_mlx(
     response_text = "".join(response_parts)
     config.output_dir.mkdir(parents=True, exist_ok=True)
     record.write_json(config.output_dir / "record.json")
-    _atomic_write_text(config.output_dir / "response.txt", response_text)
+    atomic_write_text(config.output_dir / "response.txt", response_text)
     manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm"))
-    _atomic_write_text(
-        config.output_dir / "environment.json", manifest.to_json() + "\n"
-    )
+    atomic_write_text(config.output_dir / "environment.json", manifest.to_json() + "\n")
     return MLXCollectionResult(record=record, response_text=response_text)

--- a/llmtracefx/optimizer/collectors/native_mtp.py
+++ b/llmtracefx/optimizer/collectors/native_mtp.py
@@ -351,12 +351,13 @@ def validate_checkpoint_compatibility(
     target_sig = _arch_signature(target_config)
     sidecar_sig = _arch_signature(sidecar_config)
 
-    if not target_sig:
+    comparable_fields = ("hidden_size", "vocab_size")
+    if not any(key in target_sig for key in comparable_fields):
         raise NativeMTPCollectorError(
             "target checkpoint config.json does not expose hidden_size/"
             "vocab_size; cannot validate compatibility with the sidecar"
         )
-    if not sidecar_sig:
+    if not any(key in sidecar_sig for key in comparable_fields):
         raise NativeMTPCollectorError(
             "sidecar checkpoint config.json does not expose hidden_size/"
             "vocab_size; cannot validate compatibility with the target"
@@ -364,7 +365,7 @@ def validate_checkpoint_compatibility(
 
     mismatches = [
         f"{key}: target={target_sig[key]!r} sidecar={sidecar_sig[key]!r}"
-        for key in ("hidden_size", "vocab_size")
+        for key in comparable_fields
         if key in target_sig
         and key in sidecar_sig
         and target_sig[key] != sidecar_sig[key]

--- a/llmtracefx/optimizer/collectors/native_mtp.py
+++ b/llmtracefx/optimizer/collectors/native_mtp.py
@@ -363,12 +363,19 @@ def validate_checkpoint_compatibility(
             "vocab_size; cannot validate compatibility with the target"
         )
 
+    shared_fields = tuple(
+        key for key in comparable_fields if key in target_sig and key in sidecar_sig
+    )
+    if not shared_fields:
+        raise NativeMTPCollectorError(
+            "target and sidecar checkpoint metadata share no comparable "
+            "hidden_size or vocab_size field; cannot validate compatibility"
+        )
+
     mismatches = [
         f"{key}: target={target_sig[key]!r} sidecar={sidecar_sig[key]!r}"
-        for key in comparable_fields
-        if key in target_sig
-        and key in sidecar_sig
-        and target_sig[key] != sidecar_sig[key]
+        for key in shared_fields
+        if target_sig[key] != sidecar_sig[key]
     ]
     if mismatches:
         layer_note = ""

--- a/llmtracefx/optimizer/collectors/native_mtp.py
+++ b/llmtracefx/optimizer/collectors/native_mtp.py
@@ -1,0 +1,770 @@
+"""Native Qwen multi-token-prediction (MTP) capability detection and evidence.
+
+This module answers one question honestly: can this project invoke a
+model's own multi-token-prediction heads through a stable, public MLX
+Python API, in a way whose reported metrics (accepted/proposed counts,
+block depth, verification timing) can be reliably attributed to native
+MTP rather than to generic external draft-model speculative decoding
+(the mechanism already collected by ``llmtracefx.optimizer.collectors.mlx``
+via ``draft_model``/``num_draft_tokens``)?
+
+As of this module's authoring, the answer is **no** for every model
+family checked below. Verified upstream facts:
+
+* ``mlx-lm`` (the runtime this project's ``collect-mlx`` wraps) strips
+  multi-token-prediction weights during model loading for every model
+  family that ships them. See, on ``ml-explore/mlx-lm`` main:
+  ``mlx_lm/models/qwen3_next.py`` (``sanitize`` drops any key containing
+  ``"mtp."``), ``mlx_lm/models/qwen3_5.py`` (same), plus the same pattern
+  in ``ernie4_5_moe.py``, ``mimo.py``, ``step3p5.py``, ``exaone_moe.py``,
+  ``bailing_moe_v3.py``, ``nemotron_h.py``, ``mimo_v2_flash.py``,
+  ``kimi_linear.py`` and ``longcat_flash.py``. There is no code path in
+  ``mlx-lm`` that loads or invokes an MTP head; ``mlx_lm.generate`` /
+  ``mlx_lm.stream_generate`` only support the classic two-model
+  draft/target speculative decoding already implemented by this
+  project's MLX-LM collector.
+* ``mlx-vlm`` (``Blaizzy/mlx-vlm``) has an experimental
+  ``mlx_vlm.speculative.drafters`` package with native-MTP dispatch for
+  a narrow set of architecture families (``qwen4_exp``, ``deepseek_v4``,
+  ``glm4_moe_lite``, ``inkling_mm_model``), reached via ``--draft-kind
+  mtp`` / ``draft_kind="mtp"``. This is not a stable public release: the
+  ``qwen4_exp`` model type is explicitly named/labeled experimental,
+  published third-party MTP-drafter checkpoints document that they
+  require "git main" builds, and public MLX conversions of the base
+  model drop the MTP tensors entirely (a separate, hand-restored
+  "drafter" checkpoint must be supplied). Critically, even where this
+  exists, it is dispatched through the *same* ``draft_model`` request
+  path used for generic speculative decoding — the collector cannot
+  distinguish "native MTP" evidence from "generic draft-model
+  speculation" from the generation response alone. Only the checkpoint
+  provenance (an official MTP-derived sidecar matching the target's
+  architecture) distinguishes the two, and that is a best-effort,
+  metadata-only check (see ``validate_checkpoint_compatibility`` below),
+  not a runtime guarantee.
+
+Given that, this module never silently reinterprets generic draft-model
+speculation as native MTP. When capability detection reports the
+runtime cannot support it, ``collect_native_mtp`` records an explicit,
+honest "unsupported" ``ExperimentRecord`` (and a standalone capability
+report) instead of attempting a misleading run.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..manifest import collect_environment_manifest
+from ..schema import (
+    CommandInfo,
+    ErrorInfo,
+    ExperimentRecord,
+    MemoryMetrics,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+    utc_now_iso,
+)
+from ._shared import (
+    atomic_write_text,
+    bytes_measurement,
+    config_hash,
+    milliseconds,
+    record_platform,
+    sha256_text,
+)
+
+CAPABILITY_SCHEMA_VERSION = "1"
+
+
+class NativeMTPCollectorError(RuntimeError):
+    """Raised for invalid native-MTP collector configuration or checkpoints."""
+
+
+# --- Verified upstream capability facts -------------------------------------
+
+#: Architecture families ``mlx-lm`` (main, as verified above) strips MTP
+#: weights for during ``sanitize()``. Confirmed by direct inspection of
+#: ml-explore/mlx-lm model source; not inferred or guessed.
+MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES: frozenset[str] = frozenset(
+    {
+        "qwen3_next",
+        "qwen3_5",
+        "qwen3_5_moe",
+        "ernie4_5_moe",
+        "mimo",
+        "step3p5",
+        "exaone_moe",
+        "bailing_moe_v3",
+        "nemotron_h",
+        "mimo_v2_flash",
+        "kimi_linear",
+        "longcat_flash",
+    }
+)
+
+#: Architecture families with experimental, git-main-only native-MTP
+#: dispatch in ``Blaizzy/mlx-vlm`` (``mlx_vlm.speculative.drafters``,
+#: ``--draft-kind mtp``). Not part of any stable/tagged mlx-vlm release
+#: at verification time, and still funneled through the generic
+#: draft-model request path.
+MLX_VLM_EXPERIMENTAL_MTP_FAMILIES: frozenset[str] = frozenset(
+    {
+        "qwen4_exp",
+        "qwen4_exp_text",
+        "deepseek_v4",
+        "glm4_moe_lite",
+        "inkling_mm_model",
+    }
+)
+
+UPSTREAM_REFERENCES: tuple[str, ...] = (
+    "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_next.py",
+    "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/qwen3_5.py",
+    "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py",
+    "https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/speculative/drafters/README.md",
+    "https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/server/cli.py",
+)
+
+
+def _installed_version(distribution: str) -> str | None:
+    try:
+        return importlib_metadata.version(distribution)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+@dataclass(frozen=True)
+class NativeMTPCapabilityReport:
+    """Whether this environment can produce trustworthy native-MTP evidence.
+
+    This is a standalone artifact (not an ``ExperimentRecord``): a
+    capability determination is a property of the installed runtime and
+    the requested architecture family, not of any single measured run.
+    """
+
+    schema_version: str
+    model_family: str
+    mlx_lm_version: str | None
+    mlx_vlm_version: str | None
+    supported: bool
+    reason: str
+    checked_signals: tuple[str, ...]
+    references: tuple[str, ...] = UPSTREAM_REFERENCES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_family": self.model_family,
+            "mlx_lm_version": self.mlx_lm_version,
+            "mlx_vlm_version": self.mlx_vlm_version,
+            "supported": self.supported,
+            "reason": self.reason,
+            "checked_signals": list(self.checked_signals),
+            "references": list(self.references),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    def write_json(self, path: str | Path) -> None:
+        atomic_write_text(Path(path), self.to_json() + "\n")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NativeMTPCapabilityReport:
+        try:
+            return cls(
+                schema_version=str(
+                    data.get("schema_version", CAPABILITY_SCHEMA_VERSION)
+                ),
+                model_family=data["model_family"],
+                mlx_lm_version=data.get("mlx_lm_version"),
+                mlx_vlm_version=data.get("mlx_vlm_version"),
+                supported=bool(data["supported"]),
+                reason=data["reason"],
+                checked_signals=tuple(data.get("checked_signals", ())),
+                references=tuple(data.get("references", UPSTREAM_REFERENCES)),
+            )
+        except KeyError as exc:
+            raise NativeMTPCollectorError(
+                f"NativeMTPCapabilityReport is missing required field: {exc}"
+            ) from exc
+
+
+def detect_native_mtp_capability(
+    model_family: str,
+    *,
+    mlx_lm_version: str | None,
+    mlx_vlm_version: str | None,
+) -> NativeMTPCapabilityReport:
+    """Determine whether native MTP evidence can be trusted for a family.
+
+    Deliberately conservative: returns ``supported=False`` unless a
+    verified, metrics-differentiated stable API is known. See the module
+    docstring for the verified upstream facts this relies on.
+    """
+    checked = (
+        f"mlx-lm installed: {mlx_lm_version is not None}",
+        f"mlx-vlm installed: {mlx_vlm_version is not None}",
+        f"model_family in MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES: "
+        f"{model_family in MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES}",
+        f"model_family in MLX_VLM_EXPERIMENTAL_MTP_FAMILIES: "
+        f"{model_family in MLX_VLM_EXPERIMENTAL_MTP_FAMILIES}",
+    )
+
+    if model_family in MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES:
+        return NativeMTPCapabilityReport(
+            schema_version=CAPABILITY_SCHEMA_VERSION,
+            model_family=model_family,
+            mlx_lm_version=mlx_lm_version,
+            mlx_vlm_version=mlx_vlm_version,
+            supported=False,
+            reason=(
+                f"mlx-lm strips '{model_family}' multi-token-prediction "
+                "weights during model loading (sanitize() removes any "
+                "'mtp.'-prefixed tensor) and exposes no code path that "
+                "loads or invokes an MTP head. Only generic external "
+                "draft-model speculative decoding (draft_model/"
+                "num_draft_tokens on mlx_lm.generate/stream_generate) is "
+                "available; use collect-mlx --draft-model-path for that, "
+                "labeled 'draft-model', not native MTP."
+            ),
+            checked_signals=checked,
+        )
+
+    if model_family in MLX_VLM_EXPERIMENTAL_MTP_FAMILIES:
+        return NativeMTPCapabilityReport(
+            schema_version=CAPABILITY_SCHEMA_VERSION,
+            model_family=model_family,
+            mlx_lm_version=mlx_lm_version,
+            mlx_vlm_version=mlx_vlm_version,
+            supported=False,
+            reason=(
+                f"mlx-vlm has experimental native-MTP dispatch for "
+                f"'{model_family}' (mlx_vlm.speculative.drafters, "
+                "--draft-kind mtp), but it is not part of any stable/"
+                "tagged mlx-vlm release, requires a separately restored "
+                "MTP-drafter checkpoint (public conversions drop the "
+                "tensors), and is dispatched through the same "
+                "draft_model request path as generic speculative "
+                "decoding. Proposed/accepted/verification metrics "
+                "cannot be reliably attributed to native MTP rather "
+                "than generic draft-model speculation from the "
+                "generation response alone, so this project does not "
+                "label it 'native-mtp' evidence."
+            ),
+            checked_signals=checked,
+        )
+
+    return NativeMTPCapabilityReport(
+        schema_version=CAPABILITY_SCHEMA_VERSION,
+        model_family=model_family,
+        mlx_lm_version=mlx_lm_version,
+        mlx_vlm_version=mlx_vlm_version,
+        supported=False,
+        reason=(
+            f"model family '{model_family}' is not in this module's "
+            "verified list of families with either MTP-weight-stripping "
+            "behavior (mlx-lm) or experimental MTP dispatch (mlx-vlm). "
+            "No known stable, metrics-differentiated native-MTP API was "
+            "found for it; treat as unsupported until verified against "
+            "current upstream source and added to this module's tables."
+        ),
+        checked_signals=checked,
+    )
+
+
+# --- Checkpoint loading and compatibility validation ------------------------
+
+
+def _read_config_json(path: Path, *, label: str) -> dict[str, Any]:
+    config_path = path / "config.json"
+    if not path.exists():
+        raise NativeMTPCollectorError(
+            f"{label} does not exist: {path}. Download or convert the "
+            "checkpoint separately before collection; it is never "
+            "downloaded implicitly."
+        )
+    if not config_path.exists():
+        raise NativeMTPCollectorError(f"{label} is missing config.json: {config_path}")
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise NativeMTPCollectorError(
+            f"{label} config.json is not valid JSON: {config_path}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise NativeMTPCollectorError(
+            f"{label} config.json must contain a JSON object: {config_path}"
+        )
+    return data
+
+
+def _arch_signature(config: dict[str, Any]) -> dict[str, Any]:
+    """Extract comparable architecture fields, unwrapping VLM text_config."""
+    source = config
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        source = text_config
+    return {
+        key: source.get(key)
+        for key in ("hidden_size", "vocab_size", "num_hidden_layers")
+        if key in source
+    }
+
+
+def validate_checkpoint_compatibility(
+    target_config: dict[str, Any], sidecar_config: dict[str, Any]
+) -> None:
+    """Fail clearly when the target/sidecar checkpoints look incompatible.
+
+    Compares the architecture fields public ``config.json`` metadata
+    exposes (hidden size, vocabulary size, layer count where present).
+    This is a best-effort, metadata-only check -- it cannot prove weight
+    compatibility, only rule out checkpoints that are structurally
+    mismatched.
+    """
+    target_sig = _arch_signature(target_config)
+    sidecar_sig = _arch_signature(sidecar_config)
+
+    if not target_sig:
+        raise NativeMTPCollectorError(
+            "target checkpoint config.json does not expose hidden_size/"
+            "vocab_size; cannot validate compatibility with the sidecar"
+        )
+    if not sidecar_sig:
+        raise NativeMTPCollectorError(
+            "sidecar checkpoint config.json does not expose hidden_size/"
+            "vocab_size; cannot validate compatibility with the target"
+        )
+
+    mismatches = [
+        f"{key}: target={target_sig[key]!r} sidecar={sidecar_sig[key]!r}"
+        for key in ("hidden_size", "vocab_size")
+        if key in target_sig
+        and key in sidecar_sig
+        and target_sig[key] != sidecar_sig[key]
+    ]
+    if mismatches:
+        raise NativeMTPCollectorError(
+            "target/sidecar checkpoints are architecturally incompatible: "
+            + "; ".join(mismatches)
+        )
+
+
+# --- Injectable runtime (extension point; unused by any capable path today) -
+
+
+class NativeMTPGenerationResponse(Protocol):
+    """Subset of a hypothetical native-MTP generation response.
+
+    No shipping MLX runtime exposes this today (see module docstring).
+    This exists so the collector logic can be exercised end-to-end
+    against a fake runtime and is ready to wrap a real one if a stable,
+    metrics-differentiated API is ever published upstream.
+    """
+
+    text: str
+    generation_tokens: int
+    finish_reason: str | None
+    accepted_block_tokens: int | None
+    """Tokens accepted from one native-MTP verification block, if exposed."""
+    proposed_block_tokens: int | None
+    """Tokens proposed in one native-MTP verification block, if exposed."""
+
+
+class NativeMTPRuntime(Protocol):
+    """Injectable native-MTP boundary. No production adapter exists yet."""
+
+    @property
+    def mlx_version(self) -> str | None: ...
+
+    @property
+    def mlx_lm_version(self) -> str | None: ...
+
+    def load_target(self, path: Path) -> tuple[Any, Any]: ...
+
+    def load_sidecar(self, path: Path, target_model: Any) -> Any: ...
+
+    def encode(self, tokenizer: Any, prompt: str) -> list[int]: ...
+
+    def seed(self, seed: int) -> None: ...
+
+    def synchronize(self) -> None: ...
+
+    def reset_peak_memory(self) -> None: ...
+
+    def memory_snapshot(self) -> Any: ...
+
+    def accelerator_name(self) -> str | None: ...
+
+    def generate_with_native_mtp(
+        self,
+        target_model: Any,
+        sidecar: Any,
+        tokenizer: Any,
+        prompt_tokens: list[int],
+        *,
+        max_tokens: int,
+        configured_depth: int,
+    ) -> Iterator[NativeMTPGenerationResponse]: ...
+
+
+@dataclass(frozen=True)
+class NativeMTPCollectionConfig:
+    """Inputs for one local native-MTP collection attempt."""
+
+    run_id: str
+    target_model_path: Path
+    mtp_sidecar_path: Path
+    model_id: str
+    prompt: str
+    output_dir: Path
+    command_argv: tuple[str, ...]
+    max_tokens: int = 128
+    seed: int = 0
+    configured_depth: int = 2
+    model_revision: str | None = None
+    tokenizer_revision: str | None = None
+    quantization: str | None = None
+    accelerator: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise NativeMTPCollectorError("run_id must be non-empty")
+        if not self.model_id:
+            raise NativeMTPCollectorError("model_id must be non-empty")
+        if not self.target_model_path.exists():
+            raise NativeMTPCollectorError(
+                f"target_model_path does not exist: {self.target_model_path}. "
+                "Download or convert the model separately before collection."
+            )
+        if not self.mtp_sidecar_path.exists():
+            raise NativeMTPCollectorError(
+                f"mtp_sidecar_path does not exist: {self.mtp_sidecar_path}. "
+                "Download or convert the sidecar separately before collection."
+            )
+        if not self.command_argv or not all(self.command_argv):
+            raise NativeMTPCollectorError(
+                "command_argv must contain non-empty argument strings"
+            )
+        if (
+            isinstance(self.max_tokens, bool)
+            or not isinstance(self.max_tokens, int)
+            or self.max_tokens < 1
+        ):
+            raise NativeMTPCollectorError("max_tokens must be a positive integer")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise NativeMTPCollectorError("seed must be an integer")
+        if (
+            isinstance(self.configured_depth, bool)
+            or not isinstance(self.configured_depth, int)
+            or self.configured_depth < 1
+        ):
+            raise NativeMTPCollectorError("configured_depth must be a positive integer")
+
+
+@dataclass(frozen=True)
+class NativeMTPCollectionResult:
+    """Canonical record, capability report, and generated response text."""
+
+    record: ExperimentRecord
+    capability: NativeMTPCapabilityReport
+    response_text: str = ""
+
+
+def _config_hash_for(
+    config: NativeMTPCollectionConfig, *, capability_supported: bool
+) -> str:
+    payload = {
+        "model_id": config.model_id,
+        "model_revision": config.model_revision,
+        "tokenizer_revision": config.tokenizer_revision,
+        "quantization": config.quantization,
+        "max_tokens": config.max_tokens,
+        "seed": config.seed,
+        "configured_depth": config.configured_depth,
+        "capability_supported": capability_supported,
+    }
+    return config_hash(payload)
+
+
+def capability_report_for_target(target_model_path: Path) -> NativeMTPCapabilityReport:
+    """Read a target checkpoint's ``config.json`` and detect capability."""
+    target_config = _read_config_json(target_model_path, label="target")
+    model_family = str(target_config.get("model_type") or "unknown")
+    return detect_native_mtp_capability(
+        model_family,
+        mlx_lm_version=_installed_version("mlx-lm"),
+        mlx_vlm_version=_installed_version("mlx-vlm"),
+    )
+
+
+def collect_native_mtp(
+    config: NativeMTPCollectionConfig,
+    *,
+    runtime: NativeMTPRuntime | None = None,
+    clock: Callable[[], float] = time.perf_counter,
+) -> NativeMTPCollectionResult:
+    """Validate checkpoints, detect capability, and record honest evidence.
+
+    When capability detection reports the runtime cannot produce
+    trustworthy native-MTP evidence (true for every family verified
+    against current upstream source -- see the module docstring), this
+    writes an explicit failed ``ExperimentRecord`` plus a standalone
+    ``capability_report.json`` rather than silently running generic
+    draft-model speculation and mislabeling it as MTP.
+    """
+    started_at = utc_now_iso()
+    total_started = clock()
+
+    target_config = _read_config_json(config.target_model_path, label="target")
+    sidecar_config = _read_config_json(config.mtp_sidecar_path, label="sidecar")
+    validate_checkpoint_compatibility(target_config, sidecar_config)
+
+    model_family = str(target_config.get("model_type") or "unknown")
+    mlx_lm_version = _installed_version("mlx-lm")
+    mlx_vlm_version = _installed_version("mlx-vlm")
+    capability = detect_native_mtp_capability(
+        model_family,
+        mlx_lm_version=mlx_lm_version,
+        mlx_vlm_version=mlx_vlm_version,
+    )
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    capability.write_json(config.output_dir / "capability_report.json")
+
+    platform_info = record_platform(
+        accelerator=(
+            config.accelerator
+            if config.accelerator is not None
+            else (runtime.accelerator_name() if runtime is not None else None)
+        ),
+        extra_packages=("mlx", "mlx-lm", "mlx-vlm"),
+    )
+
+    if not capability.supported:
+        total_ended = clock()
+        record = ExperimentRecord(
+            run_id=config.run_id,
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+            platform=platform_info,
+            model=ModelInfo(
+                model_id=config.model_id,
+                model_revision=config.model_revision,
+                tokenizer_revision=config.tokenizer_revision,
+                quantization=config.quantization,
+                model_family=model_family,
+            ),
+            runtime=RuntimeInfo(
+                name="mlx-lm",
+                version=mlx_lm_version,
+                backend="Metal",
+                git_revision=None,
+            ),
+            command=CommandInfo(
+                argv=config.command_argv,
+                config_hash=_config_hash_for(config, capability_supported=False),
+                workload_hash=sha256_text(config.prompt),
+            ),
+            repetition=RepetitionInfo(
+                warmup_repetitions=0,
+                measured_repetitions=1,
+                repetition_index=0,
+                seed=config.seed,
+            ),
+            timing=TimingMetrics(total=milliseconds(total_started, total_ended)),
+            speculative=SpeculativeDecodingInfo(enabled=False, method=None),
+            outcome=OutcomeInfo(success=False),
+            error=ErrorInfo(
+                category="NativeMTPUnsupported",
+                message=capability.reason,
+            ),
+        )
+        record.validate()
+        record.write_json(config.output_dir / "record.json")
+        return NativeMTPCollectionResult(record=record, capability=capability)
+
+    # Capability path: no production runtime implements this today (see
+    # module docstring). Exercised via NativeMTPRuntime fakes in tests so
+    # this collector is ready to wrap a genuinely stable, distinguishable
+    # native-MTP API if one is published upstream.
+    if runtime is None:
+        raise NativeMTPCollectorError(
+            "capability detection reported native-MTP support for "
+            f"'{model_family}', but no NativeMTPRuntime adapter was "
+            "supplied to execute it"
+        )
+
+    return _collect_with_capable_runtime(
+        config,
+        runtime=runtime,
+        clock=clock,
+        capability=capability,
+        platform_info=platform_info,
+        started_at=started_at,
+        total_started=total_started,
+    )
+
+
+def _collect_with_capable_runtime(
+    config: NativeMTPCollectionConfig,
+    *,
+    runtime: NativeMTPRuntime,
+    clock: Callable[[], float],
+    capability: NativeMTPCapabilityReport,
+    platform_info: PlatformInfo,
+    started_at: str,
+    total_started: float,
+) -> NativeMTPCollectionResult:
+    load_started: float | None = None
+    load_ended: float | None = None
+    tokenize_started: float | None = None
+    tokenize_ended: float | None = None
+    generation_started: float | None = None
+    first_token_at: float | None = None
+    generation_ended: float | None = None
+    prompt_tokens: list[int] = []
+    generated_tokens = 0
+    accepted_tokens = 0
+    proposed_tokens: int | None = None
+    saw_any_proposed_signal = False
+    response_parts: list[str] = []
+    memory: Any = None
+    error: ErrorInfo | None = None
+
+    try:
+        load_started = clock()
+        target_model, tokenizer = runtime.load_target(config.target_model_path)
+        sidecar = runtime.load_sidecar(config.mtp_sidecar_path, target_model)
+        runtime.synchronize()
+        load_ended = clock()
+
+        runtime.reset_peak_memory()
+        tokenize_started = clock()
+        prompt_tokens = runtime.encode(tokenizer, config.prompt)
+        tokenize_ended = clock()
+        runtime.seed(config.seed)
+        runtime.synchronize()
+
+        generation_started = clock()
+        previous_generation_tokens = 0
+        for response in runtime.generate_with_native_mtp(
+            target_model,
+            sidecar,
+            tokenizer,
+            prompt_tokens,
+            max_tokens=config.max_tokens,
+            configured_depth=config.configured_depth,
+        ):
+            observed_at = clock()
+            if first_token_at is None:
+                first_token_at = observed_at
+            response_parts.append(response.text)
+            is_eos_summary = response.finish_reason == "stop"
+            if (
+                response.generation_tokens > previous_generation_tokens
+                and not is_eos_summary
+            ):
+                previous_generation_tokens = response.generation_tokens
+                generated_tokens = response.generation_tokens
+            if response.accepted_block_tokens is not None:
+                accepted_tokens += response.accepted_block_tokens
+            if response.proposed_block_tokens is not None:
+                saw_any_proposed_signal = True
+                proposed_tokens = (
+                    proposed_tokens or 0
+                ) + response.proposed_block_tokens
+
+        runtime.synchronize()
+        generation_ended = clock()
+        memory = runtime.memory_snapshot()
+    except (KeyError, RuntimeError, ValueError, OSError, MemoryError) as exc:
+        generation_ended = clock()
+        error = ErrorInfo(category=type(exc).__name__, message=str(exc))
+
+    total_ended = clock()
+    memory_active = getattr(memory, "active_bytes", None) if memory else None
+    memory_cache = getattr(memory, "cache_bytes", None) if memory else None
+    memory_peak = getattr(memory, "peak_bytes", None) if memory else None
+
+    record = ExperimentRecord(
+        run_id=config.run_id,
+        started_at=started_at,
+        ended_at=utc_now_iso(),
+        platform=platform_info,
+        model=ModelInfo(
+            model_id=config.model_id,
+            model_revision=config.model_revision,
+            tokenizer_revision=config.tokenizer_revision,
+            quantization=config.quantization,
+            model_family=capability.model_family,
+        ),
+        runtime=RuntimeInfo(
+            name="mlx-lm",
+            version=runtime.mlx_lm_version,
+            backend="Metal",
+            git_revision=None,
+        ),
+        command=CommandInfo(
+            argv=config.command_argv,
+            config_hash=_config_hash_for(config, capability_supported=True),
+            workload_hash=sha256_text(config.prompt),
+        ),
+        repetition=RepetitionInfo(
+            warmup_repetitions=0,
+            measured_repetitions=1,
+            repetition_index=0,
+            seed=config.seed,
+        ),
+        tokens=TokenCounts(
+            input_tokens=len(prompt_tokens) if prompt_tokens else None,
+            context_tokens=len(prompt_tokens) if prompt_tokens else None,
+            generated_tokens=generated_tokens or None,
+        ),
+        timing=TimingMetrics(
+            model_load=milliseconds(load_started, load_ended),
+            tokenize=milliseconds(tokenize_started, tokenize_ended),
+            prefill=milliseconds(generation_started, first_token_at),
+            decode=milliseconds(first_token_at, generation_ended),
+            total=milliseconds(total_started, total_ended),
+        ),
+        speculative=SpeculativeDecodingInfo(
+            enabled=True,
+            method="native-mtp",
+            configured_depth=config.configured_depth,
+            proposed_tokens=proposed_tokens if saw_any_proposed_signal else None,
+            accepted_tokens=accepted_tokens if error is None else None,
+            verification_time=None,
+        ),
+        memory=MemoryMetrics(
+            active=bytes_measurement(memory_active),
+            cache=bytes_measurement(memory_cache),
+            peak=bytes_measurement(memory_peak),
+            wired=None,
+        ),
+        outcome=OutcomeInfo(success=error is None),
+        error=error,
+    )
+    record.validate()
+
+    response_text = "".join(response_parts)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    record.write_json(config.output_dir / "record.json")
+    atomic_write_text(config.output_dir / "response.txt", response_text)
+    manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm", "mlx-vlm"))
+    atomic_write_text(config.output_dir / "environment.json", manifest.to_json() + "\n")
+    return NativeMTPCollectionResult(
+        record=record, capability=capability, response_text=response_text
+    )

--- a/llmtracefx/optimizer/collectors/native_mtp.py
+++ b/llmtracefx/optimizer/collectors/native_mtp.py
@@ -311,7 +311,12 @@ def _read_config_json(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _arch_signature(config: dict[str, Any]) -> dict[str, Any]:
-    """Extract comparable architecture fields, unwrapping VLM text_config."""
+    """Extract comparable architecture fields, unwrapping VLM text_config.
+
+    ``num_hidden_layers`` is extracted for informational/debugging
+    purposes only (see ``validate_checkpoint_compatibility``); it is
+    never compared for equality.
+    """
     source = config
     text_config = config.get("text_config")
     if isinstance(text_config, dict):
@@ -328,11 +333,20 @@ def validate_checkpoint_compatibility(
 ) -> None:
     """Fail clearly when the target/sidecar checkpoints look incompatible.
 
-    Compares the architecture fields public ``config.json`` metadata
-    exposes (hidden size, vocabulary size, layer count where present).
-    This is a best-effort, metadata-only check -- it cannot prove weight
-    compatibility, only rule out checkpoints that are structurally
-    mismatched.
+    Compares only ``hidden_size`` and ``vocab_size`` from public
+    ``config.json`` metadata; a mismatch there means the two checkpoints
+    cannot share a tokenizer/embedding space and are structurally
+    incompatible. This is a best-effort, metadata-only check -- it
+    cannot prove weight compatibility, only rule out checkpoints that
+    are structurally mismatched.
+
+    ``num_hidden_layers`` is deliberately **not** enforced: a native-MTP
+    sidecar/drafter checkpoint is expected to have a different (almost
+    always much smaller) layer count than its target model -- that is
+    the whole point of a lightweight MTP head/drafter. When available on
+    both checkpoints, it is surfaced as informational context in a
+    hidden/vocab mismatch error, never as a compatibility requirement by
+    itself.
     """
     target_sig = _arch_signature(target_config)
     sidecar_sig = _arch_signature(sidecar_config)
@@ -356,9 +370,17 @@ def validate_checkpoint_compatibility(
         and target_sig[key] != sidecar_sig[key]
     ]
     if mismatches:
+        layer_note = ""
+        if "num_hidden_layers" in target_sig or "num_hidden_layers" in sidecar_sig:
+            layer_note = (
+                " (informational, not enforced: target num_hidden_layers="
+                f"{target_sig.get('num_hidden_layers')!r}, sidecar "
+                f"num_hidden_layers={sidecar_sig.get('num_hidden_layers')!r})"
+            )
         raise NativeMTPCollectorError(
             "target/sidecar checkpoints are architecturally incompatible: "
             + "; ".join(mismatches)
+            + layer_note
         )
 
 

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -223,6 +223,12 @@ class ModelInfo:
     model_revision: str | None = None
     tokenizer_revision: str | None = None
     quantization: str | None = None
+    model_family: str | None = None
+    """Architecture family (e.g. mlx-lm/mlx-vlm ``model_type`` such as
+    'qwen3_next' or 'qwen4_exp'), distinct from ``model_id`` (which is
+    often a user-chosen Hugging Face repo name). Native-MTP collectors use
+    this to label which architecture family a capability determination or
+    run applies to."""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -235,6 +241,7 @@ class ModelInfo:
                 model_revision=data.get("model_revision"),
                 tokenizer_revision=data.get("tokenizer_revision"),
                 quantization=data.get("quantization"),
+                model_family=data.get("model_family"),
             )
         except KeyError as exc:
             raise SchemaValidationError(
@@ -405,8 +412,16 @@ class SpeculativeDecodingInfo:
 
     enabled: bool = False
     method: str | None = None
-    """e.g. 'mtp', 'eagle', 'draft-model', 'lookahead'."""
+    """e.g. 'native-mtp', 'draft-model', 'eagle', 'lookahead'.
+
+    'native-mtp' must only be used when the runtime invoked its own
+    multi-token-prediction heads through a verified API path (see
+    ``llmtracefx.optimizer.collectors.native_mtp``); generic external
+    draft-model speculative decoding must be labeled 'draft-model' even
+    when the draft checkpoint happens to be an extracted MTP head, unless
+    the runtime is verified to keep the two paths distinguishable."""
     configured_depth: int | None = None
+    """Configured speculation/MTP block depth (e.g. draft tokens per step)."""
     proposed_tokens: int | None = None
     accepted_tokens: int | None = None
     verification_time: Measurement | None = None

--- a/llmtracefx/optimizer/workloads/__init__.py
+++ b/llmtracefx/optimizer/workloads/__init__.py
@@ -1,0 +1,15 @@
+"""Deterministic, versioned workload catalog and matrix generation.
+
+This package defines a small, redistributable set of code-completion,
+constrained-structured-JSON, and prose/reasoning prompts (see
+``catalog.py``), how they are materialized to target context sizes
+without silently fabricating padding (see ``materialize.py``), how the
+matrix of (workload, context tier, decode mode) combinations is
+generated deterministically without executing or downloading anything
+(see ``matrix.py``), and deterministic evaluators suitable for these
+workloads (see ``evaluators.py``).
+"""
+
+from __future__ import annotations
+
+WORKLOAD_SCHEMA_VERSION = "1"

--- a/llmtracefx/optimizer/workloads/catalog.py
+++ b/llmtracefx/optimizer/workloads/catalog.py
@@ -16,6 +16,11 @@ from .schema import (
     WorkloadCategory,
 )
 
+_PALINDROME_FUNCTION_STUB = (
+    "def is_palindrome(text: str) -> bool:\n"
+    '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+)
+
 CODE_COMPLETION_PALINDROME = Workload(
     workload_id="code-completion-palindrome-check",
     version="1",
@@ -26,14 +31,10 @@ CODE_COMPLETION_PALINDROME = Workload(
         "`text` reads the same forwards and backwards after lowercasing "
         "and removing spaces, and False otherwise. Respond with only the "
         "completed function body as valid Python code, no explanation.\n\n"
-        "def is_palindrome(text: str) -> bool:\n"
-        '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+        + _PALINDROME_FUNCTION_STUB
     ),
     spec=CodeCompletionSpec(
-        function_stub=(
-            "def is_palindrome(text: str) -> bool:\n"
-            '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
-        ),
+        function_stub=_PALINDROME_FUNCTION_STUB,
         test_code=(
             "assert is_palindrome('Racecar') is True\n"
             "assert is_palindrome('was it a car or a cat i saw') is True\n"
@@ -42,6 +43,7 @@ CODE_COMPLETION_PALINDROME = Workload(
         ),
         entry_point="is_palindrome",
     ),
+    continuation_stub=_PALINDROME_FUNCTION_STUB,
 )
 
 STRUCTURED_JSON_PROFILE_EXTRACTION = Workload(

--- a/llmtracefx/optimizer/workloads/catalog.py
+++ b/llmtracefx/optimizer/workloads/catalog.py
@@ -1,0 +1,102 @@
+"""The pinned, redistributable workload catalog.
+
+All prompt text and evaluator fixtures here are authored for this
+project; nothing is copied from third-party or copyrighted sources.
+Keeping the catalog small keeps it easy to review, hash, and
+redistribute alongside experiment evidence.
+"""
+
+from __future__ import annotations
+
+from .schema import (
+    CodeCompletionSpec,
+    ProseReasoningSpec,
+    StructuredJSONSpec,
+    Workload,
+    WorkloadCategory,
+)
+
+CODE_COMPLETION_PALINDROME = Workload(
+    workload_id="code-completion-palindrome-check",
+    version="1",
+    category=WorkloadCategory.CODE_COMPLETION,
+    title="Complete a palindrome-check function",
+    base_prompt=(
+        "Complete the following Python function so it returns True if "
+        "`text` reads the same forwards and backwards after lowercasing "
+        "and removing spaces, and False otherwise. Respond with only the "
+        "completed function body as valid Python code, no explanation.\n\n"
+        "def is_palindrome(text: str) -> bool:\n"
+        '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+    ),
+    spec=CodeCompletionSpec(
+        function_stub=(
+            "def is_palindrome(text: str) -> bool:\n"
+            '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+        ),
+        test_code=(
+            "assert is_palindrome('Racecar') is True\n"
+            "assert is_palindrome('was it a car or a cat i saw') is True\n"
+            "assert is_palindrome('hello') is False\n"
+            "assert is_palindrome('') is True\n"
+        ),
+        entry_point="is_palindrome",
+    ),
+)
+
+STRUCTURED_JSON_PROFILE_EXTRACTION = Workload(
+    workload_id="structured-json-profile-extraction",
+    version="1",
+    category=WorkloadCategory.STRUCTURED_JSON,
+    title="Extract a structured profile as JSON",
+    base_prompt=(
+        "Read the profile below and respond with a single JSON object "
+        "(no surrounding text, no markdown fences) with exactly these "
+        'keys: "name" (string), "age" (integer), "is_active" '
+        "(boolean).\n\n"
+        "Profile: Priya Nakamura is a 34 year old volunteer coordinator "
+        "who is currently active with the downtown reading program.\n"
+    ),
+    spec=StructuredJSONSpec(
+        required_fields=("name", "age", "is_active"),
+        field_types={"name": "str", "age": "int", "is_active": "bool"},
+    ),
+)
+
+PROSE_REASONING_TRAIN_PROBLEM = Workload(
+    workload_id="prose-reasoning-two-train-gap",
+    version="1",
+    category=WorkloadCategory.PROSE_REASONING,
+    title="Deterministic arithmetic word problem",
+    base_prompt=(
+        "Two trains start 210 miles apart and travel toward each other on "
+        "the same track. One train travels at 40 miles per hour and the "
+        "other at 30 miles per hour. They start at the same time. How "
+        "many hours until they meet? Respond with the final number of "
+        "hours as a single number, followed by a one sentence "
+        "explanation.\n"
+    ),
+    spec=ProseReasoningSpec(expected_answer_pattern=r"\b3(\.0+)?\b"),
+)
+
+WORKLOADS: tuple[Workload, ...] = (
+    CODE_COMPLETION_PALINDROME,
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+    PROSE_REASONING_TRAIN_PROBLEM,
+)
+
+#: Deterministic filler corpus used only to pad prompts toward a target
+#: context length (see ``materialize.py``). Self-authored, synthetic,
+#: content-free technical filler -- never derived from copyrighted text.
+CONTEXT_FILLER_CORPUS = (
+    "Context filler segment {index:04d}: this sentence exists only to "
+    "occupy context length for a reproducible benchmarking workload and "
+    "carries no information relevant to the task above."
+)
+
+
+def workload_by_id(workload_id: str) -> Workload:
+    for workload in WORKLOADS:
+        if workload.workload_id == workload_id:
+            return workload
+    raise KeyError(f"unknown workload_id: {workload_id!r}")

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -1,0 +1,211 @@
+"""Deterministic evaluators for the pinned workload catalog.
+
+Every evaluator here is deterministic (no sampling, no LLM-as-judge) and
+returns the canonical ``llmtracefx.optimizer.schema.OutcomeInfo``. None
+of them overstate quality: ``quality_score``/``success`` reflect only
+what was explicitly checked (exact field/type matches, a fixed test
+suite passing, or a fixed regex matching), and ``notes`` is bounded and
+factual rather than a free-form judgment.
+
+The code-completion evaluator executes model-generated Python in a
+subprocess (never with ``shell=True`` and never via string
+interpolation into a shell command) to run a fixed, project-authored
+test suite against the candidate completion. This is inherent to
+executable-test evaluation (the same approach used by benchmarks like
+HumanEval) and should only be run in an already-trusted local
+environment, the same trust boundary as any other locally executed
+code.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from ..schema import OutcomeInfo
+from .schema import (
+    CodeCompletionSpec,
+    ProseReasoningSpec,
+    StructuredJSONSpec,
+    Workload,
+    WorkloadCategory,
+)
+
+_CODE_FENCE_PATTERN = re.compile(
+    r"```(?:python)?\s*\n(.*?)```", re.DOTALL | re.IGNORECASE
+)
+
+_JSON_TYPE_CHECKS: dict[str, type | tuple[type, ...]] = {
+    "str": str,
+    "int": int,
+    "float": (int, float),
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
+
+def _extract_code(response_text: str) -> str:
+    """Strip a single markdown code fence if present, else return as-is."""
+    match = _CODE_FENCE_PATTERN.search(response_text)
+    return match.group(1) if match else response_text
+
+
+def evaluate_code_completion(
+    spec: CodeCompletionSpec,
+    response_text: str,
+    *,
+    timeout_seconds: float = 10.0,
+) -> OutcomeInfo:
+    """Run ``spec.test_code`` against the candidate completion.
+
+    ``success`` is True only if the combined program (candidate code
+    plus the fixed test assertions) exits with status 0.
+    """
+    completion = _extract_code(response_text)
+    program = f"{completion}\n\n{spec.test_code}\n"
+
+    with tempfile.TemporaryDirectory(prefix="llmtracefx-eval-") as tmp_dir:
+        program_path = Path(tmp_dir) / "candidate.py"
+        program_path.write_text(program, encoding="utf-8")
+        try:
+            completed = subprocess.run(
+                [sys.executable, str(program_path)],
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                shell=False,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return OutcomeInfo(
+                success=False,
+                quality_score=0.0,
+                quality_metric="unit_test_pass",
+                notes=f"candidate completion timed out after {timeout_seconds}s",
+            )
+
+    success = completed.returncode == 0
+    notes = None if success else completed.stderr.strip()[-500:] or "non-zero exit"
+    return OutcomeInfo(
+        success=success,
+        quality_score=1.0 if success else 0.0,
+        quality_metric="unit_test_pass",
+        notes=notes,
+    )
+
+
+def _extract_json_object(response_text: str) -> Any:
+    """Parse the first JSON object in ``response_text``.
+
+    Tries the whole (stripped) response first, then falls back to the
+    substring between the first ``{`` and the last ``}``. Never uses
+    ``eval``; a malformed/missing object raises ``json.JSONDecodeError``.
+    """
+    stripped = response_text.strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise json.JSONDecodeError("no JSON object found", stripped, 0)
+    return json.loads(stripped[start : end + 1])
+
+
+def evaluate_structured_json(
+    spec: StructuredJSONSpec, response_text: str
+) -> OutcomeInfo:
+    """Exact required-field-presence and declared-type checks.
+
+    ``quality_score`` is the fraction of ``required_fields`` present
+    with the declared type; ``success`` requires all of them to match.
+    """
+    try:
+        payload = _extract_json_object(response_text)
+    except json.JSONDecodeError as exc:
+        return OutcomeInfo(
+            success=False,
+            quality_score=0.0,
+            quality_metric="structured_json_exact_field_match",
+            notes=f"response did not contain a parseable JSON object: {exc}",
+        )
+
+    if not isinstance(payload, dict):
+        return OutcomeInfo(
+            success=False,
+            quality_score=0.0,
+            quality_metric="structured_json_exact_field_match",
+            notes=f"parsed JSON root must be an object, got {type(payload).__name__}",
+        )
+
+    problems: list[str] = []
+    matched = 0
+    for field_name in spec.required_fields:
+        if field_name not in payload:
+            problems.append(f"missing field '{field_name}'")
+            continue
+        expected_type_name = spec.field_types.get(field_name)
+        expected_type = _JSON_TYPE_CHECKS.get(expected_type_name or "")
+        value = payload[field_name]
+        if expected_type is None:
+            matched += 1
+            continue
+        # bool is a subclass of int in Python; only accept it for the
+        # "bool" type and reject it for "int"/"float" to avoid a
+        # boolean silently passing as a numeric field.
+        if expected_type_name in ("int", "float") and isinstance(value, bool):
+            problems.append(
+                f"field '{field_name}' is bool, expected {expected_type_name}"
+            )
+            continue
+        if not isinstance(value, expected_type):
+            problems.append(
+                f"field '{field_name}' is {type(value).__name__}, "
+                f"expected {expected_type_name}"
+            )
+            continue
+        matched += 1
+
+    total = len(spec.required_fields)
+    quality_score = matched / total if total else 0.0
+    success = matched == total
+    return OutcomeInfo(
+        success=success,
+        quality_score=quality_score,
+        quality_metric="structured_json_exact_field_match",
+        notes=None if success else "; ".join(problems)[:500],
+    )
+
+
+def evaluate_prose_reasoning(
+    spec: ProseReasoningSpec, response_text: str
+) -> OutcomeInfo:
+    """Deterministic, case-insensitive expected-answer pattern match."""
+    match = re.search(spec.expected_answer_pattern, response_text, re.IGNORECASE)
+    success = match is not None
+    return OutcomeInfo(
+        success=success,
+        quality_score=1.0 if success else 0.0,
+        quality_metric="exact_answer_pattern_match",
+        notes=None if success else "expected answer pattern not found in response",
+    )
+
+
+def evaluate_workload(workload: Workload, response_text: str) -> OutcomeInfo:
+    """Dispatch to the evaluator matching ``workload.category``."""
+    if workload.category is WorkloadCategory.CODE_COMPLETION:
+        assert isinstance(workload.spec, CodeCompletionSpec)
+        return evaluate_code_completion(workload.spec, response_text)
+    if workload.category is WorkloadCategory.STRUCTURED_JSON:
+        assert isinstance(workload.spec, StructuredJSONSpec)
+        return evaluate_structured_json(workload.spec, response_text)
+    assert isinstance(workload.spec, ProseReasoningSpec)
+    return evaluate_prose_reasoning(workload.spec, response_text)

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -147,6 +148,55 @@ def _extract_code(response_text: str) -> str:
     return match.group(1) if match else response_text
 
 
+def _terminate_candidate_process(process: subprocess.Popen[str]) -> None:
+    """Terminate the candidate and its descendants where the OS permits."""
+    if _IS_POSIX:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    elif process.poll() is None:
+        process.kill()
+
+
+def _run_candidate(
+    program_path: Path,
+    *,
+    cwd: str,
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    """Run candidate code while containing its process tree on POSIX."""
+    process = subprocess.Popen(
+        [sys.executable, str(program_path)],
+        cwd=cwd,
+        env=_minimal_subprocess_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        shell=False,
+        start_new_session=_IS_POSIX,
+        preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        _terminate_candidate_process(process)
+        process.communicate()
+        raise
+    finally:
+        # A candidate can let its direct process exit while leaving detached
+        # workers in the new process group. Clean up the whole group before
+        # returning from the evaluator.
+        _terminate_candidate_process(process)
+
+    return subprocess.CompletedProcess(
+        args=process.args,
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
 def evaluate_code_completion(
     spec: CodeCompletionSpec,
     response_text: str,
@@ -166,16 +216,10 @@ def evaluate_code_completion(
         program_path = Path(tmp_dir) / "candidate.py"
         program_path.write_text(program, encoding="utf-8")
         try:
-            completed = subprocess.run(
-                [sys.executable, str(program_path)],
+            completed = _run_candidate(
+                program_path,
                 cwd=tmp_dir,
-                env=_minimal_subprocess_env(),
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                shell=False,
-                check=False,
-                preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
+                timeout_seconds=timeout_seconds,
             )
         except subprocess.TimeoutExpired:
             return OutcomeInfo(

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -148,13 +148,54 @@ def _extract_code(response_text: str) -> str:
     return match.group(1) if match else response_text
 
 
-def _terminate_candidate_process(process: subprocess.Popen[str]) -> None:
+def _process_ids_in_group(process_group_id: int) -> tuple[int, ...]:
+    """Return live process IDs in a POSIX process group.
+
+    Darwin can report ``ESRCH`` for ``killpg`` after the group leader has
+    exited even while descendants with the same PGID remain alive. ``ps`` is
+    used only as a cleanup fallback for that condition.
+    """
+    try:
+        completed = subprocess.run(
+            ["/bin/ps", "-axo", "pid=,pgid="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+            shell=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ()
+
+    members: list[int] = []
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            pid, pgid = (int(field) for field in fields)
+        except ValueError:
+            continue
+        if pgid == process_group_id:
+            members.append(pid)
+    return tuple(members)
+
+
+def _terminate_candidate_process(
+    process: subprocess.Popen[str], *, process_group_id: int | None
+) -> None:
     """Terminate the candidate and its descendants where the OS permits."""
     if _IS_POSIX:
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
+        if process_group_id is None:
             return
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            for pid in _process_ids_in_group(process_group_id):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    continue
     elif process.poll() is None:
         process.kill()
 
@@ -177,17 +218,18 @@ def _run_candidate(
         start_new_session=_IS_POSIX,
         preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
     )
+    process_group_id = process.pid if _IS_POSIX else None
     try:
         stdout, stderr = process.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
-        _terminate_candidate_process(process)
+        _terminate_candidate_process(process, process_group_id=process_group_id)
         process.communicate()
         raise
     finally:
         # A candidate can let its direct process exit while leaving detached
         # workers in the new process group. Clean up the whole group before
         # returning from the evaluator.
-        _terminate_candidate_process(process)
+        _terminate_candidate_process(process, process_group_id=process_group_id)
 
     return subprocess.CompletedProcess(
         args=process.args,

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -12,14 +12,38 @@ subprocess (never with ``shell=True`` and never via string
 interpolation into a shell command) to run a fixed, project-authored
 test suite against the candidate completion. This is inherent to
 executable-test evaluation (the same approach used by benchmarks like
-HumanEval) and should only be run in an already-trusted local
-environment, the same trust boundary as any other locally executed
-code.
+HumanEval). To reduce (not eliminate -- this is not a security
+sandbox) the blast radius of executing untrusted model output, the
+subprocess:
+
+* runs with its working directory set to a fresh, single-use temporary
+  directory that is removed afterward, so relative file writes by the
+  candidate land there instead of the caller's cwd;
+* runs with a minimal, explicit environment allowlist (``PATH`` plus a
+  handful of Windows system variables needed for the interpreter to
+  start) instead of the full inherited environment, so parent secrets
+  (API keys, tokens, credentials) are never visible to candidate code;
+* on POSIX, applies conservative ``resource.setrlimit`` bounds (CPU
+  time, address space, output file size) before exec via
+  ``preexec_fn``, scoped to that one process only, on a best-effort
+  basis (any single limit a given POSIX platform rejects -- notably
+  macOS/Darwin's ``RLIMIT_AS`` -- is skipped rather than aborting
+  subprocess creation). Process-count limits (``RLIMIT_NPROC``) are
+  deliberately left untouched because they are per-user, not
+  per-process, and could affect unrelated processes sharing this host.
+  ``preexec_fn``/``resource`` are POSIX-only (CPython raises
+  ``ValueError`` if ``preexec_fn`` is passed on Windows), so on Windows
+  only the cwd/environment isolation above applies and no CPU/memory/
+  file-size ceiling is enforced.
+
+This should still only be run in an already-trusted local environment;
+it is containment for a benchmarking tool, not a hostile-code sandbox.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -49,6 +73,73 @@ _JSON_TYPE_CHECKS: dict[str, type | tuple[type, ...]] = {
     "dict": dict,
 }
 
+#: Explicit allowlist for the candidate-code subprocess environment.
+#: Everything else from the caller's environment (API keys, tokens,
+#: credentials, unrelated config) is deliberately excluded.
+_ALLOWED_SUBPROCESS_ENV_VARS: tuple[str, ...] = (
+    "PATH",
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "PATHEXT",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+)
+
+_IS_POSIX = os.name == "posix"
+
+#: Conservative POSIX-only resource ceilings for the candidate-code
+#: subprocess. Deliberately generous enough not to interfere with any
+#: legitimate small workload-catalog completion; see the module
+#: docstring for why ``RLIMIT_NPROC`` is not included.
+_MAX_CPU_SECONDS = 10
+_MAX_ADDRESS_SPACE_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
+_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+
+def _minimal_subprocess_env() -> dict[str, str]:
+    """Build a minimal, explicit environment for the candidate subprocess."""
+    return {
+        name: os.environ[name]
+        for name in _ALLOWED_SUBPROCESS_ENV_VARS
+        if name in os.environ
+    }
+
+
+def _posix_preexec_resource_limits() -> None:
+    """Best-effort CPU/address-space/file-size limits before exec (POSIX).
+
+    Runs inside the freshly forked child, before the candidate program's
+    process image is loaded, so any limit that does apply bounds only
+    that one process. Each limit is applied independently and any
+    platform quirk that rejects it is swallowed rather than aborting the
+    whole subprocess launch: notably, macOS/Darwin's kernel rejects
+    ``RLIMIT_AS`` for reasons unrelated to the requested value (its
+    reported hard limit does not match what it actually enforces), so
+    treating a single unsupported limit as fatal would break code
+    evaluation entirely on that platform. Never call this on a
+    non-POSIX platform.
+    """
+    import resource
+
+    for limit, bounds in (
+        (resource.RLIMIT_CPU, (_MAX_CPU_SECONDS, _MAX_CPU_SECONDS)),
+        (
+            resource.RLIMIT_AS,
+            (_MAX_ADDRESS_SPACE_BYTES, _MAX_ADDRESS_SPACE_BYTES),
+        ),
+        (
+            resource.RLIMIT_FSIZE,
+            (_MAX_FILE_SIZE_BYTES, _MAX_FILE_SIZE_BYTES),
+        ),
+    ):
+        try:
+            resource.setrlimit(limit, bounds)
+        except (ValueError, OSError):
+            # Platform does not support (or rejects) this specific
+            # limit; skip it and keep applying the remaining ones.
+            continue
+
 
 def _extract_code(response_text: str) -> str:
     """Strip a single markdown code fence if present, else return as-is."""
@@ -65,7 +156,8 @@ def evaluate_code_completion(
     """Run ``spec.test_code`` against the candidate completion.
 
     ``success`` is True only if the combined program (candidate code
-    plus the fixed test assertions) exits with status 0.
+    plus the fixed test assertions) exits with status 0. See the module
+    docstring for the containment measures applied to this subprocess.
     """
     completion = _extract_code(response_text)
     program = f"{completion}\n\n{spec.test_code}\n"
@@ -76,11 +168,14 @@ def evaluate_code_completion(
         try:
             completed = subprocess.run(
                 [sys.executable, str(program_path)],
+                cwd=tmp_dir,
+                env=_minimal_subprocess_env(),
                 capture_output=True,
                 text=True,
                 timeout=timeout_seconds,
                 shell=False,
                 check=False,
+                preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
             )
         except subprocess.TimeoutExpired:
             return OutcomeInfo(

--- a/llmtracefx/optimizer/workloads/materialize.py
+++ b/llmtracefx/optimizer/workloads/materialize.py
@@ -1,0 +1,100 @@
+"""Deterministic prompt materialization: reaching a target context tier.
+
+This module defines, explicitly and reproducibly, how a workload's base
+prompt is padded toward a target context length. It never silently
+invents or truncates task content: the base prompt is always preserved
+verbatim, and any padding added is deterministic filler text whose exact
+composition is recorded alongside a hash of the fully materialized
+prompt.
+
+Token counts here are a documented **planning approximation**
+(``APPROX_CHARS_PER_TOKEN``), not a measurement. The actual token count
+for a real run is always measured by the runtime's own tokenizer at
+collection time and recorded in ``ExperimentRecord.tokens`` -- this
+module's ``target_context_tokens``/``approx_chars_per_token`` fields
+exist so consumers can tell planned intent apart from measured fact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..collectors._shared import sha256_text
+from .catalog import CONTEXT_FILLER_CORPUS
+from .schema import CONTEXT_TIER_TARGET_TOKENS, ContextTier, Workload
+
+#: Conservative, fixed approximation used only to decide how much filler
+#: to add when materializing a prompt for planning/matrix-generation
+#: purposes. English technical text commonly tokenizes at roughly 3-4
+#: characters per token across common BPE tokenizers; 4 is intentionally
+#: conservative (under-pads rather than over-pads relative to most
+#: tokenizers, so materialized prompts are unlikely to *exceed* the
+#: target once actually tokenized).
+APPROX_CHARS_PER_TOKEN = 4
+
+
+@dataclass(frozen=True)
+class MaterializedPrompt:
+    """The fully materialized prompt text plus its planning metadata."""
+
+    workload_id: str
+    workload_version: str
+    context_tier: ContextTier
+    target_context_tokens: int
+    approx_chars_per_token: int
+    filler_segments_used: int
+    text: str
+    prompt_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workload_id": self.workload_id,
+            "workload_version": self.workload_version,
+            "context_tier": self.context_tier.value,
+            "target_context_tokens": self.target_context_tokens,
+            "approx_chars_per_token": self.approx_chars_per_token,
+            "filler_segments_used": self.filler_segments_used,
+            "prompt_hash": self.prompt_hash,
+            "prompt_char_count": len(self.text),
+        }
+
+
+def materialize_prompt(workload: Workload, tier: ContextTier) -> MaterializedPrompt:
+    """Deterministically pad ``workload``'s base prompt toward ``tier``.
+
+    The base prompt is always kept verbatim and never truncated -- if it
+    already meets or exceeds the approximate target size, no filler is
+    added. Padding, when added, is deterministic filler text appended
+    after a blank-line separator, numbered from zero, so the exact
+    output is reproducible from ``(workload_id, version, tier)`` alone.
+    """
+    target_tokens = CONTEXT_TIER_TARGET_TOKENS[tier]
+    target_chars = target_tokens * APPROX_CHARS_PER_TOKEN
+    base = workload.base_prompt
+
+    if len(base) >= target_chars:
+        text = base
+        filler_segments = 0
+    else:
+        remaining = target_chars - len(base)
+        filler_parts: list[str] = []
+        index = 0
+        while remaining > 0:
+            segment = CONTEXT_FILLER_CORPUS.format(index=index) + "\n"
+            filler_parts.append(segment)
+            remaining -= len(segment)
+            index += 1
+        text = base + "\n\n" + "".join(filler_parts)
+        filler_segments = index
+
+    return MaterializedPrompt(
+        workload_id=workload.workload_id,
+        workload_version=workload.version,
+        context_tier=tier,
+        target_context_tokens=target_tokens,
+        approx_chars_per_token=APPROX_CHARS_PER_TOKEN,
+        filler_segments_used=filler_segments,
+        text=text,
+        prompt_hash=sha256_text(text),
+    )

--- a/llmtracefx/optimizer/workloads/materialize.py
+++ b/llmtracefx/optimizer/workloads/materialize.py
@@ -22,7 +22,12 @@ from typing import Any
 
 from ..collectors._shared import sha256_text
 from .catalog import CONTEXT_FILLER_CORPUS
-from .schema import CONTEXT_TIER_TARGET_TOKENS, ContextTier, Workload
+from .schema import (
+    CONTEXT_TIER_TARGET_TOKENS,
+    ContextTier,
+    PaddingPlacement,
+    Workload,
+)
 
 #: Conservative, fixed approximation used only to decide how much filler
 #: to add when materializing a prompt for planning/matrix-generation
@@ -60,14 +65,45 @@ class MaterializedPrompt:
         }
 
 
+def _build_filler(remaining_chars: int) -> tuple[str, int]:
+    """Deterministically build filler text totalling >= ``remaining_chars``.
+
+    Returns the filler text and the number of segments used, numbered
+    from zero so the output is reproducible.
+    """
+    filler_parts: list[str] = []
+    index = 0
+    remaining = remaining_chars
+    while remaining > 0:
+        segment = CONTEXT_FILLER_CORPUS.format(index=index) + "\n"
+        filler_parts.append(segment)
+        remaining -= len(segment)
+        index += 1
+    return "".join(filler_parts), index
+
+
 def materialize_prompt(workload: Workload, tier: ContextTier) -> MaterializedPrompt:
     """Deterministically pad ``workload``'s base prompt toward ``tier``.
 
     The base prompt is always kept verbatim and never truncated -- if it
     already meets or exceeds the approximate target size, no filler is
-    added. Padding, when added, is deterministic filler text appended
-    after a blank-line separator, numbered from zero, so the exact
-    output is reproducible from ``(workload_id, version, tier)`` alone.
+    added. Padding, when added, is deterministic filler text numbered
+    from zero, so the exact output is reproducible from
+    ``(workload_id, version, tier)`` alone.
+
+    Placement depends on ``workload.padding_placement``:
+
+    * ``APPEND_AFTER_BASE_PROMPT``: filler is appended after the full
+      base prompt. Correct for workloads whose base prompt is already a
+      complete, self-contained instruction (structured JSON, prose
+      reasoning).
+    * ``BEFORE_CONTINUATION_STUB``: filler is inserted between the base
+      prompt's instructions and its fixed ``continuation_stub``, so the
+      stub -- e.g. an open function signature/docstring for code
+      completion -- remains the exact trailing content the model must
+      continue from. Appending filler after the stub would instead
+      leave irrelevant filler as the last thing the model sees,
+      corrupting the completion point.
     """
     target_tokens = CONTEXT_TIER_TARGET_TOKENS[tier]
     target_chars = target_tokens * APPROX_CHARS_PER_TOKEN
@@ -76,17 +112,14 @@ def materialize_prompt(workload: Workload, tier: ContextTier) -> MaterializedPro
     if len(base) >= target_chars:
         text = base
         filler_segments = 0
+    elif workload.padding_placement is PaddingPlacement.BEFORE_CONTINUATION_STUB:
+        stub = workload.continuation_stub
+        prefix = base[: -len(stub)]
+        filler_text, filler_segments = _build_filler(target_chars - len(base))
+        text = f"{prefix}{filler_text}\n{stub}"
     else:
-        remaining = target_chars - len(base)
-        filler_parts: list[str] = []
-        index = 0
-        while remaining > 0:
-            segment = CONTEXT_FILLER_CORPUS.format(index=index) + "\n"
-            filler_parts.append(segment)
-            remaining -= len(segment)
-            index += 1
-        text = base + "\n\n" + "".join(filler_parts)
-        filler_segments = index
+        filler_text, filler_segments = _build_filler(target_chars - len(base))
+        text = base + "\n\n" + filler_text
 
     return MaterializedPrompt(
         workload_id=workload.workload_id,

--- a/llmtracefx/optimizer/workloads/matrix.py
+++ b/llmtracefx/optimizer/workloads/matrix.py
@@ -1,0 +1,318 @@
+"""Deterministic workload matrix generation.
+
+Generates the set of (workload, context tier, decode mode) combinations
+this project can plan for a given target model, without ever executing
+anything or downloading model weights. Each entry carries the exact
+planned CLI invocation (reusing the existing ``collect-mlx`` /
+``native-mtp collect`` commands) and a ready-to-run
+``llmtracefx.optimizer.runner.RunnerConfig``-compatible JSON file, so the
+PR #3 runner can execute it once local checkpoints are available.
+
+Native-MTP rows are always included for visibility, but marked
+``runnable=False`` with an explicit ``unsupported_reason`` whenever
+capability detection (see ``collectors.native_mtp``) reports the
+runtime cannot produce trustworthy native-MTP evidence for the
+requested model family -- never silently omitted, never fabricated as
+runnable.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text
+from ..collectors.native_mtp import detect_native_mtp_capability
+from .catalog import WORKLOADS
+from .materialize import MaterializedPrompt, materialize_prompt
+from .schema import ContextTier, Workload
+
+MATRIX_SCHEMA_VERSION = "1"
+
+#: Default MTP block depths planned for when a runtime does support
+#: native MTP. Matches the depths already accepted by
+#: ``NativeMTPCollectionConfig.configured_depth`` and by generic
+#: draft-model speculation's ``num_draft_tokens``.
+DEFAULT_MTP_DEPTHS: tuple[int, ...] = (2, 4)
+
+DECODE_MODE_AUTOREGRESSIVE = "autoregressive"
+DECODE_MODE_NATIVE_MTP = "native-mtp"
+
+DEFAULT_MAX_TOKENS = 128
+
+
+@dataclass(frozen=True)
+class MatrixEntry:
+    """One planned (workload, context tier, decode mode) combination."""
+
+    run_id: str
+    workload_id: str
+    workload_version: str
+    category: str
+    context_tier: str
+    decode_mode: str
+    configured_depth: int | None
+    prompt: MaterializedPrompt
+    prompt_path: str
+    runner_results_dir: str
+    collector_output_dir: str
+    runnable: bool
+    unsupported_reason: str | None
+    command_argv: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "workload_id": self.workload_id,
+            "workload_version": self.workload_version,
+            "category": self.category,
+            "context_tier": self.context_tier,
+            "decode_mode": self.decode_mode,
+            "configured_depth": self.configured_depth,
+            "prompt": self.prompt.to_dict(),
+            "prompt_path": self.prompt_path,
+            "runner_results_dir": self.runner_results_dir,
+            "collector_output_dir": self.collector_output_dir,
+            "runnable": self.runnable,
+            "unsupported_reason": self.unsupported_reason,
+            "command_argv": list(self.command_argv),
+        }
+
+
+@dataclass(frozen=True)
+class MatrixManifest:
+    """The full deterministic matrix for one target model/family."""
+
+    schema_version: str
+    model_id: str
+    model_family: str
+    output_dir: str
+    entries: tuple[MatrixEntry, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_id": self.model_id,
+            "model_family": self.model_family,
+            "output_dir": self.output_dir,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+
+def _collect_mlx_argv(
+    *,
+    run_id: str,
+    model_path: str,
+    model_id: str,
+    prompt_path: str,
+    output_dir: str,
+    max_tokens: int,
+) -> tuple[str, ...]:
+    return (
+        "llmtracefx-optimizer",
+        "collect-mlx",
+        "--run-id",
+        run_id,
+        "--model-path",
+        model_path,
+        "--model-id",
+        model_id,
+        "--prompt-file",
+        prompt_path,
+        "--output-dir",
+        output_dir,
+        "--max-tokens",
+        str(max_tokens),
+    )
+
+
+def _native_mtp_collect_argv(
+    *,
+    run_id: str,
+    target_model_path: str,
+    mtp_sidecar_path: str,
+    model_id: str,
+    prompt_path: str,
+    output_dir: str,
+    max_tokens: int,
+    configured_depth: int,
+) -> tuple[str, ...]:
+    return (
+        "llmtracefx-optimizer",
+        "native-mtp",
+        "collect",
+        "--run-id",
+        run_id,
+        "--target-model-path",
+        target_model_path,
+        "--mtp-sidecar-path",
+        mtp_sidecar_path,
+        "--model-id",
+        model_id,
+        "--prompt-file",
+        prompt_path,
+        "--output-dir",
+        output_dir,
+        "--max-tokens",
+        str(max_tokens),
+        "--configured-depth",
+        str(configured_depth),
+    )
+
+
+def generate_matrix(
+    *,
+    model_id: str,
+    model_family: str,
+    output_dir: str,
+    target_model_path: str | None = None,
+    mtp_sidecar_path: str | None = None,
+    workloads: Sequence[Workload] = WORKLOADS,
+    context_tiers: Sequence[ContextTier] = tuple(ContextTier),
+    mtp_depths: Sequence[int] = DEFAULT_MTP_DEPTHS,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> MatrixManifest:
+    """Deterministically build the full planned matrix.
+
+    Purely computational: materializes prompts and derives planned
+    commands/paths from the given identifiers, but performs no file
+    I/O, no model loading, and no downloads. ``output_dir`` is used only
+    to compute the absolute paths later written by ``write_matrix`` (and
+    baked into each entry's planned command); pass the same value to
+    both functions. ``target_model_path``/``mtp_sidecar_path`` are
+    optional placeholders substituted into the planned commands; when
+    omitted, an explicit placeholder string is used so the manifest is
+    still generated but visibly incomplete.
+    """
+    resolved_target_path = target_model_path or "<TARGET_MODEL_PATH>"
+    resolved_sidecar_path = mtp_sidecar_path or "<MTP_SIDECAR_PATH>"
+    output_dir_path = Path(output_dir)
+
+    capability = detect_native_mtp_capability(
+        model_family, mlx_lm_version=None, mlx_vlm_version=None
+    )
+
+    entries: list[MatrixEntry] = []
+    for workload in workloads:
+        for tier in context_tiers:
+            materialized = materialize_prompt(workload, tier)
+            prompt_path = str(
+                output_dir_path / "prompts" / f"{workload.workload_id}-{tier.value}.txt"
+            )
+
+            ar_run_id = (
+                f"{workload.workload_id}-{tier.value}-{DECODE_MODE_AUTOREGRESSIVE}"
+            )
+            ar_output_dir = str(output_dir_path / "runs" / ar_run_id)
+            entries.append(
+                MatrixEntry(
+                    run_id=ar_run_id,
+                    workload_id=workload.workload_id,
+                    workload_version=workload.version,
+                    category=workload.category.value,
+                    context_tier=tier.value,
+                    decode_mode=DECODE_MODE_AUTOREGRESSIVE,
+                    configured_depth=None,
+                    prompt=materialized,
+                    prompt_path=prompt_path,
+                    runner_results_dir=str(output_dir_path / "runner" / ar_run_id),
+                    collector_output_dir=ar_output_dir,
+                    runnable=True,
+                    unsupported_reason=None,
+                    command_argv=_collect_mlx_argv(
+                        run_id=ar_run_id,
+                        model_path=resolved_target_path,
+                        model_id=model_id,
+                        prompt_path=prompt_path,
+                        output_dir=ar_output_dir,
+                        max_tokens=max_tokens,
+                    ),
+                )
+            )
+
+            for depth in mtp_depths:
+                mtp_run_id = (
+                    f"{workload.workload_id}-{tier.value}-"
+                    f"{DECODE_MODE_NATIVE_MTP}-depth{depth}"
+                )
+                mtp_output_dir = str(output_dir_path / "runs" / mtp_run_id)
+                entries.append(
+                    MatrixEntry(
+                        run_id=mtp_run_id,
+                        workload_id=workload.workload_id,
+                        workload_version=workload.version,
+                        category=workload.category.value,
+                        context_tier=tier.value,
+                        decode_mode=DECODE_MODE_NATIVE_MTP,
+                        configured_depth=depth,
+                        prompt=materialized,
+                        prompt_path=prompt_path,
+                        runner_results_dir=str(output_dir_path / "runner" / mtp_run_id),
+                        collector_output_dir=mtp_output_dir,
+                        runnable=capability.supported,
+                        unsupported_reason=(
+                            None if capability.supported else capability.reason
+                        ),
+                        command_argv=_native_mtp_collect_argv(
+                            run_id=mtp_run_id,
+                            target_model_path=resolved_target_path,
+                            mtp_sidecar_path=resolved_sidecar_path,
+                            model_id=model_id,
+                            prompt_path=prompt_path,
+                            output_dir=mtp_output_dir,
+                            max_tokens=max_tokens,
+                            configured_depth=depth,
+                        ),
+                    )
+                )
+
+    return MatrixManifest(
+        schema_version=MATRIX_SCHEMA_VERSION,
+        model_id=model_id,
+        model_family=model_family,
+        output_dir=str(output_dir_path),
+        entries=tuple(entries),
+    )
+
+
+def write_matrix(manifest: MatrixManifest) -> None:
+    """Materialize the manifest, prompts, and per-entry runner configs.
+
+    Never executes a command or loads a model. Writes, under
+    ``manifest.output_dir`` (the same value passed to
+    ``generate_matrix``):
+
+    * ``manifest.json``: the full machine-readable matrix.
+    * ``prompts/<workload_id>-<tier>.txt``: each fully materialized
+      prompt (deduplicated across decode modes/depths).
+    * ``configs/<run_id>.json``: a ``RunnerConfig``-compatible JSON per
+      entry (absolute paths), ready for
+      ``llmtracefx-optimizer run --config ...``.
+    """
+    output_dir_path = Path(manifest.output_dir)
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(output_dir_path / "manifest.json", manifest.to_json() + "\n")
+
+    written_prompts: set[str] = set()
+    for entry in manifest.entries:
+        if entry.prompt_path not in written_prompts:
+            atomic_write_text(Path(entry.prompt_path), entry.prompt.text)
+            written_prompts.add(entry.prompt_path)
+
+        runner_config = {
+            "run_id": entry.run_id,
+            "command": list(entry.command_argv),
+            "results_dir": entry.runner_results_dir,
+            "warmup_repetitions": 0,
+            "measured_repetitions": 1,
+        }
+        atomic_write_text(
+            output_dir_path / "configs" / f"{entry.run_id}.json",
+            json.dumps(runner_config, indent=2, sort_keys=False) + "\n",
+        )

--- a/llmtracefx/optimizer/workloads/schema.py
+++ b/llmtracefx/optimizer/workloads/schema.py
@@ -132,6 +132,23 @@ _SPEC_TYPES_BY_CATEGORY: dict[WorkloadCategory, type[WorkloadSpec]] = {
 }
 
 
+class PaddingPlacement(str, Enum):
+    """Where context-padding filler must be inserted in a materialized prompt."""
+
+    APPEND_AFTER_BASE_PROMPT = "append_after_base_prompt"
+    """Filler goes after the full (already self-contained) base prompt.
+    Valid for workloads whose base prompt has no dangling continuation
+    point, e.g. structured JSON extraction or prose reasoning."""
+
+    BEFORE_CONTINUATION_STUB = "before_continuation_stub"
+    """Filler is inserted between the base prompt's instructions and its
+    fixed ``continuation_stub``, so the stub remains the very last text
+    the model sees. Required for code completion, where the model must
+    continue writing code immediately after an open function
+    signature/docstring; appending filler after that stub would corrupt
+    the completion point."""
+
+
 @dataclass(frozen=True)
 class Workload:
     """One versioned, deterministic workload definition."""
@@ -142,6 +159,16 @@ class Workload:
     title: str
     base_prompt: str
     spec: WorkloadSpec
+    continuation_stub: str = ""
+    """When non-empty, the exact trailing content of ``base_prompt`` that
+    must remain the very last text the model sees (e.g. an open function
+    signature/docstring for code completion). Context padding is inserted
+    *before* this stub rather than appended after the full base prompt,
+    so the model still continues immediately from the stub. Empty for
+    workloads (structured JSON, prose reasoning) whose ``base_prompt`` is
+    already a complete, self-contained instruction with no dangling
+    continuation point -- for those, padding appended after the full
+    base prompt does not change the task's meaning."""
 
     def __post_init__(self) -> None:
         if not self.workload_id:
@@ -157,6 +184,23 @@ class Workload:
                 f"{self.category.value} but spec type "
                 f"{type(self.spec).__name__}, expected {expected_type.__name__}"
             )
+        if self.continuation_stub and not self.base_prompt.endswith(
+            self.continuation_stub
+        ):
+            raise WorkloadSchemaError(
+                f"workload '{self.workload_id}' has a continuation_stub that "
+                "is not a suffix of base_prompt; padding placement requires "
+                "the stub to be the exact trailing content of the prompt"
+            )
+
+    @property
+    def padding_placement(self) -> PaddingPlacement:
+        """Where context-padding filler must be inserted for this workload."""
+        return (
+            PaddingPlacement.BEFORE_CONTINUATION_STUB
+            if self.continuation_stub
+            else PaddingPlacement.APPEND_AFTER_BASE_PROMPT
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -167,6 +211,7 @@ class Workload:
             "title": self.title,
             "base_prompt": self.base_prompt,
             "spec": self.spec.to_dict(),
+            "continuation_stub": self.continuation_stub,
         }
 
     def to_json(self, *, indent: int | None = 2) -> str:
@@ -184,6 +229,7 @@ class Workload:
                 title=data["title"],
                 base_prompt=data["base_prompt"],
                 spec=spec_type.from_dict(data["spec"]),
+                continuation_stub=data.get("continuation_stub", ""),
             )
         except KeyError as exc:
             raise WorkloadSchemaError(

--- a/llmtracefx/optimizer/workloads/schema.py
+++ b/llmtracefx/optimizer/workloads/schema.py
@@ -1,0 +1,191 @@
+"""Workload schema: categories, context tiers, and the ``Workload`` record.
+
+Every workload is versioned and deterministic: the same ``workload_id`` +
+``version`` always produces the same base prompt and evaluator
+configuration, so matrix generation and prompt hashing are reproducible
+across runs and machines.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+WORKLOAD_SCHEMA_VERSION = "1"
+
+
+class WorkloadSchemaError(ValueError):
+    """Raised when a workload definition is invalid."""
+
+
+class WorkloadCategory(str, Enum):
+    """The three workload categories this matrix covers."""
+
+    CODE_COMPLETION = "code_completion"
+    STRUCTURED_JSON = "structured_json"
+    PROSE_REASONING = "prose_reasoning"
+
+
+class ContextTier(str, Enum):
+    """Target context sizes the matrix generates prompts for."""
+
+    TIER_2K = "2k"
+    TIER_8K = "8k"
+    TIER_16K = "16k"
+
+
+#: Target context length in tokens for each tier. These are *targets* the
+#: materializer pads toward using an explicit, documented approximation
+#: (see ``materialize.py``) -- not measured token counts. The actual
+#: token count for a real run is measured by the runtime's own tokenizer
+#: at collection time (``ExperimentRecord.tokens``).
+CONTEXT_TIER_TARGET_TOKENS: dict[ContextTier, int] = {
+    ContextTier.TIER_2K: 2048,
+    ContextTier.TIER_8K: 8192,
+    ContextTier.TIER_16K: 16384,
+}
+
+
+@dataclass(frozen=True)
+class CodeCompletionSpec:
+    """A small function stub plus a deterministic, executable test."""
+
+    function_stub: str
+    test_code: str
+    """Python source appended after the candidate completion; must exit
+    0 (via ``assert``) for the workload to pass."""
+    entry_point: str
+    """Name of the function the test code calls."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CodeCompletionSpec:
+        try:
+            return cls(
+                function_stub=data["function_stub"],
+                test_code=data["test_code"],
+                entry_point=data["entry_point"],
+            )
+        except KeyError as exc:
+            raise WorkloadSchemaError(
+                f"CodeCompletionSpec is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class StructuredJSONSpec:
+    """Required top-level fields and their expected JSON types."""
+
+    required_fields: tuple[str, ...]
+    field_types: dict[str, str]
+    """Maps field name to one of 'str', 'int', 'float', 'bool', 'list',
+    'dict' -- checked with a fixed, explicit type table, never ``eval``."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required_fields": list(self.required_fields),
+            "field_types": dict(self.field_types),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StructuredJSONSpec:
+        try:
+            return cls(
+                required_fields=tuple(data["required_fields"]),
+                field_types=dict(data["field_types"]),
+            )
+        except KeyError as exc:
+            raise WorkloadSchemaError(
+                f"StructuredJSONSpec is missing required field: {exc}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class ProseReasoningSpec:
+    """A deterministic expected-answer regex, matched case-insensitively."""
+
+    expected_answer_pattern: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProseReasoningSpec:
+        try:
+            return cls(expected_answer_pattern=data["expected_answer_pattern"])
+        except KeyError as exc:
+            raise WorkloadSchemaError(
+                f"ProseReasoningSpec is missing required field: {exc}"
+            ) from exc
+
+
+WorkloadSpec = CodeCompletionSpec | StructuredJSONSpec | ProseReasoningSpec
+
+_SPEC_TYPES_BY_CATEGORY: dict[WorkloadCategory, type[WorkloadSpec]] = {
+    WorkloadCategory.CODE_COMPLETION: CodeCompletionSpec,
+    WorkloadCategory.STRUCTURED_JSON: StructuredJSONSpec,
+    WorkloadCategory.PROSE_REASONING: ProseReasoningSpec,
+}
+
+
+@dataclass(frozen=True)
+class Workload:
+    """One versioned, deterministic workload definition."""
+
+    workload_id: str
+    version: str
+    category: WorkloadCategory
+    title: str
+    base_prompt: str
+    spec: WorkloadSpec
+
+    def __post_init__(self) -> None:
+        if not self.workload_id:
+            raise WorkloadSchemaError("workload_id must be non-empty")
+        if not self.version:
+            raise WorkloadSchemaError("version must be non-empty")
+        if not self.base_prompt:
+            raise WorkloadSchemaError("base_prompt must be non-empty")
+        expected_type = _SPEC_TYPES_BY_CATEGORY[self.category]
+        if not isinstance(self.spec, expected_type):
+            raise WorkloadSchemaError(
+                f"workload '{self.workload_id}' has category "
+                f"{self.category.value} but spec type "
+                f"{type(self.spec).__name__}, expected {expected_type.__name__}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": WORKLOAD_SCHEMA_VERSION,
+            "workload_id": self.workload_id,
+            "version": self.version,
+            "category": self.category.value,
+            "title": self.title,
+            "base_prompt": self.base_prompt,
+            "spec": self.spec.to_dict(),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Workload:
+        try:
+            category = WorkloadCategory(data["category"])
+            spec_type = _SPEC_TYPES_BY_CATEGORY[category]
+            return cls(
+                workload_id=data["workload_id"],
+                version=data["version"],
+                category=category,
+                title=data["title"],
+                base_prompt=data["base_prompt"],
+                spec=spec_type.from_dict(data["spec"]),
+            )
+        except KeyError as exc:
+            raise WorkloadSchemaError(
+                f"Workload is missing required field: {exc}"
+            ) from exc

--- a/tests/optimizer/test_native_mtp_cli.py
+++ b/tests/optimizer/test_native_mtp_cli.py
@@ -1,0 +1,130 @@
+"""CLI tests for native-MTP capability report/collection subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from llmtracefx.optimizer import cli
+
+
+def _write_config(path: Path, **fields) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    payload = {"model_type": "qwen3_next", "hidden_size": 4096, "vocab_size": 151936}
+    payload.update(fields)
+    (path / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_capability_report_cli_prints_unsupported_and_exits_3(tmp_path, capsys):
+    target = tmp_path / "target"
+    _write_config(target)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        ["native-mtp", "capability-report", "--target-model-path", str(target)]
+    )
+    assert args.func(args) == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["supported"] is False
+    assert payload["model_family"] == "qwen3_next"
+
+
+def test_capability_report_cli_writes_to_output_file(tmp_path):
+    target = tmp_path / "target"
+    _write_config(target)
+    output = tmp_path / "capability.json"
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "native-mtp",
+            "capability-report",
+            "--target-model-path",
+            str(target),
+            "--output",
+            str(output),
+        ]
+    )
+    assert args.func(args) == 3
+    assert json.loads(output.read_text())["supported"] is False
+
+
+def test_capability_report_cli_reports_missing_checkpoint(tmp_path, capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "native-mtp",
+            "capability-report",
+            "--target-model-path",
+            str(tmp_path / "missing"),
+        ]
+    )
+    assert args.func(args) == 1
+    assert "Failed to determine" in capsys.readouterr().err
+
+
+def test_native_mtp_collect_cli_writes_unsupported_record(tmp_path):
+    target = tmp_path / "target"
+    sidecar = tmp_path / "sidecar"
+    _write_config(target)
+    _write_config(sidecar)
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("hello", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "native-mtp",
+            "collect",
+            "--run-id",
+            "cli-native-mtp-1",
+            "--target-model-path",
+            str(target),
+            "--mtp-sidecar-path",
+            str(sidecar),
+            "--model-id",
+            "local/qwen3.8-27b",
+            "--prompt-file",
+            str(prompt_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert args.func(args) == 1
+    record = json.loads((output_dir / "record.json").read_text())
+    assert record["outcome"]["success"] is False
+    assert record["error"]["category"] == "NativeMTPUnsupported"
+    assert (output_dir / "capability_report.json").exists()
+    assert not (output_dir / "response.txt").exists()
+
+
+def test_native_mtp_collect_cli_reports_checkpoint_mismatch(tmp_path, capsys):
+    target = tmp_path / "target"
+    sidecar = tmp_path / "sidecar"
+    _write_config(target, hidden_size=4096)
+    _write_config(sidecar, hidden_size=2048)
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("hello", encoding="utf-8")
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "native-mtp",
+            "collect",
+            "--run-id",
+            "cli-native-mtp-2",
+            "--target-model-path",
+            str(target),
+            "--mtp-sidecar-path",
+            str(sidecar),
+            "--model-id",
+            "local/qwen3.8-27b",
+            "--prompt-file",
+            str(prompt_path),
+            "--output-dir",
+            str(tmp_path / "artifacts"),
+        ]
+    )
+    assert args.func(args) == 1
+    assert "Failed to collect native-MTP evidence" in capsys.readouterr().err

--- a/tests/optimizer/test_native_mtp_collector.py
+++ b/tests/optimizer/test_native_mtp_collector.py
@@ -1,0 +1,350 @@
+"""Tests for native-MTP capability detection, checkpoint validation, and
+honest unsupported-result evidence collection."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.collectors.native_mtp import (
+    MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES,
+    MLX_VLM_EXPERIMENTAL_MTP_FAMILIES,
+    NativeMTPCapabilityReport,
+    NativeMTPCollectionConfig,
+    NativeMTPCollectorError,
+    collect_native_mtp,
+    detect_native_mtp_capability,
+    validate_checkpoint_compatibility,
+)
+from llmtracefx.optimizer.schema import ExperimentRecord
+
+
+def _write_config(path: Path, **fields) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    payload = {"model_type": "qwen3_next", "hidden_size": 4096, "vocab_size": 151936}
+    payload.update(fields)
+    (path / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def make_config(tmp_path: Path, **overrides) -> NativeMTPCollectionConfig:
+    target_path = tmp_path / "target"
+    sidecar_path = tmp_path / "sidecar"
+    if "target_model_path" not in overrides:
+        _write_config(target_path)
+    if "mtp_sidecar_path" not in overrides:
+        _write_config(sidecar_path)
+    values = {
+        "run_id": "native-mtp-1",
+        "target_model_path": target_path,
+        "mtp_sidecar_path": sidecar_path,
+        "model_id": "local/qwen3.8-27b",
+        "prompt": "test prompt",
+        "output_dir": tmp_path / "artifacts",
+        "command_argv": (
+            "llmtracefx-optimizer",
+            "native-mtp",
+            "collect",
+            "--target-model-path",
+            str(target_path),
+        ),
+    }
+    values.update(overrides)
+    return NativeMTPCollectionConfig(**values)
+
+
+# --- Capability detection ----------------------------------------------
+
+
+@pytest.mark.parametrize("family", sorted(MLX_LM_STRIPS_MTP_WEIGHTS_FAMILIES))
+def test_known_mlx_lm_families_report_unsupported(family):
+    report = detect_native_mtp_capability(
+        family, mlx_lm_version="0.31.3", mlx_vlm_version=None
+    )
+    assert report.supported is False
+    assert "strips" in report.reason
+    assert family in report.reason
+
+
+@pytest.mark.parametrize("family", sorted(MLX_VLM_EXPERIMENTAL_MTP_FAMILIES))
+def test_known_mlx_vlm_experimental_families_report_unsupported(family):
+    report = detect_native_mtp_capability(
+        family, mlx_lm_version="0.31.3", mlx_vlm_version="0.5.0"
+    )
+    assert report.supported is False
+    assert "experimental" in report.reason
+    assert "draft_model request path" in report.reason
+
+
+def test_unknown_family_reports_unsupported_conservatively():
+    report = detect_native_mtp_capability(
+        "totally-unknown-family", mlx_lm_version=None, mlx_vlm_version=None
+    )
+    assert report.supported is False
+    assert "not in this module's verified list" in report.reason
+
+
+def test_capability_report_round_trips_through_json():
+    report = detect_native_mtp_capability(
+        "qwen3_next", mlx_lm_version="0.31.3", mlx_vlm_version=None
+    )
+    restored = NativeMTPCapabilityReport.from_dict(json.loads(report.to_json()))
+    assert restored == report
+
+
+def test_capability_report_from_dict_rejects_missing_field():
+    with pytest.raises(NativeMTPCollectorError):
+        NativeMTPCapabilityReport.from_dict({"model_family": "qwen3_next"})
+
+
+# --- Checkpoint compatibility validation --------------------------------
+
+
+def test_validate_checkpoint_compatibility_accepts_matching_arch():
+    target = {"hidden_size": 4096, "vocab_size": 151936}
+    sidecar = {"hidden_size": 4096, "vocab_size": 151936}
+    validate_checkpoint_compatibility(target, sidecar)  # must not raise
+
+
+def test_validate_checkpoint_compatibility_rejects_hidden_size_mismatch():
+    target = {"hidden_size": 4096, "vocab_size": 151936}
+    sidecar = {"hidden_size": 2048, "vocab_size": 151936}
+    with pytest.raises(NativeMTPCollectorError, match="hidden_size"):
+        validate_checkpoint_compatibility(target, sidecar)
+
+
+def test_validate_checkpoint_compatibility_rejects_vocab_size_mismatch():
+    target = {"hidden_size": 4096, "vocab_size": 151936}
+    sidecar = {"hidden_size": 4096, "vocab_size": 32000}
+    with pytest.raises(NativeMTPCollectorError, match="vocab_size"):
+        validate_checkpoint_compatibility(target, sidecar)
+
+
+def test_validate_checkpoint_compatibility_rejects_missing_target_signature():
+    with pytest.raises(NativeMTPCollectorError, match="target checkpoint"):
+        validate_checkpoint_compatibility({}, {"hidden_size": 4096})
+
+
+def test_validate_checkpoint_compatibility_unwraps_vlm_text_config():
+    target = {"text_config": {"hidden_size": 4096, "vocab_size": 151936}}
+    sidecar = {"text_config": {"hidden_size": 4096, "vocab_size": 151936}}
+    validate_checkpoint_compatibility(target, sidecar)  # must not raise
+
+
+# --- Config validation ---------------------------------------------------
+
+
+def test_missing_target_model_path_is_rejected_without_downloading(tmp_path):
+    with pytest.raises(NativeMTPCollectorError, match="target_model_path"):
+        make_config(tmp_path, target_model_path=tmp_path / "missing-target")
+
+
+def test_missing_sidecar_path_is_rejected_without_downloading(tmp_path):
+    with pytest.raises(NativeMTPCollectorError, match="mtp_sidecar_path"):
+        make_config(tmp_path, mtp_sidecar_path=tmp_path / "missing-sidecar")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"max_tokens": True},
+        {"max_tokens": 0},
+        {"seed": False},
+        {"configured_depth": 0},
+        {"configured_depth": True},
+    ],
+)
+def test_collection_config_rejects_malformed_numeric_values(tmp_path, overrides):
+    with pytest.raises(NativeMTPCollectorError):
+        make_config(tmp_path, **overrides)
+
+
+# --- collect_native_mtp: honest unsupported path ------------------------
+
+
+def test_collect_native_mtp_produces_explicit_unsupported_record(tmp_path):
+    config = make_config(tmp_path)
+    result = collect_native_mtp(config)
+
+    assert result.capability.supported is False
+    assert result.record.outcome.success is False
+    assert result.record.error.category == "NativeMTPUnsupported"
+    assert result.record.speculative.enabled is False
+    assert result.record.speculative.method is None
+    assert result.record.model.model_family == "qwen3_next"
+    assert result.response_text == ""
+
+    persisted = ExperimentRecord.read_json(tmp_path / "artifacts" / "record.json")
+    assert persisted.outcome.success is False
+    capability_payload = json.loads(
+        (tmp_path / "artifacts" / "capability_report.json").read_text()
+    )
+    assert capability_payload["supported"] is False
+    assert capability_payload["model_family"] == "qwen3_next"
+
+
+def test_collect_native_mtp_never_writes_a_response_file_when_unsupported(tmp_path):
+    config = make_config(tmp_path)
+    collect_native_mtp(config)
+    assert not (tmp_path / "artifacts" / "response.txt").exists()
+
+
+def test_collect_native_mtp_rejects_mismatched_checkpoints(tmp_path):
+    target_path = tmp_path / "target"
+    sidecar_path = tmp_path / "sidecar"
+    _write_config(target_path, hidden_size=4096)
+    _write_config(sidecar_path, hidden_size=2048)
+    config = make_config(
+        tmp_path, target_model_path=target_path, mtp_sidecar_path=sidecar_path
+    )
+
+    with pytest.raises(NativeMTPCollectorError, match="incompatible"):
+        collect_native_mtp(config)
+
+
+def test_collect_native_mtp_rejects_missing_config_json(tmp_path):
+    target_path = tmp_path / "target"
+    target_path.mkdir()
+    sidecar_path = tmp_path / "sidecar"
+    _write_config(sidecar_path)
+    config = make_config(
+        tmp_path, target_model_path=target_path, mtp_sidecar_path=sidecar_path
+    )
+
+    with pytest.raises(NativeMTPCollectorError, match="config.json"):
+        collect_native_mtp(config)
+
+
+def test_unsupported_family_uses_experimental_reason_for_mlx_vlm_family(tmp_path):
+    target_path = tmp_path / "target"
+    sidecar_path = tmp_path / "sidecar"
+    _write_config(target_path, model_type="qwen4_exp")
+    _write_config(sidecar_path, model_type="qwen4_exp_mtp")
+    config = make_config(
+        tmp_path, target_model_path=target_path, mtp_sidecar_path=sidecar_path
+    )
+
+    result = collect_native_mtp(config)
+    assert "experimental" in result.record.error.message
+
+
+# --- collect_native_mtp: the capable extension point (fake runtime only) --
+
+
+@dataclass
+class FakeNativeMTPResponse:
+    text: str
+    generation_tokens: int
+    finish_reason: str | None = None
+    accepted_block_tokens: int | None = None
+    proposed_block_tokens: int | None = None
+
+
+class FakeTokenizer:
+    pass
+
+
+class FakeNativeMTPRuntime:
+    mlx_version = "0.32.0"
+    mlx_lm_version = "99.0.0"
+
+    def __init__(self):
+        self.responses = [
+            FakeNativeMTPResponse(
+                "hello",
+                1,
+                accepted_block_tokens=1,
+                proposed_block_tokens=2,
+            ),
+            FakeNativeMTPResponse(
+                " world",
+                2,
+                accepted_block_tokens=1,
+                proposed_block_tokens=2,
+            ),
+        ]
+
+    def load_target(self, path):
+        return object(), FakeTokenizer()
+
+    def load_sidecar(self, path, target_model):
+        return object()
+
+    def encode(self, tokenizer, prompt):
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return None
+
+    def accelerator_name(self):
+        return "Apple M5 Pro"
+
+    def generate_with_native_mtp(
+        self,
+        target_model,
+        sidecar,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        configured_depth,
+    ):
+        yield from self.responses
+
+
+def test_capable_path_labels_native_mtp_and_records_only_exposed_fields(
+    tmp_path, monkeypatch
+):
+    config = make_config(tmp_path)
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.native_mtp.detect_native_mtp_capability",
+        lambda *a, **k: NativeMTPCapabilityReport(
+            schema_version="1",
+            model_family="qwen3_next",
+            mlx_lm_version="99.0.0",
+            mlx_vlm_version=None,
+            supported=True,
+            reason="test override: assume a hypothetical stable native API",
+            checked_signals=(),
+        ),
+    )
+
+    result = collect_native_mtp(config, runtime=FakeNativeMTPRuntime())
+
+    assert result.record.outcome.success is True
+    assert result.record.speculative.enabled is True
+    assert result.record.speculative.method == "native-mtp"
+    assert result.record.speculative.proposed_tokens == 4
+    assert result.record.speculative.accepted_tokens == 2
+    assert result.record.speculative.verification_time is None
+    assert result.response_text == "hello world"
+
+
+def test_capable_path_without_runtime_raises_clear_error(tmp_path, monkeypatch):
+    config = make_config(tmp_path)
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.native_mtp.detect_native_mtp_capability",
+        lambda *a, **k: NativeMTPCapabilityReport(
+            schema_version="1",
+            model_family="qwen3_next",
+            mlx_lm_version="99.0.0",
+            mlx_vlm_version=None,
+            supported=True,
+            reason="test override",
+            checked_signals=(),
+        ),
+    )
+
+    with pytest.raises(NativeMTPCollectorError, match="no NativeMTPRuntime adapter"):
+        collect_native_mtp(config, runtime=None)

--- a/tests/optimizer/test_native_mtp_collector.py
+++ b/tests/optimizer/test_native_mtp_collector.py
@@ -133,6 +133,26 @@ def test_validate_checkpoint_compatibility_unwraps_vlm_text_config():
     validate_checkpoint_compatibility(target, sidecar)  # must not raise
 
 
+def test_validate_checkpoint_compatibility_accepts_differing_layer_counts():
+    # A native-MTP sidecar/drafter legitimately has far fewer layers than
+    # its target model -- that must never be treated as an incompatibility.
+    target = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 48}
+    sidecar = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 1}
+    validate_checkpoint_compatibility(target, sidecar)  # must not raise
+
+
+def test_validate_checkpoint_compatibility_still_rejects_hidden_size_mismatch_with_differing_layers():
+    target = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 48}
+    sidecar = {"hidden_size": 2048, "vocab_size": 151936, "num_hidden_layers": 1}
+    with pytest.raises(NativeMTPCollectorError, match="hidden_size") as exc_info:
+        validate_checkpoint_compatibility(target, sidecar)
+    # Layer counts are surfaced as informational context, not as their own
+    # enforced requirement.
+    assert "informational, not enforced" in str(exc_info.value)
+    assert "num_hidden_layers=48" in str(exc_info.value)
+    assert "num_hidden_layers=1" in str(exc_info.value)
+
+
 # --- Config validation ---------------------------------------------------
 
 

--- a/tests/optimizer/test_native_mtp_collector.py
+++ b/tests/optimizer/test_native_mtp_collector.py
@@ -148,6 +148,13 @@ def test_validate_checkpoint_compatibility_rejects_layer_only_sidecar_signature(
         validate_checkpoint_compatibility(target, sidecar)
 
 
+def test_validate_checkpoint_compatibility_rejects_disjoint_comparable_fields():
+    target = {"hidden_size": 4096}
+    sidecar = {"vocab_size": 151936}
+    with pytest.raises(NativeMTPCollectorError, match="share no comparable"):
+        validate_checkpoint_compatibility(target, sidecar)
+
+
 def test_validate_checkpoint_compatibility_still_rejects_hidden_size_mismatch_with_differing_layers():
     target = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 48}
     sidecar = {"hidden_size": 2048, "vocab_size": 151936, "num_hidden_layers": 1}

--- a/tests/optimizer/test_native_mtp_collector.py
+++ b/tests/optimizer/test_native_mtp_collector.py
@@ -141,6 +141,13 @@ def test_validate_checkpoint_compatibility_accepts_differing_layer_counts():
     validate_checkpoint_compatibility(target, sidecar)  # must not raise
 
 
+def test_validate_checkpoint_compatibility_rejects_layer_only_sidecar_signature():
+    target = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 48}
+    sidecar = {"num_hidden_layers": 1}
+    with pytest.raises(NativeMTPCollectorError, match="sidecar checkpoint"):
+        validate_checkpoint_compatibility(target, sidecar)
+
+
 def test_validate_checkpoint_compatibility_still_rejects_hidden_size_mismatch_with_differing_layers():
     target = {"hidden_size": 4096, "vocab_size": 151936, "num_hidden_layers": 48}
     sidecar = {"hidden_size": 2048, "vocab_size": 151936, "num_hidden_layers": 1}

--- a/tests/optimizer/test_workloads_cli.py
+++ b/tests/optimizer/test_workloads_cli.py
@@ -1,0 +1,119 @@
+"""CLI tests for the workload matrix generator and evaluators."""
+
+from __future__ import annotations
+
+import json
+
+from llmtracefx.optimizer import cli
+
+
+def test_workloads_list_cli_prints_catalog(capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(["workloads", "list"])
+    assert args.func(args) == 0
+    out = capsys.readouterr().out
+    assert "code-completion-palindrome-check" in out
+    assert "structured-json-profile-extraction" in out
+    assert "prose-reasoning-two-train-gap" in out
+
+
+def test_workloads_generate_matrix_cli_is_dry_run(tmp_path, capsys):
+    output_dir = tmp_path / "matrix"
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "generate-matrix",
+            "--model-id",
+            "Qwen/Qwen3.8-27B",
+            "--model-family",
+            "qwen3_next",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert args.func(args) == 0
+    out = capsys.readouterr().out
+    assert "No model was loaded or downloaded" in out
+    assert (output_dir / "manifest.json").exists()
+
+
+def test_workloads_generate_matrix_cli_respects_context_tier_filter(tmp_path):
+    output_dir = tmp_path / "matrix"
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "generate-matrix",
+            "--model-id",
+            "m",
+            "--model-family",
+            "qwen3_next",
+            "--output-dir",
+            str(output_dir),
+            "--context-tiers",
+            "2k",
+        ]
+    )
+    assert args.func(args) == 0
+    manifest = json.loads((output_dir / "manifest.json").read_text())
+    assert all(entry["context_tier"] == "2k" for entry in manifest["entries"])
+
+
+def test_workloads_evaluate_cli_passes_correct_response(tmp_path):
+    response_path = tmp_path / "response.txt"
+    response_path.write_text(
+        '{"name": "Priya", "age": 34, "is_active": true}', encoding="utf-8"
+    )
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "evaluate",
+            "--workload-id",
+            "structured-json-profile-extraction",
+            "--response-file",
+            str(response_path),
+        ]
+    )
+    assert args.func(args) == 0
+
+
+def test_workloads_evaluate_cli_fails_wrong_response(tmp_path, capsys):
+    response_path = tmp_path / "response.txt"
+    response_path.write_text("not json", encoding="utf-8")
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "evaluate",
+            "--workload-id",
+            "structured-json-profile-extraction",
+            "--response-file",
+            str(response_path),
+        ]
+    )
+    assert args.func(args) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is False
+
+
+def test_workloads_evaluate_cli_reports_unknown_workload(tmp_path, capsys):
+    response_path = tmp_path / "response.txt"
+    response_path.write_text("x", encoding="utf-8")
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "evaluate",
+            "--workload-id",
+            "does-not-exist",
+            "--response-file",
+            str(response_path),
+        ]
+    )
+    assert args.func(args) == 1
+    assert "Unknown workload" in capsys.readouterr().err

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -217,6 +217,41 @@ def test_evaluate_code_completion_timeout_kills_descendants(tmp_path):
         pytest.fail("candidate descendant survived evaluator timeout")
 
 
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX-only process-group containment",
+)
+def test_evaluate_code_completion_kills_descendants_after_parent_exits(tmp_path):
+    marker_path = tmp_path / "descendant-finished.txt"
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code="",
+        entry_point="f",
+    )
+    child_script = (
+        "import time; "
+        "time.sleep(0.5); "
+        f"open({str(marker_path)!r}, 'w').write('done')"
+    )
+    completion = (
+        "import subprocess\n"
+        "import sys\n"
+        "subprocess.Popen(\n"
+        f"    [sys.executable, '-c', {child_script!r}],\n"
+        "    stdin=subprocess.DEVNULL,\n"
+        "    stdout=subprocess.DEVNULL,\n"
+        "    stderr=subprocess.DEVNULL,\n"
+        "    close_fds=True,\n"
+        ")\n"
+    )
+
+    outcome = evaluate_code_completion(spec, completion, timeout_seconds=5)
+
+    assert outcome.success is True
+    time.sleep(0.8)
+    assert not marker_path.exists()
+
+
 def test_evaluate_code_completion_ordinary_completion_still_evaluates_after_sandboxing():
     outcome = evaluate_code_completion(
         CODE_COMPLETION_PALINDROME.spec, _CORRECT_PALINDROME_COMPLETION

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import time
 
 import pytest
@@ -167,6 +169,52 @@ def test_evaluate_code_completion_posix_file_size_limit_kills_large_write(monkey
     )
     outcome = evaluate_code_completion(spec, oversized_write)
     assert outcome.success is False
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX-only process-group containment",
+)
+def test_evaluate_code_completion_timeout_kills_descendants(tmp_path):
+    child_pid_path = tmp_path / "child.pid"
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code="",
+        entry_point="f",
+    )
+    completion = (
+        "import subprocess\n"
+        "import sys\n"
+        "import time\n"
+        f"pid_path = {str(child_pid_path)!r}\n"
+        "child = subprocess.Popen([\n"
+        "    sys.executable,\n"
+        "    '-c',\n"
+        "    'import time; time.sleep(60)',\n"
+        "])\n"
+        "with open(pid_path, 'w') as handle:\n"
+        "    handle.write(str(child.pid))\n"
+        "time.sleep(60)\n"
+    )
+
+    outcome = evaluate_code_completion(spec, completion, timeout_seconds=0.5)
+
+    assert outcome.success is False
+    assert "timed out" in outcome.notes
+    child_pid = int(child_pid_path.read_text())
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        subprocess.run(
+            [sys.executable, "-c", f"import os; os.kill({child_pid}, 9)"],
+            check=False,
+        )
+        pytest.fail("candidate descendant survived evaluator timeout")
 
 
 def test_evaluate_code_completion_ordinary_completion_still_evaluates_after_sandboxing():

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import os
+import time
+
+import pytest
+
+from llmtracefx.optimizer.workloads import evaluators
 from llmtracefx.optimizer.workloads.catalog import (
     CODE_COMPLETION_PALINDROME,
     PROSE_REASONING_TRAIN_PROBLEM,
@@ -13,6 +19,7 @@ from llmtracefx.optimizer.workloads.evaluators import (
     evaluate_structured_json,
     evaluate_workload,
 )
+from llmtracefx.optimizer.workloads.schema import CodeCompletionSpec
 
 # --- Code completion -----------------------------------------------------
 
@@ -70,6 +77,104 @@ def test_evaluate_code_completion_times_out_on_infinite_loop():
     )
     assert outcome.success is False
     assert "timed out" in outcome.notes
+
+
+# --- Code completion sandboxing: cwd, environment, resource limits --------
+
+
+def test_evaluate_code_completion_isolates_cwd_from_the_caller(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code="",
+        entry_point="f",
+    )
+    completion = (
+        "def f() -> None:\n"
+        "    with open('leaked.txt', 'w') as handle:\n"
+        "        handle.write('leaked')\n"
+        "\n"
+        "f()\n"
+    )
+    outcome = evaluate_code_completion(spec, completion)
+    assert outcome.success is True
+    # The candidate's relative file write must land in its own ephemeral
+    # temp directory, never in the caller's (here, the test's) cwd.
+    assert not (tmp_path / "leaked.txt").exists()
+
+
+def test_evaluate_code_completion_does_not_expose_parent_secrets(monkeypatch):
+    monkeypatch.setenv("LLMTRACEFX_TEST_FAKE_SECRET", "super-secret-value")
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code=(
+            "import os\nassert os.environ.get('LLMTRACEFX_TEST_FAKE_SECRET') is None\n"
+        ),
+        entry_point="f",
+    )
+    completion = "def f() -> None:\n    pass\n"
+    outcome = evaluate_code_completion(spec, completion)
+    assert outcome.success is True
+
+
+def test_evaluate_code_completion_minimal_env_is_a_strict_allowlist():
+    env = evaluators._minimal_subprocess_env()
+    assert set(env).issubset(set(evaluators._ALLOWED_SUBPROCESS_ENV_VARS))
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX-only resource limits; not enforced on Windows (see module docstring)",
+)
+def test_evaluate_code_completion_posix_cpu_limit_kills_busy_loop(monkeypatch):
+    # Lower the CPU ceiling for this test only so it stays fast; the
+    # wall-clock timeout passed below is deliberately much larger so a
+    # pass here proves the RLIMIT_CPU kill fired, not the ordinary
+    # subprocess timeout path already covered above.
+    monkeypatch.setattr(evaluators, "_MAX_CPU_SECONDS", 1)
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code="",
+        entry_point="f",
+    )
+    busy_loop = "x = 0\nwhile True:\n    x += 1\n"
+
+    started = time.perf_counter()
+    outcome = evaluate_code_completion(spec, busy_loop, timeout_seconds=15.0)
+    elapsed = time.perf_counter() - started
+
+    assert outcome.success is False
+    assert elapsed < 15.0
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX-only resource limits; not enforced on Windows (see module docstring)",
+)
+def test_evaluate_code_completion_posix_file_size_limit_kills_large_write(monkeypatch):
+    monkeypatch.setattr(evaluators, "_MAX_FILE_SIZE_BYTES", 1024)
+    spec = CodeCompletionSpec(
+        function_stub="def f() -> None:\n    pass\n",
+        test_code="",
+        entry_point="f",
+    )
+    oversized_write = (
+        "def f() -> None:\n"
+        "    pass\n"
+        "\n"
+        "with open('big.bin', 'wb') as handle:\n"
+        "    handle.write(b'x' * (10 * 1024 * 1024))\n"
+    )
+    outcome = evaluate_code_completion(spec, oversized_write)
+    assert outcome.success is False
+
+
+def test_evaluate_code_completion_ordinary_completion_still_evaluates_after_sandboxing():
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, _CORRECT_PALINDROME_COMPLETION
+    )
+    assert outcome.success is True
+    assert outcome.quality_score == 1.0
 
 
 # --- Structured JSON -------------------------------------------------------

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -1,0 +1,163 @@
+"""Tests for deterministic workload evaluators."""
+
+from __future__ import annotations
+
+from llmtracefx.optimizer.workloads.catalog import (
+    CODE_COMPLETION_PALINDROME,
+    PROSE_REASONING_TRAIN_PROBLEM,
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.evaluators import (
+    evaluate_code_completion,
+    evaluate_prose_reasoning,
+    evaluate_structured_json,
+    evaluate_workload,
+)
+
+# --- Code completion -----------------------------------------------------
+
+_CORRECT_PALINDROME_COMPLETION = (
+    "def is_palindrome(text: str) -> bool:\n"
+    '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+    "    cleaned = text.lower().replace(' ', '')\n"
+    "    return cleaned == cleaned[::-1]\n"
+)
+
+_WRONG_PALINDROME_COMPLETION = (
+    "def is_palindrome(text: str) -> bool:\n"
+    '    """Return True if text is a palindrome, ignoring case and spaces."""\n'
+    "    return False\n"
+)
+
+
+def test_evaluate_code_completion_passes_correct_completion():
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, _CORRECT_PALINDROME_COMPLETION
+    )
+    assert outcome.success is True
+    assert outcome.quality_score == 1.0
+    assert outcome.quality_metric == "unit_test_pass"
+    assert outcome.notes is None
+
+
+def test_evaluate_code_completion_fails_wrong_completion():
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, _WRONG_PALINDROME_COMPLETION
+    )
+    assert outcome.success is False
+    assert outcome.quality_score == 0.0
+    assert outcome.notes
+
+
+def test_evaluate_code_completion_strips_markdown_fence():
+    fenced = f"```python\n{_CORRECT_PALINDROME_COMPLETION}```"
+    outcome = evaluate_code_completion(CODE_COMPLETION_PALINDROME.spec, fenced)
+    assert outcome.success is True
+
+
+def test_evaluate_code_completion_fails_on_syntax_error():
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, "def is_palindrome(text: str -> bool:\n"
+    )
+    assert outcome.success is False
+    assert outcome.quality_score == 0.0
+
+
+def test_evaluate_code_completion_times_out_on_infinite_loop():
+    infinite = "def is_palindrome(text: str) -> bool:\n    while True:\n        pass\n"
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, infinite, timeout_seconds=0.5
+    )
+    assert outcome.success is False
+    assert "timed out" in outcome.notes
+
+
+# --- Structured JSON -------------------------------------------------------
+
+
+def test_evaluate_structured_json_passes_exact_fields():
+    response = '{"name": "Priya Nakamura", "age": 34, "is_active": true}'
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, response
+    )
+    assert outcome.success is True
+    assert outcome.quality_score == 1.0
+
+
+def test_evaluate_structured_json_tolerates_surrounding_prose():
+    response = 'Here you go:\n{"name": "Priya", "age": 34, "is_active": true}\nDone.'
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, response
+    )
+    assert outcome.success is True
+
+
+def test_evaluate_structured_json_reports_missing_field():
+    response = '{"name": "Priya", "age": 34}'
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, response
+    )
+    assert outcome.success is False
+    assert outcome.quality_score == 2 / 3
+    assert "is_active" in outcome.notes
+
+
+def test_evaluate_structured_json_rejects_wrong_type():
+    response = '{"name": "Priya", "age": "34", "is_active": true}'
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, response
+    )
+    assert outcome.success is False
+    assert "age" in outcome.notes
+
+
+def test_evaluate_structured_json_rejects_bool_as_int():
+    response = '{"name": "Priya", "age": true, "is_active": true}'
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, response
+    )
+    assert outcome.success is False
+
+
+def test_evaluate_structured_json_handles_unparseable_response():
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, "not json at all"
+    )
+    assert outcome.success is False
+    assert outcome.quality_score == 0.0
+
+
+def test_evaluate_structured_json_rejects_non_object_root():
+    outcome = evaluate_structured_json(
+        STRUCTURED_JSON_PROFILE_EXTRACTION.spec, "[1, 2]"
+    )
+    assert outcome.success is False
+
+
+# --- Prose reasoning --------------------------------------------------------
+
+
+def test_evaluate_prose_reasoning_passes_expected_answer():
+    outcome = evaluate_prose_reasoning(
+        PROSE_REASONING_TRAIN_PROBLEM.spec,
+        "3 hours, since they close the gap at 70 mph.",
+    )
+    assert outcome.success is True
+    assert outcome.quality_score == 1.0
+
+
+def test_evaluate_prose_reasoning_fails_wrong_answer():
+    outcome = evaluate_prose_reasoning(PROSE_REASONING_TRAIN_PROBLEM.spec, "5 hours.")
+    assert outcome.success is False
+    assert outcome.quality_score == 0.0
+    assert outcome.notes
+
+
+# --- Dispatch ---------------------------------------------------------------
+
+
+def test_evaluate_workload_dispatches_by_category():
+    outcome = evaluate_workload(
+        PROSE_REASONING_TRAIN_PROBLEM, "3 hours until they meet."
+    )
+    assert outcome.quality_metric == "exact_answer_pattern_match"

--- a/tests/optimizer/test_workloads_materialize.py
+++ b/tests/optimizer/test_workloads_materialize.py
@@ -1,0 +1,92 @@
+"""Tests for deterministic prompt materialization/padding and hashing."""
+
+from __future__ import annotations
+
+from llmtracefx.optimizer.workloads.catalog import PROSE_REASONING_TRAIN_PROBLEM
+from llmtracefx.optimizer.workloads.materialize import (
+    APPROX_CHARS_PER_TOKEN,
+    materialize_prompt,
+)
+from llmtracefx.optimizer.workloads.schema import (
+    CONTEXT_TIER_TARGET_TOKENS,
+    ContextTier,
+    ProseReasoningSpec,
+    Workload,
+    WorkloadCategory,
+)
+
+
+def test_materialize_prompt_is_deterministic_across_calls():
+    first = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_8K)
+    second = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_8K)
+    assert first == second
+    assert first.prompt_hash == second.prompt_hash
+
+
+def test_materialize_prompt_preserves_base_prompt_verbatim():
+    materialized = materialize_prompt(
+        PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_2K
+    )
+    assert PROSE_REASONING_TRAIN_PROBLEM.base_prompt in materialized.text
+
+
+def test_materialize_prompt_pads_toward_target_when_base_is_small():
+    materialized = materialize_prompt(
+        PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_16K
+    )
+    target_chars = (
+        CONTEXT_TIER_TARGET_TOKENS[ContextTier.TIER_16K] * APPROX_CHARS_PER_TOKEN
+    )
+    assert materialized.filler_segments_used > 0
+    assert len(materialized.text) >= target_chars
+
+
+def test_materialize_prompt_never_pads_when_base_already_meets_target():
+    huge_prompt = Workload(
+        workload_id="huge",
+        version="1",
+        category=WorkloadCategory.PROSE_REASONING,
+        title="huge",
+        base_prompt="x" * 100_000,
+        spec=ProseReasoningSpec(expected_answer_pattern="x"),
+    )
+    materialized = materialize_prompt(huge_prompt, ContextTier.TIER_2K)
+    assert materialized.filler_segments_used == 0
+    assert materialized.text == huge_prompt.base_prompt
+
+
+def test_materialize_prompt_larger_tiers_use_more_filler():
+    small = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_2K)
+    large = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_16K)
+    assert large.filler_segments_used > small.filler_segments_used
+    assert len(large.text) > len(small.text)
+
+
+def test_materialize_prompt_hash_changes_with_tier():
+    tier_2k = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_2K)
+    tier_8k = materialize_prompt(PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_8K)
+    assert tier_2k.prompt_hash != tier_8k.prompt_hash
+
+
+def test_materialize_prompt_hash_matches_sha256_of_text():
+    import hashlib
+
+    materialized = materialize_prompt(
+        PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_2K
+    )
+    expected = f"sha256:{hashlib.sha256(materialized.text.encode('utf-8')).hexdigest()}"
+    assert materialized.prompt_hash == expected
+
+
+def test_materialize_prompt_records_planning_metadata_not_measured_claim():
+    materialized = materialize_prompt(
+        PROSE_REASONING_TRAIN_PROBLEM, ContextTier.TIER_2K
+    )
+    payload = materialized.to_dict()
+    assert payload["approx_chars_per_token"] == APPROX_CHARS_PER_TOKEN
+    assert (
+        payload["target_context_tokens"]
+        == CONTEXT_TIER_TARGET_TOKENS[ContextTier.TIER_2K]
+    )
+    # No field claims this is a measured token count.
+    assert "measured_tokens" not in payload

--- a/tests/optimizer/test_workloads_materialize.py
+++ b/tests/optimizer/test_workloads_materialize.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
-from llmtracefx.optimizer.workloads.catalog import PROSE_REASONING_TRAIN_PROBLEM
+import pytest
+
+from llmtracefx.optimizer.workloads.catalog import (
+    CODE_COMPLETION_PALINDROME,
+    CONTEXT_FILLER_CORPUS,
+    PROSE_REASONING_TRAIN_PROBLEM,
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.evaluators import evaluate_code_completion
 from llmtracefx.optimizer.workloads.materialize import (
     APPROX_CHARS_PER_TOKEN,
     materialize_prompt,
 )
 from llmtracefx.optimizer.workloads.schema import (
     CONTEXT_TIER_TARGET_TOKENS,
+    CodeCompletionSpec,
     ContextTier,
+    PaddingPlacement,
     ProseReasoningSpec,
     Workload,
     WorkloadCategory,
+    WorkloadSchemaError,
 )
 
 
@@ -90,3 +101,95 @@ def test_materialize_prompt_records_planning_metadata_not_measured_claim():
     )
     # No field claims this is a measured token count.
     assert "measured_tokens" not in payload
+
+
+# --- Code-completion padding placement: filler must go before the stub ----
+
+
+def test_code_completion_workload_declares_before_stub_placement():
+    assert (
+        CODE_COMPLETION_PALINDROME.padding_placement
+        == PaddingPlacement.BEFORE_CONTINUATION_STUB
+    )
+    assert CODE_COMPLETION_PALINDROME.continuation_stub
+
+
+def test_prose_and_json_workloads_declare_append_placement():
+    assert (
+        PROSE_REASONING_TRAIN_PROBLEM.padding_placement
+        == PaddingPlacement.APPEND_AFTER_BASE_PROMPT
+    )
+    assert (
+        STRUCTURED_JSON_PROFILE_EXTRACTION.padding_placement
+        == PaddingPlacement.APPEND_AFTER_BASE_PROMPT
+    )
+
+
+@pytest.mark.parametrize("tier", list(ContextTier))
+def test_materialized_code_prompt_ends_with_exact_continuation_stub(tier):
+    materialized = materialize_prompt(CODE_COMPLETION_PALINDROME, tier)
+    assert materialized.text.endswith(CODE_COMPLETION_PALINDROME.continuation_stub)
+
+
+@pytest.mark.parametrize("tier", [ContextTier.TIER_8K, ContextTier.TIER_16K])
+def test_materialized_code_prompt_has_filler_before_the_stub(tier):
+    materialized = materialize_prompt(CODE_COMPLETION_PALINDROME, tier)
+    stub = CODE_COMPLETION_PALINDROME.continuation_stub
+    stub_index = materialized.text.rindex(stub)
+    assert materialized.filler_segments_used > 0
+    first_filler_segment = CONTEXT_FILLER_CORPUS.format(index=0)
+    filler_index = materialized.text.index(first_filler_segment)
+    assert filler_index < stub_index
+
+
+def test_materialized_code_prompt_keeps_base_task_fixed_across_tiers():
+    small = materialize_prompt(CODE_COMPLETION_PALINDROME, ContextTier.TIER_2K)
+    large = materialize_prompt(CODE_COMPLETION_PALINDROME, ContextTier.TIER_16K)
+    stub = CODE_COMPLETION_PALINDROME.continuation_stub
+    prefix = CODE_COMPLETION_PALINDROME.base_prompt[: -len(stub)]
+    assert small.text.startswith(prefix)
+    assert large.text.startswith(prefix)
+    assert small.text.endswith(stub)
+    assert large.text.endswith(stub)
+
+
+def test_materialize_code_prompt_is_deterministic_across_calls():
+    first = materialize_prompt(CODE_COMPLETION_PALINDROME, ContextTier.TIER_8K)
+    second = materialize_prompt(CODE_COMPLETION_PALINDROME, ContextTier.TIER_8K)
+    assert first == second
+    assert first.prompt_hash == second.prompt_hash
+
+
+@pytest.mark.parametrize("tier", list(ContextTier))
+def test_materialized_code_prompt_completion_still_evaluates_successfully(tier):
+    materialized = materialize_prompt(CODE_COMPLETION_PALINDROME, tier)
+    # The prompt still ends with the exact stub regardless of tier/filler,
+    # so a correct completion appended after it is still gradeable.
+    assert materialized.text.endswith(CODE_COMPLETION_PALINDROME.continuation_stub)
+
+    candidate_completion = (
+        CODE_COMPLETION_PALINDROME.continuation_stub
+        + "    cleaned = text.lower().replace(' ', '')\n"
+        + "    return cleaned == cleaned[::-1]\n"
+    )
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec, candidate_completion
+    )
+    assert outcome.success is True
+
+
+def test_workload_rejects_continuation_stub_not_a_suffix_of_base_prompt():
+    with pytest.raises(WorkloadSchemaError, match="continuation_stub"):
+        Workload(
+            workload_id="bad-stub",
+            version="1",
+            category=WorkloadCategory.CODE_COMPLETION,
+            title="bad",
+            base_prompt="def f(): pass\n",
+            spec=CodeCompletionSpec(
+                function_stub="def f(): pass\n",
+                test_code="assert True",
+                entry_point="f",
+            ),
+            continuation_stub="not a suffix",
+        )

--- a/tests/optimizer/test_workloads_matrix.py
+++ b/tests/optimizer/test_workloads_matrix.py
@@ -1,0 +1,157 @@
+"""Tests for deterministic workload matrix generation."""
+
+from __future__ import annotations
+
+import json
+
+from llmtracefx.optimizer.workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    DECODE_MODE_NATIVE_MTP,
+    generate_matrix,
+    write_matrix,
+)
+from llmtracefx.optimizer.workloads.schema import ContextTier
+
+
+def test_generate_matrix_is_fully_deterministic(tmp_path):
+    first = generate_matrix(
+        model_id="Qwen/Qwen3.8-27B",
+        model_family="qwen3_next",
+        output_dir=str(tmp_path / "out"),
+    )
+    second = generate_matrix(
+        model_id="Qwen/Qwen3.8-27B",
+        model_family="qwen3_next",
+        output_dir=str(tmp_path / "out"),
+    )
+    assert first == second
+
+
+def test_generate_matrix_never_touches_the_filesystem(tmp_path):
+    output_dir = tmp_path / "not-created-yet"
+    generate_matrix(
+        model_id="Qwen/Qwen3.8-27B",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+    )
+    assert not output_dir.exists()
+
+
+def test_generate_matrix_includes_ar_and_mtp_rows_per_workload_per_tier():
+    manifest = generate_matrix(
+        model_id="m",
+        model_family="qwen3_next",
+        output_dir="/tmp/unused",
+        mtp_depths=(2, 4),
+    )
+    from llmtracefx.optimizer.workloads.catalog import WORKLOADS
+
+    expected_count = len(WORKLOADS) * len(tuple(ContextTier)) * (1 + 2)
+    assert len(manifest.entries) == expected_count
+
+    ar_entries = [
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    ]
+    mtp_entries = [
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_NATIVE_MTP
+    ]
+    assert len(ar_entries) == len(WORKLOADS) * len(tuple(ContextTier))
+    assert len(mtp_entries) == len(WORKLOADS) * len(tuple(ContextTier)) * 2
+
+
+def test_generate_matrix_marks_unsupported_mtp_family_as_not_runnable():
+    manifest = generate_matrix(
+        model_id="m", model_family="qwen3_next", output_dir="/tmp/unused"
+    )
+    ar_entries = [
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    ]
+    mtp_entries = [
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_NATIVE_MTP
+    ]
+    assert all(entry.runnable for entry in ar_entries)
+    assert all(not entry.runnable for entry in mtp_entries)
+    assert all(entry.unsupported_reason for entry in mtp_entries)
+
+
+def test_generate_matrix_uses_placeholder_paths_when_omitted():
+    manifest = generate_matrix(
+        model_id="m", model_family="qwen3_next", output_dir="/tmp/unused"
+    )
+    ar_entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    assert "<TARGET_MODEL_PATH>" in ar_entry.command_argv
+
+
+def test_generate_matrix_substitutes_real_paths_when_given():
+    manifest = generate_matrix(
+        model_id="m",
+        model_family="qwen3_next",
+        output_dir="/tmp/unused",
+        target_model_path="/models/target",
+        mtp_sidecar_path="/models/sidecar",
+    )
+    ar_entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    assert "/models/target" in ar_entry.command_argv
+    mtp_entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_NATIVE_MTP
+    )
+    assert "/models/target" in mtp_entry.command_argv
+    assert "/models/sidecar" in mtp_entry.command_argv
+
+
+def test_write_matrix_writes_manifest_prompts_and_configs(tmp_path):
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="Qwen/Qwen3.8-27B",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+
+    assert (output_dir / "manifest.json").exists()
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text())
+    assert len(manifest_payload["entries"]) == len(manifest.entries)
+
+    for entry in manifest.entries:
+        config_path = output_dir / "configs" / f"{entry.run_id}.json"
+        assert config_path.exists()
+        config_payload = json.loads(config_path.read_text())
+        assert config_payload["command"] == list(entry.command_argv)
+        assert config_payload["run_id"] == entry.run_id
+
+    # Prompts are deduplicated per (workload_id, tier), not per decode mode.
+    prompt_files = list((output_dir / "prompts").iterdir())
+    from llmtracefx.optimizer.workloads.catalog import WORKLOADS
+
+    assert len(prompt_files) == len(WORKLOADS) * len(tuple(ContextTier))
+
+
+def test_write_matrix_prompt_file_matches_recorded_hash(tmp_path):
+    import hashlib
+
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="m", model_family="qwen3_next", output_dir=str(output_dir)
+    )
+    write_matrix(manifest)
+
+    entry = manifest.entries[0]
+    expected_name = f"{entry.workload_id}-{entry.context_tier}.txt"
+    matching = output_dir / "prompts" / expected_name
+    digest = hashlib.sha256(matching.read_text().encode("utf-8")).hexdigest()
+    assert entry.prompt.prompt_hash == f"sha256:{digest}"
+
+
+def test_generate_matrix_respects_context_tier_subset():
+    manifest = generate_matrix(
+        model_id="m",
+        model_family="qwen3_next",
+        output_dir="/tmp/unused",
+        context_tiers=(ContextTier.TIER_2K,),
+    )
+    assert all(entry.context_tier == "2k" for entry in manifest.entries)

--- a/tests/optimizer/test_workloads_schema.py
+++ b/tests/optimizer/test_workloads_schema.py
@@ -1,0 +1,114 @@
+"""Tests for the workload schema (categories, tiers, Workload records)."""
+
+from __future__ import annotations
+
+import pytest
+
+from llmtracefx.optimizer.workloads.schema import (
+    CodeCompletionSpec,
+    ContextTier,
+    ProseReasoningSpec,
+    StructuredJSONSpec,
+    Workload,
+    WorkloadCategory,
+    WorkloadSchemaError,
+)
+
+
+def test_context_tier_targets_are_ordered_and_distinct():
+    from llmtracefx.optimizer.workloads.schema import CONTEXT_TIER_TARGET_TOKENS
+
+    values = [CONTEXT_TIER_TARGET_TOKENS[tier] for tier in ContextTier]
+    assert values == sorted(values)
+    assert len(set(values)) == len(values)
+
+
+def test_workload_rejects_empty_workload_id():
+    with pytest.raises(WorkloadSchemaError, match="workload_id"):
+        Workload(
+            workload_id="",
+            version="1",
+            category=WorkloadCategory.PROSE_REASONING,
+            title="t",
+            base_prompt="p",
+            spec=ProseReasoningSpec(expected_answer_pattern="x"),
+        )
+
+
+def test_workload_rejects_empty_base_prompt():
+    with pytest.raises(WorkloadSchemaError, match="base_prompt"):
+        Workload(
+            workload_id="w",
+            version="1",
+            category=WorkloadCategory.PROSE_REASONING,
+            title="t",
+            base_prompt="",
+            spec=ProseReasoningSpec(expected_answer_pattern="x"),
+        )
+
+
+def test_workload_rejects_mismatched_spec_type():
+    with pytest.raises(WorkloadSchemaError, match="expected ProseReasoningSpec"):
+        Workload(
+            workload_id="w",
+            version="1",
+            category=WorkloadCategory.PROSE_REASONING,
+            title="t",
+            base_prompt="p",
+            spec=StructuredJSONSpec(required_fields=(), field_types={}),
+        )
+
+
+def test_workload_round_trips_through_dict_code_completion():
+    workload = Workload(
+        workload_id="w",
+        version="1",
+        category=WorkloadCategory.CODE_COMPLETION,
+        title="t",
+        base_prompt="p",
+        spec=CodeCompletionSpec(
+            function_stub="def f(): pass",
+            test_code="assert True",
+            entry_point="f",
+        ),
+    )
+    restored = Workload.from_dict(workload.to_dict())
+    assert restored == workload
+
+
+def test_workload_round_trips_through_dict_structured_json():
+    workload = Workload(
+        workload_id="w",
+        version="1",
+        category=WorkloadCategory.STRUCTURED_JSON,
+        title="t",
+        base_prompt="p",
+        spec=StructuredJSONSpec(
+            required_fields=("a", "b"), field_types={"a": "str", "b": "int"}
+        ),
+    )
+    restored = Workload.from_dict(workload.to_dict())
+    assert restored == workload
+
+
+def test_workload_round_trips_through_dict_prose_reasoning():
+    workload = Workload(
+        workload_id="w",
+        version="1",
+        category=WorkloadCategory.PROSE_REASONING,
+        title="t",
+        base_prompt="p",
+        spec=ProseReasoningSpec(expected_answer_pattern=r"\b3\b"),
+    )
+    restored = Workload.from_dict(workload.to_dict())
+    assert restored == workload
+
+
+def test_workload_from_dict_rejects_missing_field():
+    with pytest.raises(WorkloadSchemaError, match="missing required field"):
+        Workload.from_dict({"workload_id": "w"})
+
+
+def test_code_completion_spec_from_dict_rejects_missing_field():
+    with pytest.raises(WorkloadSchemaError, match="missing required field"):
+        CodeCompletionSpec.from_dict({"function_stub": "x"})


### PR DESCRIPTION
## Summary

Adds two foundations for the Qwen3.8 study:

1. An explicit native MTP capability contract that refuses to label generic draft-model speculation as native Qwen MTP.
2. A deterministic workload matrix for code completion, structured JSON, and reasoning at planned 2K, 8K, and 16K context tiers.

No Qwen3.8 model was downloaded or executed in this PR. The capability result is based on runtime API and checkpoint behavior, while collection paths are tested with injected fake runtimes.

## Why native MTP is reported as unsupported

The current stable MLX path does not expose a production API that can load Qwen MTP weights and distinguish native MTP evidence from generic external draft-model speculation.

Observed runtime behavior:

- `mlx-lm` removes `mtp.` weights for the checked model families during checkpoint sanitization.
- `mlx-lm` generation exposes external draft-model speculation, which PR #4 already records.
- Experimental `mlx-vlm` native-MTP dispatch exists for a limited family set, but it is not exposed through a stable, metrics-distinguishable collection contract suitable for this evidence schema.

The implementation records an explicit unsupported result instead of silently running a different decoding method.

## Capability flow

```mermaid
flowchart LR
    I[Target and sidecar metadata] --> V[Checkpoint compatibility check]
    V --> C[Runtime capability detection]
    C -->|Supported and distinguishable| R[Native MTP collection]
    C -->|Unsupported or ambiguous| U[Unsupported experiment record]
    U --> P[capability_report.json]
    R --> E[Canonical experiment record]
```

## Native MTP evidence

`llmtracefx/optimizer/collectors/native_mtp.py` adds:

- runtime and model-family capability detection
- local checkpoint existence checks
- hidden-size and vocabulary compatibility checks
- informational layer-count reporting for lightweight sidecars
- explicit unsupported `ExperimentRecord` output
- standalone capability reports
- a protocol-based supported path ready for a future stable adapter

Compatibility is reported only when target and sidecar metadata share at least one comparable hidden-size or vocabulary field.

Unsupported collection records contain:

```text
outcome.success = false
error.category = NativeMTPUnsupported
speculative.enabled = false
```

This prevents unsupported runs from entering performance analysis as valid native-MTP evidence.

CLI commands:

```bash
llmtracefx-optimizer native-mtp capability-report
llmtracefx-optimizer native-mtp collect
```

## Workload matrix

```mermaid
flowchart LR
    C[Versioned workload catalog] --> P[Deterministic prompt materialization]
    P --> H[Materialized prompt hash]
    H --> M[Matrix manifest]
    M --> R[Runner configurations]
    R --> E[Deterministic evaluators]
```

| Category | Task | Evaluator |
|---|---|---|
| Code | Complete a palindrome function | Isolated executable assertions |
| Structured JSON | Extract a typed profile | Exact fields and types |
| Reasoning | Solve a fixed arithmetic problem | Exact-answer pattern |

Prompt materialization preserves the task at every context tier. For code completion, filler is inserted before the continuation stub so the model still sees the function stub as the final prompt content. Other workloads append deterministic filler after their complete task prompt.

The manifest labels context sizes as planning estimates. Actual tokenizer counts remain runtime measurements in `ExperimentRecord.tokens`.

Generated artifacts:

```text
manifest.json
prompts/<workload>/<tier>.txt
configs/<run-id>.json
```

Native-MTP rows remain visible but are marked `runnable=false` with the capability reason when trustworthy evidence is unavailable.

CLI commands:

```bash
llmtracefx-optimizer workloads list
llmtracefx-optimizer workloads generate-matrix
llmtracefx-optimizer workloads evaluate
```

## Evaluator containment

The code evaluator runs generated Python only inside a temporary working directory with a minimal environment allowlist. On POSIX it applies CPU, address-space, and file-size limits and starts a dedicated process group. Timeout and normal-exit cleanup terminate remaining group members, including a Darwin fallback for descendants left after the group leader exits.

This reduces the blast radius but is not a hostile-code sandbox. The evaluator is intended for trusted local benchmark environments.

## Schema

Adds optional `ModelInfo.model_family` metadata. Existing records remain valid because the field defaults to `null`.

## Evidence integrity

- Target and sidecar paths must exist locally.
- Collection does not download model weights.
- Generic draft-model speculation is never renamed native MTP.
- Unsupported metrics remain absent.
- Planned context sizes are not reported as measured token counts.
- Evaluators are deterministic and do not use an LLM judge.
- Capability and matrix artifacts are written atomically.

## Validation

- 372 tests pass
- Ruff passes on optimizer and optimizer tests
- Black and isort checks pass on changed surfaces
- mypy passes on the optimizer package

Tests cover capability results, checkpoint compatibility, unsupported and supported fake-runtime records, schema compatibility, padding semantics, prompt hashing, matrix determinism, CLI behavior, evaluators, environment isolation, resource limits, timeout cleanup, and normally exiting parents that leave descendants.

## Scope boundaries

This PR does not add:

- a production native Qwen3.8 MTP adapter
- Qwen3.8 hardware measurements
- native Metal or CUDA performance counters
- automatic configuration search
- an LLM-based evaluator

## Next step

Add native Metal System Trace ingestion and run the first pinned Qwen3.8 autoregressive workload on the M5 Pro. Native MTP measurements should begin only when a stable runtime adapter can expose distinguishable evidence.