### PR TITLE
feat(optimizer): add resumable workload verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,15 +860,67 @@ uv run llmtracefx-optimizer workloads evaluate \
   --response-file /tmp/response.txt
 ```
 
+### Executing the matrix: `workloads run` and `workloads summarize`
+
+`workloads generate-matrix` only plans; it never loads a model or downloads
+anything. `workloads run` consumes that manifest and actually executes the
+runnable rows through the same `collect-mlx` collector used above, evaluates
+each response with the deterministic evaluator, and writes a canonical
+result per row:
+
+```bash
+uv run llmtracefx-optimizer workloads run \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --model-path /path/to/local/qwen3.8-checkpoint \
+  --output-dir artifacts/qwen3.8-run \
+  --mode autoregressive \
+  --context-tier 2k
+```
+
+- `--model-path` (and the optional `--draft-model-path` for generic
+  draft-model speculation) must already exist on disk; nothing is ever
+  downloaded.
+- `--run-id`/`--category`/`--context-tier`/`--mode` filter which manifest
+  rows are selected; omit all of them to select every row.
+- `native-mtp` rows are always rejected as `unsupported` and never
+  executed -- they are never silently downgraded to generic draft-model
+  speculation, matching the capability report above.
+- `--dry-run` prints every selected row's required local paths, expected
+  artifacts, and blockers (missing model path, a prompt file whose hash no
+  longer matches the manifest, workload catalog drift) without loading a
+  model.
+- Re-running with the same `--output-dir` resumes: a row is only skipped
+  if its prior `verification.json` is `completed`/`skipped` *and* its
+  prompt hash, run-binding hash (model paths, seed, `max_tokens`,
+  `num_draft_tokens`), and workload version all still match; any mismatch
+  reruns the row instead of trusting stale data.
+
+Each row writes `runs/<run_id>/collection/{record.json,response.txt,
+environment.json}` (the raw collector output), `final_record.json` (the
+canonical `ExperimentRecord`, with the evaluator's outcome layered onto a
+successful collection -- a runtime failure is always persisted as-is and
+never overwritten by an evaluator result), and `verification.json` (a
+machine-readable summary: status, hashes, quality, timing, and artifact
+paths). Aggregate a completed run:
+
+```bash
+uv run llmtracefx-optimizer workloads summarize --results artifacts/qwen3.8-run
+```
+
+which reports pass rate and "correct cases per minute" (computed only from
+rows that both passed and have measured timing) overall and broken down by
+decode mode and context tier -- deliberately not blended into one combined
+score.
+
 **Not yet included** (tracked as a follow-up PR): a genuinely capable
 native-MTP runtime adapter (none exists upstream today), native Metal/CUDA
-performance-counter ingestion, CUDA/vLLM/SGLang collectors, automatic
-tuning/search, and any actual Qwen3.8-27B benchmark results -- everything in
-this section was verified against fake runtimes and small local checkpoints,
-never a real Qwen3.8-27B run. The fixtures under
-`tests/optimizer/fixtures/llama_cpp/` are synthetic, hand-written logs for
-testing the parser and doctor rule — not benchmark evidence (see the
-`PROVENANCE.md` in that directory).
+performance-counter ingestion, CUDA/vLLM/SGLang collectors, an automatic
+tuning/recommendation command (`tune`) built on top of the evidence above,
+and any actual Qwen3.8-27B benchmark results -- everything in this section
+was verified against fake runtimes and small local checkpoints, never a real
+Qwen3.8-27B run. The fixtures under `tests/optimizer/fixtures/llama_cpp/` are
+synthetic, hand-written logs for testing the parser and doctor rule -- not
+benchmark evidence (see the `PROVENANCE.md` in that directory).
 
 ## 📄 License
 

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -7,7 +7,9 @@ Subcommands:
     native-mtp       Native Qwen MTP capability report / evidence collection.
     parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
     doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
-    workloads        Generate a deterministic code/JSON/reasoning workload matrix.
+    workloads        Generate a deterministic code/JSON/reasoning workload matrix,
+                     execute selected runnable rows (``workloads run``), and
+                     aggregate results (``workloads summarize``).
 """
 
 from __future__ import annotations
@@ -43,10 +45,26 @@ from .schema import (
     SchemaValidationError,
     utc_now_iso,
 )
+from .workloads.aggregate import summarize_results, write_summary
 from .workloads.catalog import WORKLOADS, workload_by_id
 from .workloads.evaluators import evaluate_workload
-from .workloads.matrix import generate_matrix, write_matrix
-from .workloads.schema import ContextTier, WorkloadSchemaError
+from .workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    DECODE_MODE_NATIVE_MTP,
+    MatrixManifest,
+    MatrixSchemaError,
+    generate_matrix,
+    write_matrix,
+)
+from .workloads.schema import ContextTier, WorkloadCategory, WorkloadSchemaError
+from .workloads.verify import (
+    RowSelection,
+    RowStatus,
+    RunBinding,
+    VerifyError,
+    plan_selected_rows,
+    run_selected_rows,
+)
 
 
 def _platform_from_manifest(*, accelerator: str | None = None) -> PlatformInfo:
@@ -402,6 +420,144 @@ def _cmd_workloads_evaluate(args: argparse.Namespace) -> int:
     return 0 if outcome.success else 1
 
 
+def _row_selection_from_args(args: argparse.Namespace) -> RowSelection:
+    return RowSelection(
+        run_ids=frozenset(args.run_id) if args.run_id else None,
+        categories=frozenset(args.category) if args.category else None,
+        context_tiers=frozenset(args.context_tier) if args.context_tier else None,
+        decode_modes=frozenset(args.mode) if args.mode else None,
+    )
+
+
+def _optional_run_binding(args: argparse.Namespace) -> RunBinding | None:
+    """Best-effort binding for dry-run reporting: ``None`` on any problem.
+
+    Invalid/missing paths are surfaced as per-row blockers by
+    ``plan_selected_rows`` rather than aborting the dry run outright.
+    """
+    if not args.model_path:
+        return None
+    try:
+        return RunBinding(
+            target_model_path=Path(args.model_path),
+            draft_model_path=(
+                Path(args.draft_model_path) if args.draft_model_path else None
+            ),
+            seed=args.seed,
+            num_draft_tokens=args.num_draft_tokens,
+        )
+    except VerifyError:
+        return None
+
+
+def _cmd_workloads_run(args: argparse.Namespace) -> int:
+    matrix_path = Path(args.matrix)
+    try:
+        manifest = MatrixManifest.read_json(matrix_path)
+    except (OSError, MatrixSchemaError) as exc:
+        print(f"Failed to load matrix manifest: {exc}", file=sys.stderr)
+        return 1
+
+    selection = _row_selection_from_args(args)
+    output_dir = Path(args.output_dir)
+    manifest_dir = matrix_path.parent
+
+    if args.dry_run:
+        plans = plan_selected_rows(
+            manifest,
+            manifest_dir=manifest_dir,
+            output_dir=output_dir,
+            selection=selection,
+            binding=_optional_run_binding(args),
+        )
+        if not plans:
+            print("No matrix rows matched the selection filters", file=sys.stderr)
+            return 1
+
+        for plan in plans:
+            label = (
+                "UNSUPPORTED"
+                if plan.unsupported
+                else ("READY" if plan.ready else "BLOCKED")
+            )
+            print(
+                f"[{label}] {plan.entry.run_id} "
+                f"({plan.entry.decode_mode}, {plan.entry.context_tier})"
+            )
+            print(f"    prompt file: {plan.prompt_path}")
+            print(f"    collection dir: {plan.collection_dir}")
+            print(f"    final record: {plan.final_record_path}")
+            if plan.unsupported:
+                print(f"    unsupported reason: {plan.unsupported_reason}")
+            for blocker in plan.blockers:
+                print(f"    blocker: {blocker}")
+
+        blocked = sum(1 for plan in plans if not plan.unsupported and not plan.ready)
+        unsupported = sum(1 for plan in plans if plan.unsupported)
+        print(
+            f"{len(plans)} row(s) selected, {blocked} blocked, "
+            f"{unsupported} unsupported; no model was loaded or downloaded"
+        )
+        return 0 if blocked == 0 else 2
+
+    if not args.model_path:
+        print("--model-path is required unless --dry-run is set", file=sys.stderr)
+        return 1
+
+    try:
+        binding = RunBinding(
+            target_model_path=Path(args.model_path),
+            draft_model_path=(
+                Path(args.draft_model_path) if args.draft_model_path else None
+            ),
+            seed=args.seed,
+            num_draft_tokens=args.num_draft_tokens,
+        )
+    except VerifyError as exc:
+        print(f"Invalid model path binding: {exc}", file=sys.stderr)
+        return 1
+
+    results = run_selected_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        output_dir=output_dir,
+        selection=selection,
+        binding=binding,
+        resume=not args.no_resume,
+        runtime_factory=MLXLMRuntime,
+    )
+    if not results:
+        print("No matrix rows matched the selection filters", file=sys.stderr)
+        return 1
+
+    for result in results:
+        status = result.verification.status.value.upper()
+        suffix = f": {result.verification.reason}" if result.verification.reason else ""
+        print(f"[{status}] {result.entry.run_id}{suffix}")
+
+    failed = sum(1 for r in results if r.verification.status == RowStatus.FAILED)
+    inconclusive = sum(
+        1 for r in results if r.verification.status == RowStatus.INCONCLUSIVE
+    )
+    print(f"Artifacts written to {output_dir}")
+    if failed:
+        return 1
+    if inconclusive:
+        return 2
+    return 0
+
+
+def _cmd_workloads_summarize(args: argparse.Namespace) -> int:
+    results_dir = Path(args.results)
+    summary = summarize_results(results_dir)
+    if args.output:
+        write_summary(summary, Path(args.output))
+        print(f"Verification summary written to {args.output}")
+    else:
+        print(summary.to_json())
+    return 0 if summary.overall.total > 0 else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llmtracefx-optimizer",
@@ -672,6 +828,94 @@ def build_parser() -> argparse.ArgumentParser:
         "--response-file", required=True, help="Path to the model's response text"
     )
     evaluate_parser.set_defaults(func=_cmd_workloads_evaluate)
+
+    run_parser = workloads_subparsers.add_parser(
+        "run",
+        help=(
+            "Execute selected runnable matrix rows through the MLX-LM "
+            "collector and evaluate them deterministically"
+        ),
+    )
+    run_parser.add_argument(
+        "--matrix",
+        required=True,
+        help="Path to a `workloads generate-matrix` manifest.json",
+    )
+    run_parser.add_argument(
+        "--model-path",
+        default=None,
+        help=(
+            "Existing local target MLX model directory; required unless "
+            "--dry-run (models are never downloaded)"
+        ),
+    )
+    run_parser.add_argument(
+        "--draft-model-path",
+        default=None,
+        help=(
+            "Optional existing local MLX draft model; enables generic "
+            "draft-model speculation on selected autoregressive rows, "
+            "never on native-mtp rows"
+        ),
+    )
+    run_parser.add_argument("--num-draft-tokens", type=int, default=2)
+    run_parser.add_argument("--output-dir", required=True)
+    run_parser.add_argument(
+        "--run-id", nargs="+", default=None, help="Select specific run_id(s)"
+    )
+    run_parser.add_argument(
+        "--category",
+        nargs="+",
+        default=None,
+        choices=[category.value for category in WorkloadCategory],
+        help="Filter selected rows by workload category",
+    )
+    run_parser.add_argument(
+        "--context-tier",
+        nargs="+",
+        default=None,
+        choices=[tier.value for tier in ContextTier],
+        help="Filter selected rows by context tier",
+    )
+    run_parser.add_argument(
+        "--mode",
+        nargs="+",
+        default=None,
+        choices=[DECODE_MODE_AUTOREGRESSIVE, DECODE_MODE_NATIVE_MTP],
+        help=(
+            "Filter selected rows by decode mode; native-mtp rows are "
+            "always rejected as unsupported, never executed"
+        ),
+    )
+    run_parser.add_argument("--seed", type=int, default=0)
+    run_parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Re-run all selected rows even if a hash-matching completed artifact exists",
+    )
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print selected rows, required local model paths, expected "
+            "artifacts, and blockers without loading any model"
+        ),
+    )
+    run_parser.set_defaults(func=_cmd_workloads_run)
+
+    summarize_parser = workloads_subparsers.add_parser(
+        "summarize",
+        help="Aggregate pass rate/throughput/status counts across a `workloads run` results directory",
+    )
+    summarize_parser.add_argument(
+        "--results", required=True, help="The --output-dir passed to `workloads run`"
+    )
+    summarize_parser.add_argument(
+        "--output",
+        default=None,
+        help="Write the summary JSON to this path instead of stdout",
+    )
+    summarize_parser.set_defaults(func=_cmd_workloads_summarize)
 
     return parser
 

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -1,0 +1,180 @@
+"""Aggregation/reporting across executed verify-pipeline rows.
+
+Reads every ``verification.json`` written by ``verify.execute_row`` under a
+``workloads run --output-dir`` results directory and reports a small set of
+distinct, well-defined metrics: how many rows landed in each
+``RowStatus``, the pass rate among rows that were actually evaluated, and
+a throughput figure ("correct cases per minute") computed only from rows
+that both passed and have measured timing. Per-``decode_mode`` and
+per-``context_tier`` breakdowns use the same definitions.
+
+This module deliberately does **not** blend correctness and speed into a
+single combined "performance score" -- that would hide which axis (quality
+vs. throughput) any one number reflects. Callers that want an overall
+picture should read ``pass_rate`` and ``correct_cases_per_minute``
+side by side.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text
+from .verify import RowStatus, RowVerification, VerifyError
+
+AGGREGATE_SCHEMA_VERSION = "1"
+
+
+def _load_verifications(results_dir: Path) -> tuple[RowVerification, ...]:
+    runs_dir = results_dir / "runs"
+    if not runs_dir.is_dir():
+        return ()
+    verifications: list[RowVerification] = []
+    for verification_path in sorted(runs_dir.glob("*/verification.json")):
+        try:
+            verifications.append(RowVerification.read_json(verification_path))
+        except (OSError, json.JSONDecodeError, VerifyError):
+            # A corrupt/partial artifact must not silently skew aggregates;
+            # it is simply excluded rather than crashing the whole summary.
+            continue
+    return tuple(verifications)
+
+
+def _pass_rate(pass_count: int, evaluated_count: int) -> float | None:
+    return pass_count / evaluated_count if evaluated_count else None
+
+
+def _correct_cases_per_minute(pass_count: int, total_pass_ms: float) -> float | None:
+    if pass_count == 0 or total_pass_ms <= 0:
+        return None
+    minutes = total_pass_ms / 1000.0 / 60.0
+    return pass_count / minutes
+
+
+@dataclass(frozen=True)
+class GroupSummary:
+    """Aggregate metrics for one group (overall, one mode, or one tier)."""
+
+    key: str
+    total: int
+    completed: int
+    failed: int
+    unsupported: int
+    skipped: int
+    inconclusive: int
+    evaluated_total: int
+    evaluated_pass: int
+    pass_rate: float | None
+    correct_cases_per_minute: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "total": self.total,
+            "completed": self.completed,
+            "failed": self.failed,
+            "unsupported": self.unsupported,
+            "skipped": self.skipped,
+            "inconclusive": self.inconclusive,
+            "evaluated_total": self.evaluated_total,
+            "evaluated_pass": self.evaluated_pass,
+            "pass_rate": self.pass_rate,
+            "correct_cases_per_minute": self.correct_cases_per_minute,
+        }
+
+
+def _summarize_group(
+    key: str, verifications: Iterable[RowVerification]
+) -> GroupSummary:
+    items = list(verifications)
+    counts = dict.fromkeys(RowStatus, 0)
+    for item in items:
+        counts[item.status] += 1
+
+    # "Evaluated" rows are ones that actually produced a quality signal:
+    # freshly completed or trusted-and-skipped rows with a quality score.
+    # Failed/unsupported/inconclusive rows are excluded from pass rate and
+    # throughput so they cannot be misread as passing or failing quality
+    # checks they never ran.
+    evaluated = [
+        item
+        for item in items
+        if item.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+        and item.quality_score is not None
+    ]
+    evaluated_pass = [item for item in evaluated if item.outcome_success]
+    total_pass_ms = sum(
+        item.total_ms for item in evaluated_pass if item.total_ms is not None
+    )
+
+    return GroupSummary(
+        key=key,
+        total=len(items),
+        completed=counts[RowStatus.COMPLETED],
+        failed=counts[RowStatus.FAILED],
+        unsupported=counts[RowStatus.UNSUPPORTED],
+        skipped=counts[RowStatus.SKIPPED],
+        inconclusive=counts[RowStatus.INCONCLUSIVE],
+        evaluated_total=len(evaluated),
+        evaluated_pass=len(evaluated_pass),
+        pass_rate=_pass_rate(len(evaluated_pass), len(evaluated)),
+        correct_cases_per_minute=_correct_cases_per_minute(
+            len(evaluated_pass), total_pass_ms
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class VerificationSummary:
+    """Aggregate report across every ``verification.json`` in a results dir."""
+
+    schema_version: str
+    results_dir: str
+    overall: GroupSummary
+    by_decode_mode: tuple[GroupSummary, ...]
+    by_context_tier: tuple[GroupSummary, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "results_dir": self.results_dir,
+            "overall": self.overall.to_dict(),
+            "by_decode_mode": [group.to_dict() for group in self.by_decode_mode],
+            "by_context_tier": [group.to_dict() for group in self.by_context_tier],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+
+def summarize_results(results_dir: Path) -> VerificationSummary:
+    """Aggregate every ``verification.json`` found under ``results_dir``."""
+    verifications = _load_verifications(results_dir)
+    overall = _summarize_group("overall", verifications)
+
+    by_mode: dict[str, list[RowVerification]] = {}
+    by_tier: dict[str, list[RowVerification]] = {}
+    for item in verifications:
+        by_mode.setdefault(item.decode_mode, []).append(item)
+        by_tier.setdefault(item.context_tier, []).append(item)
+
+    return VerificationSummary(
+        schema_version=AGGREGATE_SCHEMA_VERSION,
+        results_dir=str(results_dir),
+        overall=overall,
+        by_decode_mode=tuple(
+            _summarize_group(key, items) for key, items in sorted(by_mode.items())
+        ),
+        by_context_tier=tuple(
+            _summarize_group(key, items) for key, items in sorted(by_tier.items())
+        ),
+    )
+
+
+def write_summary(summary: VerificationSummary, path: Path) -> None:
+    """Atomically write ``summary`` as pretty JSON to ``path``."""
+    atomic_write_text(path, summary.to_json() + "\n")

--- a/llmtracefx/optimizer/workloads/materialize.py
+++ b/llmtracefx/optimizer/workloads/materialize.py
@@ -64,6 +64,36 @@ class MaterializedPrompt:
             "prompt_char_count": len(self.text),
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MaterializedPrompt:
+        """Reconstruct planning metadata from a persisted matrix manifest.
+
+        ``to_dict`` deliberately never persists ``text`` (the prompt body
+        lives in its own ``prompts/<id>-<tier>.txt`` file so it is not
+        duplicated into ``manifest.json``), so ``text`` is always empty
+        here. This is intentional: callers loading a manifest back from
+        disk must read the prompt file at the owning entry's
+        ``prompt_path`` and verify its hash against ``prompt_hash``
+        rather than trusting an in-memory copy, which is exactly the
+        prompt-integrity check the verification pipeline performs before
+        executing any row.
+        """
+        try:
+            return cls(
+                workload_id=data["workload_id"],
+                workload_version=data["workload_version"],
+                context_tier=ContextTier(data["context_tier"]),
+                target_context_tokens=int(data["target_context_tokens"]),
+                approx_chars_per_token=int(data["approx_chars_per_token"]),
+                filler_segments_used=int(data["filler_segments_used"]),
+                text="",
+                prompt_hash=data["prompt_hash"],
+            )
+        except KeyError as exc:
+            raise ValueError(
+                f"MaterializedPrompt is missing required field: {exc}"
+            ) from exc
+
 
 def _build_filler(remaining_chars: int) -> tuple[str, int]:
     """Deterministically build filler text totalling >= ``remaining_chars``.

--- a/llmtracefx/optimizer/workloads/matrix.py
+++ b/llmtracefx/optimizer/workloads/matrix.py
@@ -44,6 +44,10 @@ DECODE_MODE_NATIVE_MTP = "native-mtp"
 DEFAULT_MAX_TOKENS = 128
 
 
+class MatrixSchemaError(ValueError):
+    """Raised when a persisted matrix manifest is malformed."""
+
+
 @dataclass(frozen=True)
 class MatrixEntry:
     """One planned (workload, context tier, decode mode) combination."""
@@ -62,6 +66,7 @@ class MatrixEntry:
     runnable: bool
     unsupported_reason: str | None
     command_argv: tuple[str, ...]
+    max_tokens: int = DEFAULT_MAX_TOKENS
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -79,7 +84,41 @@ class MatrixEntry:
             "runnable": self.runnable,
             "unsupported_reason": self.unsupported_reason,
             "command_argv": list(self.command_argv),
+            "max_tokens": self.max_tokens,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MatrixEntry:
+        try:
+            command_argv = data["command_argv"]
+            if isinstance(command_argv, (str, bytes)) or not isinstance(
+                command_argv, Sequence
+            ):
+                raise MatrixSchemaError(
+                    f"MatrixEntry.command_argv must be a list of strings, "
+                    f"got {command_argv!r}"
+                )
+            return cls(
+                run_id=data["run_id"],
+                workload_id=data["workload_id"],
+                workload_version=data["workload_version"],
+                category=data["category"],
+                context_tier=data["context_tier"],
+                decode_mode=data["decode_mode"],
+                configured_depth=data.get("configured_depth"),
+                prompt=MaterializedPrompt.from_dict(data["prompt"]),
+                prompt_path=data["prompt_path"],
+                runner_results_dir=data["runner_results_dir"],
+                collector_output_dir=data["collector_output_dir"],
+                runnable=bool(data["runnable"]),
+                unsupported_reason=data.get("unsupported_reason"),
+                command_argv=tuple(command_argv),
+                max_tokens=int(data.get("max_tokens", DEFAULT_MAX_TOKENS)),
+            )
+        except KeyError as exc:
+            raise MatrixSchemaError(
+                f"MatrixEntry is missing required field: {exc}"
+            ) from exc
 
 
 @dataclass(frozen=True)
@@ -103,6 +142,38 @@ class MatrixManifest:
 
     def to_json(self, *, indent: int | None = 2) -> str:
         return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MatrixManifest:
+        try:
+            entries_raw = data["entries"]
+            if not isinstance(entries_raw, list):
+                raise MatrixSchemaError("MatrixManifest.entries must be a list")
+            return cls(
+                schema_version=str(data.get("schema_version", MATRIX_SCHEMA_VERSION)),
+                model_id=data["model_id"],
+                model_family=data["model_family"],
+                output_dir=data["output_dir"],
+                entries=tuple(MatrixEntry.from_dict(entry) for entry in entries_raw),
+            )
+        except KeyError as exc:
+            raise MatrixSchemaError(
+                f"MatrixManifest is missing required field: {exc}"
+            ) from exc
+
+    @classmethod
+    def from_json(cls, payload: str) -> MatrixManifest:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise MatrixSchemaError(f"Invalid JSON for MatrixManifest: {exc}") from exc
+        if not isinstance(data, dict):
+            raise MatrixSchemaError("MatrixManifest JSON must be an object")
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> MatrixManifest:
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))
 
 
 def _collect_mlx_argv(
@@ -233,6 +304,7 @@ def generate_matrix(
                         output_dir=ar_output_dir,
                         max_tokens=max_tokens,
                     ),
+                    max_tokens=max_tokens,
                 )
             )
 
@@ -269,6 +341,7 @@ def generate_matrix(
                             max_tokens=max_tokens,
                             configured_depth=depth,
                         ),
+                        max_tokens=max_tokens,
                     )
                 )
 

--- a/llmtracefx/optimizer/workloads/matrix.py
+++ b/llmtracefx/optimizer/workloads/matrix.py
@@ -263,7 +263,9 @@ def generate_matrix(
     """
     resolved_target_path = target_model_path or "<TARGET_MODEL_PATH>"
     resolved_sidecar_path = mtp_sidecar_path or "<MTP_SIDECAR_PATH>"
-    output_dir_path = Path(output_dir)
+    # Persist absolute artifact paths so a manifest generated with a relative
+    # --output-dir remains consumable from any later working directory.
+    output_dir_path = Path(output_dir).expanduser().resolve()
 
     capability = detect_native_mtp_capability(
         model_family, mlx_lm_version=None, mlx_vlm_version=None

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -644,6 +644,7 @@ def execute_row(
 
     if not collected_record.outcome.success:
         # A runtime failure is never overwritten by an evaluator result.
+        collected_record.write_json(final_record_path)
         return _finish(
             RowStatus.FAILED,
             (

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -1,0 +1,725 @@
+"""Executable, resumable, quality-aware verification pipeline.
+
+This module turns the dry-run matrix produced by ``matrix.generate_matrix``
+into real, evaluated evidence. It is the foundation the future ``tune``
+command will build on: a user with an existing local MLX model (and,
+optionally, an existing local draft model) selects rows from a matrix
+manifest and this module executes each one through the existing MLX-LM
+collector (``collectors.mlx.collect_mlx``, added in PR #4), evaluates the
+response with the deterministic PR #5 evaluators, and persists a canonical
+``ExperimentRecord`` whose ``OutcomeInfo`` reflects task quality.
+
+Data flow per selected row
+--------------------------
+1. **Reject unsupported rows explicitly.** Any row whose ``decode_mode`` is
+   ``native-mtp`` (or that the matrix already marked ``runnable=False``) is
+   never executed and never silently downgraded to generic draft-model
+   speculation; it is recorded as ``RowStatus.UNSUPPORTED`` with the exact
+   reason. Native-MTP support does not exist in this project (see
+   ``collectors.native_mtp``'s capability detection) and this pipeline does
+   not add one.
+2. **Verify the prompt.** The exact fully materialized prompt text is read
+   from the entry's ``prompt_path`` (never from an in-memory copy) and its
+   sha256 hash is compared against the hash recorded in the matrix
+   manifest. A mismatch means the prompt file was edited (or the manifest
+   is stale) after matrix generation, so the row fails clearly instead of
+   silently executing a different prompt than the one the matrix planned.
+3. **Verify the workload catalog binding.** The workload is looked up by
+   ``workload_id`` and its ``version`` must match the version pinned in the
+   manifest; catalog drift fails the row clearly rather than evaluating
+   against a different (possibly incompatible) spec.
+4. **Resume by trusting only hash-matching completed artifacts.** If a
+   prior ``verification.json`` for this run_id exists, has a status of
+   ``completed``/``skipped``, and its recorded prompt hash / run-binding
+   hash (target+draft model paths, seed, max_tokens, num_draft_tokens) /
+   workload version all still match, the prior ``final_record.json`` is
+   trusted and reused (``RowStatus.SKIPPED``) without re-executing.
+   Otherwise the row is (re-)executed.
+5. **Execute via the existing MLX-LM collector.** Only ``collect_mlx`` is
+   used; models are never downloaded (``RunBinding`` requires the target
+   and any draft path to already exist on disk). Supplying
+   ``--draft-model-path`` enables generic external draft-model speculative
+   decoding (labeled ``"draft-model"`` by the collector, per PR #5's
+   native-MTP-vs-draft-model distinction) -- it is never applied to
+   native-MTP rows.
+6. **Evaluate without ever overwriting a runtime failure.** If the
+   collector reports a runtime failure (``outcome.success is False``), the
+   collected record is persisted unchanged as the final record
+   (``RowStatus.FAILED``); the evaluator is not invoked. If collection
+   succeeds, the deterministic evaluator's ``OutcomeInfo`` replaces the
+   collector's placeholder outcome in the final record
+   (``RowStatus.COMPLETED``). If the evaluator itself raises an unexpected
+   error despite a successful collection, the row is recorded as
+   ``RowStatus.INCONCLUSIVE`` with measurement evidence preserved and
+   ``quality_score`` left ``None`` (never guessed).
+7. **Persist atomically.** ``collect_mlx`` already atomically writes
+   ``record.json``/``response.txt``/``environment.json`` under the row's
+   ``collection/`` directory; this module additionally writes
+   ``final_record.json`` (the evaluated canonical record) and
+   ``verification.json`` (a machine-readable summary with statuses,
+   hashes, and artifact paths) using the same atomic write-then-rename
+   helper used throughout this project.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text, config_hash, sha256_text
+from ..collectors.mlx import (
+    MLXCollectionConfig,
+    MLXCollectorError,
+    MLXRuntime,
+    collect_mlx,
+)
+from ..schema import ExperimentRecord, OutcomeInfo, SchemaValidationError, utc_now_iso
+from .catalog import workload_by_id
+from .evaluators import evaluate_workload
+from .matrix import DECODE_MODE_NATIVE_MTP, MatrixEntry, MatrixManifest
+from .schema import WorkloadSchemaError
+
+VERIFICATION_SCHEMA_VERSION = "1"
+
+
+class VerifyError(ValueError):
+    """Raised for invalid verify-pipeline configuration (not row outcomes)."""
+
+
+class RowStatus(str, Enum):
+    """Explicit, machine-readable outcome for one selected matrix row."""
+
+    COMPLETED = "completed"
+    """Executed and evaluated; ``outcome`` in the final record reflects
+    task quality (which may itself be a pass or a fail)."""
+
+    FAILED = "failed"
+    """A runtime/collector failure, a stale prompt/catalog mismatch, or an
+    invalid collector configuration prevented producing evidence."""
+
+    UNSUPPORTED = "unsupported"
+    """The row's decode mode is not runnable (native-MTP); rejected
+    explicitly rather than silently downgraded to generic speculation."""
+
+    SKIPPED = "skipped"
+    """A prior hash-matching completed artifact was trusted and reused
+    instead of re-executing (resume)."""
+
+    INCONCLUSIVE = "inconclusive"
+    """Collection succeeded but the deterministic evaluator could not
+    render a verdict (an unexpected, non-quality-related error); timing
+    evidence is preserved but ``quality_score`` is left unset."""
+
+
+_TRUSTABLE_RESUME_STATUSES = (RowStatus.COMPLETED, RowStatus.SKIPPED)
+
+
+@dataclass(frozen=True)
+class RowSelection:
+    """Row selection filters for ``workloads run``.
+
+    Each field is either ``None`` (no filter on that axis) or a
+    ``frozenset`` of allowed values; a row must match every non-``None``
+    filter to be selected. An empty ``RowSelection()`` selects every row
+    in the manifest.
+    """
+
+    run_ids: frozenset[str] | None = None
+    categories: frozenset[str] | None = None
+    context_tiers: frozenset[str] | None = None
+    decode_modes: frozenset[str] | None = None
+
+    def matches(self, entry: MatrixEntry) -> bool:
+        if self.run_ids is not None and entry.run_id not in self.run_ids:
+            return False
+        if self.categories is not None and entry.category not in self.categories:
+            return False
+        if (
+            self.context_tiers is not None
+            and entry.context_tier not in self.context_tiers
+        ):
+            return False
+        if self.decode_modes is not None and entry.decode_mode not in self.decode_modes:
+            return False
+        return True
+
+
+def select_entries(
+    manifest: MatrixManifest, selection: RowSelection
+) -> tuple[MatrixEntry, ...]:
+    """Return the manifest entries matching ``selection``, in manifest order."""
+    return tuple(entry for entry in manifest.entries if selection.matches(entry))
+
+
+def _resolve_path(raw: str, *, base_dir: Path) -> Path:
+    """Resolve a manifest-relative path against the manifest's directory.
+
+    Mirrors ``RunnerConfig.from_file``'s handling of relative
+    ``results_dir``: paths recorded in the manifest are relative to the
+    directory the manifest itself was generated into, not the current
+    process's working directory, so a manifest can be consumed correctly
+    regardless of where ``workloads run`` happens to be invoked from.
+    """
+    path = Path(raw)
+    return path if path.is_absolute() else base_dir / path
+
+
+@dataclass(frozen=True)
+class RunBinding:
+    """Explicit, no-download local path binding for one verify run.
+
+    Requires the target model path (and, if given, the draft model path)
+    to already exist on disk. A model identifier is never turned into an
+    implicit download by this pipeline.
+    """
+
+    target_model_path: Path
+    draft_model_path: Path | None = None
+    seed: int = 0
+    num_draft_tokens: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.target_model_path.exists():
+            raise VerifyError(
+                f"target model path does not exist: {self.target_model_path}. "
+                "Provide an existing local model path; models are never "
+                "downloaded by this pipeline."
+            )
+        if self.draft_model_path is not None and not self.draft_model_path.exists():
+            raise VerifyError(
+                f"draft model path does not exist: {self.draft_model_path}. "
+                "Provide an existing local model path; models are never "
+                "downloaded by this pipeline."
+            )
+
+    def hash_payload(self, *, max_tokens: int) -> dict[str, Any]:
+        return {
+            "target_model_path": str(self.target_model_path),
+            "draft_model_path": (
+                str(self.draft_model_path)
+                if self.draft_model_path is not None
+                else None
+            ),
+            "seed": self.seed,
+            "num_draft_tokens": self.num_draft_tokens,
+            "max_tokens": max_tokens,
+        }
+
+    def run_binding_hash(self, *, max_tokens: int) -> str:
+        return config_hash(self.hash_payload(max_tokens=max_tokens))
+
+
+@dataclass(frozen=True)
+class RowVerification:
+    """Machine-readable per-row verification summary (``verification.json``)."""
+
+    schema_version: str
+    run_id: str
+    workload_id: str
+    workload_version: str
+    category: str
+    context_tier: str
+    decode_mode: str
+    status: RowStatus
+    reason: str | None
+    recorded_prompt_hash: str | None
+    verified_prompt_hash: str | None
+    run_binding_hash: str | None
+    resumed: bool
+    outcome_success: bool | None
+    quality_score: float | None
+    total_ms: float | None
+    started_at: str
+    ended_at: str
+    final_record_path: str | None
+    collection_dir: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "workload_id": self.workload_id,
+            "workload_version": self.workload_version,
+            "category": self.category,
+            "context_tier": self.context_tier,
+            "decode_mode": self.decode_mode,
+            "status": self.status.value,
+            "reason": self.reason,
+            "recorded_prompt_hash": self.recorded_prompt_hash,
+            "verified_prompt_hash": self.verified_prompt_hash,
+            "run_binding_hash": self.run_binding_hash,
+            "resumed": self.resumed,
+            "outcome_success": self.outcome_success,
+            "quality_score": self.quality_score,
+            "total_ms": self.total_ms,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "final_record_path": self.final_record_path,
+            "collection_dir": self.collection_dir,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=False) + "\n"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RowVerification:
+        try:
+            return cls(
+                schema_version=str(
+                    data.get("schema_version", VERIFICATION_SCHEMA_VERSION)
+                ),
+                run_id=data["run_id"],
+                workload_id=data["workload_id"],
+                workload_version=data["workload_version"],
+                category=data["category"],
+                context_tier=data["context_tier"],
+                decode_mode=data["decode_mode"],
+                status=RowStatus(data["status"]),
+                reason=data.get("reason"),
+                recorded_prompt_hash=data.get("recorded_prompt_hash"),
+                verified_prompt_hash=data.get("verified_prompt_hash"),
+                run_binding_hash=data.get("run_binding_hash"),
+                resumed=bool(data.get("resumed", False)),
+                outcome_success=data.get("outcome_success"),
+                quality_score=data.get("quality_score"),
+                total_ms=data.get("total_ms"),
+                started_at=data["started_at"],
+                ended_at=data["ended_at"],
+                final_record_path=data.get("final_record_path"),
+                collection_dir=data.get("collection_dir"),
+            )
+        except (KeyError, ValueError) as exc:
+            raise VerifyError(f"invalid verification.json: {exc}") from exc
+
+    @classmethod
+    def read_json(cls, path: Path) -> RowVerification:
+        return cls.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _load_prior_verification(path: Path) -> RowVerification | None:
+    if not path.exists():
+        return None
+    try:
+        return RowVerification.read_json(path)
+    except (OSError, json.JSONDecodeError, VerifyError):
+        # A corrupt/partial artifact from an interrupted previous run must
+        # never be mistaken for a trustworthy completed result.
+        return None
+
+
+def _total_ms(record: ExperimentRecord | None) -> float | None:
+    if record is None or record.timing.total is None:
+        return None
+    return record.timing.total.value
+
+
+@dataclass(frozen=True)
+class RowResult:
+    """Outcome of planning/executing one selected matrix row."""
+
+    entry: MatrixEntry
+    verification: RowVerification
+    final_record: ExperimentRecord | None
+
+
+@dataclass(frozen=True)
+class RowPlan:
+    """A dry-run description of one selected row: what would happen."""
+
+    entry: MatrixEntry
+    unsupported: bool
+    unsupported_reason: str | None
+    ready: bool
+    blockers: tuple[str, ...]
+    prompt_path: Path
+    collection_dir: Path
+    final_record_path: Path
+    verification_path: Path
+
+
+def _run_dir(entry: MatrixEntry, *, output_dir: Path) -> Path:
+    return output_dir / "runs" / entry.run_id
+
+
+def plan_row(
+    entry: MatrixEntry,
+    *,
+    manifest_dir: Path,
+    output_dir: Path,
+    binding: RunBinding | None,
+) -> RowPlan:
+    """Describe what running ``entry`` would do, without loading a model."""
+    run_dir = _run_dir(entry, output_dir=output_dir)
+    prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
+
+    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
+        reason = entry.unsupported_reason or (
+            "native-mtp execution is not implemented by this pipeline; no "
+            "capable runtime is wired into `workloads run`"
+        )
+        return RowPlan(
+            entry=entry,
+            unsupported=True,
+            unsupported_reason=reason,
+            ready=False,
+            blockers=(),
+            prompt_path=prompt_path,
+            collection_dir=run_dir / "collection",
+            final_record_path=run_dir / "final_record.json",
+            verification_path=run_dir / "verification.json",
+        )
+
+    blockers: list[str] = []
+    if binding is None:
+        blockers.append("no --model-path binding was provided")
+
+    if not prompt_path.exists():
+        blockers.append(f"prompt file missing: {prompt_path}")
+    else:
+        verified_hash = sha256_text(prompt_path.read_text(encoding="utf-8"))
+        if verified_hash != entry.prompt.prompt_hash:
+            blockers.append(
+                "prompt hash mismatch: matrix metadata records "
+                f"{entry.prompt.prompt_hash} but {prompt_path} hashes to "
+                f"{verified_hash}; regenerate the matrix or restore the "
+                "original prompt file"
+            )
+
+    try:
+        workload = workload_by_id(entry.workload_id)
+    except KeyError:
+        blockers.append(f"unknown workload_id in catalog: {entry.workload_id!r}")
+    else:
+        if workload.version != entry.workload_version:
+            blockers.append(
+                f"workload '{entry.workload_id}' version drift: matrix "
+                f"pinned v{entry.workload_version}, catalog has "
+                f"v{workload.version}"
+            )
+
+    return RowPlan(
+        entry=entry,
+        unsupported=False,
+        unsupported_reason=None,
+        ready=not blockers,
+        blockers=tuple(blockers),
+        prompt_path=prompt_path,
+        collection_dir=run_dir / "collection",
+        final_record_path=run_dir / "final_record.json",
+        verification_path=run_dir / "verification.json",
+    )
+
+
+def plan_selected_rows(
+    manifest: MatrixManifest,
+    *,
+    manifest_dir: Path,
+    output_dir: Path,
+    selection: RowSelection,
+    binding: RunBinding | None,
+) -> tuple[RowPlan, ...]:
+    """Dry-run: describe every selected row without loading any model."""
+    return tuple(
+        plan_row(
+            entry, manifest_dir=manifest_dir, output_dir=output_dir, binding=binding
+        )
+        for entry in select_entries(manifest, selection)
+    )
+
+
+def _build_command_argv(
+    entry: MatrixEntry, *, binding: RunBinding, model_id: str
+) -> tuple[str, ...]:
+    argv = [
+        "llmtracefx-optimizer",
+        "collect-mlx",
+        "--run-id",
+        entry.run_id,
+        "--model-path",
+        str(binding.target_model_path),
+        "--model-id",
+        model_id,
+        "--max-tokens",
+        str(entry.max_tokens),
+        "--seed",
+        str(binding.seed),
+    ]
+    if binding.draft_model_path is not None:
+        argv.extend(
+            (
+                "--draft-model-path",
+                str(binding.draft_model_path),
+                "--num-draft-tokens",
+                str(binding.num_draft_tokens),
+            )
+        )
+    return tuple(argv)
+
+
+def execute_row(
+    entry: MatrixEntry,
+    *,
+    manifest_dir: Path,
+    output_dir: Path,
+    model_id: str,
+    binding: RunBinding,
+    resume: bool,
+    runtime_factory: Callable[[], MLXRuntime],
+) -> RowResult:
+    """Verify, (maybe) execute, and evaluate one selected matrix row.
+
+    ``runtime_factory`` is only invoked immediately before the collector
+    actually needs to run (never for unsupported/rejected rows, resume-
+    trusted rows, or rows that fail verification before execution), so
+    selecting only unsupported native-MTP rows never constructs (and
+    therefore never imports or platform-checks) an MLX runtime.
+    """
+    started_at = utc_now_iso()
+    run_dir = _run_dir(entry, output_dir=output_dir)
+    verification_path = run_dir / "verification.json"
+    collection_dir = run_dir / "collection"
+    final_record_path = run_dir / "final_record.json"
+
+    def _finish(
+        status: RowStatus,
+        reason: str | None,
+        *,
+        final_record: ExperimentRecord | None = None,
+        verified_hash: str | None = None,
+        binding_hash: str | None = None,
+        resumed: bool = False,
+        wrote_collection: bool = False,
+    ) -> RowResult:
+        verification = RowVerification(
+            schema_version=VERIFICATION_SCHEMA_VERSION,
+            run_id=entry.run_id,
+            workload_id=entry.workload_id,
+            workload_version=entry.workload_version,
+            category=entry.category,
+            context_tier=entry.context_tier,
+            decode_mode=entry.decode_mode,
+            status=status,
+            reason=reason,
+            recorded_prompt_hash=entry.prompt.prompt_hash,
+            verified_prompt_hash=verified_hash,
+            run_binding_hash=binding_hash,
+            resumed=resumed,
+            outcome_success=(
+                final_record.outcome.success if final_record is not None else None
+            ),
+            quality_score=(
+                final_record.outcome.quality_score if final_record is not None else None
+            ),
+            total_ms=_total_ms(final_record),
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+            final_record_path=(
+                str(final_record_path) if final_record is not None else None
+            ),
+            collection_dir=(
+                str(collection_dir)
+                if final_record is not None and wrote_collection
+                else None
+            ),
+        )
+        atomic_write_text(verification_path, verification.to_json())
+        return RowResult(
+            entry=entry, verification=verification, final_record=final_record
+        )
+
+    # 1. Native-MTP / unsupported rows: reject explicitly, never execute,
+    #    never silently downgrade to generic draft-model speculation.
+    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
+        reason = entry.unsupported_reason or (
+            "native-mtp execution is not implemented by this pipeline; no "
+            "capable runtime is wired into `workloads run`, so this row is "
+            "rejected rather than silently downgraded to generic "
+            "draft-model speculation"
+        )
+        return _finish(RowStatus.UNSUPPORTED, reason)
+
+    # 2. Verify the fully materialized prompt against the matrix metadata.
+    prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
+    if not prompt_path.exists():
+        return _finish(RowStatus.FAILED, f"prompt file missing: {prompt_path}")
+
+    prompt_text = prompt_path.read_text(encoding="utf-8")
+    verified_hash = sha256_text(prompt_text)
+    if verified_hash != entry.prompt.prompt_hash:
+        return _finish(
+            RowStatus.FAILED,
+            "prompt hash mismatch: matrix metadata records "
+            f"{entry.prompt.prompt_hash} but {prompt_path} hashes to "
+            f"{verified_hash}; regenerate the matrix or restore the "
+            "original prompt file before running",
+            verified_hash=verified_hash,
+        )
+
+    # 3. Verify the workload catalog binding.
+    try:
+        workload = workload_by_id(entry.workload_id)
+    except KeyError:
+        return _finish(
+            RowStatus.FAILED,
+            f"unknown workload_id in catalog: {entry.workload_id!r}",
+            verified_hash=verified_hash,
+        )
+    if workload.version != entry.workload_version:
+        return _finish(
+            RowStatus.FAILED,
+            f"workload '{entry.workload_id}' version drift: matrix pinned "
+            f"v{entry.workload_version}, catalog has v{workload.version}; "
+            "regenerate the matrix",
+            verified_hash=verified_hash,
+        )
+
+    binding_hash = binding.run_binding_hash(max_tokens=entry.max_tokens)
+
+    # 4. Resume: trust only a prior completed/skipped artifact whose
+    #    hashes still match every current input.
+    if resume:
+        prior = _load_prior_verification(verification_path)
+        if (
+            prior is not None
+            and prior.status in _TRUSTABLE_RESUME_STATUSES
+            and prior.verified_prompt_hash == verified_hash
+            and prior.run_binding_hash == binding_hash
+            and prior.workload_version == workload.version
+        ):
+            try:
+                trusted_record = ExperimentRecord.read_json(final_record_path)
+            except (OSError, SchemaValidationError):
+                trusted_record = None
+            if trusted_record is not None:
+                return _finish(
+                    RowStatus.SKIPPED,
+                    "trusted prior completed artifact (hash-matching); not "
+                    "re-executed",
+                    final_record=trusted_record,
+                    verified_hash=verified_hash,
+                    binding_hash=binding_hash,
+                    resumed=True,
+                    wrote_collection=True,
+                )
+
+    # 5. Execute via the existing MLX-LM collector.
+    try:
+        config = MLXCollectionConfig(
+            run_id=entry.run_id,
+            model_path=binding.target_model_path,
+            model_id=model_id,
+            prompt=prompt_text,
+            output_dir=collection_dir,
+            command_argv=_build_command_argv(entry, binding=binding, model_id=model_id),
+            max_tokens=entry.max_tokens,
+            seed=binding.seed,
+            draft_model_path=binding.draft_model_path,
+            num_draft_tokens=binding.num_draft_tokens,
+        )
+    except MLXCollectorError as exc:
+        return _finish(
+            RowStatus.FAILED,
+            f"invalid collector configuration: {exc}",
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+        )
+
+    try:
+        runtime = runtime_factory()
+    except MLXCollectorError as exc:
+        return _finish(
+            RowStatus.FAILED,
+            f"MLX runtime is unavailable in this environment: {exc}",
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+        )
+
+    collection_result = collect_mlx(config, runtime=runtime)
+    collected_record = collection_result.record
+
+    if not collected_record.outcome.success:
+        # A runtime failure is never overwritten by an evaluator result.
+        return _finish(
+            RowStatus.FAILED,
+            (
+                collected_record.error.message
+                if collected_record.error is not None
+                else "collector reported failure without an error detail"
+            ),
+            final_record=collected_record,
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+            wrote_collection=True,
+        )
+
+    try:
+        evaluated_outcome = evaluate_workload(workload, collection_result.response_text)
+    except (WorkloadSchemaError, OSError, RuntimeError) as exc:
+        inconclusive_record = dataclasses.replace(
+            collected_record,
+            outcome=OutcomeInfo(
+                success=collected_record.outcome.success,
+                quality_score=None,
+                quality_metric=None,
+                notes=f"evaluation inconclusive: {exc}",
+            ),
+        )
+        inconclusive_record.write_json(final_record_path)
+        return _finish(
+            RowStatus.INCONCLUSIVE,
+            f"evaluator raised an unexpected error: {exc}",
+            final_record=inconclusive_record,
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+            wrote_collection=True,
+        )
+
+    final_record = dataclasses.replace(collected_record, outcome=evaluated_outcome)
+    final_record.write_json(final_record_path)
+    return _finish(
+        RowStatus.COMPLETED,
+        None,
+        final_record=final_record,
+        verified_hash=verified_hash,
+        binding_hash=binding_hash,
+        wrote_collection=True,
+    )
+
+
+def run_selected_rows(
+    manifest: MatrixManifest,
+    *,
+    manifest_dir: Path,
+    output_dir: Path,
+    selection: RowSelection,
+    binding: RunBinding,
+    resume: bool,
+    runtime_factory: Callable[[], MLXRuntime],
+) -> tuple[RowResult, ...]:
+    """Verify, execute, and evaluate every selected matrix row in order.
+
+    ``runtime_factory`` is passed through to ``execute_row`` and invoked
+    lazily, so a batch consisting only of unsupported/resumed rows never
+    constructs an MLX runtime.
+    """
+    return tuple(
+        execute_row(
+            entry,
+            manifest_dir=manifest_dir,
+            output_dir=output_dir,
+            model_id=manifest.model_id,
+            binding=binding,
+            resume=resume,
+            runtime_factory=runtime_factory,
+        )
+        for entry in select_entries(manifest, selection)
+    )
+
+
+def iter_result_statuses(results: Iterable[RowResult]) -> Iterable[RowStatus]:
+    return (result.verification.status for result in results)

--- a/tests/optimizer/test_workloads_aggregate.py
+++ b/tests/optimizer/test_workloads_aggregate.py
@@ -1,0 +1,268 @@
+"""Tests for aggregation/reporting across executed verify-pipeline rows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from llmtracefx.optimizer.workloads.aggregate import summarize_results, write_summary
+from llmtracefx.optimizer.workloads.verify import RowStatus, RowVerification
+
+SCHEMA_VERSION = "1"
+
+
+def _write_verification(
+    results_dir: Path,
+    run_id: str,
+    *,
+    status: RowStatus,
+    decode_mode: str = "autoregressive",
+    context_tier: str = "2k",
+    outcome_success: bool | None = None,
+    quality_score: float | None = None,
+    total_ms: float | None = None,
+) -> None:
+    verification = RowVerification(
+        schema_version=SCHEMA_VERSION,
+        run_id=run_id,
+        workload_id="structured-json-profile-extraction",
+        workload_version="1",
+        category="structured_json",
+        context_tier=context_tier,
+        decode_mode=decode_mode,
+        status=status,
+        reason=None,
+        recorded_prompt_hash="sha256:abc",
+        verified_prompt_hash="sha256:abc",
+        run_binding_hash="sha256:def",
+        resumed=False,
+        outcome_success=outcome_success,
+        quality_score=quality_score,
+        total_ms=total_ms,
+        started_at="2024-01-01T00:00:00.000000Z",
+        ended_at="2024-01-01T00:00:01.000000Z",
+        final_record_path=str(results_dir / "runs" / run_id / "final_record.json"),
+        collection_dir=str(results_dir / "runs" / run_id / "collection"),
+    )
+    run_dir = results_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "verification.json").write_text(verification.to_json(), encoding="utf-8")
+
+
+def test_summarize_results_with_no_runs_dir_is_empty(tmp_path):
+    summary = summarize_results(tmp_path / "does-not-exist")
+    assert summary.overall.total == 0
+    assert summary.overall.pass_rate is None
+    assert summary.by_decode_mode == ()
+    assert summary.by_context_tier == ()
+
+
+def test_summarize_results_counts_by_status(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "r1",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    _write_verification(
+        results_dir,
+        "r2",
+        status=RowStatus.COMPLETED,
+        outcome_success=False,
+        quality_score=0.0,
+        total_ms=1000,
+    )
+    _write_verification(results_dir, "r3", status=RowStatus.FAILED)
+    _write_verification(
+        results_dir, "r4", status=RowStatus.UNSUPPORTED, decode_mode="native-mtp"
+    )
+    _write_verification(
+        results_dir, "r5", status=RowStatus.INCONCLUSIVE, outcome_success=True
+    )
+    _write_verification(
+        results_dir,
+        "r6",
+        status=RowStatus.SKIPPED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=500,
+    )
+
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.total == 6
+    assert summary.overall.completed == 2
+    assert summary.overall.failed == 1
+    assert summary.overall.unsupported == 1
+    assert summary.overall.inconclusive == 1
+    assert summary.overall.skipped == 1
+
+
+def test_summarize_results_pass_rate_excludes_failed_unsupported_inconclusive(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "pass1",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    _write_verification(
+        results_dir,
+        "fail1",
+        status=RowStatus.COMPLETED,
+        outcome_success=False,
+        quality_score=0.0,
+        total_ms=1000,
+    )
+    _write_verification(results_dir, "unsupported1", status=RowStatus.UNSUPPORTED)
+    _write_verification(results_dir, "failed-runtime", status=RowStatus.FAILED)
+    _write_verification(
+        results_dir,
+        "inconclusive1",
+        status=RowStatus.INCONCLUSIVE,
+        outcome_success=True,
+    )
+
+    summary = summarize_results(results_dir)
+
+    # Only the two COMPLETED rows with a quality_score count toward pass rate.
+    assert summary.overall.evaluated_total == 2
+    assert summary.overall.evaluated_pass == 1
+    assert summary.overall.pass_rate == 0.5
+
+
+def test_correct_cases_per_minute_uses_only_passing_timed_rows(tmp_path):
+    results_dir = tmp_path / "results"
+    # Two correct cases each taking 30s (30_000 ms) => 60s total => 2 cases/min.
+    _write_verification(
+        results_dir,
+        "r1",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=30_000,
+    )
+    _write_verification(
+        results_dir,
+        "r2",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=30_000,
+    )
+    # An incorrect (but timed) case must not count toward throughput.
+    _write_verification(
+        results_dir,
+        "r3",
+        status=RowStatus.COMPLETED,
+        outcome_success=False,
+        quality_score=0.0,
+        total_ms=5_000,
+    )
+
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.correct_cases_per_minute == 2.0
+
+
+def test_correct_cases_per_minute_is_none_without_timing(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "r1",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=None,
+    )
+
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.correct_cases_per_minute is None
+
+
+def test_summary_groups_by_decode_mode_and_context_tier(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "ar-2k",
+        status=RowStatus.COMPLETED,
+        decode_mode="autoregressive",
+        context_tier="2k",
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    _write_verification(
+        results_dir,
+        "mtp-2k",
+        status=RowStatus.UNSUPPORTED,
+        decode_mode="native-mtp",
+        context_tier="2k",
+    )
+    _write_verification(
+        results_dir,
+        "ar-8k",
+        status=RowStatus.COMPLETED,
+        decode_mode="autoregressive",
+        context_tier="8k",
+        outcome_success=False,
+        quality_score=0.0,
+        total_ms=1000,
+    )
+
+    summary = summarize_results(results_dir)
+
+    modes = {group.key: group for group in summary.by_decode_mode}
+    assert modes["autoregressive"].total == 2
+    assert modes["native-mtp"].total == 1
+    assert modes["native-mtp"].unsupported == 1
+
+    tiers = {group.key: group for group in summary.by_context_tier}
+    assert tiers["2k"].total == 2
+    assert tiers["8k"].total == 1
+    assert tiers["8k"].evaluated_pass == 0
+
+
+def test_summarize_results_skips_corrupt_verification_files(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "good",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    corrupt_dir = results_dir / "runs" / "corrupt"
+    corrupt_dir.mkdir(parents=True)
+    (corrupt_dir / "verification.json").write_text("not json", encoding="utf-8")
+
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.total == 1
+
+
+def test_write_summary_persists_json(tmp_path):
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "r1",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    summary = summarize_results(results_dir)
+
+    output_path = tmp_path / "summary.json"
+    write_summary(summary, output_path)
+
+    payload = json.loads(output_path.read_text())
+    assert payload["overall"]["total"] == 1
+    assert payload["schema_version"] == "1"

--- a/tests/optimizer/test_workloads_cli.py
+++ b/tests/optimizer/test_workloads_cli.py
@@ -226,6 +226,73 @@ def test_workloads_run_cli_executes_autoregressive_rows(tmp_path, monkeypatch):
     assert (run_dirs[0] / "verification.json").exists()
 
 
+def test_relative_matrix_output_can_be_dry_run_and_executed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    parser = cli.build_parser()
+    generate_args = parser.parse_args(
+        [
+            "workloads",
+            "generate-matrix",
+            "--model-id",
+            "local/test-model",
+            "--model-family",
+            "qwen3_next",
+            "--output-dir",
+            "artifacts/qwen3.8-matrix",
+            "--context-tiers",
+            "2k",
+        ]
+    )
+    assert generate_args.func(generate_args) == 0
+
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    matrix_path = "artifacts/qwen3.8-matrix/manifest.json"
+    selection = [
+        "--category",
+        "structured_json",
+        "--context-tier",
+        "2k",
+        "--mode",
+        "autoregressive",
+    ]
+
+    dry_run_args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            matrix_path,
+            "--model-path",
+            "model",
+            "--output-dir",
+            "results",
+            "--dry-run",
+            *selection,
+        ]
+    )
+    assert dry_run_args.func(dry_run_args) == 0
+
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+    run_args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            matrix_path,
+            "--model-path",
+            "model",
+            "--output-dir",
+            "results",
+            *selection,
+        ]
+    )
+    assert run_args.func(run_args) == 0
+    run_dirs = list((tmp_path / "results" / "runs").iterdir())
+    assert len(run_dirs) == 1
+    assert (run_dirs[0] / "final_record.json").exists()
+
+
 def test_workloads_run_cli_rejects_native_mtp_rows_as_unsupported(
     tmp_path, monkeypatch
 ):

--- a/tests/optimizer/test_workloads_cli.py
+++ b/tests/optimizer/test_workloads_cli.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
 from llmtracefx.optimizer import cli
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.workloads.matrix import generate_matrix, write_matrix
+from llmtracefx.optimizer.workloads.schema import ContextTier
 
 
 def test_workloads_list_cli_prints_catalog(capsys):
@@ -117,3 +121,319 @@ def test_workloads_evaluate_cli_reports_unknown_workload(tmp_path, capsys):
     )
     assert args.func(args) == 1
     assert "Unknown workload" in capsys.readouterr().err
+
+
+@dataclass
+class _FakeResponse:
+    text: str = '{"name": "Priya", "age": 34, "is_active": true}'
+    from_draft: bool = False
+    prompt_tokens: int = 3
+    generation_tokens: int = 1
+    finish_reason: str | None = None
+
+
+class _FakeTokenizer:
+    bos_token = None
+
+
+class _FakeMLXRuntime:
+    mlx_version = "0.32.0"
+    mlx_lm_version = "0.31.3"
+
+    def __init__(self, response_text=None):
+        self.response_text = response_text or _FakeResponse.text
+        self.load_calls = []
+
+    def load_model(self, path):
+        self.load_calls.append(path)
+        return object(), _FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return MLXMemorySnapshot(active_bytes=1024, cache_bytes=256, peak_bytes=2048)
+
+    def accelerator_name(self):
+        return "Apple M5 Pro (test)"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        yield _FakeResponse(self.response_text)
+
+
+def _build_small_matrix(tmp_path):
+    from llmtracefx.optimizer.workloads.catalog import (
+        STRUCTURED_JSON_PROFILE_EXTRACTION,
+    )
+
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        workloads=(STRUCTURED_JSON_PROFILE_EXTRACTION,),
+        context_tiers=(ContextTier.TIER_2K,),
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+    return output_dir / "manifest.json"
+
+
+def test_workloads_run_cli_executes_autoregressive_rows(tmp_path, monkeypatch):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(results_dir),
+            "--mode",
+            "autoregressive",
+        ]
+    )
+    assert args.func(args) == 0
+    run_dirs = list((results_dir / "runs").iterdir())
+    assert len(run_dirs) == 1
+    assert (run_dirs[0] / "final_record.json").exists()
+    assert (run_dirs[0] / "verification.json").exists()
+
+
+def test_workloads_run_cli_rejects_native_mtp_rows_as_unsupported(
+    tmp_path, monkeypatch
+):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(results_dir),
+            "--mode",
+            "native-mtp",
+        ]
+    )
+    assert args.func(args) == 0
+    verification = json.loads(
+        (next((results_dir / "runs").iterdir()) / "verification.json").read_text()
+    )
+    assert verification["status"] == "unsupported"
+
+
+def test_workloads_run_cli_requires_model_path_without_dry_run(tmp_path):
+    matrix_path = _build_small_matrix(tmp_path)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--output-dir",
+            str(tmp_path / "results"),
+        ]
+    )
+    assert args.func(args) == 1
+
+
+def test_workloads_run_cli_dry_run_reports_blockers_without_loading_model(
+    tmp_path, capsys
+):
+    matrix_path = _build_small_matrix(tmp_path)
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--mode",
+            "autoregressive",
+            "--dry-run",
+        ]
+    )
+    assert args.func(args) == 2  # blocked: no --model-path given
+    out = capsys.readouterr().out
+    assert "no model was loaded or downloaded" in out
+    assert "blocker" in out
+
+
+def test_workloads_run_cli_dry_run_ready_with_valid_model_path(tmp_path, capsys):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--mode",
+            "autoregressive",
+            "--dry-run",
+        ]
+    )
+    assert args.func(args) == 0
+    assert "READY" in capsys.readouterr().out
+
+
+def test_workloads_run_cli_reports_runtime_failure_with_exit_1(tmp_path, monkeypatch):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    class FailingRuntime(_FakeMLXRuntime):
+        def load_model(self, path):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: FailingRuntime())
+
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--mode",
+            "autoregressive",
+        ]
+    )
+    assert args.func(args) == 1
+
+
+def test_workloads_run_cli_unknown_matrix_manifest_fails(tmp_path, capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(tmp_path / "missing-manifest.json"),
+            "--output-dir",
+            str(tmp_path / "results"),
+        ]
+    )
+    assert args.func(args) == 1
+    assert "Failed to load matrix manifest" in capsys.readouterr().err
+
+
+def test_workloads_summarize_cli_reports_pass_rate(tmp_path, monkeypatch):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    run_parser = cli.build_parser()
+    run_args = run_parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(results_dir),
+            "--mode",
+            "autoregressive",
+        ]
+    )
+    assert run_args.func(run_args) == 0
+
+    summarize_parser = cli.build_parser()
+    summarize_args = summarize_parser.parse_args(
+        ["workloads", "summarize", "--results", str(results_dir)]
+    )
+    assert summarize_args.func(summarize_args) == 0
+
+
+def test_workloads_summarize_cli_writes_to_output_file(tmp_path, monkeypatch):
+    matrix_path = _build_small_matrix(tmp_path)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    run_parser = cli.build_parser()
+    run_args = run_parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--model-path",
+            str(model_path),
+            "--output-dir",
+            str(results_dir),
+        ]
+    )
+    run_args.func(run_args)
+
+    summary_path = tmp_path / "summary.json"
+    summarize_parser = cli.build_parser()
+    summarize_args = summarize_parser.parse_args(
+        [
+            "workloads",
+            "summarize",
+            "--results",
+            str(results_dir),
+            "--output",
+            str(summary_path),
+        ]
+    )
+    assert summarize_args.func(summarize_args) == 0
+    payload = json.loads(summary_path.read_text())
+    assert payload["overall"]["total"] > 0

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -1,0 +1,742 @@
+"""Tests for the workload-matrix verification pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.schema import ExperimentRecord
+from llmtracefx.optimizer.workloads.catalog import (
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    DECODE_MODE_NATIVE_MTP,
+    MatrixManifest,
+    generate_matrix,
+    write_matrix,
+)
+from llmtracefx.optimizer.workloads.schema import ContextTier
+from llmtracefx.optimizer.workloads.verify import (
+    RowSelection,
+    RowStatus,
+    RunBinding,
+    VerifyError,
+    execute_row,
+    plan_selected_rows,
+    run_selected_rows,
+    select_entries,
+)
+
+GOOD_RESPONSE = '{"name": "Priya", "age": 34, "is_active": true}'
+BAD_RESPONSE = "not json at all"
+
+
+@dataclass
+class FakeResponse:
+    text: str
+    from_draft: bool = False
+    prompt_tokens: int = 3
+    generation_tokens: int = 1
+    finish_reason: str | None = None
+
+
+class FakeTokenizer:
+    bos_token = None
+
+
+class FakeMLXRuntime:
+    """Minimal injectable MLX runtime; no Apple hardware or MLX import needed."""
+
+    mlx_version = "0.32.0"
+    mlx_lm_version = "0.31.3"
+
+    def __init__(self, response_text: str = GOOD_RESPONSE, *, fail: bool = False):
+        self.response_text = response_text
+        self.fail = fail
+        self.load_calls: list[Path] = []
+        self.generate_calls: list[dict] = []
+
+    def load_model(self, path):
+        self.load_calls.append(path)
+        if self.fail:
+            raise RuntimeError("simulated model load failure")
+        return object(), FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return MLXMemorySnapshot(active_bytes=1024, cache_bytes=256, peak_bytes=2048)
+
+    def accelerator_name(self):
+        return "Apple M5 Pro (test)"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        self.generate_calls.append(
+            {"draft_model": draft_model, "num_draft_tokens": num_draft_tokens}
+        )
+        yield FakeResponse(self.response_text, generation_tokens=1)
+
+
+def build_manifest(
+    tmp_path: Path,
+    *,
+    target_model_path: Path | None = None,
+    context_tiers=(ContextTier.TIER_2K,),
+) -> tuple[MatrixManifest, Path]:
+    """Generate+write a small (single workload) matrix for fast tests."""
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        target_model_path=(str(target_model_path) if target_model_path else None),
+        workloads=(STRUCTURED_JSON_PROFILE_EXTRACTION,),
+        context_tiers=context_tiers,
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+    reloaded = MatrixManifest.read_json(output_dir / "manifest.json")
+    return reloaded, output_dir
+
+
+def make_target_model(tmp_path: Path) -> Path:
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    return model_path
+
+
+# --- Row selection -----------------------------------------------------------
+
+
+def test_select_entries_filters_by_decode_mode(tmp_path):
+    manifest, _ = build_manifest(tmp_path)
+    selection = RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE}))
+    selected = select_entries(manifest, selection)
+    assert selected
+    assert all(e.decode_mode == DECODE_MODE_AUTOREGRESSIVE for e in selected)
+
+
+def test_select_entries_filters_by_run_id(tmp_path):
+    manifest, _ = build_manifest(tmp_path)
+    target = manifest.entries[0].run_id
+    selected = select_entries(manifest, RowSelection(run_ids=frozenset({target})))
+    assert len(selected) == 1
+    assert selected[0].run_id == target
+
+
+def test_select_entries_filters_by_category_and_context_tier(tmp_path):
+    manifest, _ = build_manifest(tmp_path)
+    selection = RowSelection(
+        categories=frozenset({"structured_json"}), context_tiers=frozenset({"2k"})
+    )
+    selected = select_entries(manifest, selection)
+    assert selected
+    assert all(
+        e.category == "structured_json" and e.context_tier == "2k" for e in selected
+    )
+
+
+def test_select_entries_empty_selection_matches_everything(tmp_path):
+    manifest, _ = build_manifest(tmp_path)
+    assert select_entries(manifest, RowSelection()) == manifest.entries
+
+
+# --- Path binding / no-download invariants -----------------------------------
+
+
+def test_run_binding_rejects_missing_target_model_path(tmp_path):
+    with pytest.raises(VerifyError, match="never downloaded"):
+        RunBinding(target_model_path=tmp_path / "missing-model")
+
+
+def test_run_binding_rejects_missing_draft_model_path(tmp_path):
+    target = make_target_model(tmp_path)
+    with pytest.raises(VerifyError, match="never downloaded"):
+        RunBinding(
+            target_model_path=target, draft_model_path=tmp_path / "missing-draft"
+        )
+
+
+def test_run_binding_accepts_existing_paths(tmp_path):
+    target = make_target_model(tmp_path)
+    draft = tmp_path / "draft"
+    draft.mkdir()
+    binding = RunBinding(target_model_path=target, draft_model_path=draft)
+    assert binding.target_model_path == target
+    assert binding.draft_model_path == draft
+
+
+# --- Unsupported (native-mtp) rows -------------------------------------------
+
+
+def test_native_mtp_rows_are_rejected_explicitly_never_executed(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path, target_model_path=None)
+    target = make_target_model(tmp_path)
+    entry = next(e for e in manifest.entries if e.decode_mode == DECODE_MODE_NATIVE_MTP)
+    runtime = FakeMLXRuntime()
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.UNSUPPORTED
+    assert result.verification.reason
+    assert result.final_record is None
+    assert runtime.load_calls == []  # never touched the model
+
+
+def test_native_mtp_only_selection_never_constructs_a_runtime(tmp_path):
+    """A batch with only unsupported rows must never invoke the runtime
+    factory at all -- not even to construct it -- so an environment
+    without MLX installed can still report native-mtp rows as
+    unsupported instead of crashing."""
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+
+    def _factory_that_must_not_be_called():
+        raise AssertionError("runtime factory must not be called for unsupported rows")
+
+    results = run_selected_rows(
+        manifest,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_NATIVE_MTP})),
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=_factory_that_must_not_be_called,
+    )
+
+    assert results
+    assert all(r.verification.status == RowStatus.UNSUPPORTED for r in results)
+
+
+def test_unavailable_mlx_runtime_fails_the_row_cleanly(tmp_path):
+    """If the runtime factory itself raises (e.g. MLX not installed), the
+    row must fail cleanly with an explicit reason rather than crashing
+    the whole batch."""
+    from llmtracefx.optimizer.collectors.mlx import MLXCollectorError
+
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+
+    def _unavailable_runtime():
+        raise MLXCollectorError("MLX collection requires Apple Silicon running macOS")
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=_unavailable_runtime,
+    )
+
+    assert result.verification.status == RowStatus.FAILED
+    assert "MLX runtime is unavailable" in result.verification.reason
+
+
+def test_native_mtp_rows_not_downgraded_even_with_draft_model_path(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    draft = tmp_path / "draft"
+    draft.mkdir()
+    entry = next(e for e in manifest.entries if e.decode_mode == DECODE_MODE_NATIVE_MTP)
+    runtime = FakeMLXRuntime()
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target, draft_model_path=draft),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.UNSUPPORTED
+    assert runtime.generate_calls == []
+
+
+# --- Prompt hash verification -------------------------------------------------
+
+
+def test_prompt_hash_mismatch_fails_the_row_without_executing(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    Path(entry.prompt_path).write_text(
+        "this text was edited after matrix generation", encoding="utf-8"
+    )
+    runtime = FakeMLXRuntime()
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.FAILED
+    assert "prompt hash mismatch" in result.verification.reason
+    assert runtime.load_calls == []
+
+
+def test_prompt_hash_match_allows_execution(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
+# --- Evaluator success/failure ------------------------------------------------
+
+
+def test_completed_row_reflects_correct_evaluator_outcome(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert result.final_record.outcome.success is True
+    assert result.final_record.outcome.quality_score == 1.0
+    assert result.verification.outcome_success is True
+
+
+def test_completed_row_reflects_incorrect_evaluator_outcome(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(BAD_RESPONSE)
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert result.final_record.outcome.success is False
+    assert result.final_record.outcome.quality_score == 0.0
+
+
+# --- Runtime failure preservation ---------------------------------------------
+
+
+def test_runtime_failure_is_preserved_and_not_overwritten_by_evaluator(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(fail=True)
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.FAILED
+    assert result.final_record is not None
+    assert result.final_record.outcome.success is False
+    assert result.final_record.error is not None
+    assert result.final_record.error.category == "RuntimeError"
+    assert "simulated model load failure" in result.verification.reason
+
+
+# --- Inconclusive evaluator errors --------------------------------------------
+
+
+def test_evaluator_error_produces_inconclusive_status(tmp_path, monkeypatch):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+
+    import llmtracefx.optimizer.workloads.verify as verify_module
+
+    def _boom(workload, response_text):
+        raise OSError("evaluator subprocess could not start")
+
+    monkeypatch.setattr(verify_module, "evaluate_workload", _boom)
+
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.INCONCLUSIVE
+    assert result.final_record.outcome.quality_score is None
+    assert result.final_record.outcome.success is True  # runtime itself succeeded
+    assert "inconclusive" in result.final_record.outcome.notes
+
+
+# --- Atomic artifacts ----------------------------------------------------------
+
+
+def test_completed_row_persists_all_expected_artifacts(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    results_dir = tmp_path / "results"
+
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    run_dir = results_dir / "runs" / entry.run_id
+    assert (run_dir / "collection" / "record.json").exists()
+    assert (run_dir / "collection" / "response.txt").exists()
+    assert (run_dir / "collection" / "environment.json").exists()
+    assert (run_dir / "final_record.json").exists()
+    assert (run_dir / "verification.json").exists()
+
+    final_record = ExperimentRecord.read_json(run_dir / "final_record.json")
+    assert final_record.outcome.success is True
+
+    verification_payload = json.loads((run_dir / "verification.json").read_text())
+    assert verification_payload["status"] == "completed"
+    assert verification_payload["recorded_prompt_hash"] == entry.prompt.prompt_hash
+
+
+# --- Resume / staleness detection ----------------------------------------------
+
+
+def test_resume_trusts_hash_matching_completed_artifact(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+
+    first_runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: first_runtime,
+    )
+    assert first_runtime.load_calls == [target]
+
+    second_runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: second_runtime,
+    )
+
+    assert result.verification.status == RowStatus.SKIPPED
+    assert result.verification.resumed is True
+    assert second_runtime.load_calls == []  # not re-executed
+    assert result.final_record.outcome.success is True
+
+
+def test_resume_reruns_when_prompt_content_changes(tmp_path):
+    """A stale hash-mismatched artifact must be re-run, not blindly trusted."""
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+
+    # Regenerate the matrix with a different workload so the prompt content
+    # (and its recorded hash) legitimately changes, simulating an edited
+    # catalog/matrix; force the run_id to collide with the prior artifact
+    # directory to exercise the resume-trust path against stale data.
+    import dataclasses
+
+    from llmtracefx.optimizer.workloads.catalog import CODE_COMPLETION_PALINDROME
+
+    regenerated = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        workloads=(CODE_COMPLETION_PALINDROME,),
+        context_tiers=(ContextTier.TIER_2K,),
+        mtp_depths=(2,),
+    )
+    write_matrix(regenerated)
+    reloaded = MatrixManifest.read_json(output_dir / "manifest.json")
+    new_entry = next(
+        e for e in reloaded.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    assert new_entry.prompt.prompt_hash != entry.prompt.prompt_hash
+    colliding_entry = dataclasses.replace(new_entry, run_id=entry.run_id)
+
+    runtime = FakeMLXRuntime("def is_palindrome(text): return True")
+    execute_row(
+        colliding_entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert runtime.load_calls == [target]  # re-executed, not trusted as stale
+
+
+def test_resume_reruns_when_run_binding_changes(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target, seed=0),
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=RunBinding(target_model_path=target, seed=7),  # different seed
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]  # re-executed, binding changed
+
+
+def test_no_resume_forces_reexecution(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=False,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
+# --- Dry run planning ------------------------------------------------------
+
+
+def test_plan_selected_rows_reports_ready_rows_without_touching_model(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    binding = RunBinding(target_model_path=target)
+
+    plans = plan_selected_rows(
+        manifest,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=binding,
+    )
+
+    assert len(plans) == 1
+    assert plans[0].ready is True
+    assert plans[0].unsupported is False
+    assert plans[0].blockers == ()
+
+
+def test_plan_selected_rows_flags_native_mtp_as_unsupported(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+
+    plans = plan_selected_rows(
+        manifest,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_NATIVE_MTP})),
+        binding=None,
+    )
+
+    assert len(plans) == 1
+    assert plans[0].unsupported is True
+    assert plans[0].unsupported_reason
+
+
+def test_plan_selected_rows_flags_missing_binding_as_blocker(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+
+    plans = plan_selected_rows(
+        manifest,
+        manifest_dir=output_dir,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=None,
+    )
+
+    assert len(plans) == 1
+    assert plans[0].ready is False
+    assert any("--model-path" in blocker for blocker in plans[0].blockers)
+
+
+# --- End-to-end fake matrix run -------------------------------------------------
+
+
+def test_run_selected_rows_end_to_end_over_full_matrix(tmp_path):
+    manifest, output_dir = build_manifest(
+        tmp_path, context_tiers=(ContextTier.TIER_2K, ContextTier.TIER_8K)
+    )
+    target = make_target_model(tmp_path)
+    results_dir = tmp_path / "results"
+
+    results = run_selected_rows(
+        manifest,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        selection=RowSelection(),
+        binding=RunBinding(target_model_path=target),
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+
+    assert len(results) == len(manifest.entries)
+    statuses = {r.verification.status for r in results}
+    assert RowStatus.COMPLETED in statuses
+    assert RowStatus.UNSUPPORTED in statuses
+    for result in results:
+        assert (
+            results_dir / "runs" / result.entry.run_id / "verification.json"
+        ).exists()

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -419,6 +419,16 @@ def test_runtime_failure_is_preserved_and_not_overwritten_by_evaluator(tmp_path)
     assert result.final_record.error is not None
     assert result.final_record.error.category == "RuntimeError"
     assert "simulated model load failure" in result.verification.reason
+    final_record_path = Path(result.verification.final_record_path)
+    assert final_record_path.exists()
+    persisted = ExperimentRecord.read_json(final_record_path)
+    assert persisted.error is not None
+    assert persisted.error.category == "RuntimeError"
+    verification_path = (
+        tmp_path / "results" / "runs" / entry.run_id / "verification.json"
+    )
+    verification = json.loads(verification_path.read_text(encoding="utf-8"))
+    assert verification["final_record_path"] == str(final_record_path)
 
 
 # --- Inconclusive evaluator errors --------------------------------------------


### PR DESCRIPTION
## Summary

Turns the deterministic workload matrix from PR #5 into an executable, resumable verification pipeline.

A user with an existing local MLX model can select matrix rows, verify the materialized prompt, run supported configurations, evaluate output deterministically, and persist a canonical quality-aware experiment record. Unsupported native-MTP rows remain explicit and are never downgraded to generic draft-model speculation.

## Verification flow

```mermaid
flowchart LR
    M[Matrix manifest] --> S[Row selection]
    S --> H[Prompt and workload hash checks]
    H --> R[Local model path binding]
    R --> C[MLX collector]
    C -->|Runtime failure| F[Failed final record]
    C -->|Successful response| E[Deterministic evaluator]
    E --> V[Evaluated final record]
    F --> A[verification.json]
    V --> A
```

## Row execution

`workloads run` performs these steps for every selected row:

1. Select by run ID, category, context tier, and decode mode.
2. Reject unsupported rows explicitly.
3. Read the materialized prompt from disk and verify its SHA-256.
4. Verify the workload catalog version.
5. Check whether a prior artifact is safe to resume.
6. Execute through the existing MLX-LM collector.
7. Preserve runtime failures or apply the deterministic evaluator.
8. Write collection, final record, and verification artifacts atomically.

## Supported modes

| Mode | Behavior |
|---|---|
| `autoregressive` | Executes through the MLX-LM collector |
| `autoregressive` with `--draft-model-path` | Executes generic external draft-model speculation |
| `native-mtp` | Records `unsupported`; never executes or downgrades |

The target model and optional draft model must already exist as local paths. A model ID is never converted into an implicit download.

## Resume integrity

A prior result is reused only when all of these still match:

- materialized prompt hash
- workload version
- target model path
- draft model path
- seed
- maximum output tokens
- draft-token configuration

Missing, stale, corrupt, or mismatched artifacts cause a rerun instead of reuse.

## Artifacts

Each row writes:

```text
<output-dir>/runs/<run-id>/
  collection/
    record.json
    response.txt
    environment.json
  final_record.json
  verification.json
```

Runtime failures are persisted to `final_record.json` before `verification.json` references that path. Evaluator output never replaces a runtime error.

## Path contract

Matrix generation resolves its output directory to an absolute expanded path before storing prompt, runner, and collection paths. A matrix created with a relative path remains executable from a later working directory without duplicated path prefixes.

## Aggregation

`workloads summarize` reports:

- completed, failed, unsupported, skipped, and inconclusive counts
- pass rate for rows with a quality signal
- correct cases per minute for passing rows with measured timing
- per-mode and per-context breakdowns

Quality and throughput are not blended into a synthetic score.

## CLI

```bash
llmtracefx-optimizer workloads run \
  --matrix artifacts/qwen38-matrix/manifest.json \
  --model-path /existing/local/mlx/model \
  --output-dir artifacts/qwen38-run \
  --mode autoregressive \
  --context-tier 2k

llmtracefx-optimizer workloads summarize \
  --results artifacts/qwen38-run
```

`--dry-run` prints selected rows, required local paths, expected artifacts, and blockers without loading a model.

## Validation

- 416 tests pass
- Ruff passes on the optimizer package and tests
- Black and isort checks pass on changed surfaces
- mypy passes on the optimizer package

Tests cover selection filters, prompt integrity, workload drift, no-download path binding, unsupported native-MTP behavior, lazy runtime creation, runtime failure preservation, evaluator outcomes, stale resume detection, relative matrix paths, artifact persistence, aggregation math, and CLI exit codes.

## Scope boundaries

This PR does not add:

- native Qwen MTP execution
- automatic configuration tuning
- native Metal or CUDA counters
- model downloads
- dashboard changes

## Next step

Build constrained configuration recommendations from verified `final_record.json` and `verification.json` artifacts. The tuner should reject candidates that fail quality or memory constraints before ranking surviving configurations.