### PR TITLE
feat(optimizer): add constraints-first inference tuning

### DIFF
--- a/examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json
+++ b/examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1",
+  "name": "fastest-passing-under-20gb-m5-pro",
+  "description": "Example only, not a measured claim: recommend the fastest verified configuration for a workload/hardware target whose peak memory stays under a 20 GB cap, intended for an Apple M5 Pro-class accelerator. Grouping (workload/version, context tier, model id/family, accelerator, runtime/backend, workload prompt hash) already keeps this policy from ever comparing across different hardware; the memory cap here is an additional, explicit safety margin on top of that.",
+  "objective": "min_mean_total_latency_ms",
+  "constraints": {
+    "required_statuses": ["completed", "skipped"],
+    "min_pass_rate": 1.0,
+    "max_peak_memory_bytes": 21474836480,
+    "allowed_provenances": ["measured_native", "measured_wall_clock"],
+    "min_measured_repetitions": 2,
+    "max_coefficient_of_variation": 0.15
+  }
+}

--- a/examples/optimizer/tune-policy-structured-json-throughput.json
+++ b/examples/optimizer/tune-policy-structured-json-throughput.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1",
+  "name": "max-correct-cases-per-minute-structured-json",
+  "description": "Example only, not a measured claim: recommend the highest passing-cases-per-minute configuration for a structured-JSON extraction workload, requiring every accepted run to have been scored by the structured_json_exact_field_match evaluator (see workloads.evaluators) so throughput is never computed from evidence that used a different or absent quality metric.",
+  "objective": "max_correct_cases_per_minute",
+  "constraints": {
+    "required_statuses": ["completed", "skipped"],
+    "min_pass_rate": 0.95,
+    "min_quality_score": 1.0,
+    "required_quality_metric": "structured_json_exact_field_match",
+    "allowed_provenances": ["measured_native", "measured_wall_clock"],
+    "min_measured_repetitions": 2,
+    "max_coefficient_of_variation": 0.2
+  }
+}

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -10,6 +10,8 @@ Subcommands:
     workloads        Generate a deterministic code/JSON/reasoning workload matrix,
                      execute selected runnable rows (``workloads run``), and
                      aggregate results (``workloads summarize``).
+    tune             Offline, evidence-constrained recommendation of the best
+                     verified configuration for a workload/hardware target.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+from .collectors._shared import atomic_write_text
 from .collectors.mlx import (
     MLXCollectionConfig,
     MLXCollectorError,
@@ -45,6 +48,10 @@ from .schema import (
     SchemaValidationError,
     utc_now_iso,
 )
+from .tune.explain import format_report_text
+from .tune.loader import TuneInputError
+from .tune.policy import TunePolicy, TunePolicyError
+from .tune.tuner import tune
 from .workloads.aggregate import summarize_results, write_summary
 from .workloads.catalog import WORKLOADS, workload_by_id
 from .workloads.evaluators import evaluate_workload
@@ -558,6 +565,36 @@ def _cmd_workloads_summarize(args: argparse.Namespace) -> int:
     return 0 if summary.overall.total > 0 else 1
 
 
+def _cmd_tune(args: argparse.Namespace) -> int:
+    try:
+        policy = TunePolicy.from_file(args.policy)
+    except TunePolicyError as exc:
+        print(f"Invalid tune policy: {exc}", file=sys.stderr)
+        return 1
+
+    results_dirs = tuple(Path(path) for path in args.results)
+    try:
+        report = tune(results_dirs=results_dirs, policy=policy)
+    except TuneInputError as exc:
+        print(f"Invalid tuning input: {exc}", file=sys.stderr)
+        return 1
+
+    print(format_report_text(report, verbose=args.explain))
+
+    if args.output:
+        atomic_write_text(Path(args.output), report.to_json() + "\n")
+        print(f"\nTune report written to {args.output}")
+
+    if not report.groups:
+        print(
+            "\nNo comparable groups were found across the given results "
+            "directories.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0 if report.has_recommendation else 2
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llmtracefx-optimizer",
@@ -916,6 +953,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write the summary JSON to this path instead of stdout",
     )
     summarize_parser.set_defaults(func=_cmd_workloads_summarize)
+
+    tune_parser = subparsers.add_parser(
+        "tune",
+        help=(
+            "Offline, evidence-constrained recommendation of the fastest "
+            "verified configuration for a workload/hardware target. Reads "
+            "already-collected `workloads run` verification.json + "
+            "final_record.json artifacts; never loads a model, requires a "
+            "GPU, or executes a benchmark."
+        ),
+    )
+    tune_parser.add_argument(
+        "--results",
+        nargs="+",
+        required=True,
+        help="One or more `workloads run --output-dir` results directories",
+    )
+    tune_parser.add_argument(
+        "--policy",
+        required=True,
+        help="Path to a tune policy JSON/YAML file (objective + constraints)",
+    )
+    tune_parser.add_argument(
+        "--output",
+        default=None,
+        help="Atomically write the full tune report JSON to this path",
+    )
+    tune_parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Print every violated constraint for every rejected candidate "
+            "and the full accepted-candidate ranking (default: a concise "
+            "summary with only the top rejection reason per candidate)"
+        ),
+    )
+    tune_parser.set_defaults(func=_cmd_tune)
 
     return parser
 

--- a/llmtracefx/optimizer/tune/__init__.py
+++ b/llmtracefx/optimizer/tune/__init__.py
@@ -1,0 +1,27 @@
+"""Offline, evidence-constrained inference-configuration tuning.
+
+This package turns the verified evidence produced by
+``llmtracefx.optimizer.workloads.verify`` (``verification.json`` +
+``final_record.json`` under a results directory) into constraint-filtered,
+ranked configuration recommendations.
+
+It never loads a model, requires a GPU, executes a benchmark, or downloads
+anything. It only reads already-collected, already-verified artifacts from
+disk, re-validates them, and reports:
+
+* which comparable group each candidate configuration belongs to,
+* which candidates satisfy every configured constraint and which do not
+  (with the precise reason for every rejection),
+* the single recommended candidate per comparable group under exactly one
+  ranking objective, and
+* an optional autoregressive-baseline comparison using the existing
+  speculative-decoding doctor rule.
+
+See ``policy.py`` for the tuning policy schema, ``tuner.py`` for the
+grouping/constraint/ranking engine, ``report.py`` for the output schema,
+and ``explain.py`` for the human-readable terminal summary.
+"""
+
+from __future__ import annotations
+
+TUNE_SCHEMA_VERSION = "1"

--- a/llmtracefx/optimizer/tune/explain.py
+++ b/llmtracefx/optimizer/tune/explain.py
@@ -1,0 +1,115 @@
+"""Human-readable terminal rendering of a ``TuneReport``.
+
+Two levels of detail are supported: a concise default (one line per
+rejected candidate, showing why it lost) and a verbose ``--explain`` mode
+(every violated constraint for every rejected candidate, plus the full
+accepted-candidate ranking). Both always explain the winner: which
+candidate was recommended, its measured objective value, and -- when more
+than one candidate was accepted -- what distinguishes it from the runner
+up.
+"""
+
+from __future__ import annotations
+
+from .report import CandidateReport, GroupOutcome, GroupReport, TuneReport
+
+
+def _format_candidate_summary(candidate: CandidateReport) -> str:
+    parts = [
+        f"objective({candidate.objective_name})={candidate.objective_value:.4f}",
+        f"evidence={candidate.evidence_count}",
+    ]
+    if candidate.mean_total_latency_ms is not None:
+        parts.append(f"mean_total_ms={candidate.mean_total_latency_ms:.2f}")
+    if candidate.correct_cases_per_minute is not None:
+        parts.append(f"correct_cases_per_min={candidate.correct_cases_per_minute:.3f}")
+    if candidate.pass_rate is not None:
+        parts.append(f"pass_rate={candidate.pass_rate:.2f}")
+    if candidate.mean_peak_memory_bytes is not None:
+        parts.append(
+            f"peak_mem_mb={candidate.mean_peak_memory_bytes / (1024 * 1024):.1f}"
+        )
+    return ", ".join(parts)
+
+
+def _format_group(group: GroupReport, *, verbose: bool) -> list[str]:
+    lines = [f"Group: {group.group_key.label()}"]
+
+    if group.outcome == GroupOutcome.RECOMMENDED and group.recommended is not None:
+        winner = group.recommended
+        lines.append(f"  RECOMMENDED: {winner.candidate_key.label()}")
+        lines.append(f"    {_format_candidate_summary(winner)}")
+        lines.append(f"    run(s): {', '.join(winner.run_ids)}")
+        if len(group.accepted) > 1:
+            runner_up = group.accepted[1]
+            lines.append(
+                "    beat runner-up "
+                f"{runner_up.candidate_key.label()} "
+                f"({_format_candidate_summary(runner_up)})"
+            )
+        if group.baseline_comparison is not None:
+            comparison = group.baseline_comparison
+            lines.append(
+                "    vs. autoregressive baseline "
+                f"({comparison.baseline_candidate_key.label()}): "
+                f"{comparison.report.verdict.value} -- {comparison.report.reason}"
+            )
+    else:
+        lines.append(f"  INCONCLUSIVE: {group.inconclusive_reason}")
+
+    if group.accepted and (verbose or group.outcome == GroupOutcome.INCONCLUSIVE):
+        lines.append("  Accepted candidates:")
+        for candidate in group.accepted:
+            lines.append(
+                f"    #{candidate.rank} {candidate.candidate_key.label()}: "
+                f"{_format_candidate_summary(candidate)}"
+            )
+
+    if group.rejected:
+        lines.append(f"  Rejected candidates ({len(group.rejected)}):")
+        for rejected in group.rejected:
+            lines.append(
+                f"    - {rejected.candidate_key.label()} "
+                f"(run(s): {', '.join(rejected.run_ids)})"
+            )
+            reasons = rejected.reasons if verbose else rejected.reasons[:1]
+            for reason in reasons:
+                lines.append(f"        reason: {reason}")
+            omitted = len(rejected.reasons) - len(reasons)
+            if omitted > 0:
+                lines.append(
+                    f"        (+{omitted} more reason(s); rerun with --explain "
+                    "to see all)"
+                )
+    return lines
+
+
+def format_report_text(report: TuneReport, *, verbose: bool = False) -> str:
+    """Render ``report`` as a human-readable terminal summary."""
+    lines: list[str] = [
+        f"Tune report (schema {report.schema_version}), generated "
+        f"{report.generated_at}",
+        f"Objective: {report.policy.objective.value}"
+        + (f" ({report.policy.name})" if report.policy.name else ""),
+        f"Results directories: {', '.join(report.results_dirs)}",
+    ]
+
+    if report.excluded_runs:
+        lines.append(
+            f"{len(report.excluded_runs)} run(s) excluded (unusable evidence):"
+        )
+        for run in report.excluded_runs:
+            lines.append(f"  - {run.run_id} [{run.source_results_dir}]: {run.reason}")
+
+    if not report.groups:
+        lines.append("")
+        lines.append(
+            "No comparable groups were found in the provided results " "directories."
+        )
+        return "\n".join(lines)
+
+    for group in report.groups:
+        lines.append("")
+        lines.extend(_format_group(group, verbose=verbose))
+
+    return "\n".join(lines)

--- a/llmtracefx/optimizer/tune/identity.py
+++ b/llmtracefx/optimizer/tune/identity.py
@@ -1,0 +1,183 @@
+"""Comparable-group and candidate-identity keys for the tuner.
+
+Two runs are only ever ranked against each other if they share a
+``GroupKey``: the same workload/version, context tier, model id/family,
+accelerator, runtime/backend, and workload prompt hash. Everything else
+(quantization, speculative settings, model/tokenizer revisions, seed, the
+collector's own config hash) distinguishes different *candidates* within
+one group -- see ``CandidateKey``. Grouping and identity are computed only
+from already-validated ``RowVerification``/``ExperimentRecord`` pairs (see
+``loader.py``); nothing here re-derives or guesses a value that was not
+actually recorded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..schema import ExperimentRecord
+from ..workloads.verify import RowVerification
+
+
+@dataclass(frozen=True)
+class GroupKey:
+    """Identifies one set of directly comparable candidate configurations."""
+
+    workload_id: str
+    workload_version: str
+    context_tier: str
+    model_id: str
+    model_family: str | None
+    accelerator: str | None
+    runtime_name: str
+    runtime_backend: str | None
+    workload_prompt_hash: str
+
+    def label(self) -> str:
+        family = f"/{self.model_family}" if self.model_family else ""
+        return (
+            f"{self.workload_id}@v{self.workload_version} [{self.context_tier}] "
+            f"model={self.model_id}{family} "
+            f"accelerator={self.accelerator or 'unknown'} "
+            f"runtime={self.runtime_name}/{self.runtime_backend or 'unknown'}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workload_id": self.workload_id,
+            "workload_version": self.workload_version,
+            "context_tier": self.context_tier,
+            "model_id": self.model_id,
+            "model_family": self.model_family,
+            "accelerator": self.accelerator,
+            "runtime_name": self.runtime_name,
+            "runtime_backend": self.runtime_backend,
+            "workload_prompt_hash": self.workload_prompt_hash,
+        }
+
+    def sort_key(self) -> tuple[Any, ...]:
+        return (
+            self.workload_id,
+            self.workload_version,
+            self.context_tier,
+            self.model_id,
+            self.model_family or "",
+            self.accelerator or "",
+            self.runtime_name,
+            self.runtime_backend or "",
+            self.workload_prompt_hash,
+        )
+
+
+@dataclass(frozen=True)
+class CandidateKey:
+    """Identifies one distinct inference configuration within a group.
+
+    Deliberately conservative: two runs are only ever treated as the same
+    candidate (i.e. their measurements are averaged together) when every
+    one of these fields matches exactly. Seed is always included (never
+    only "when relevant") so this module never silently merges evidence
+    collected under different seeds.
+    """
+
+    decode_mode: str
+    runtime_version: str | None
+    quantization: str | None
+    model_revision: str | None
+    tokenizer_revision: str | None
+    speculative_enabled: bool
+    speculative_method: str | None
+    speculative_configured_depth: int | None
+    seed: int | None
+    config_hash: str | None
+
+    def label(self) -> str:
+        spec = (
+            f"{self.speculative_method or 'none'}"
+            f"(depth={self.speculative_configured_depth})"
+            if self.speculative_enabled
+            else "none"
+        )
+        return (
+            f"{self.decode_mode} quant={self.quantization or 'unspecified'} "
+            f"speculative={spec} seed={self.seed if self.seed is not None else 'unspecified'} "
+            f"model_rev={self.model_revision or 'unspecified'}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decode_mode": self.decode_mode,
+            "runtime_version": self.runtime_version,
+            "quantization": self.quantization,
+            "model_revision": self.model_revision,
+            "tokenizer_revision": self.tokenizer_revision,
+            "speculative_enabled": self.speculative_enabled,
+            "speculative_method": self.speculative_method,
+            "speculative_configured_depth": self.speculative_configured_depth,
+            "seed": self.seed,
+            "config_hash": self.config_hash,
+        }
+
+    def sort_key(self) -> tuple[Any, ...]:
+        return (
+            self.decode_mode,
+            self.runtime_version or "",
+            self.quantization or "",
+            self.model_revision or "",
+            self.tokenizer_revision or "",
+            self.speculative_enabled,
+            self.speculative_method or "",
+            (
+                self.speculative_configured_depth
+                if self.speculative_configured_depth is not None
+                else -1
+            ),
+            self.seed if self.seed is not None else -1,
+            self.config_hash or "",
+        )
+
+
+def group_key_for(verification: RowVerification, record: ExperimentRecord) -> GroupKey:
+    """Build the comparable-group key for one verified run.
+
+    ``verification.verified_prompt_hash`` (the hash the verify pipeline
+    actually measured from the executed prompt file, not merely the hash
+    the matrix expected) is used for ``workload_prompt_hash``; callers must
+    have already confirmed this matches ``record.command.workload_hash``
+    (see ``loader.py``) before trusting this key.
+    """
+    if verification.verified_prompt_hash is None:
+        raise ValueError(
+            "cannot build a GroupKey without a verified_prompt_hash "
+            f"(run_id={verification.run_id!r})"
+        )
+    return GroupKey(
+        workload_id=verification.workload_id,
+        workload_version=verification.workload_version,
+        context_tier=verification.context_tier,
+        model_id=record.model.model_id,
+        model_family=record.model.model_family,
+        accelerator=record.platform.accelerator,
+        runtime_name=record.runtime.name,
+        runtime_backend=record.runtime.backend,
+        workload_prompt_hash=verification.verified_prompt_hash,
+    )
+
+
+def candidate_key_for(
+    verification: RowVerification, record: ExperimentRecord
+) -> CandidateKey:
+    """Build the within-group candidate identity key for one verified run."""
+    return CandidateKey(
+        decode_mode=verification.decode_mode,
+        runtime_version=record.runtime.version,
+        quantization=record.model.quantization,
+        model_revision=record.model.model_revision,
+        tokenizer_revision=record.model.tokenizer_revision,
+        speculative_enabled=record.speculative.enabled,
+        speculative_method=record.speculative.method,
+        speculative_configured_depth=record.speculative.configured_depth,
+        seed=record.repetition.seed,
+        config_hash=record.command.config_hash,
+    )

--- a/llmtracefx/optimizer/tune/loader.py
+++ b/llmtracefx/optimizer/tune/loader.py
@@ -1,0 +1,243 @@
+"""Load and re-validate verified evidence from one or more results directories.
+
+Consumes exactly the artifacts PR #6's verification pipeline produces:
+``<results_dir>/runs/<run_id>/verification.json`` and the
+``final_record.json`` it references. Never trusts a ``verification.json``
+summary at face value -- the referenced ``final_record.json`` is always
+re-read and re-validated (``ExperimentRecord.from_json`` already enforces
+the canonical schema), and run/workload/hash identity between the two
+artifacts is re-checked here. A row whose identity does not check out is
+excluded entirely (not merely rejected as a candidate) because nothing
+about it can be trusted enough to even place it in a comparable group.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..schema import ExperimentRecord, SchemaValidationError
+from ..workloads.verify import RowStatus, RowVerification, VerifyError
+
+
+class TuneInputError(ValueError):
+    """Raised for unrecoverable problems with the tuning input artifacts.
+
+    Unlike a single excluded run (a per-row problem that is reported and
+    skipped), this is raised when the *set* of inputs itself cannot be
+    trusted, e.g. two results directories disagree about what run_id
+    ``X`` means.
+    """
+
+
+@dataclass(frozen=True)
+class ExcludedRun:
+    """A run that could not be used at all (not even as a rejected candidate)."""
+
+    run_id: str
+    source_results_dir: str
+    reason: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "run_id": self.run_id,
+            "source_results_dir": self.source_results_dir,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class RunEvidence:
+    """One fully loaded, identity-checked (verification, final_record) pair."""
+
+    run_id: str
+    source_results_dir: str
+    verification: RowVerification
+    verification_path: Path
+    final_record: ExperimentRecord
+    final_record_path: Path
+
+
+@dataclass(frozen=True)
+class LoadedEvidence:
+    """Everything loaded from the requested results directories."""
+
+    usable: tuple[RunEvidence, ...]
+    excluded: tuple[ExcludedRun, ...]
+
+
+def _resolve_artifact_path(raw: str | None, *, results_dir: Path, run_id: str) -> Path:
+    if raw is None:
+        return results_dir / "runs" / run_id / "final_record.json"
+    path = Path(raw)
+    return path if path.is_absolute() else results_dir / raw
+
+
+def _record_identity_error(
+    verification: RowVerification, record: ExperimentRecord
+) -> str | None:
+    """Return a reason string if ``record`` does not match ``verification``.
+
+    Checks the identity facts a hand-edited or stale artifact pair could
+    disagree on: which run produced it, and whether the prompt that was
+    actually hashed at verify-time is the same prompt the collector hashed
+    while producing the final record.
+    """
+    if record.run_id != verification.run_id:
+        return (
+            f"final_record.run_id ({record.run_id!r}) does not match "
+            f"verification.run_id ({verification.run_id!r})"
+        )
+    if (
+        verification.recorded_prompt_hash is not None
+        and verification.verified_prompt_hash is not None
+        and verification.recorded_prompt_hash != verification.verified_prompt_hash
+    ):
+        return (
+            "verification.json itself records a recorded/verified prompt hash "
+            "mismatch (recorded="
+            f"{verification.recorded_prompt_hash!r}, verified="
+            f"{verification.verified_prompt_hash!r}); this artifact predates a "
+            "resolved drift and cannot be trusted"
+        )
+    if (
+        verification.verified_prompt_hash is not None
+        and record.command.workload_hash is not None
+        and verification.verified_prompt_hash != record.command.workload_hash
+    ):
+        return (
+            "final_record.command.workload_hash "
+            f"({record.command.workload_hash!r}) does not match "
+            f"verification.verified_prompt_hash ({verification.verified_prompt_hash!r})"
+        )
+    return None
+
+
+def _load_one_run(
+    verification_path: Path, *, results_dir: Path
+) -> tuple[RunEvidence | None, ExcludedRun | None]:
+    run_id = verification_path.parent.name
+    try:
+        verification = RowVerification.read_json(verification_path)
+    except (OSError, VerifyError) as exc:
+        return None, ExcludedRun(
+            run_id=run_id,
+            source_results_dir=str(results_dir),
+            reason=f"could not read/parse verification.json: {exc}",
+        )
+
+    if verification.status == RowStatus.UNSUPPORTED:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=(
+                verification.reason
+                or "row is unsupported (e.g. native-mtp); no final_record.json "
+                "was ever produced for it"
+            ),
+        )
+
+    if verification.final_record_path is None:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=(
+                "verification.json has no final_record_path recorded (no "
+                f"canonical evidence was produced); row status was "
+                f"'{verification.status.value}'"
+            ),
+        )
+
+    final_record_path = _resolve_artifact_path(
+        verification.final_record_path, results_dir=results_dir, run_id=run_id
+    )
+    try:
+        record = ExperimentRecord.read_json(final_record_path)
+    except OSError as exc:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=f"could not read final_record.json ({final_record_path}): {exc}",
+        )
+    except SchemaValidationError as exc:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=(
+                f"final_record.json ({final_record_path}) failed schema "
+                f"validation: {exc}"
+            ),
+        )
+
+    identity_error = _record_identity_error(verification, record)
+    if identity_error is not None:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=identity_error,
+        )
+
+    return (
+        RunEvidence(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            verification=verification,
+            verification_path=verification_path,
+            final_record=record,
+            final_record_path=final_record_path,
+        ),
+        None,
+    )
+
+
+def load_evidence(results_dirs: tuple[Path, ...]) -> LoadedEvidence:
+    """Load and identity-check every run under every given results directory.
+
+    Raises ``TuneInputError`` if the same ``run_id`` appears more than once
+    with materially different content (different verification or final
+    record payloads) -- this project never silently picks one of two
+    conflicting artifacts. An exact duplicate (identical content, e.g. the
+    same results directory passed twice or an overlapping directory tree)
+    is harmless and is de-duplicated.
+    """
+    usable: dict[str, RunEvidence] = {}
+    excluded: list[ExcludedRun] = []
+
+    for results_dir in results_dirs:
+        runs_dir = results_dir / "runs"
+        if not runs_dir.is_dir():
+            continue
+        for verification_path in sorted(runs_dir.glob("*/verification.json")):
+            evidence, excluded_run = _load_one_run(
+                verification_path, results_dir=results_dir
+            )
+            if evidence is None:
+                if excluded_run is not None:
+                    excluded.append(excluded_run)
+                continue
+
+            prior = usable.get(evidence.run_id)
+            if prior is None:
+                usable[evidence.run_id] = evidence
+                continue
+
+            if (
+                prior.verification.to_dict() == evidence.verification.to_dict()
+                and prior.final_record.to_dict() == evidence.final_record.to_dict()
+            ):
+                # Identical duplicate (e.g. an overlapping/reused results
+                # directory): harmless, keep the first copy.
+                continue
+
+            raise TuneInputError(
+                f"duplicate run_id {evidence.run_id!r} found in both "
+                f"{prior.source_results_dir!r} and "
+                f"{evidence.source_results_dir!r} with conflicting artifact "
+                "content; refusing to silently pick one. Remove or reconcile "
+                "the stale/duplicate results directory before tuning."
+            )
+
+    return LoadedEvidence(
+        usable=tuple(usable[run_id] for run_id in sorted(usable)),
+        excluded=tuple(excluded),
+    )

--- a/llmtracefx/optimizer/tune/policy.py
+++ b/llmtracefx/optimizer/tune/policy.py
@@ -18,6 +18,7 @@ one measured repetition).
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -73,7 +74,7 @@ def _coerce_optional_positive_float(
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
     numeric = float(value)
-    if numeric <= 0:
+    if not math.isfinite(numeric) or numeric <= 0:
         raise TunePolicyError(f"{context}.{key} must be > 0, got {numeric!r}")
     return numeric
 
@@ -87,7 +88,7 @@ def _coerce_optional_unit_interval(
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
     numeric = float(value)
-    if not (0.0 <= numeric <= 1.0):
+    if not math.isfinite(numeric) or not (0.0 <= numeric <= 1.0):
         raise TunePolicyError(f"{context}.{key} must be within [0, 1], got {numeric!r}")
     return numeric
 
@@ -101,7 +102,7 @@ def _coerce_optional_non_negative_float(
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
     numeric = float(value)
-    if numeric < 0:
+    if not math.isfinite(numeric) or numeric < 0:
         raise TunePolicyError(f"{context}.{key} must be >= 0, got {numeric!r}")
     return numeric
 

--- a/llmtracefx/optimizer/tune/policy.py
+++ b/llmtracefx/optimizer/tune/policy.py
@@ -147,6 +147,24 @@ class TuneConstraints:
             )
         if self.min_measured_repetitions < 1:
             raise TunePolicyError("constraints.min_measured_repetitions must be >= 1")
+        # Defense in depth: every numeric field must be finite even when a
+        # caller constructs ``TuneConstraints`` directly instead of going
+        # through ``from_dict``/``from_file`` (which already reject
+        # non-finite JSON/YAML input before this constructor ever runs). A
+        # NaN/Infinity threshold here would otherwise silently disable the
+        # ceiling it is supposed to enforce.
+        for field_name, numeric_value in (
+            ("min_pass_rate", self.min_pass_rate),
+            ("min_quality_score", self.min_quality_score),
+            ("max_peak_memory_bytes", self.max_peak_memory_bytes),
+            ("max_total_latency_ms", self.max_total_latency_ms),
+            ("max_coefficient_of_variation", self.max_coefficient_of_variation),
+        ):
+            if numeric_value is not None and not math.isfinite(numeric_value):
+                raise TunePolicyError(
+                    f"constraints.{field_name} must be a finite number, got "
+                    f"{numeric_value!r}"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/llmtracefx/optimizer/tune/policy.py
+++ b/llmtracefx/optimizer/tune/policy.py
@@ -1,0 +1,344 @@
+"""Typed, strictly-validated tuning policy configuration.
+
+A ``TunePolicy`` is user-authored (JSON or YAML) and declares, explicitly:
+
+* the single ranking objective for this tuning run (never a blended score,
+  see ``TuneObjective``), and
+* every constraint a candidate configuration must satisfy to be considered
+  at all (see ``TuneConstraints``).
+
+Loading mirrors ``llmtracefx.optimizer.runner.RunnerConfig.from_file``: JSON
+by default, optional YAML via PyYAML, with an explicit, typed error on any
+malformed or inconsistent input. Nothing here is inferred from evidence --
+a policy with no configured constraint imposes no limit on that axis (the
+only always-on constraints are the required row status and a minimum of
+one measured repetition).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..schema import MetricProvenance
+from ..workloads.verify import RowStatus
+
+TUNE_POLICY_SCHEMA_VERSION = "1"
+
+#: Row statuses a constraint policy may require. Deliberately excludes
+#: "failed", "unsupported", and "inconclusive" -- only rows that were
+#: actually executed and evaluated (``completed``) or trusted-and-reused
+#: from a hash-matching prior run (``skipped``) can ever back a
+#: recommendation.
+ALLOWED_REQUIRED_STATUSES: frozenset[RowStatus] = frozenset(
+    {RowStatus.COMPLETED, RowStatus.SKIPPED}
+)
+
+DEFAULT_REQUIRED_STATUSES: frozenset[RowStatus] = frozenset(
+    {RowStatus.COMPLETED, RowStatus.SKIPPED}
+)
+
+
+class TunePolicyError(ValueError):
+    """Raised when a tuning policy is invalid or malformed."""
+
+
+class TuneObjective(str, Enum):
+    """The single ranking objective for one tuning run.
+
+    Exactly one objective is used per run; this project never blends
+    latency and throughput (or anything else) into one combined score,
+    because doing so would hide which axis a recommendation actually
+    reflects.
+    """
+
+    MIN_MEAN_TOTAL_LATENCY_MS = "min_mean_total_latency_ms"
+    """Prefer the candidate with the lowest mean ``timing.total``."""
+
+    MAX_CORRECT_CASES_PER_MINUTE = "max_correct_cases_per_minute"
+    """Prefer the candidate with the highest passing-cases-per-minute
+    throughput, using the same definition as
+    ``workloads.aggregate.correct_cases_per_minute``."""
+
+
+def _coerce_optional_positive_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    numeric = float(value)
+    if numeric <= 0:
+        raise TunePolicyError(f"{context}.{key} must be > 0, got {numeric!r}")
+    return numeric
+
+
+def _coerce_optional_unit_interval(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    numeric = float(value)
+    if not (0.0 <= numeric <= 1.0):
+        raise TunePolicyError(f"{context}.{key} must be within [0, 1], got {numeric!r}")
+    return numeric
+
+
+def _coerce_optional_non_negative_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TunePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    numeric = float(value)
+    if numeric < 0:
+        raise TunePolicyError(f"{context}.{key} must be >= 0, got {numeric!r}")
+    return numeric
+
+
+@dataclass(frozen=True)
+class TuneConstraints:
+    """Every explicit requirement a candidate must satisfy to be accepted.
+
+    A field left at its default imposes no additional limit on that axis;
+    the only requirements that are always active are ``required_statuses``
+    (defaults to completed/trusted-skipped only) and
+    ``min_measured_repetitions`` (defaults to 1).
+    """
+
+    required_statuses: frozenset[RowStatus] = field(
+        default_factory=lambda: DEFAULT_REQUIRED_STATUSES
+    )
+    min_pass_rate: float | None = None
+    min_quality_score: float | None = None
+    required_quality_metric: str | None = None
+    max_peak_memory_bytes: float | None = None
+    max_total_latency_ms: float | None = None
+    allowed_provenances: frozenset[MetricProvenance] | None = None
+    min_measured_repetitions: int = 1
+    max_coefficient_of_variation: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.required_statuses:
+            raise TunePolicyError("constraints.required_statuses must be non-empty")
+        disallowed = self.required_statuses - ALLOWED_REQUIRED_STATUSES
+        if disallowed:
+            raise TunePolicyError(
+                "constraints.required_statuses may only contain "
+                f"{sorted(s.value for s in ALLOWED_REQUIRED_STATUSES)}, "
+                f"got disallowed value(s) {sorted(s.value for s in disallowed)}"
+            )
+        if self.min_quality_score is not None and self.required_quality_metric is None:
+            raise TunePolicyError(
+                "constraints.required_quality_metric must be set when "
+                "constraints.min_quality_score is configured, so a candidate's "
+                "quality_score is never compared against a mismatched metric"
+            )
+        if self.min_measured_repetitions < 1:
+            raise TunePolicyError("constraints.min_measured_repetitions must be >= 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required_statuses": sorted(s.value for s in self.required_statuses),
+            "min_pass_rate": self.min_pass_rate,
+            "min_quality_score": self.min_quality_score,
+            "required_quality_metric": self.required_quality_metric,
+            "max_peak_memory_bytes": self.max_peak_memory_bytes,
+            "max_total_latency_ms": self.max_total_latency_ms,
+            "allowed_provenances": (
+                None
+                if self.allowed_provenances is None
+                else sorted(p.value for p in self.allowed_provenances)
+            ),
+            "min_measured_repetitions": self.min_measured_repetitions,
+            "max_coefficient_of_variation": self.max_coefficient_of_variation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TuneConstraints:
+        context = "constraints"
+        raw_statuses = data.get(
+            "required_statuses", [s.value for s in DEFAULT_REQUIRED_STATUSES]
+        )
+        if not isinstance(raw_statuses, list) or not raw_statuses:
+            raise TunePolicyError(
+                f"{context}.required_statuses must be a non-empty list of strings"
+            )
+        try:
+            required_statuses = frozenset(RowStatus(value) for value in raw_statuses)
+        except ValueError as exc:
+            raise TunePolicyError(
+                f"{context}.required_statuses contains an unknown status: {exc}"
+            ) from exc
+
+        allowed_provenances_raw = data.get("allowed_provenances")
+        allowed_provenances: frozenset[MetricProvenance] | None
+        if allowed_provenances_raw is None:
+            allowed_provenances = None
+        else:
+            if not isinstance(allowed_provenances_raw, list) or not (
+                allowed_provenances_raw
+            ):
+                raise TunePolicyError(
+                    f"{context}.allowed_provenances must be a non-empty list of "
+                    "strings, or omitted/null to allow any provenance"
+                )
+            try:
+                allowed_provenances = frozenset(
+                    MetricProvenance(value) for value in allowed_provenances_raw
+                )
+            except ValueError as exc:
+                raise TunePolicyError(
+                    f"{context}.allowed_provenances contains an unknown "
+                    f"provenance: {exc}"
+                ) from exc
+
+        required_quality_metric = data.get("required_quality_metric")
+        if required_quality_metric is not None and not isinstance(
+            required_quality_metric, str
+        ):
+            raise TunePolicyError(
+                f"{context}.required_quality_metric must be a string or null"
+            )
+
+        min_measured_repetitions_raw = data.get("min_measured_repetitions", 1)
+        if isinstance(min_measured_repetitions_raw, bool) or not isinstance(
+            min_measured_repetitions_raw, int
+        ):
+            raise TunePolicyError(
+                f"{context}.min_measured_repetitions must be an integer"
+            )
+
+        return cls(
+            required_statuses=required_statuses,
+            min_pass_rate=_coerce_optional_unit_interval(
+                data, "min_pass_rate", context=context
+            ),
+            min_quality_score=_coerce_optional_non_negative_float(
+                data, "min_quality_score", context=context
+            ),
+            required_quality_metric=required_quality_metric,
+            max_peak_memory_bytes=_coerce_optional_positive_float(
+                data, "max_peak_memory_bytes", context=context
+            ),
+            max_total_latency_ms=_coerce_optional_positive_float(
+                data, "max_total_latency_ms", context=context
+            ),
+            allowed_provenances=allowed_provenances,
+            min_measured_repetitions=int(min_measured_repetitions_raw),
+            max_coefficient_of_variation=_coerce_optional_non_negative_float(
+                data, "max_coefficient_of_variation", context=context
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TunePolicy:
+    """A complete, validated tuning policy: one objective plus constraints."""
+
+    objective: TuneObjective
+    constraints: TuneConstraints = field(default_factory=TuneConstraints)
+    schema_version: str = TUNE_POLICY_SCHEMA_VERSION
+    name: str | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "description": self.description,
+            "objective": self.objective.value,
+            "constraints": self.constraints.to_dict(),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TunePolicy:
+        if not isinstance(data, dict):
+            raise TunePolicyError("tune policy must be a JSON/YAML object")
+        try:
+            objective = TuneObjective(data["objective"])
+        except KeyError as exc:
+            raise TunePolicyError(
+                "tune policy is missing required field: 'objective'"
+            ) from exc
+        except ValueError as exc:
+            raise TunePolicyError(
+                f"tune policy has an invalid objective: {exc}"
+            ) from exc
+
+        name = data.get("name")
+        if name is not None and not isinstance(name, str):
+            raise TunePolicyError("tune policy 'name' must be a string or null")
+        description = data.get("description")
+        if description is not None and not isinstance(description, str):
+            raise TunePolicyError("tune policy 'description' must be a string or null")
+
+        constraints_raw = data.get("constraints", {})
+        if not isinstance(constraints_raw, dict):
+            raise TunePolicyError("tune policy 'constraints' must be an object")
+
+        return cls(
+            schema_version=str(data.get("schema_version", TUNE_POLICY_SCHEMA_VERSION)),
+            name=name,
+            description=description,
+            objective=objective,
+            constraints=TuneConstraints.from_dict(constraints_raw),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> TunePolicy:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TunePolicyError(f"invalid JSON for tune policy: {exc}") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> TunePolicy:
+        """Load a policy from a ``.json`` or ``.yaml``/``.yml`` file.
+
+        Mirrors ``RunnerConfig.from_file``'s extension dispatch and explicit
+        (never silent) failure on an unsupported extension or missing
+        PyYAML dependency.
+        """
+        config_path = Path(path)
+        text = config_path.read_text(encoding="utf-8")
+        suffix = config_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise TunePolicyError(
+                    "YAML tune policy requires PyYAML to be installed "
+                    "(`uv add pyyaml`); use a .json policy instead if it is "
+                    "unavailable"
+                ) from exc
+            data = yaml.safe_load(text)
+        elif suffix == ".json":
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise TunePolicyError(f"invalid JSON in {config_path}: {exc}") from exc
+        else:
+            raise TunePolicyError(
+                f"unsupported tune policy extension '{suffix}' (use .json or .yaml)"
+            )
+
+        if not isinstance(data, dict):
+            raise TunePolicyError(
+                f"tune policy in {config_path} must be a JSON/YAML object"
+            )
+        return cls.from_dict(data)

--- a/llmtracefx/optimizer/tune/report.py
+++ b/llmtracefx/optimizer/tune/report.py
@@ -1,0 +1,179 @@
+"""Output schema for a completed tuning run: the ``tune`` report.
+
+Every number here traces back to a specific accepted run's canonical
+``ExperimentRecord``; nothing is fabricated when evidence is missing. See
+``tuner.py`` for how these are built and ``explain.py`` for the
+human-readable rendering of the same data.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from ..doctor.speculative import SpeculativeRegressionReport
+from .identity import CandidateKey, GroupKey
+from .loader import ExcludedRun
+from .policy import TunePolicy
+
+TUNE_REPORT_SCHEMA_VERSION = "1"
+
+
+class GroupOutcome(str, Enum):
+    """Whether a comparable group produced an actionable recommendation."""
+
+    RECOMMENDED = "recommended"
+    """At least one candidate was accepted and a winner was selected."""
+
+    INCONCLUSIVE = "inconclusive"
+    """No candidate survived every constraint, or the leading candidates
+    are tied within measurement noise; see ``inconclusive_reason``."""
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    """One accepted candidate's measurements, evidence, and rank."""
+
+    candidate_key: CandidateKey
+    rank: int
+    run_ids: tuple[str, ...]
+    verification_paths: tuple[str, ...]
+    final_record_paths: tuple[str, ...]
+    evidence_count: int
+    objective_name: str
+    objective_value: float
+    mean_total_latency_ms: float | None
+    stdev_total_latency_ms: float | None
+    coefficient_of_variation: float | None
+    correct_cases_per_minute: float | None
+    pass_rate: float | None
+    mean_quality_score: float | None
+    quality_metric: str | None
+    mean_peak_memory_bytes: float | None
+    max_peak_memory_bytes: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_key": self.candidate_key.to_dict(),
+            "rank": self.rank,
+            "run_ids": list(self.run_ids),
+            "verification_paths": list(self.verification_paths),
+            "final_record_paths": list(self.final_record_paths),
+            "evidence_count": self.evidence_count,
+            "objective_name": self.objective_name,
+            "objective_value": self.objective_value,
+            "mean_total_latency_ms": self.mean_total_latency_ms,
+            "stdev_total_latency_ms": self.stdev_total_latency_ms,
+            "coefficient_of_variation": self.coefficient_of_variation,
+            "correct_cases_per_minute": self.correct_cases_per_minute,
+            "pass_rate": self.pass_rate,
+            "mean_quality_score": self.mean_quality_score,
+            "quality_metric": self.quality_metric,
+            "mean_peak_memory_bytes": self.mean_peak_memory_bytes,
+            "max_peak_memory_bytes": self.max_peak_memory_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class RejectedCandidateReport:
+    """One rejected candidate and every constraint it violated."""
+
+    candidate_key: CandidateKey
+    run_ids: tuple[str, ...]
+    verification_paths: tuple[str, ...]
+    final_record_paths: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_key": self.candidate_key.to_dict(),
+            "run_ids": list(self.run_ids),
+            "verification_paths": list(self.verification_paths),
+            "final_record_paths": list(self.final_record_paths),
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class BaselineComparison:
+    """Optional autoregressive-baseline comparison for a group's winner."""
+
+    baseline_candidate_key: CandidateKey
+    speculative_candidate_key: CandidateKey
+    report: SpeculativeRegressionReport
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "baseline_candidate_key": self.baseline_candidate_key.to_dict(),
+            "speculative_candidate_key": self.speculative_candidate_key.to_dict(),
+            "verdict": self.report.verdict.value,
+            "reason": self.report.reason,
+            "baseline_run_ids": list(self.report.baseline_run_ids),
+            "speculative_run_ids": list(self.report.speculative_run_ids),
+            "baseline_mean_total_ms": self.report.baseline_mean_total_ms,
+            "speculative_mean_total_ms": self.report.speculative_mean_total_ms,
+            "delta_ms": self.report.delta_ms,
+            "delta_pct": self.report.delta_pct,
+        }
+
+
+@dataclass(frozen=True)
+class GroupReport:
+    """One comparable group's full accepted/rejected candidate breakdown."""
+
+    group_key: GroupKey
+    outcome: GroupOutcome
+    recommended: CandidateReport | None
+    accepted: tuple[CandidateReport, ...]
+    rejected: tuple[RejectedCandidateReport, ...]
+    inconclusive_reason: str | None
+    baseline_comparison: BaselineComparison | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "group_key": self.group_key.to_dict(),
+            "group_label": self.group_key.label(),
+            "outcome": self.outcome.value,
+            "recommended": (
+                None if self.recommended is None else self.recommended.to_dict()
+            ),
+            "accepted": [candidate.to_dict() for candidate in self.accepted],
+            "rejected": [candidate.to_dict() for candidate in self.rejected],
+            "inconclusive_reason": self.inconclusive_reason,
+            "baseline_comparison": (
+                None
+                if self.baseline_comparison is None
+                else self.baseline_comparison.to_dict()
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class TuneReport:
+    """The complete output of one ``tune`` invocation."""
+
+    schema_version: str
+    generated_at: str
+    results_dirs: tuple[str, ...]
+    policy: TunePolicy
+    groups: tuple[GroupReport, ...]
+    excluded_runs: tuple[ExcludedRun, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "results_dirs": list(self.results_dirs),
+            "policy": self.policy.to_dict(),
+            "groups": [group.to_dict() for group in self.groups],
+            "excluded_runs": [run.to_dict() for run in self.excluded_runs],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    @property
+    def has_recommendation(self) -> bool:
+        return any(group.outcome == GroupOutcome.RECOMMENDED for group in self.groups)

--- a/llmtracefx/optimizer/tune/tuner.py
+++ b/llmtracefx/optimizer/tune/tuner.py
@@ -1,0 +1,563 @@
+"""Constraint evaluation and ranking engine for the ``tune`` command.
+
+Given already loaded, identity-checked evidence (``loader.load_evidence``),
+this module:
+
+1. Buckets runs into comparable groups (``identity.GroupKey``) and, within
+   each group, into distinct candidate configurations
+   (``identity.CandidateKey``).
+2. Evaluates every candidate against the policy's constraints, collecting
+   *every* violated constraint rather than stopping at the first one.
+3. Ranks the candidates that satisfy every constraint by exactly one
+   configured objective, with deterministic tie-breaking, and flags a
+   group as inconclusive if no candidate survives or the top two
+   candidates are indistinguishable from measurement noise.
+4. Optionally compares a speculative-decoding winner against the best
+   available autoregressive baseline candidate in the same group, reusing
+   ``doctor.speculative.diagnose_speculative_regression`` verbatim rather
+   than re-implementing similar logic.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..doctor.speculative import diagnose_speculative_regression
+from ..schema import Measurement, MetricProvenance, utc_now_iso
+from ..workloads.aggregate import correct_cases_per_minute, pass_rate
+from .identity import CandidateKey, GroupKey, candidate_key_for, group_key_for
+from .loader import ExcludedRun, RunEvidence, load_evidence
+from .policy import TuneConstraints, TuneObjective, TunePolicy
+from .report import (
+    TUNE_REPORT_SCHEMA_VERSION,
+    BaselineComparison,
+    CandidateReport,
+    GroupOutcome,
+    GroupReport,
+    RejectedCandidateReport,
+    TuneReport,
+)
+
+
+def _provenance_allowed(
+    measurement: Measurement, allowed: frozenset[MetricProvenance] | None
+) -> bool:
+    if allowed is None:
+        return True
+    return measurement.provenance in allowed
+
+
+@dataclass(frozen=True)
+class _CandidateEvaluation:
+    """Internal, pre-ranking evaluation of one candidate within a group."""
+
+    candidate_key: CandidateKey
+    runs: tuple[RunEvidence, ...]
+    eligible_runs: tuple[RunEvidence, ...]
+    timed_runs: tuple[RunEvidence, ...]
+    accepted: bool
+    reasons: tuple[str, ...]
+    objective_value: float | None
+    mean_total_latency_ms: float | None
+    stdev_total_latency_ms: float | None
+    coefficient_of_variation: float | None
+    correct_cases_per_minute: float | None
+    pass_rate: float | None
+    mean_quality_score: float | None
+    quality_metric: str | None
+    mean_peak_memory_bytes: float | None
+    max_peak_memory_bytes: float | None
+
+
+def _evaluate_candidate(
+    candidate_key: CandidateKey,
+    runs: Sequence[RunEvidence],
+    *,
+    constraints: TuneConstraints,
+    objective: TuneObjective,
+) -> _CandidateEvaluation:
+    reasons: list[str] = []
+
+    eligible = [
+        run for run in runs if run.verification.status in constraints.required_statuses
+    ]
+    for run in runs:
+        if run.verification.status not in constraints.required_statuses:
+            reasons.append(
+                f"run {run.run_id}: status '{run.verification.status.value}' is "
+                "not one of the required statuses "
+                f"{sorted(s.value for s in constraints.required_statuses)}"
+            )
+
+    # Numeric ceilings are checked across *every* run of this candidate,
+    # not only status-eligible ones: a run that is already disqualified by
+    # status can still independently violate a latency/memory ceiling, and
+    # a rejected candidate's report should show every violation, not stop
+    # at the first one.
+    for run in runs:
+        total = run.final_record.timing.total
+        if (
+            total is not None
+            and _provenance_allowed(total, constraints.allowed_provenances)
+            and constraints.max_total_latency_ms is not None
+            and total.value > constraints.max_total_latency_ms
+        ):
+            reasons.append(
+                f"run {run.run_id}: total latency {total.value:.2f} ms exceeds "
+                f"the maximum {constraints.max_total_latency_ms} ms"
+            )
+        peak = run.final_record.memory.peak
+        if (
+            peak is not None
+            and _provenance_allowed(peak, constraints.allowed_provenances)
+            and constraints.max_peak_memory_bytes is not None
+            and peak.value > constraints.max_peak_memory_bytes
+        ):
+            reasons.append(
+                f"run {run.run_id}: peak memory {peak.value:.0f} bytes exceeds "
+                f"the maximum {constraints.max_peak_memory_bytes:.0f} bytes"
+            )
+
+    if not eligible:
+        return _CandidateEvaluation(
+            candidate_key=candidate_key,
+            runs=tuple(runs),
+            eligible_runs=(),
+            timed_runs=(),
+            accepted=False,
+            reasons=tuple(reasons),
+            objective_value=None,
+            mean_total_latency_ms=None,
+            stdev_total_latency_ms=None,
+            coefficient_of_variation=None,
+            correct_cases_per_minute=None,
+            pass_rate=None,
+            mean_quality_score=None,
+            quality_metric=None,
+            mean_peak_memory_bytes=None,
+            max_peak_memory_bytes=None,
+        )
+
+    # --- Task success / pass rate -------------------------------------
+    successes = [run for run in eligible if run.final_record.outcome.success]
+    pass_rate_value = pass_rate(len(successes), len(eligible))
+    if constraints.min_pass_rate is not None and (
+        pass_rate_value is None or pass_rate_value < constraints.min_pass_rate
+    ):
+        reasons.append(
+            f"pass rate {pass_rate_value} is below the required minimum "
+            f"{constraints.min_pass_rate}"
+        )
+
+    # --- Quality score / metric ----------------------------------------
+    quality_metrics_seen: set[str] = set()
+    quality_scores: list[float] = []
+    for run in eligible:
+        metric = run.final_record.outcome.quality_metric
+        score = run.final_record.outcome.quality_score
+        if metric is not None:
+            quality_metrics_seen.add(metric)
+        if (
+            constraints.required_quality_metric is not None
+            and metric is not None
+            and metric != constraints.required_quality_metric
+        ):
+            reasons.append(
+                f"run {run.run_id}: quality_metric {metric!r} does not match "
+                f"the required quality_metric "
+                f"{constraints.required_quality_metric!r}"
+            )
+        if score is not None:
+            quality_scores.append(score)
+        elif constraints.min_quality_score is not None:
+            reasons.append(
+                f"run {run.run_id}: missing outcome.quality_score, required "
+                f"by min_quality_score={constraints.min_quality_score}"
+            )
+    if len(quality_metrics_seen) > 1:
+        reasons.append(
+            "runs report inconsistent outcome.quality_metric values "
+            f"{sorted(quality_metrics_seen)}; they cannot be treated as one "
+            "candidate's quality evidence"
+        )
+    mean_quality = statistics.mean(quality_scores) if quality_scores else None
+    if (
+        constraints.min_quality_score is not None
+        and mean_quality is not None
+        and mean_quality < constraints.min_quality_score
+    ):
+        reasons.append(
+            f"mean quality_score {mean_quality:.4f} is below the required "
+            f"minimum {constraints.min_quality_score}"
+        )
+    quality_metric_label = (
+        next(iter(quality_metrics_seen)) if len(quality_metrics_seen) == 1 else None
+    )
+
+    # --- Timing / latency ------------------------------------------------
+    timed: list[tuple[RunEvidence, float]] = []
+    for run in eligible:
+        total = run.final_record.timing.total
+        if total is None:
+            reasons.append(f"run {run.run_id}: missing timing.total measurement")
+            continue
+        if not _provenance_allowed(total, constraints.allowed_provenances):
+            allowed = constraints.allowed_provenances or frozenset()
+            reasons.append(
+                f"run {run.run_id}: timing.total provenance "
+                f"'{total.provenance.value}' is not in the allowed provenance "
+                f"set {sorted(p.value for p in allowed)}"
+            )
+            continue
+        timed.append((run, total.value))
+
+    mean_total: float | None
+    stdev_total: float | None
+    cv: float | None
+    if not timed:
+        reasons.append(
+            "no eligible run has a usable timing.total measurement; latency "
+            "and throughput cannot be computed for this candidate"
+        )
+        mean_total = None
+        stdev_total = None
+        cv = None
+    else:
+        totals = [total_value for _run, total_value in timed]
+        mean_total = statistics.mean(totals)
+        stdev_total = statistics.pstdev(totals) if len(totals) > 1 else 0.0
+        cv = stdev_total / mean_total if mean_total > 0 else None
+        if (
+            len(totals) > 1
+            and constraints.max_coefficient_of_variation is not None
+            and cv is not None
+            and cv > constraints.max_coefficient_of_variation
+        ):
+            reasons.append(
+                f"coefficient of variation {cv:.4f} exceeds the maximum "
+                f"{constraints.max_coefficient_of_variation}"
+            )
+
+    if len(timed) < constraints.min_measured_repetitions:
+        reasons.append(
+            f"only {len(timed)} run(s) with usable timing evidence; policy "
+            f"requires at least {constraints.min_measured_repetitions}"
+        )
+
+    # --- Memory ------------------------------------------------------
+    peaks: list[float] = []
+    for run in eligible:
+        peak = run.final_record.memory.peak
+        if peak is None:
+            if constraints.max_peak_memory_bytes is not None:
+                reasons.append(
+                    f"run {run.run_id}: missing memory.peak measurement, "
+                    "required by max_peak_memory_bytes="
+                    f"{constraints.max_peak_memory_bytes}"
+                )
+            continue
+        if not _provenance_allowed(peak, constraints.allowed_provenances):
+            if constraints.max_peak_memory_bytes is not None:
+                allowed = constraints.allowed_provenances or frozenset()
+                reasons.append(
+                    f"run {run.run_id}: memory.peak provenance "
+                    f"'{peak.provenance.value}' is not in the allowed "
+                    f"provenance set "
+                    f"{sorted(p.value for p in allowed)}"
+                )
+            continue
+        peaks.append(peak.value)
+    mean_peak = statistics.mean(peaks) if peaks else None
+    max_peak = max(peaks) if peaks else None
+
+    # --- Objective ------------------------------------------------------
+    passing_timed = [
+        total_value for run, total_value in timed if run.final_record.outcome.success
+    ]
+    pass_total_ms = sum(passing_timed)
+    ccpm = correct_cases_per_minute(len(passing_timed), pass_total_ms)
+
+    objective_value: float | None
+    if objective == TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS:
+        objective_value = mean_total
+        if objective_value is None:
+            reasons.append(
+                "objective 'min_mean_total_latency_ms' cannot be computed: no "
+                "usable timing.total evidence"
+            )
+    elif objective == TuneObjective.MAX_CORRECT_CASES_PER_MINUTE:
+        objective_value = ccpm
+        if objective_value is None:
+            reasons.append(
+                "objective 'max_correct_cases_per_minute' cannot be computed: "
+                "no passing run has usable timing.total evidence"
+            )
+    else:  # pragma: no cover - TuneObjective is exhaustively defined above
+        raise AssertionError(f"unhandled tune objective: {objective!r}")
+
+    accepted = not reasons
+
+    return _CandidateEvaluation(
+        candidate_key=candidate_key,
+        runs=tuple(runs),
+        eligible_runs=tuple(eligible),
+        timed_runs=tuple(run for run, _total_value in timed),
+        accepted=accepted,
+        reasons=tuple(reasons),
+        objective_value=objective_value,
+        mean_total_latency_ms=mean_total,
+        stdev_total_latency_ms=stdev_total,
+        coefficient_of_variation=cv,
+        correct_cases_per_minute=ccpm,
+        pass_rate=pass_rate_value,
+        mean_quality_score=mean_quality,
+        quality_metric=quality_metric_label,
+        mean_peak_memory_bytes=mean_peak,
+        max_peak_memory_bytes=max_peak,
+    )
+
+
+def _objective_noise(
+    evaluation: _CandidateEvaluation, objective: TuneObjective
+) -> float:
+    """A rough absolute noise band for tie detection, in the objective's units."""
+    if objective == TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS:
+        return evaluation.stdev_total_latency_ms or 0.0
+    if evaluation.coefficient_of_variation and evaluation.objective_value:
+        return abs(evaluation.objective_value * evaluation.coefficient_of_variation)
+    return 0.0
+
+
+def _tie_reason(
+    best: _CandidateEvaluation,
+    second: _CandidateEvaluation | None,
+    objective: TuneObjective,
+) -> str | None:
+    if second is None:
+        return None
+    # Both are accepted, so objective_value is never None here.
+    best_value = best.objective_value
+    second_value = second.objective_value
+    if best_value is None or second_value is None:  # pragma: no cover - defensive
+        raise AssertionError("accepted candidates must have an objective_value")
+    if best_value == second_value:
+        return (
+            f"top two candidates are exactly tied on {objective.value} "
+            f"({best_value:.6g})"
+        )
+    noise = _objective_noise(best, objective) + _objective_noise(second, objective)
+    delta = abs(best_value - second_value)
+    if noise > 0 and delta < noise:
+        return (
+            f"top two candidates differ by {delta:.6g} on {objective.value}, "
+            f"smaller than their combined measurement noise ({noise:.6g}); "
+            "collect more repetitions to distinguish them"
+        )
+    return None
+
+
+def _to_candidate_report(
+    evaluation: _CandidateEvaluation, *, rank: int, objective: TuneObjective
+) -> CandidateReport:
+    objective_value = evaluation.objective_value
+    if objective_value is None:  # pragma: no cover - defensive; accepted implies set
+        raise AssertionError("accepted candidate must have an objective_value")
+    return CandidateReport(
+        candidate_key=evaluation.candidate_key,
+        rank=rank,
+        run_ids=tuple(run.run_id for run in evaluation.eligible_runs),
+        verification_paths=tuple(
+            str(run.verification_path) for run in evaluation.eligible_runs
+        ),
+        final_record_paths=tuple(
+            str(run.final_record_path) for run in evaluation.eligible_runs
+        ),
+        evidence_count=len(evaluation.timed_runs),
+        objective_name=objective.value,
+        objective_value=objective_value,
+        mean_total_latency_ms=evaluation.mean_total_latency_ms,
+        stdev_total_latency_ms=evaluation.stdev_total_latency_ms,
+        coefficient_of_variation=evaluation.coefficient_of_variation,
+        correct_cases_per_minute=evaluation.correct_cases_per_minute,
+        pass_rate=evaluation.pass_rate,
+        mean_quality_score=evaluation.mean_quality_score,
+        quality_metric=evaluation.quality_metric,
+        mean_peak_memory_bytes=evaluation.mean_peak_memory_bytes,
+        max_peak_memory_bytes=evaluation.max_peak_memory_bytes,
+    )
+
+
+def _to_rejected_report(evaluation: _CandidateEvaluation) -> RejectedCandidateReport:
+    return RejectedCandidateReport(
+        candidate_key=evaluation.candidate_key,
+        run_ids=tuple(run.run_id for run in evaluation.runs),
+        verification_paths=tuple(str(run.verification_path) for run in evaluation.runs),
+        final_record_paths=tuple(str(run.final_record_path) for run in evaluation.runs),
+        reasons=evaluation.reasons,
+    )
+
+
+def _maybe_baseline_comparison(
+    winner: _CandidateEvaluation,
+    accepted: Sequence[_CandidateEvaluation],
+) -> BaselineComparison | None:
+    """Compare a speculative-decoding winner to the best autoregressive baseline.
+
+    Reuses ``doctor.speculative.diagnose_speculative_regression`` verbatim.
+    Returns ``None`` (not attempted, never fabricated) when the winner is
+    not speculative-enabled or no accepted autoregressive-baseline
+    candidate exists in the same group.
+    """
+    if not winner.candidate_key.speculative_enabled:
+        return None
+    baseline_candidates = [
+        evaluation
+        for evaluation in accepted
+        if not evaluation.candidate_key.speculative_enabled
+    ]
+    if not baseline_candidates:
+        return None
+    baseline = max(
+        baseline_candidates,
+        key=lambda evaluation: (
+            len(evaluation.timed_runs),
+            evaluation.candidate_key.sort_key(),
+        ),
+    )
+    doctor_report = diagnose_speculative_regression(
+        [run.final_record for run in baseline.timed_runs],
+        [run.final_record for run in winner.timed_runs],
+    )
+    return BaselineComparison(
+        baseline_candidate_key=baseline.candidate_key,
+        speculative_candidate_key=winner.candidate_key,
+        report=doctor_report,
+    )
+
+
+def _build_group_report(
+    group_key: GroupKey,
+    candidates_by_key: dict[CandidateKey, list[RunEvidence]],
+    policy: TunePolicy,
+) -> GroupReport:
+    evaluations = [
+        _evaluate_candidate(
+            candidate_key,
+            runs,
+            constraints=policy.constraints,
+            objective=policy.objective,
+        )
+        for candidate_key, runs in candidates_by_key.items()
+    ]
+    evaluations.sort(key=lambda evaluation: evaluation.candidate_key.sort_key())
+
+    accepted_evals = [evaluation for evaluation in evaluations if evaluation.accepted]
+    rejected_evals = [
+        evaluation for evaluation in evaluations if not evaluation.accepted
+    ]
+
+    minimize = policy.objective == TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS
+
+    def _sort_metric(evaluation: _CandidateEvaluation) -> tuple[float, tuple[Any, ...]]:
+        value = evaluation.objective_value
+        if value is None:  # pragma: no cover - defensive; accepted implies set
+            raise AssertionError("accepted candidate must have an objective_value")
+        return (value if minimize else -value, evaluation.candidate_key.sort_key())
+
+    accepted_evals.sort(key=_sort_metric)
+
+    rejected_reports = tuple(
+        _to_rejected_report(evaluation) for evaluation in rejected_evals
+    )
+
+    if not accepted_evals:
+        return GroupReport(
+            group_key=group_key,
+            outcome=GroupOutcome.INCONCLUSIVE,
+            recommended=None,
+            accepted=(),
+            rejected=rejected_reports,
+            inconclusive_reason=(
+                "no candidate satisfied every constraint in this policy"
+            ),
+        )
+
+    accepted_reports = tuple(
+        _to_candidate_report(evaluation, rank=index + 1, objective=policy.objective)
+        for index, evaluation in enumerate(accepted_evals)
+    )
+
+    best = accepted_evals[0]
+    second = accepted_evals[1] if len(accepted_evals) > 1 else None
+    tie_reason = _tie_reason(best, second, policy.objective)
+
+    if tie_reason is not None:
+        return GroupReport(
+            group_key=group_key,
+            outcome=GroupOutcome.INCONCLUSIVE,
+            recommended=None,
+            accepted=accepted_reports,
+            rejected=rejected_reports,
+            inconclusive_reason=tie_reason,
+        )
+
+    return GroupReport(
+        group_key=group_key,
+        outcome=GroupOutcome.RECOMMENDED,
+        recommended=accepted_reports[0],
+        accepted=accepted_reports,
+        rejected=rejected_reports,
+        inconclusive_reason=None,
+        baseline_comparison=_maybe_baseline_comparison(best, accepted_evals),
+    )
+
+
+def _build_groups(
+    runs: Sequence[RunEvidence],
+) -> tuple[dict[GroupKey, dict[CandidateKey, list[RunEvidence]]], list[ExcludedRun]]:
+    groups: dict[GroupKey, dict[CandidateKey, list[RunEvidence]]] = {}
+    excluded: list[ExcludedRun] = []
+    for run in runs:
+        try:
+            group_key = group_key_for(run.verification, run.final_record)
+            candidate_key = candidate_key_for(run.verification, run.final_record)
+        except ValueError as exc:
+            excluded.append(
+                ExcludedRun(
+                    run_id=run.run_id,
+                    source_results_dir=run.source_results_dir,
+                    reason=f"could not derive a comparable-group identity: {exc}",
+                )
+            )
+            continue
+        groups.setdefault(group_key, {}).setdefault(candidate_key, []).append(run)
+    return groups, excluded
+
+
+def tune(*, results_dirs: Sequence[Path], policy: TunePolicy) -> TuneReport:
+    """Load, group, constrain, and rank evidence into a full ``TuneReport``."""
+    loaded = load_evidence(tuple(results_dirs))
+    groups, extra_excluded = _build_groups(loaded.usable)
+
+    group_reports = tuple(
+        _build_group_report(group_key, groups[group_key], policy)
+        for group_key in sorted(groups, key=lambda key: key.sort_key())
+    )
+
+    all_excluded = sorted(
+        (*loaded.excluded, *extra_excluded),
+        key=lambda run: (run.source_results_dir, run.run_id),
+    )
+
+    return TuneReport(
+        schema_version=TUNE_REPORT_SCHEMA_VERSION,
+        generated_at=utc_now_iso(),
+        results_dirs=tuple(str(directory) for directory in results_dirs),
+        policy=policy,
+        groups=group_reports,
+        excluded_runs=tuple(all_excluded),
+    )

--- a/llmtracefx/optimizer/tune/tuner.py
+++ b/llmtracefx/optimizer/tune/tuner.py
@@ -20,6 +20,7 @@ this module:
 
 from __future__ import annotations
 
+import math
 import statistics
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -49,6 +50,27 @@ def _provenance_allowed(
     if allowed is None:
         return True
     return measurement.provenance in allowed
+
+
+def _finite_measurement_value(measurement: Measurement | None) -> float | None:
+    if measurement is None or not math.isfinite(measurement.value):
+        return None
+    return measurement.value
+
+
+def _finite_or_none(value: float | None) -> float | None:
+    """Guard a derived (mean/stdev/ratio) computation against non-finite results.
+
+    Every input list feeding ``statistics.mean``/``pstdev`` and
+    ``correct_cases_per_minute`` is already filtered to finite values by
+    the time it reaches these computations, so this only guards against
+    the extreme, unrealistic case of the aggregation itself overflowing
+    (e.g. summing many near-``float`` max values); it never masks a
+    legitimate finite result.
+    """
+    if value is None or not math.isfinite(value):
+        return None
+    return value
 
 
 @dataclass(frozen=True)
@@ -100,25 +122,37 @@ def _evaluate_candidate(
     # at the first one.
     for run in runs:
         total = run.final_record.timing.total
+        total_value = _finite_measurement_value(total)
+        if total is not None and total_value is None:
+            reasons.append(f"run {run.run_id}: timing.total is non-finite and unusable")
         if (
-            total is not None
+            total_value is not None
+            and total is not None
             and _provenance_allowed(total, constraints.allowed_provenances)
             and constraints.max_total_latency_ms is not None
-            and total.value > constraints.max_total_latency_ms
+            and total_value > constraints.max_total_latency_ms
         ):
             reasons.append(
-                f"run {run.run_id}: total latency {total.value:.2f} ms exceeds "
+                f"run {run.run_id}: total latency {total_value:.2f} ms exceeds "
                 f"the maximum {constraints.max_total_latency_ms} ms"
             )
         peak = run.final_record.memory.peak
+        peak_value = _finite_measurement_value(peak)
         if (
             peak is not None
+            and peak_value is None
+            and constraints.max_peak_memory_bytes is not None
+        ):
+            reasons.append(f"run {run.run_id}: memory.peak is non-finite and unusable")
+        if (
+            peak_value is not None
+            and peak is not None
             and _provenance_allowed(peak, constraints.allowed_provenances)
             and constraints.max_peak_memory_bytes is not None
-            and peak.value > constraints.max_peak_memory_bytes
+            and peak_value > constraints.max_peak_memory_bytes
         ):
             reasons.append(
-                f"run {run.run_id}: peak memory {peak.value:.0f} bytes exceeds "
+                f"run {run.run_id}: peak memory {peak_value:.0f} bytes exceeds "
                 f"the maximum {constraints.max_peak_memory_bytes:.0f} bytes"
             )
 
@@ -172,7 +206,13 @@ def _evaluate_candidate(
                 f"{constraints.required_quality_metric!r}"
             )
         if score is not None:
-            quality_scores.append(score)
+            if math.isfinite(score):
+                quality_scores.append(score)
+            else:
+                reasons.append(
+                    f"run {run.run_id}: outcome.quality_score is non-finite "
+                    "and unusable"
+                )
         elif constraints.min_quality_score is not None:
             reasons.append(
                 f"run {run.run_id}: missing outcome.quality_score, required "
@@ -184,7 +224,9 @@ def _evaluate_candidate(
             f"{sorted(quality_metrics_seen)}; they cannot be treated as one "
             "candidate's quality evidence"
         )
-    mean_quality = statistics.mean(quality_scores) if quality_scores else None
+    mean_quality = (
+        _finite_or_none(statistics.mean(quality_scores)) if quality_scores else None
+    )
     if (
         constraints.min_quality_score is not None
         and mean_quality is not None
@@ -205,6 +247,9 @@ def _evaluate_candidate(
         if total is None:
             reasons.append(f"run {run.run_id}: missing timing.total measurement")
             continue
+        total_value = _finite_measurement_value(total)
+        if total_value is None:
+            continue
         if not _provenance_allowed(total, constraints.allowed_provenances):
             allowed = constraints.allowed_provenances or frozenset()
             reasons.append(
@@ -213,7 +258,7 @@ def _evaluate_candidate(
                 f"set {sorted(p.value for p in allowed)}"
             )
             continue
-        timed.append((run, total.value))
+        timed.append((run, total_value))
 
     mean_total: float | None
     stdev_total: float | None
@@ -228,9 +273,15 @@ def _evaluate_candidate(
         cv = None
     else:
         totals = [total_value for _run, total_value in timed]
-        mean_total = statistics.mean(totals)
-        stdev_total = statistics.pstdev(totals) if len(totals) > 1 else 0.0
-        cv = stdev_total / mean_total if mean_total > 0 else None
+        mean_total = _finite_or_none(statistics.mean(totals))
+        stdev_total = (
+            _finite_or_none(statistics.pstdev(totals)) if len(totals) > 1 else 0.0
+        )
+        cv = (
+            _finite_or_none(stdev_total / mean_total)
+            if mean_total is not None and stdev_total is not None and mean_total > 0
+            else None
+        )
         if (
             len(totals) > 1
             and constraints.max_coefficient_of_variation is not None
@@ -260,6 +311,9 @@ def _evaluate_candidate(
                     f"{constraints.max_peak_memory_bytes}"
                 )
             continue
+        peak_value = _finite_measurement_value(peak)
+        if peak_value is None:
+            continue
         if not _provenance_allowed(peak, constraints.allowed_provenances):
             if constraints.max_peak_memory_bytes is not None:
                 allowed = constraints.allowed_provenances or frozenset()
@@ -270,8 +324,8 @@ def _evaluate_candidate(
                     f"{sorted(p.value for p in allowed)}"
                 )
             continue
-        peaks.append(peak.value)
-    mean_peak = statistics.mean(peaks) if peaks else None
+        peaks.append(peak_value)
+    mean_peak = _finite_or_none(statistics.mean(peaks)) if peaks else None
     max_peak = max(peaks) if peaks else None
 
     # --- Objective ------------------------------------------------------
@@ -279,7 +333,7 @@ def _evaluate_candidate(
         total_value for run, total_value in timed if run.final_record.outcome.success
     ]
     pass_total_ms = sum(passing_timed)
-    ccpm = correct_cases_per_minute(len(passing_timed), pass_total_ms)
+    ccpm = _finite_or_none(correct_cases_per_minute(len(passing_timed), pass_total_ms))
 
     objective_value: float | None
     if objective == TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS:

--- a/llmtracefx/optimizer/tune/tuner.py
+++ b/llmtracefx/optimizer/tune/tuner.py
@@ -195,16 +195,19 @@ def _evaluate_candidate(
         score = run.final_record.outcome.quality_score
         if metric is not None:
             quality_metrics_seen.add(metric)
-        if (
-            constraints.required_quality_metric is not None
-            and metric is not None
-            and metric != constraints.required_quality_metric
-        ):
-            reasons.append(
-                f"run {run.run_id}: quality_metric {metric!r} does not match "
-                f"the required quality_metric "
-                f"{constraints.required_quality_metric!r}"
-            )
+        if constraints.required_quality_metric is not None:
+            if metric is None:
+                reasons.append(
+                    f"run {run.run_id}: missing outcome.quality_metric, "
+                    "required quality_metric is "
+                    f"{constraints.required_quality_metric!r}"
+                )
+            elif metric != constraints.required_quality_metric:
+                reasons.append(
+                    f"run {run.run_id}: quality_metric {metric!r} does not match "
+                    f"the required quality_metric "
+                    f"{constraints.required_quality_metric!r}"
+                )
         if score is not None:
             if math.isfinite(score):
                 quality_scores.append(score)

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -44,11 +44,21 @@ def _load_verifications(results_dir: Path) -> tuple[RowVerification, ...]:
     return tuple(verifications)
 
 
-def _pass_rate(pass_count: int, evaluated_count: int) -> float | None:
+def pass_rate(pass_count: int, evaluated_count: int) -> float | None:
+    """Fraction of evaluated cases that passed, or ``None`` if none evaluated.
+
+    Public so other modules (e.g. ``optimizer.tune``) that need the exact
+    same pass-rate definition can reuse it instead of redefining it.
+    """
     return pass_count / evaluated_count if evaluated_count else None
 
 
-def _correct_cases_per_minute(pass_count: int, total_pass_ms: float) -> float | None:
+def correct_cases_per_minute(pass_count: int, total_pass_ms: float) -> float | None:
+    """Passing cases per minute of measured time, or ``None`` if undefined.
+
+    Public so other modules (e.g. ``optimizer.tune``) that need the exact
+    same throughput definition can reuse it instead of redefining it.
+    """
     if pass_count == 0 or total_pass_ms <= 0:
         return None
     minutes = total_pass_ms / 1000.0 / 60.0
@@ -121,8 +131,8 @@ def _summarize_group(
         inconclusive=counts[RowStatus.INCONCLUSIVE],
         evaluated_total=len(evaluated),
         evaluated_pass=len(evaluated_pass),
-        pass_rate=_pass_rate(len(evaluated_pass), len(evaluated)),
-        correct_cases_per_minute=_correct_cases_per_minute(
+        pass_rate=pass_rate(len(evaluated_pass), len(evaluated)),
+        correct_cases_per_minute=correct_cases_per_minute(
             len(evaluated_pass), total_pass_ms
         ),
     )

--- a/tests/optimizer/_tune_fixtures.py
+++ b/tests/optimizer/_tune_fixtures.py
@@ -1,0 +1,182 @@
+"""Shared full-fake-artifact-tree builder for `tune` tests.
+
+Not a test module itself (no `test_` prefix, so pytest never collects it);
+imported by the various ``test_tune_*.py`` modules that need to build a
+`workloads run --output-dir`-shaped results directory (verification.json +
+final_record.json under `<results_dir>/runs/<run_id>/`) without actually
+running the verify pipeline or loading a model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ExperimentRecord,
+    Measurement,
+    MemoryMetrics,
+    MetricProvenance,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+    utc_now_iso,
+)
+from llmtracefx.optimizer.workloads.verify import RowStatus, RowVerification
+
+DEFAULT_PROMPT_HASH = "sha256:promptabc"
+
+
+def write_run(
+    results_dir: Path,
+    run_id: str,
+    *,
+    status: RowStatus = RowStatus.COMPLETED,
+    workload_id: str = "structured-json-profile-extraction",
+    workload_version: str = "1",
+    category: str = "structured_json",
+    context_tier: str = "2k",
+    decode_mode: str = "autoregressive",
+    model_id: str = "local/qwen3-8b",
+    model_family: str | None = "qwen3_next",
+    model_revision: str | None = None,
+    tokenizer_revision: str | None = None,
+    accelerator: str | None = "Apple M5 Pro",
+    runtime_name: str = "mlx-lm",
+    runtime_version: str | None = "0.31.3",
+    runtime_backend: str | None = "Metal",
+    quantization: str | None = "Q4",
+    speculative_enabled: bool = False,
+    speculative_method: str | None = None,
+    speculative_depth: int | None = None,
+    seed: int | None = 0,
+    config_hash: str | None = "cfg-hash",
+    prompt_hash: str | None = DEFAULT_PROMPT_HASH,
+    recorded_prompt_hash: str | None = None,
+    workload_hash_override: str | None = None,
+    total_ms: float | None = 1000.0,
+    total_provenance: MetricProvenance = MetricProvenance.MEASURED_WALL_CLOCK,
+    peak_bytes: float | None = 4 * 1024**3,
+    peak_provenance: MetricProvenance = MetricProvenance.MEASURED_NATIVE,
+    success: bool = True,
+    quality_score: float | None = 1.0,
+    quality_metric: str | None = "structured_json_exact_field_match",
+    write_final_record: bool = True,
+    corrupt_final_record: bool = False,
+    reason: str | None = None,
+) -> Path:
+    """Write one fake `<run_id>` entry under `results_dir/runs/`.
+
+    Returns the run's directory. By default builds a fully passing,
+    fully-evidenced ``COMPLETED`` autoregressive row; every axis can be
+    overridden to exercise a specific rejection/edge case.
+    """
+    run_dir = results_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    final_record_path: Path | None = None
+    if write_final_record:
+        final_record_path = run_dir / "final_record.json"
+        record = ExperimentRecord(
+            run_id=run_id,
+            started_at=utc_now_iso(),
+            platform=PlatformInfo(
+                os_name="Darwin",
+                os_version="24.0",
+                architecture="arm64",
+                accelerator=accelerator,
+            ),
+            model=ModelInfo(
+                model_id=model_id,
+                model_family=model_family,
+                model_revision=model_revision,
+                tokenizer_revision=tokenizer_revision,
+                quantization=quantization,
+            ),
+            runtime=RuntimeInfo(
+                name=runtime_name, version=runtime_version, backend=runtime_backend
+            ),
+            command=CommandInfo(
+                argv=("llmtracefx-optimizer", "collect-mlx"),
+                config_hash=config_hash,
+                workload_hash=(
+                    workload_hash_override
+                    if workload_hash_override is not None
+                    else prompt_hash
+                ),
+            ),
+            repetition=RepetitionInfo(
+                warmup_repetitions=0,
+                measured_repetitions=1,
+                repetition_index=0,
+                seed=seed,
+            ),
+            tokens=TokenCounts(input_tokens=10, context_tokens=10, generated_tokens=20),
+            timing=TimingMetrics(
+                total=(
+                    None
+                    if total_ms is None
+                    else Measurement(
+                        value=total_ms, provenance=total_provenance, unit="ms"
+                    )
+                )
+            ),
+            speculative=SpeculativeDecodingInfo(
+                enabled=speculative_enabled,
+                method=speculative_method,
+                configured_depth=speculative_depth,
+            ),
+            memory=MemoryMetrics(
+                peak=(
+                    None
+                    if peak_bytes is None
+                    else Measurement(
+                        value=peak_bytes, provenance=peak_provenance, unit="bytes"
+                    )
+                )
+            ),
+            outcome=OutcomeInfo(
+                success=success,
+                quality_score=quality_score,
+                quality_metric=quality_metric,
+            ),
+        )
+        if corrupt_final_record:
+            final_record_path.parent.mkdir(parents=True, exist_ok=True)
+            final_record_path.write_text("not json", encoding="utf-8")
+        else:
+            record.write_json(final_record_path)
+
+    verification = RowVerification(
+        schema_version="1",
+        run_id=run_id,
+        workload_id=workload_id,
+        workload_version=workload_version,
+        category=category,
+        context_tier=context_tier,
+        decode_mode=decode_mode,
+        status=status,
+        reason=reason,
+        recorded_prompt_hash=(
+            recorded_prompt_hash if recorded_prompt_hash is not None else prompt_hash
+        ),
+        verified_prompt_hash=prompt_hash,
+        run_binding_hash="sha256:bindingabc",
+        resumed=(status == RowStatus.SKIPPED),
+        outcome_success=success if write_final_record else None,
+        quality_score=quality_score if write_final_record else None,
+        total_ms=total_ms if write_final_record else None,
+        started_at=utc_now_iso(),
+        ended_at=utc_now_iso(),
+        final_record_path=(
+            str(final_record_path) if final_record_path is not None else None
+        ),
+        collection_dir=str(run_dir / "collection") if write_final_record else None,
+    )
+    (run_dir / "verification.json").write_text(verification.to_json(), encoding="utf-8")
+    return run_dir

--- a/tests/optimizer/test_tune.py
+++ b/tests/optimizer/test_tune.py
@@ -13,7 +13,12 @@ from _tune_fixtures import write_run
 
 from llmtracefx.optimizer.schema import MetricProvenance
 from llmtracefx.optimizer.tune.loader import TuneInputError, load_evidence
-from llmtracefx.optimizer.tune.policy import TuneConstraints, TuneObjective, TunePolicy
+from llmtracefx.optimizer.tune.policy import (
+    TuneConstraints,
+    TuneObjective,
+    TunePolicy,
+    TunePolicyError,
+)
 from llmtracefx.optimizer.tune.report import GroupOutcome
 from llmtracefx.optimizer.tune.tuner import tune
 from llmtracefx.optimizer.workloads.verify import RowStatus
@@ -339,6 +344,90 @@ def test_non_finite_quality_score_is_rejected(tmp_path):
     assert "quality_score is non-finite" in " ".join(
         report.groups[0].rejected[0].reasons
     )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_non_finite_peak_memory_without_memory_constraint_does_not_reject(
+    tmp_path, value
+):
+    # No max_peak_memory_bytes configured: a non-finite peak measurement is
+    # excluded from memory reporting but must not, by itself, block an
+    # otherwise-valid candidate from being recommended (mirrors how a
+    # *missing* peak measurement is only a rejection reason when memory is
+    # actually a constrained axis).
+    write_run(tmp_path, "r1", peak_bytes=value, total_ms=1000.0)
+
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.mean_peak_memory_bytes is None
+
+
+def test_all_non_finite_evidence_across_axes_is_fully_inconclusive(tmp_path):
+    # Every numeric signal a candidate could offer is NaN/Infinity: no
+    # candidate may survive, and nothing may be recommended.
+    write_run(
+        tmp_path,
+        "r1",
+        total_ms=float("nan"),
+        peak_bytes=float("inf"),
+        quality_score=float("nan"),
+        quality_metric="m1",
+    )
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            max_peak_memory_bytes=20 * 1024**3,
+            min_quality_score=0.5,
+            required_quality_metric="m1",
+        ),
+    )
+
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert group.recommended is None
+    assert not group.accepted
+    reasons = " ".join(group.rejected[0].reasons)
+    assert "timing.total is non-finite" in reasons
+    assert "memory.peak is non-finite" in reasons
+    assert "quality_score is non-finite" in reasons
+
+
+def test_non_finite_evidence_never_produces_a_tie(tmp_path):
+    # A NaN total must never be treated as "equal" to a finite total by the
+    # tie-detection path; the finite candidate should win outright.
+    write_run(tmp_path, "r-nan", quantization="Q4", total_ms=float("nan"))
+    write_run(tmp_path, "r-inf", quantization="Q8", total_ms=float("inf"))
+    write_run(tmp_path, "r-finite", quantization="Q4K", total_ms=1000.0)
+
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.quantization == "Q4K"
+    assert len(group.accepted) == 1
+    assert len(group.rejected) == 2
+
+
+def test_direct_construction_rejects_non_finite_constraint_values():
+    for field_name, kwargs in (
+        ("min_pass_rate", {"min_pass_rate": float("nan")}),
+        ("max_peak_memory_bytes", {"max_peak_memory_bytes": float("inf")}),
+        ("max_total_latency_ms", {"max_total_latency_ms": float("-inf")}),
+        (
+            "max_coefficient_of_variation",
+            {"max_coefficient_of_variation": float("nan")},
+        ),
+        (
+            "min_quality_score",
+            {"min_quality_score": float("inf"), "required_quality_metric": "m1"},
+        ),
+    ):
+        with pytest.raises(TunePolicyError, match=field_name):
+            TuneConstraints(**kwargs)
 
 
 def test_missing_peak_memory_rejected_only_when_constrained(tmp_path):

--- a/tests/optimizer/test_tune.py
+++ b/tests/optimizer/test_tune.py
@@ -269,6 +269,25 @@ def test_rejects_mismatched_quality_metric(tmp_path):
     assert any("quality_metric" in reason for reason in group.rejected[0].reasons)
 
 
+def test_rejects_unlabeled_quality_score_when_metric_is_required(tmp_path):
+    write_run(tmp_path, "r1", quality_score=0.99, quality_metric=None)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            min_quality_score=0.9,
+            required_quality_metric="structured_json_exact_field_match",
+        ),
+    )
+
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    reasons = " ".join(group.rejected[0].reasons)
+    assert "missing outcome.quality_metric" in reasons
+    assert "structured_json_exact_field_match" in reasons
+
+
 def test_missing_quality_score_never_treated_as_zero(tmp_path):
     write_run(tmp_path, "r1", quality_score=None, quality_metric=None)
     policy = TunePolicy(

--- a/tests/optimizer/test_tune.py
+++ b/tests/optimizer/test_tune.py
@@ -290,6 +290,57 @@ def test_missing_timing_total_never_treated_as_zero(tmp_path):
     assert "cannot be computed" in reasons
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_non_finite_timing_never_enters_objective_or_wins(tmp_path, value):
+    write_run(tmp_path, "r-invalid", quantization="Q4", total_ms=value)
+    write_run(tmp_path, "r-valid", quantization="Q8", total_ms=1000.0)
+
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.quantization == "Q8"
+    rejected_reasons = " ".join(group.rejected[0].reasons)
+    assert "timing.total is non-finite" in rejected_reasons
+
+
+def test_all_non_finite_timing_is_inconclusive(tmp_path):
+    write_run(tmp_path, "r-nan", total_ms=float("nan"))
+
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    assert report.groups[0].outcome == GroupOutcome.INCONCLUSIVE
+    assert report.groups[0].recommended is None
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_non_finite_peak_memory_is_rejected(tmp_path, value):
+    write_run(tmp_path, "r1", peak_bytes=value)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(max_peak_memory_bytes=20 * 1024**3),
+    )
+
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    assert "memory.peak is non-finite" in " ".join(report.groups[0].rejected[0].reasons)
+
+
+def test_non_finite_quality_score_is_rejected(tmp_path):
+    write_run(
+        tmp_path,
+        "r1",
+        quality_score=float("nan"),
+        quality_metric="metric",
+    )
+
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    assert "quality_score is non-finite" in " ".join(
+        report.groups[0].rejected[0].reasons
+    )
+
+
 def test_missing_peak_memory_rejected_only_when_constrained(tmp_path):
     write_run(tmp_path, "r1", peak_bytes=None)
 

--- a/tests/optimizer/test_tune.py
+++ b/tests/optimizer/test_tune.py
@@ -1,0 +1,552 @@
+"""Tests for the tune engine: loading, identity, grouping, constraints, ranking.
+
+Builds full fake `workloads run --output-dir`-shaped artifact trees (see
+``_tune_fixtures.write_run``) rather than only unit-testing helper
+functions, so these tests exercise the same on-disk shape the real verify
+pipeline produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer.schema import MetricProvenance
+from llmtracefx.optimizer.tune.loader import TuneInputError, load_evidence
+from llmtracefx.optimizer.tune.policy import TuneConstraints, TuneObjective, TunePolicy
+from llmtracefx.optimizer.tune.report import GroupOutcome
+from llmtracefx.optimizer.tune.tuner import tune
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+LATENCY_POLICY = TunePolicy(objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS)
+
+
+# --- Loading / identity checks -----------------------------------------------
+
+
+def test_load_evidence_reads_completed_run(tmp_path):
+    write_run(tmp_path, "r1")
+    loaded = load_evidence((tmp_path,))
+    assert len(loaded.usable) == 1
+    assert loaded.usable[0].run_id == "r1"
+    assert not loaded.excluded
+
+
+def test_unsupported_row_is_excluded_not_a_rejected_candidate(tmp_path):
+    write_run(
+        tmp_path,
+        "mtp-unsupported",
+        status=RowStatus.UNSUPPORTED,
+        write_final_record=False,
+        reason="native-mtp is not implemented",
+        decode_mode="native-mtp",
+    )
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert len(loaded.excluded) == 1
+    assert "native-mtp" in loaded.excluded[0].reason
+
+
+def test_corrupt_final_record_is_excluded(tmp_path):
+    write_run(tmp_path, "r1", corrupt_final_record=True)
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert len(loaded.excluded) == 1
+    assert "schema validation" in loaded.excluded[0].reason
+
+
+def test_missing_final_record_file_is_excluded(tmp_path):
+    run_dir = write_run(tmp_path, "r1")
+    (run_dir / "final_record.json").unlink()
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert len(loaded.excluded) == 1
+    assert "could not read final_record.json" in loaded.excluded[0].reason
+
+
+def test_run_id_mismatch_between_verification_and_record_is_excluded(tmp_path):
+    run_dir = write_run(tmp_path, "r1")
+    # Corrupt just the run_id inside an otherwise-valid final_record.json.
+    import json
+
+    payload = json.loads((run_dir / "final_record.json").read_text())
+    payload["run_id"] = "different-run"
+    (run_dir / "final_record.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert "run_id" in loaded.excluded[0].reason
+
+
+def test_prompt_hash_mismatch_between_verification_and_record_is_excluded(tmp_path):
+    write_run(tmp_path, "r1", workload_hash_override="sha256:different")
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert "workload_hash" in loaded.excluded[0].reason
+
+
+def test_recorded_and_verified_prompt_hash_drift_is_excluded(tmp_path):
+    write_run(
+        tmp_path,
+        "r1",
+        prompt_hash="sha256:promptabc",
+        recorded_prompt_hash="sha256:stale",
+    )
+    loaded = load_evidence((tmp_path,))
+    assert not loaded.usable
+    assert "drift" in loaded.excluded[0].reason
+
+
+def test_identical_duplicate_run_id_across_dirs_is_deduped(tmp_path):
+    import shutil
+
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    write_run(dir_a, "r1", total_ms=1000.0)
+    shutil.copytree(dir_a, dir_b)
+    loaded = load_evidence((dir_a, dir_b))
+    assert len(loaded.usable) == 1
+
+
+def test_conflicting_duplicate_run_id_raises(tmp_path):
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    write_run(dir_a, "r1", total_ms=1000.0)
+    write_run(dir_b, "r1", total_ms=2000.0)
+    with pytest.raises(TuneInputError, match="duplicate run_id"):
+        load_evidence((dir_a, dir_b))
+
+
+# --- Grouping -----------------------------------------------------------
+
+
+def test_different_accelerators_are_separate_groups(tmp_path):
+    write_run(tmp_path, "r-m5", accelerator="Apple M5 Pro")
+    write_run(tmp_path, "r-cuda", accelerator="NVIDIA RTX 4090")
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert len(report.groups) == 2
+
+
+def test_different_context_tiers_are_separate_groups(tmp_path):
+    write_run(tmp_path, "r-2k", context_tier="2k")
+    write_run(tmp_path, "r-8k", context_tier="8k")
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert len(report.groups) == 2
+
+
+def test_different_runtime_backend_are_separate_groups(tmp_path):
+    write_run(tmp_path, "r-metal", runtime_backend="Metal")
+    write_run(tmp_path, "r-cuda", runtime_backend="CUDA")
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert len(report.groups) == 2
+
+
+def test_same_group_key_different_quantization_are_separate_candidates(tmp_path):
+    write_run(tmp_path, "r-q4", quantization="Q4", total_ms=1000.0)
+    write_run(tmp_path, "r-q8", quantization="Q8", total_ms=2000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert len(report.groups) == 1
+    group = report.groups[0]
+    assert len(group.accepted) == 2
+
+
+def test_same_group_key_different_seed_are_separate_candidates(tmp_path):
+    write_run(tmp_path, "r-seed0", seed=0)
+    write_run(tmp_path, "r-seed1", seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert len(group.accepted) == 2
+
+
+def test_same_candidate_config_multiple_runs_are_averaged(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=1200.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert len(group.accepted) == 1
+    winner = group.recommended
+    assert winner.evidence_count == 2
+    assert winner.mean_total_latency_ms == pytest.approx(1100.0)
+
+
+# --- Recommendation / winner selection -----------------------------------
+
+
+def test_recommends_fastest_candidate_by_latency(tmp_path):
+    write_run(tmp_path, "r-fast", quantization="Q4", total_ms=1000.0)
+    write_run(tmp_path, "r-slow", quantization="Q8", total_ms=2000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended is not None
+    assert group.recommended.candidate_key.quantization == "Q4"
+    assert len(group.accepted) == 2
+    assert not group.rejected
+
+
+def test_recommends_highest_correct_cases_per_minute(tmp_path):
+    # r-a: 1 correct case per 30s => 2/min. r-b: 1 correct case per 10s => 6/min.
+    write_run(tmp_path, "r-a", quantization="Q4", total_ms=30_000.0)
+    write_run(tmp_path, "r-b", quantization="Q8", total_ms=10_000.0)
+    policy = TunePolicy(objective=TuneObjective.MAX_CORRECT_CASES_PER_MINUTE)
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.recommended.candidate_key.quantization == "Q8"
+    assert group.recommended.correct_cases_per_minute == pytest.approx(6.0)
+
+
+def test_failing_quality_excludes_case_from_correct_cases_per_minute(tmp_path):
+    write_run(
+        tmp_path,
+        "r-fail",
+        quantization="Q4",
+        total_ms=1000.0,
+        success=False,
+        quality_score=0.0,
+    )
+    policy = TunePolicy(objective=TuneObjective.MAX_CORRECT_CASES_PER_MINUTE)
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert group.rejected
+    assert "no passing run" in group.rejected[0].reasons[-1]
+
+
+# --- Constraint rejections -------------------------------------------------
+
+
+def test_rejects_status_not_in_required_statuses(tmp_path):
+    write_run(tmp_path, "r-failed", status=RowStatus.FAILED, success=False)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert len(group.rejected) == 1
+    assert any("status" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_below_min_pass_rate(tmp_path):
+    write_run(tmp_path, "r1", success=True, quality_score=1.0)
+    write_run(tmp_path, "r2", success=False, quality_score=0.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(min_pass_rate=0.9),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any("pass rate" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_below_min_quality_score(tmp_path):
+    write_run(tmp_path, "r1", quality_score=0.5, quality_metric="m1")
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            min_quality_score=0.9, required_quality_metric="m1"
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any("quality_score" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_mismatched_quality_metric(tmp_path):
+    write_run(tmp_path, "r1", quality_score=0.99, quality_metric="other_metric")
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            min_quality_score=0.5, required_quality_metric="m1"
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert any("quality_metric" in reason for reason in group.rejected[0].reasons)
+
+
+def test_missing_quality_score_never_treated_as_zero(tmp_path):
+    write_run(tmp_path, "r1", quality_score=None, quality_metric=None)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            min_quality_score=0.1, required_quality_metric="m1"
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert any(
+        "missing outcome.quality_score" in reason
+        for reason in group.rejected[0].reasons
+    )
+
+
+def test_missing_timing_total_never_treated_as_zero(tmp_path):
+    write_run(tmp_path, "r1", total_ms=None)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    reasons = " ".join(group.rejected[0].reasons)
+    assert "missing timing.total" in reasons
+    assert "cannot be computed" in reasons
+
+
+def test_missing_peak_memory_rejected_only_when_constrained(tmp_path):
+    write_run(tmp_path, "r1", peak_bytes=None)
+
+    # No memory constraint configured: candidate is accepted regardless.
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert report.groups[0].outcome == GroupOutcome.RECOMMENDED
+
+    # With a memory constraint configured: missing evidence is a rejection.
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(max_peak_memory_bytes=1024.0),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any("memory.peak" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_over_max_peak_memory(tmp_path):
+    write_run(tmp_path, "r1", peak_bytes=25 * 1024**3)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(max_peak_memory_bytes=20 * 1024**3),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert any("peak memory" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_over_max_total_latency(tmp_path):
+    write_run(tmp_path, "r1", total_ms=5000.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(max_total_latency_ms=1000.0),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert any("total latency" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_disallowed_timing_provenance(tmp_path):
+    write_run(tmp_path, "r1", total_provenance=MetricProvenance.ESTIMATED)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_WALL_CLOCK})
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any("provenance" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_disallowed_memory_provenance(tmp_path):
+    write_run(
+        tmp_path,
+        "r1",
+        peak_bytes=1024.0,
+        peak_provenance=MetricProvenance.ESTIMATED,
+    )
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            max_peak_memory_bytes=2048.0,
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_NATIVE}),
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert any(
+        "memory.peak provenance" in reason for reason in group.rejected[0].reasons
+    )
+
+
+def test_rejects_below_min_measured_repetitions(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(min_measured_repetitions=2),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any("requires at least 2" in reason for reason in group.rejected[0].reasons)
+
+
+def test_rejects_over_max_coefficient_of_variation(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=5000.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(max_coefficient_of_variation=0.05),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert any(
+        "coefficient of variation" in reason for reason in group.rejected[0].reasons
+    )
+
+
+def test_rejects_inconsistent_quality_metric_across_repetitions(tmp_path):
+    write_run(tmp_path, "r1", quality_score=1.0, quality_metric="m1")
+    write_run(tmp_path, "r2", quality_score=1.0, quality_metric="m2")
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert any("inconsistent" in reason for reason in group.rejected[0].reasons)
+
+
+def test_multiple_violations_all_reported(tmp_path):
+    write_run(
+        tmp_path,
+        "r1",
+        status=RowStatus.FAILED,
+        success=False,
+        total_ms=10_000.0,
+        peak_bytes=25 * 1024**3,
+    )
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        constraints=TuneConstraints(
+            max_total_latency_ms=1000.0, max_peak_memory_bytes=20 * 1024**3
+        ),
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    reasons = report.groups[0].rejected[0].reasons
+    assert any("status" in r for r in reasons)
+    assert any("total latency" in r for r in reasons)
+    assert any("peak memory" in r for r in reasons)
+
+
+# --- Ties / inconclusive --------------------------------------------------
+
+
+def test_exact_tie_is_inconclusive(tmp_path):
+    write_run(tmp_path, "r-a", quantization="Q4", total_ms=1000.0)
+    write_run(tmp_path, "r-b", quantization="Q8", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert group.recommended is None
+    assert len(group.accepted) == 2
+    assert "tied" in group.inconclusive_reason
+
+
+def test_tie_within_noise_is_inconclusive(tmp_path):
+    # Candidate A: two reps averaging 1000ms with high variance (stdev ~500).
+    write_run(tmp_path, "r-a1", quantization="Q4", total_ms=500.0)
+    write_run(tmp_path, "r-a2", quantization="Q4", total_ms=1500.0)
+    # Candidate B: single rep at 1050ms -- well within A's noise band.
+    write_run(tmp_path, "r-b1", quantization="Q8", total_ms=1050.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert "noise" in group.inconclusive_reason
+
+
+def test_clearly_separated_candidates_are_not_a_tie(tmp_path):
+    write_run(tmp_path, "r-a1", quantization="Q4", total_ms=990.0)
+    write_run(tmp_path, "r-a2", quantization="Q4", total_ms=1010.0)
+    write_run(tmp_path, "r-b1", quantization="Q8", total_ms=5000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.quantization == "Q4"
+
+
+def test_no_candidate_survives_is_inconclusive(tmp_path):
+    write_run(tmp_path, "r1", status=RowStatus.FAILED, success=False)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.INCONCLUSIVE
+    assert (
+        group.inconclusive_reason
+        == "no candidate satisfied every constraint in this policy"
+    )
+
+
+# --- Determinism -----------------------------------------------------------
+
+
+def test_ranking_and_group_ordering_is_deterministic(tmp_path):
+    write_run(tmp_path, "r-z", quantization="Q4", total_ms=1000.0, context_tier="8k")
+    write_run(tmp_path, "r-a", quantization="Q4", total_ms=1000.0, context_tier="2k")
+    report1 = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    report2 = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    labels1 = [g.group_key.label() for g in report1.groups]
+    labels2 = [g.group_key.label() for g in report2.groups]
+    assert labels1 == labels2 == sorted(labels1)
+
+
+# --- Speculative candidates & baseline comparison --------------------------
+
+
+def test_speculative_candidate_can_win_over_autoregressive_baseline(tmp_path):
+    write_run(tmp_path, "r-ar1", speculative_enabled=False, total_ms=2000.0)
+    write_run(tmp_path, "r-ar2", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        tmp_path,
+        "r-spec1",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    write_run(
+        tmp_path,
+        "r-spec2",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.speculative_enabled is True
+    assert group.baseline_comparison is not None
+    assert group.baseline_comparison.report.verdict.value == "improvement"
+
+
+def test_unsupported_native_mtp_evidence_never_wins(tmp_path):
+    write_run(tmp_path, "r-ar", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        tmp_path,
+        "r-mtp",
+        status=RowStatus.UNSUPPORTED,
+        write_final_record=False,
+        decode_mode="native-mtp",
+        reason="native-mtp execution is not implemented by this pipeline",
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert len(report.groups) == 1
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.decode_mode == "autoregressive"
+    assert not any(c.candidate_key.decode_mode == "native-mtp" for c in group.accepted)
+    assert not any(c.candidate_key.decode_mode == "native-mtp" for c in group.rejected)
+    assert any("native-mtp" in run.reason for run in report.excluded_runs)
+
+
+def test_failed_generic_draft_candidate_is_rejected_not_winning(tmp_path):
+    write_run(tmp_path, "r-ar", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        tmp_path,
+        "r-draft-failed",
+        status=RowStatus.FAILED,
+        success=False,
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1.0,
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    group = report.groups[0]
+    assert group.outcome == GroupOutcome.RECOMMENDED
+    assert group.recommended.candidate_key.speculative_enabled is False
+    assert len(group.rejected) == 1
+    assert group.rejected[0].candidate_key.speculative_enabled is True

--- a/tests/optimizer/test_tune_cli.py
+++ b/tests/optimizer/test_tune_cli.py
@@ -199,3 +199,49 @@ def test_tune_cli_accepts_multiple_results_dirs(tmp_path, capsys):
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "evidence=2" in captured.out
+
+
+def test_tune_cli_rejects_non_finite_evidence_end_to_end(tmp_path, capsys):
+    # Real on-disk artifacts containing literal JSON NaN/Infinity for
+    # timing.total: must be rejected, never recommended, exit code 2.
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r-nan", total_ms=float("nan"))
+    on_disk = (results_dir / "runs" / "r-nan" / "final_record.json").read_text(
+        encoding="utf-8"
+    )
+    assert "NaN" in on_disk
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_tune(
+        [
+            "tune",
+            "--results",
+            str(results_dir),
+            "--policy",
+            str(policy_path),
+            "--explain",
+        ]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "INCONCLUSIVE" in captured.out
+    assert "non-finite" in captured.out
+
+
+def test_tune_cli_rejects_non_finite_policy_threshold(tmp_path):
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r1", total_ms=1000.0)
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {"max_total_latency_ms": float("nan")},
+        },
+    )
+
+    exit_code = _run_tune(
+        ["tune", "--results", str(results_dir), "--policy", str(policy_path)]
+    )
+
+    assert exit_code == 1

--- a/tests/optimizer/test_tune_cli.py
+++ b/tests/optimizer/test_tune_cli.py
@@ -1,0 +1,201 @@
+"""Tests for the `llmtracefx-optimizer tune` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer.cli import build_parser
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+
+def _run_tune(argv):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+def _write_policy(tmp_path, payload):
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps(payload), encoding="utf-8")
+    return policy_path
+
+
+def test_tune_cli_exits_0_and_writes_report_when_recommended(tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r1", total_ms=1000.0)
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    output_path = tmp_path / "report.json"
+
+    exit_code = _run_tune(
+        [
+            "tune",
+            "--results",
+            str(results_dir),
+            "--policy",
+            str(policy_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "RECOMMENDED" in captured.out
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text())
+    assert payload["groups"][0]["outcome"] == "recommended"
+
+
+def test_tune_cli_exits_2_when_inconclusive(tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r1", status=RowStatus.FAILED, success=False)
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_tune(
+        ["tune", "--results", str(results_dir), "--policy", str(policy_path)]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "INCONCLUSIVE" in captured.out
+
+
+def test_tune_cli_exits_1_when_no_groups_found(tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_tune(
+        ["tune", "--results", str(results_dir), "--policy", str(policy_path)]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_cli_exits_1_on_invalid_policy(tmp_path):
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r1")
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text("not json", encoding="utf-8")
+
+    exit_code = _run_tune(
+        ["tune", "--results", str(results_dir), "--policy", str(policy_path)]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_cli_exits_1_on_duplicate_conflict(tmp_path):
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    write_run(dir_a, "r1", total_ms=1000.0)
+    write_run(dir_b, "r1", total_ms=9999.0)
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_tune(
+        [
+            "tune",
+            "--results",
+            str(dir_a),
+            str(dir_b),
+            "--policy",
+            str(policy_path),
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_cli_explain_flag_shows_every_rejection_reason(tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    write_run(
+        results_dir,
+        "r1",
+        status=RowStatus.FAILED,
+        success=False,
+        total_ms=10_000.0,
+        peak_bytes=25 * 1024**3,
+    )
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {
+                "max_total_latency_ms": 1000,
+                "max_peak_memory_bytes": 20 * 1024**3,
+            },
+        },
+    )
+
+    exit_code = _run_tune(
+        [
+            "tune",
+            "--results",
+            str(results_dir),
+            "--policy",
+            str(policy_path),
+            "--explain",
+        ]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "status" in captured.out
+    assert "total latency" in captured.out
+    assert "peak memory" in captured.out
+    assert "more reason(s)" not in captured.out
+
+
+def test_tune_cli_default_mode_truncates_rejection_reasons(tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    write_run(
+        results_dir,
+        "r1",
+        status=RowStatus.FAILED,
+        success=False,
+        total_ms=10_000.0,
+        peak_bytes=25 * 1024**3,
+    )
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {
+                "max_total_latency_ms": 1000,
+                "max_peak_memory_bytes": 20 * 1024**3,
+            },
+        },
+    )
+
+    exit_code = _run_tune(
+        ["tune", "--results", str(results_dir), "--policy", str(policy_path)]
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "more reason(s)" in captured.out
+
+
+def test_tune_cli_accepts_multiple_results_dirs(tmp_path, capsys):
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    write_run(dir_a, "r1", total_ms=1000.0)
+    write_run(dir_b, "r2", total_ms=1000.0)
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_tune(
+        [
+            "tune",
+            "--results",
+            str(dir_a),
+            str(dir_b),
+            "--policy",
+            str(policy_path),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "evidence=2" in captured.out

--- a/tests/optimizer/test_tune_policy.py
+++ b/tests/optimizer/test_tune_policy.py
@@ -115,6 +115,17 @@ def test_from_file_loads_yaml(tmp_path):
     assert policy.constraints.min_quality_score == 0.8
 
 
+def test_from_file_json_rejects_non_finite_threshold(tmp_path):
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        '{"objective":"min_mean_total_latency_ms",'
+        '"constraints":{"max_peak_memory_bytes":Infinity}}',
+        encoding="utf-8",
+    )
+    with pytest.raises(TunePolicyError, match="max_peak_memory_bytes"):
+        TunePolicy.from_file(policy_path)
+
+
 def test_from_file_unsupported_extension_raises(tmp_path):
     policy_path = tmp_path / "policy.txt"
     policy_path.write_text("{}", encoding="utf-8")
@@ -163,13 +174,25 @@ def test_numeric_constraints_reject_non_finite_values(field, value):
         TuneConstraints.from_dict(data)
 
 
-@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
-def test_policy_json_rejects_non_standard_non_finite_numbers(token):
+@pytest.mark.parametrize(
+    ("field", "token", "extra"),
+    [
+        ("max_total_latency_ms", "NaN", ""),
+        ("max_total_latency_ms", "Infinity", ""),
+        ("max_total_latency_ms", "-Infinity", ""),
+        ("max_peak_memory_bytes", "NaN", ""),
+        ("max_peak_memory_bytes", "Infinity", ""),
+        ("max_coefficient_of_variation", "NaN", ""),
+        ("min_pass_rate", "NaN", ""),
+        ("min_quality_score", "Infinity", ',"required_quality_metric":"m1"'),
+    ],
+)
+def test_policy_json_rejects_non_standard_non_finite_numbers(field, token, extra):
     payload = (
         '{"objective":"min_mean_total_latency_ms",'
-        f'"constraints":{{"max_total_latency_ms":{token}}}}}'
+        f'"constraints":{{"{field}":{token}{extra}}}}}'
     )
-    with pytest.raises(TunePolicyError, match="max_total_latency_ms"):
+    with pytest.raises(TunePolicyError, match=field):
         TunePolicy.from_json(payload)
 
 

--- a/tests/optimizer/test_tune_policy.py
+++ b/tests/optimizer/test_tune_policy.py
@@ -1,0 +1,163 @@
+"""Tests for the tune policy schema: validation, JSON/YAML loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.schema import MetricProvenance
+from llmtracefx.optimizer.tune.policy import (
+    TuneConstraints,
+    TuneObjective,
+    TunePolicy,
+    TunePolicyError,
+)
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+
+def test_default_constraints_require_completed_or_skipped_only():
+    constraints = TuneConstraints()
+    assert constraints.required_statuses == {RowStatus.COMPLETED, RowStatus.SKIPPED}
+    assert constraints.min_measured_repetitions == 1
+
+
+def test_required_statuses_rejects_disallowed_status():
+    with pytest.raises(TunePolicyError, match="required_statuses"):
+        TuneConstraints(required_statuses=frozenset({RowStatus.FAILED}))
+
+
+def test_required_statuses_rejects_empty():
+    with pytest.raises(TunePolicyError, match="non-empty"):
+        TuneConstraints(required_statuses=frozenset())
+
+
+def test_min_quality_score_requires_required_quality_metric():
+    with pytest.raises(TunePolicyError, match="required_quality_metric"):
+        TuneConstraints(min_quality_score=0.9)
+
+
+def test_min_quality_score_with_metric_is_valid():
+    constraints = TuneConstraints(
+        min_quality_score=0.9,
+        required_quality_metric="structured_json_exact_field_match",
+    )
+    assert constraints.min_quality_score == 0.9
+
+
+def test_min_measured_repetitions_must_be_positive():
+    with pytest.raises(TunePolicyError, match="min_measured_repetitions"):
+        TuneConstraints(min_measured_repetitions=0)
+
+
+def test_policy_round_trips_through_json():
+    policy = TunePolicy(
+        objective=TuneObjective.MAX_CORRECT_CASES_PER_MINUTE,
+        constraints=TuneConstraints(
+            min_pass_rate=0.5,
+            max_peak_memory_bytes=1024.0,
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_WALL_CLOCK}),
+        ),
+        name="example",
+    )
+    reloaded = TunePolicy.from_json(policy.to_json())
+    assert reloaded.objective == TuneObjective.MAX_CORRECT_CASES_PER_MINUTE
+    assert reloaded.constraints.min_pass_rate == 0.5
+    assert reloaded.constraints.max_peak_memory_bytes == 1024.0
+    assert reloaded.constraints.allowed_provenances == frozenset(
+        {MetricProvenance.MEASURED_WALL_CLOCK}
+    )
+    assert reloaded.name == "example"
+
+
+def test_from_dict_missing_objective_raises():
+    with pytest.raises(TunePolicyError, match="objective"):
+        TunePolicy.from_dict({})
+
+
+def test_from_dict_invalid_objective_raises():
+    with pytest.raises(TunePolicyError, match="objective"):
+        TunePolicy.from_dict({"objective": "max_vibes"})
+
+
+def test_from_json_invalid_json_raises():
+    with pytest.raises(TunePolicyError, match="invalid JSON"):
+        TunePolicy.from_json("not json")
+
+
+def test_from_file_loads_json(tmp_path):
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps({"objective": "min_mean_total_latency_ms"}), encoding="utf-8"
+    )
+    policy = TunePolicy.from_file(policy_path)
+    assert policy.objective == TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS
+
+
+def test_from_file_loads_yaml(tmp_path):
+    yaml = pytest.importorskip("yaml")
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "objective": "max_correct_cases_per_minute",
+                "constraints": {
+                    "required_quality_metric": "structured_json_exact_field_match",
+                    "min_quality_score": 0.8,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    policy = TunePolicy.from_file(policy_path)
+    assert policy.objective == TuneObjective.MAX_CORRECT_CASES_PER_MINUTE
+    assert policy.constraints.min_quality_score == 0.8
+
+
+def test_from_file_unsupported_extension_raises(tmp_path):
+    policy_path = tmp_path / "policy.txt"
+    policy_path.write_text("{}", encoding="utf-8")
+    with pytest.raises(TunePolicyError, match="unsupported"):
+        TunePolicy.from_file(policy_path)
+
+
+def test_from_dict_rejects_non_object_constraints():
+    with pytest.raises(TunePolicyError, match="constraints"):
+        TunePolicy.from_dict(
+            {"objective": "min_mean_total_latency_ms", "constraints": "nope"}
+        )
+
+
+def test_allowed_provenances_rejects_unknown_value():
+    with pytest.raises(TunePolicyError, match="provenance"):
+        TuneConstraints.from_dict({"allowed_provenances": ["telepathy"]})
+
+
+def test_max_peak_memory_bytes_must_be_positive():
+    with pytest.raises(TunePolicyError, match="max_peak_memory_bytes"):
+        TuneConstraints.from_dict({"max_peak_memory_bytes": -1})
+
+
+def test_min_pass_rate_must_be_within_unit_interval():
+    with pytest.raises(TunePolicyError, match="min_pass_rate"):
+        TuneConstraints.from_dict({"min_pass_rate": 1.5})
+
+
+EXAMPLES_DIR = Path(__file__).parent.parent.parent / "examples" / "optimizer"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "tune-policy-fastest-under-20gb-m5-pro.json",
+        "tune-policy-structured-json-throughput.json",
+    ],
+)
+def test_example_policy_files_load_and_validate(filename):
+    policy = TunePolicy.from_file(EXAMPLES_DIR / filename)
+    assert policy.objective in (
+        TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        TuneObjective.MAX_CORRECT_CASES_PER_MINUTE,
+    )
+    assert policy.constraints.required_statuses

--- a/tests/optimizer/test_tune_policy.py
+++ b/tests/optimizer/test_tune_policy.py
@@ -144,6 +144,35 @@ def test_min_pass_rate_must_be_within_unit_interval():
         TuneConstraints.from_dict({"min_pass_rate": 1.5})
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_peak_memory_bytes", float("nan")),
+        ("max_peak_memory_bytes", float("inf")),
+        ("max_total_latency_ms", float("-inf")),
+        ("max_coefficient_of_variation", float("nan")),
+        ("min_pass_rate", float("nan")),
+        ("min_quality_score", float("inf")),
+    ],
+)
+def test_numeric_constraints_reject_non_finite_values(field, value):
+    data = {field: value}
+    if field == "min_quality_score":
+        data["required_quality_metric"] = "metric"
+    with pytest.raises(TunePolicyError, match=field):
+        TuneConstraints.from_dict(data)
+
+
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_policy_json_rejects_non_standard_non_finite_numbers(token):
+    payload = (
+        '{"objective":"min_mean_total_latency_ms",'
+        f'"constraints":{{"max_total_latency_ms":{token}}}}}'
+    )
+    with pytest.raises(TunePolicyError, match="max_total_latency_ms"):
+        TunePolicy.from_json(payload)
+
+
 EXAMPLES_DIR = Path(__file__).parent.parent.parent / "examples" / "optimizer"
 
 


### PR DESCRIPTION
## Summary

Adds an offline `tune` command that recommends configurations only from verified workload evidence.

The tuner first groups comparable runs, then rejects candidates that violate status, quality, memory, latency, provenance, repetition, or noise requirements. Only surviving candidates are ranked, using one declared objective per tuning run.

It does not load models, run inference, download weights, or compare unrelated hardware and workloads.

## Decision flow

```mermaid
flowchart LR
    V[verification.json] --> L[Reload and validate final_record.json]
    L --> G[Comparable groups]
    G --> C[Configuration candidates]
    C --> R[Constraint evaluation]
    R -->|Rejected| X[Reasons and evidence]
    R -->|Accepted| O[Single objective ranking]
    O -->|Clear winner| W[Recommendation]
    O -->|Tie or noise overlap| I[Inconclusive group]
```

## Evidence trust

The loader does not trust verification summaries alone. It reopens every referenced canonical record and checks run identity, workload prompt hash, record consistency, supported status, duplicate run IDs, and schema validity.

Byte-identical duplicate runs are deduplicated. Conflicting duplicates fail explicitly.

## Comparability

Runs are separated into groups by workload, version, context tier, model, accelerator, runtime/backend, and prompt hash. Metal and CUDA evidence, different contexts, and different workloads are never ranked together by default.

Candidate identity also includes decode mode, runtime version, quantization, speculative configuration, revisions, seed, and collector configuration hash. Materially different configurations are never averaged together.

## Constraints

A tuning policy can require:

- completed or trusted-skipped status
- minimum pass rate
- minimum quality score with an exact quality metric
- maximum peak memory
- maximum total latency
- allowed metric provenances
- minimum measured repetitions
- maximum coefficient of variation

Missing required evidence rejects a candidate. Missing values are never interpreted as zero or success. A score without a metric label cannot satisfy a metric-constrained policy.

Non-finite policy values and non-finite timing, memory, or quality evidence are rejected before aggregation, ranking, tie detection, or report serialization.

## Objectives

One objective is selected per report:

- `min_mean_total_latency_ms`
- `max_correct_cases_per_minute`

Quality remains a constraint. The tuner does not blend quality and performance into a synthetic score.

## Outcomes

Each comparable group includes accepted candidates, rejected candidates with every violation, supporting artifacts, and either a recommendation or an inconclusive reason. Speculative winners can include an autoregressive baseline comparison through the existing doctor logic.

## CLI

```bash
llmtracefx-optimizer tune \
  --results artifacts/qwen38-run \
  --policy examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json \
  --output artifacts/qwen38-tune-report.json \
  --explain
```

Exit codes:

- `0`: at least one recommendation
- `1`: invalid policy, invalid evidence, duplicate conflict, or no comparable groups
- `2`: tuning completed but every group is inconclusive

## Example policies

- fastest passing configuration under a 20 GB peak-memory cap
- maximum correct structured-JSON cases per minute with an exact quality metric

These files are policy examples, not Qwen3.8 benchmark claims.

## Validation

- 513 tests pass
- Ruff passes on optimizer and optimizer tests
- Black and isort checks pass on changed surfaces
- mypy passes on the optimizer package

Tests use complete fake verification artifact trees and cover identity checks, grouping, candidate separation, missing and unlabeled evidence, provenance, quality, memory, latency, repetitions, noise, ties, duplicate conflicts, corrupt records, non-finite values, deterministic ordering, CLI behavior, explanations, and atomic reports.

## Scope boundaries

This PR does not add inference execution, model downloads, native Metal or CUDA counters, native Qwen MTP, a dashboard, or multi-objective ranking.