### PR TITLE
feat(optimizer): add private offline tune report viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,15 +912,48 @@ rows that both passed and have measured timing) overall and broken down by
 decode mode and context tier -- deliberately not blended into one combined
 score.
 
+### Offline tuning and the `tune-report` HTML viewer
+
+Once a `workloads run` results directory has been collected, `tune`
+recommends the best verified configuration for one explicit objective
+under an explicit set of constraints -- it never blends multiple objectives
+and never loads a model or executes anything itself:
+
+```bash
+uv run llmtracefx-optimizer tune \
+  --results artifacts/qwen3.8-run \
+  --policy examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json \
+  --output artifacts/qwen3.8-tune-report.json
+```
+
+`tune-report` then renders that JSON report as a single, self-contained,
+portable HTML file (inline CSS, no JavaScript, no CDN) so the recommendation,
+the full accepted/rejected candidate breakdown, any speculative-vs-baseline
+comparison, and every excluded run can be inspected offline in a browser --
+no Streamlit dashboard, no re-scoring, no new tuning logic:
+
+```bash
+uv run llmtracefx-optimizer tune-report \
+  --input artifacts/qwen3.8-tune-report.json \
+  --output artifacts/qwen3.8-tune-report.html
+```
+
+Local artifact paths (results directories, `verification.json`/
+`final_record.json` locations) are redacted to stable
+`runs/<run_id>/<file>`-style labels by default, so the HTML file is safe to
+share without leaking a machine's home-directory layout; pass
+`--include-paths` to include the full paths instead. See
+`examples/optimizer/tune-report-example.json` for a synthetic (non-benchmark)
+example report that exercises every section of the viewer.
+
 **Not yet included** (tracked as a follow-up PR): a genuinely capable
 native-MTP runtime adapter (none exists upstream today), native Metal/CUDA
-performance-counter ingestion, CUDA/vLLM/SGLang collectors, an automatic
-tuning/recommendation command (`tune`) built on top of the evidence above,
-and any actual Qwen3.8-27B benchmark results -- everything in this section
-was verified against fake runtimes and small local checkpoints, never a real
-Qwen3.8-27B run. The fixtures under `tests/optimizer/fixtures/llama_cpp/` are
-synthetic, hand-written logs for testing the parser and doctor rule -- not
-benchmark evidence (see the `PROVENANCE.md` in that directory).
+performance-counter ingestion, CUDA/vLLM/SGLang collectors, and any actual
+Qwen3.8-27B benchmark results -- everything in this section was verified
+against fake runtimes and small local checkpoints, never a real Qwen3.8-27B
+run. The fixtures under `tests/optimizer/fixtures/llama_cpp/` are synthetic,
+hand-written logs for testing the parser and doctor rule -- not benchmark
+evidence (see the `PROVENANCE.md` in that directory).
 
 ## 📄 License
 

--- a/examples/optimizer/tune-report-example.json
+++ b/examples/optimizer/tune-report-example.json
@@ -1,0 +1,239 @@
+{
+  "schema_version": "1",
+  "generated_at": "2025-01-01T00:00:00.000000Z",
+  "results_dirs": [
+    "artifacts/example-results"
+  ],
+  "policy": {
+    "schema_version": "1",
+    "name": "synthetic-example-fastest-under-20gb",
+    "description": "SYNTHETIC EXAMPLE DATA ONLY. Not a real benchmark and not evidence about any actual model's performance. Exists solely to exercise every section of the `tune-report` HTML viewer: a recommended candidate, an accepted-candidate ranking, a rejected candidate, a speculative-decoding vs. autoregressive baseline comparison, and an excluded run.",
+    "objective": "min_mean_total_latency_ms",
+    "constraints": {
+      "required_statuses": [
+        "completed",
+        "skipped"
+      ],
+      "min_pass_rate": 1.0,
+      "min_quality_score": null,
+      "required_quality_metric": null,
+      "max_peak_memory_bytes": 21474836480.0,
+      "max_total_latency_ms": null,
+      "allowed_provenances": null,
+      "min_measured_repetitions": 1,
+      "max_coefficient_of_variation": 0.2
+    }
+  },
+  "groups": [
+    {
+      "group_key": {
+        "workload_id": "structured-json-profile-extraction",
+        "workload_version": "1",
+        "context_tier": "2k",
+        "model_id": "example/synthetic-demo-7b",
+        "model_family": "synthetic_demo_family",
+        "accelerator": "Example-Accelerator-X1",
+        "runtime_name": "mlx-lm",
+        "runtime_backend": "Metal",
+        "workload_prompt_hash": "sha256:promptabc"
+      },
+      "group_label": "structured-json-profile-extraction@v1 [2k] model=example/synthetic-demo-7b/synthetic_demo_family accelerator=Example-Accelerator-X1 runtime=mlx-lm/Metal",
+      "outcome": "recommended",
+      "recommended": {
+        "candidate_key": {
+          "decode_mode": "autoregressive",
+          "runtime_version": "0.31.3",
+          "quantization": "Q4",
+          "model_revision": null,
+          "tokenizer_revision": null,
+          "speculative_enabled": true,
+          "speculative_method": "draft-model",
+          "speculative_configured_depth": 2,
+          "seed": 0,
+          "config_hash": "cfg-hash"
+        },
+        "rank": 1,
+        "run_ids": [
+          "run-spec-001",
+          "run-spec-002"
+        ],
+        "verification_paths": [
+          "artifacts/example-results/runs/run-spec-001/verification.json",
+          "artifacts/example-results/runs/run-spec-002/verification.json"
+        ],
+        "final_record_paths": [
+          "artifacts/example-results/runs/run-spec-001/final_record.json",
+          "artifacts/example-results/runs/run-spec-002/final_record.json"
+        ],
+        "evidence_count": 2,
+        "objective_name": "min_mean_total_latency_ms",
+        "objective_value": 1165.0,
+        "mean_total_latency_ms": 1165.0,
+        "stdev_total_latency_ms": 15.0,
+        "coefficient_of_variation": 0.012875536480686695,
+        "correct_cases_per_minute": 51.50214592274678,
+        "pass_rate": 1.0,
+        "mean_quality_score": 1.0,
+        "quality_metric": "structured_json_exact_field_match",
+        "mean_peak_memory_bytes": 4294967296.0,
+        "max_peak_memory_bytes": 4294967296.0
+      },
+      "accepted": [
+        {
+          "candidate_key": {
+            "decode_mode": "autoregressive",
+            "runtime_version": "0.31.3",
+            "quantization": "Q4",
+            "model_revision": null,
+            "tokenizer_revision": null,
+            "speculative_enabled": true,
+            "speculative_method": "draft-model",
+            "speculative_configured_depth": 2,
+            "seed": 0,
+            "config_hash": "cfg-hash"
+          },
+          "rank": 1,
+          "run_ids": [
+            "run-spec-001",
+            "run-spec-002"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/run-spec-001/verification.json",
+            "artifacts/example-results/runs/run-spec-002/verification.json"
+          ],
+          "final_record_paths": [
+            "artifacts/example-results/runs/run-spec-001/final_record.json",
+            "artifacts/example-results/runs/run-spec-002/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 1165.0,
+          "mean_total_latency_ms": 1165.0,
+          "stdev_total_latency_ms": 15.0,
+          "coefficient_of_variation": 0.012875536480686695,
+          "correct_cases_per_minute": 51.50214592274678,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_peak_memory_bytes": 4294967296.0,
+          "max_peak_memory_bytes": 4294967296.0
+        },
+        {
+          "candidate_key": {
+            "decode_mode": "autoregressive",
+            "runtime_version": "0.31.3",
+            "quantization": "Q4",
+            "model_revision": null,
+            "tokenizer_revision": null,
+            "speculative_enabled": false,
+            "speculative_method": null,
+            "speculative_configured_depth": null,
+            "seed": 0,
+            "config_hash": "cfg-hash"
+          },
+          "rank": 2,
+          "run_ids": [
+            "run-ar-001",
+            "run-ar-002"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/run-ar-001/verification.json",
+            "artifacts/example-results/runs/run-ar-002/verification.json"
+          ],
+          "final_record_paths": [
+            "artifacts/example-results/runs/run-ar-001/final_record.json",
+            "artifacts/example-results/runs/run-ar-002/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 2025.0,
+          "mean_total_latency_ms": 2025.0,
+          "stdev_total_latency_ms": 25.0,
+          "coefficient_of_variation": 0.012345679012345678,
+          "correct_cases_per_minute": 29.629629629629633,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_peak_memory_bytes": 4294967296.0,
+          "max_peak_memory_bytes": 4294967296.0
+        }
+      ],
+      "rejected": [
+        {
+          "candidate_key": {
+            "decode_mode": "autoregressive",
+            "runtime_version": "0.31.3",
+            "quantization": "FP16",
+            "model_revision": null,
+            "tokenizer_revision": null,
+            "speculative_enabled": false,
+            "speculative_method": null,
+            "speculative_configured_depth": null,
+            "seed": 0,
+            "config_hash": "cfg-hash"
+          },
+          "run_ids": [
+            "run-rejected-001"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/run-rejected-001/verification.json"
+          ],
+          "final_record_paths": [
+            "artifacts/example-results/runs/run-rejected-001/final_record.json"
+          ],
+          "reasons": [
+            "run run-rejected-001: peak memory 25769803776 bytes exceeds the maximum 21474836480 bytes"
+          ]
+        }
+      ],
+      "inconclusive_reason": null,
+      "baseline_comparison": {
+        "baseline_candidate_key": {
+          "decode_mode": "autoregressive",
+          "runtime_version": "0.31.3",
+          "quantization": "Q4",
+          "model_revision": null,
+          "tokenizer_revision": null,
+          "speculative_enabled": false,
+          "speculative_method": null,
+          "speculative_configured_depth": null,
+          "seed": 0,
+          "config_hash": "cfg-hash"
+        },
+        "speculative_candidate_key": {
+          "decode_mode": "autoregressive",
+          "runtime_version": "0.31.3",
+          "quantization": "Q4",
+          "model_revision": null,
+          "tokenizer_revision": null,
+          "speculative_enabled": true,
+          "speculative_method": "draft-model",
+          "speculative_configured_depth": 2,
+          "seed": 0,
+          "config_hash": "cfg-hash"
+        },
+        "verdict": "improvement",
+        "reason": "speculative decoding decreased mean total time by 860.00 ms (-42.5%) versus the autoregressive baseline",
+        "baseline_run_ids": [
+          "run-ar-001",
+          "run-ar-002"
+        ],
+        "speculative_run_ids": [
+          "run-spec-001",
+          "run-spec-002"
+        ],
+        "baseline_mean_total_ms": 2025.0,
+        "speculative_mean_total_ms": 1165.0,
+        "delta_ms": -860.0,
+        "delta_pct": -0.4246913580246914
+      }
+    }
+  ],
+  "excluded_runs": [
+    {
+      "run_id": "run-excluded-001",
+      "source_results_dir": "artifacts/example-results",
+      "reason": "final_record.json (/var/folders/fd/7wzsqj2s69l1lmhwb_7j4wn00000gn/T/tmpo0don8_5/results/runs/run-excluded-001/final_record.json) failed schema validation: Invalid JSON for ExperimentRecord: Expecting value: line 1 column 1 (char 0)"
+    }
+  ]
+}

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -12,6 +12,8 @@ Subcommands:
                      aggregate results (``workloads summarize``).
     tune             Offline, evidence-constrained recommendation of the best
                      verified configuration for a workload/hardware target.
+    tune-report      Render a `tune` JSON report as a self-contained, portable
+                     HTML file for offline inspection (no Streamlit needed).
 """
 
 from __future__ import annotations
@@ -51,6 +53,8 @@ from .schema import (
 from .tune.explain import format_report_text
 from .tune.loader import TuneInputError
 from .tune.policy import TunePolicy, TunePolicyError
+from .tune.report import TuneReport, TuneReportValidationError
+from .tune.report_html import render_tune_report_html
 from .tune.tuner import tune
 from .workloads.aggregate import summarize_results, write_summary
 from .workloads.catalog import WORKLOADS, workload_by_id
@@ -595,6 +599,39 @@ def _cmd_tune(args: argparse.Namespace) -> int:
     return 0 if report.has_recommendation else 2
 
 
+def _cmd_tune_report(args: argparse.Namespace) -> int:
+    input_path = Path(args.input)
+    try:
+        report = TuneReport.read_json(input_path)
+    except OSError as exc:
+        print(f"Could not read tune report input {input_path}: {exc}", file=sys.stderr)
+        return 1
+    except TuneReportValidationError as exc:
+        print(f"Invalid tune report in {input_path}: {exc}", file=sys.stderr)
+        return 1
+
+    html_document = render_tune_report_html(report, redact_paths=not args.include_paths)
+
+    output_path = Path(args.output)
+    try:
+        atomic_write_text(output_path, html_document)
+    except OSError as exc:
+        print(
+            f"Could not write tune report HTML to {output_path}: {exc}", file=sys.stderr
+        )
+        return 1
+
+    print(f"Tune report HTML written to {output_path}")
+    if args.include_paths:
+        print("Full local artifact paths are included (--include-paths was set).")
+    else:
+        print(
+            "Local artifact paths were redacted to basenames/stable labels; "
+            "rerun with --include-paths to include full paths."
+        )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llmtracefx-optimizer",
@@ -990,6 +1027,38 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     tune_parser.set_defaults(func=_cmd_tune)
+
+    tune_report_parser = subparsers.add_parser(
+        "tune-report",
+        help=(
+            "Render a `tune` JSON report as a single, self-contained, "
+            "portable HTML file (inline CSS, no JavaScript, no CDN, works "
+            "offline). Never re-scores or re-computes anything; purely a "
+            "read-only view over an already-produced tune report."
+        ),
+    )
+    tune_report_parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to a `tune --output` JSON report",
+    )
+    tune_report_parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to atomically write the rendered HTML report to",
+    )
+    tune_report_parser.add_argument(
+        "--include-paths",
+        action="store_true",
+        help=(
+            "Include full local artifact paths (results directories, "
+            "verification.json/final_record.json paths) as plain text. "
+            "Default: redact every path to a basename/stable "
+            "`runs/<run_id>/<file>` label so the report is safe to share "
+            "without leaking a user's home directory layout."
+        ),
+    )
+    tune_report_parser.set_defaults(func=_cmd_tune_report)
 
     return parser
 

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -603,7 +603,7 @@ def _cmd_tune_report(args: argparse.Namespace) -> int:
     input_path = Path(args.input)
     try:
         report = TuneReport.read_json(input_path)
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         print(f"Could not read tune report input {input_path}: {exc}", file=sys.stderr)
         return 1
     except TuneReportValidationError as exc:

--- a/llmtracefx/optimizer/tune/identity.py
+++ b/llmtracefx/optimizer/tune/identity.py
@@ -20,6 +20,43 @@ from ..schema import ExperimentRecord
 from ..workloads.verify import RowVerification
 
 
+class IdentityValidationError(ValueError):
+    """Raised when a ``GroupKey``/``CandidateKey`` loaded from JSON is invalid."""
+
+
+def _required_str(data: Any, key: str, *, context: str) -> str:
+    if not isinstance(data, dict) or key not in data:
+        raise IdentityValidationError(f"{context} is missing required field: {key!r}")
+    value = data[key]
+    if not isinstance(value, str) or not value:
+        raise IdentityValidationError(
+            f"{context}.{key} must be a non-empty string, got {value!r}"
+        )
+    return value
+
+
+def _optional_str(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise IdentityValidationError(
+            f"{context}.{key} must be a string or null, got {value!r}"
+        )
+    return value
+
+
+def _optional_int(data: dict[str, Any], key: str, *, context: str) -> int | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise IdentityValidationError(
+            f"{context}.{key} must be an integer or null, got {value!r}"
+        )
+    return int(value)
+
+
 @dataclass(frozen=True)
 class GroupKey:
     """Identifies one set of directly comparable candidate configurations."""
@@ -67,6 +104,25 @@ class GroupKey:
             self.runtime_name,
             self.runtime_backend or "",
             self.workload_prompt_hash,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Any) -> GroupKey:
+        if not isinstance(data, dict):
+            raise IdentityValidationError("group_key must be a JSON object")
+        context = "group_key"
+        return cls(
+            workload_id=_required_str(data, "workload_id", context=context),
+            workload_version=_required_str(data, "workload_version", context=context),
+            context_tier=_required_str(data, "context_tier", context=context),
+            model_id=_required_str(data, "model_id", context=context),
+            model_family=_optional_str(data, "model_family", context=context),
+            accelerator=_optional_str(data, "accelerator", context=context),
+            runtime_name=_required_str(data, "runtime_name", context=context),
+            runtime_backend=_optional_str(data, "runtime_backend", context=context),
+            workload_prompt_hash=_required_str(
+                data, "workload_prompt_hash", context=context
+            ),
         )
 
 
@@ -135,6 +191,36 @@ class CandidateKey:
             ),
             self.seed if self.seed is not None else -1,
             self.config_hash or "",
+        )
+
+    @classmethod
+    def from_dict(cls, data: Any) -> CandidateKey:
+        if not isinstance(data, dict):
+            raise IdentityValidationError("candidate_key must be a JSON object")
+        context = "candidate_key"
+        speculative_enabled = data.get("speculative_enabled")
+        if not isinstance(speculative_enabled, bool):
+            raise IdentityValidationError(
+                f"{context}.speculative_enabled must be a boolean, got "
+                f"{speculative_enabled!r}"
+            )
+        return cls(
+            decode_mode=_required_str(data, "decode_mode", context=context),
+            runtime_version=_optional_str(data, "runtime_version", context=context),
+            quantization=_optional_str(data, "quantization", context=context),
+            model_revision=_optional_str(data, "model_revision", context=context),
+            tokenizer_revision=_optional_str(
+                data, "tokenizer_revision", context=context
+            ),
+            speculative_enabled=speculative_enabled,
+            speculative_method=_optional_str(
+                data, "speculative_method", context=context
+            ),
+            speculative_configured_depth=_optional_int(
+                data, "speculative_configured_depth", context=context
+            ),
+            seed=_optional_int(data, "seed", context=context),
+            config_hash=_optional_str(data, "config_hash", context=context),
         )
 
 

--- a/llmtracefx/optimizer/tune/loader.py
+++ b/llmtracefx/optimizer/tune/loader.py
@@ -45,6 +45,25 @@ class ExcludedRun:
             "reason": self.reason,
         }
 
+    @classmethod
+    def from_dict(cls, data: object) -> ExcludedRun:
+        if not isinstance(data, dict):
+            raise TuneInputError("excluded run entry must be a JSON object")
+        for key in ("run_id", "source_results_dir", "reason"):
+            if key not in data:
+                raise TuneInputError(
+                    f"excluded run entry is missing required field: {key!r}"
+                )
+            if not isinstance(data[key], str):
+                raise TuneInputError(
+                    f"excluded run entry.{key} must be a string, got {data[key]!r}"
+                )
+        return cls(
+            run_id=data["run_id"],
+            source_results_dir=data["source_results_dir"],
+            reason=data["reason"],
+        )
+
 
 @dataclass(frozen=True)
 class RunEvidence:

--- a/llmtracefx/optimizer/tune/report.py
+++ b/llmtracefx/optimizer/tune/report.py
@@ -457,6 +457,26 @@ class GroupReport:
                 f"{context} has outcome 'inconclusive' but 'inconclusive_reason' "
                 "is null"
             )
+        if group.outcome == GroupOutcome.INCONCLUSIVE:
+            if group.recommended is not None:
+                raise TuneReportValidationError(
+                    f"{context} has outcome 'inconclusive' but recommended is set"
+                )
+            if group.baseline_comparison is not None:
+                raise TuneReportValidationError(
+                    f"{context} has outcome 'inconclusive' but "
+                    "baseline_comparison is set"
+                )
+        if (
+            group.baseline_comparison is not None
+            and group.recommended is not None
+            and group.baseline_comparison.speculative_candidate_key
+            != group.recommended.candidate_key
+        ):
+            raise TuneReportValidationError(
+                f"{context}.baseline_comparison speculative candidate must "
+                "equal the recommended candidate"
+            )
         return group
 
 

--- a/llmtracefx/optimizer/tune/report.py
+++ b/llmtracefx/optimizer/tune/report.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from typing import Any
 
 from ..doctor.speculative import DoctorVerdict, SpeculativeRegressionReport
-from .identity import CandidateKey, GroupKey
-from .loader import ExcludedRun
+from .identity import CandidateKey, GroupKey, IdentityValidationError
+from .loader import ExcludedRun, TuneInputError
 from .policy import TunePolicy, TunePolicyError
 
 TUNE_REPORT_SCHEMA_VERSION = "1"
@@ -29,6 +29,24 @@ TUNE_REPORT_SCHEMA_VERSION = "1"
 
 class TuneReportValidationError(ValueError):
     """Raised when a ``TuneReport`` loaded from JSON is invalid or malformed."""
+
+
+def _load_candidate_key(data: Any, *, context: str) -> CandidateKey:
+    try:
+        return CandidateKey.from_dict(data)
+    except IdentityValidationError as exc:
+        raise TuneReportValidationError(
+            f"{context}.candidate_key is invalid: {exc}"
+        ) from exc
+
+
+def _load_group_key(data: Any, *, context: str) -> GroupKey:
+    try:
+        return GroupKey.from_dict(data)
+    except IdentityValidationError as exc:
+        raise TuneReportValidationError(
+            f"{context}.group_key is invalid: {exc}"
+        ) from exc
 
 
 def _require(data: Any, key: str, *, context: str) -> Any:
@@ -173,8 +191,9 @@ class CandidateReport:
             raise TuneReportValidationError("candidate report must be a JSON object")
         context = "candidate report"
         return cls(
-            candidate_key=CandidateKey.from_dict(
-                _require(data, "candidate_key", context=context)
+            candidate_key=_load_candidate_key(
+                _require(data, "candidate_key", context=context),
+                context=context,
             ),
             rank=_require_int(data, "rank", context=context, minimum=1),
             run_ids=_string_tuple(data, "run_ids", context=context),
@@ -244,8 +263,9 @@ class RejectedCandidateReport:
             )
         context = "rejected candidate report"
         return cls(
-            candidate_key=CandidateKey.from_dict(
-                _require(data, "candidate_key", context=context)
+            candidate_key=_load_candidate_key(
+                _require(data, "candidate_key", context=context),
+                context=context,
             ),
             run_ids=_string_tuple(data, "run_ids", context=context),
             verification_paths=_string_tuple(
@@ -309,11 +329,13 @@ class BaselineComparison:
             delta_pct=_optional_finite_float(data, "delta_pct", context=context),
         )
         return cls(
-            baseline_candidate_key=CandidateKey.from_dict(
-                _require(data, "baseline_candidate_key", context=context)
+            baseline_candidate_key=_load_candidate_key(
+                _require(data, "baseline_candidate_key", context=context),
+                context=f"{context}.baseline",
             ),
-            speculative_candidate_key=CandidateKey.from_dict(
-                _require(data, "speculative_candidate_key", context=context)
+            speculative_candidate_key=_load_candidate_key(
+                _require(data, "speculative_candidate_key", context=context),
+                context=f"{context}.speculative",
             ),
             report=speculative_report,
         )
@@ -373,7 +395,18 @@ class GroupReport:
         accepted_raw = data.get("accepted", [])
         if not isinstance(accepted_raw, list):
             raise TuneReportValidationError(f"{context}.accepted must be a list")
-        accepted = tuple(CandidateReport.from_dict(item) for item in accepted_raw)
+        accepted = tuple(
+            sorted(
+                (CandidateReport.from_dict(item) for item in accepted_raw),
+                key=lambda candidate: candidate.rank,
+            )
+        )
+        accepted_ranks = tuple(candidate.rank for candidate in accepted)
+        if accepted_ranks != tuple(range(1, len(accepted) + 1)):
+            raise TuneReportValidationError(
+                f"{context}.accepted ranks must be unique and contiguous "
+                f"starting at 1, got {accepted_ranks!r}"
+            )
 
         rejected_raw = data.get("rejected", [])
         if not isinstance(rejected_raw, list):
@@ -390,7 +423,10 @@ class GroupReport:
         )
 
         group = cls(
-            group_key=GroupKey.from_dict(_require(data, "group_key", context=context)),
+            group_key=_load_group_key(
+                _require(data, "group_key", context=context),
+                context=context,
+            ),
             outcome=outcome,
             recommended=recommended,
             accepted=accepted,
@@ -404,6 +440,15 @@ class GroupReport:
             raise TuneReportValidationError(
                 f"{context} has outcome 'recommended' but 'recommended' is null"
             )
+        if group.outcome == GroupOutcome.RECOMMENDED:
+            if not group.accepted:
+                raise TuneReportValidationError(
+                    f"{context} has outcome 'recommended' but accepted is empty"
+                )
+            if group.recommended != group.accepted[0]:
+                raise TuneReportValidationError(
+                    f"{context}.recommended must equal the rank 1 accepted candidate"
+                )
         if (
             group.outcome == GroupOutcome.INCONCLUSIVE
             and group.inconclusive_reason is None
@@ -472,7 +517,12 @@ class TuneReport:
         excluded_raw = data.get("excluded_runs", [])
         if not isinstance(excluded_raw, list):
             raise TuneReportValidationError(f"{context}.excluded_runs must be a list")
-        excluded_runs = tuple(ExcludedRun.from_dict(item) for item in excluded_raw)
+        try:
+            excluded_runs = tuple(ExcludedRun.from_dict(item) for item in excluded_raw)
+        except TuneInputError as exc:
+            raise TuneReportValidationError(
+                f"{context}.excluded_runs is invalid: {exc}"
+            ) from exc
 
         return cls(
             schema_version=schema_version,

--- a/llmtracefx/optimizer/tune/report.py
+++ b/llmtracefx/optimizer/tune/report.py
@@ -3,22 +3,114 @@
 Every number here traces back to a specific accepted run's canonical
 ``ExperimentRecord``; nothing is fabricated when evidence is missing. See
 ``tuner.py`` for how these are built and ``explain.py`` for the
-human-readable rendering of the same data.
+human-readable rendering of the same data. ``TuneReport.from_dict``/
+``from_json``/``read_json`` are the only supported ways to load a tune
+report produced elsewhere (e.g. by the ``tune-report`` HTML viewer CLI):
+they never trust arbitrary fields, reject non-finite numeric values, and
+raise ``TuneReportValidationError`` on any malformed or inconsistent input.
 """
 
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
-from ..doctor.speculative import SpeculativeRegressionReport
+from ..doctor.speculative import DoctorVerdict, SpeculativeRegressionReport
 from .identity import CandidateKey, GroupKey
 from .loader import ExcludedRun
-from .policy import TunePolicy
+from .policy import TunePolicy, TunePolicyError
 
 TUNE_REPORT_SCHEMA_VERSION = "1"
+
+
+class TuneReportValidationError(ValueError):
+    """Raised when a ``TuneReport`` loaded from JSON is invalid or malformed."""
+
+
+def _require(data: Any, key: str, *, context: str) -> Any:
+    if not isinstance(data, dict) or key not in data:
+        raise TuneReportValidationError(f"{context} is missing required field: {key!r}")
+    return data[key]
+
+
+def _require_str(data: Any, key: str, *, context: str) -> str:
+    value = _require(data, key, context=context)
+    if not isinstance(value, str) or not value:
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a non-empty string, got {value!r}"
+        )
+    return value
+
+
+def _optional_str(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a string or null, got {value!r}"
+        )
+    return value
+
+
+def _string_tuple(data: dict[str, Any], key: str, *, context: str) -> tuple[str, ...]:
+    value = data.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a list of strings, got {value!r}"
+        )
+    return tuple(value)
+
+
+def _require_int(
+    data: dict[str, Any], key: str, *, context: str, minimum: int | None = None
+) -> int:
+    value = _require(data, key, context=context)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be an integer, got {value!r}"
+        )
+    if minimum is not None and value < minimum:
+        raise TuneReportValidationError(
+            f"{context}.{key} must be >= {minimum}, got {value}"
+        )
+    return int(value)
+
+
+def _require_finite_float(data: dict[str, Any], key: str, *, context: str) -> float:
+    value = _require(data, key, context=context)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a number, got {value!r}"
+        )
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    return numeric
+
+
+def _optional_finite_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a number or null, got {value!r}"
+        )
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise TuneReportValidationError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    return numeric
 
 
 class GroupOutcome(str, Enum):
@@ -75,6 +167,55 @@ class CandidateReport:
             "max_peak_memory_bytes": self.max_peak_memory_bytes,
         }
 
+    @classmethod
+    def from_dict(cls, data: Any) -> CandidateReport:
+        if not isinstance(data, dict):
+            raise TuneReportValidationError("candidate report must be a JSON object")
+        context = "candidate report"
+        return cls(
+            candidate_key=CandidateKey.from_dict(
+                _require(data, "candidate_key", context=context)
+            ),
+            rank=_require_int(data, "rank", context=context, minimum=1),
+            run_ids=_string_tuple(data, "run_ids", context=context),
+            verification_paths=_string_tuple(
+                data, "verification_paths", context=context
+            ),
+            final_record_paths=_string_tuple(
+                data, "final_record_paths", context=context
+            ),
+            evidence_count=_require_int(
+                data, "evidence_count", context=context, minimum=0
+            ),
+            objective_name=_require_str(data, "objective_name", context=context),
+            objective_value=_require_finite_float(
+                data, "objective_value", context=context
+            ),
+            mean_total_latency_ms=_optional_finite_float(
+                data, "mean_total_latency_ms", context=context
+            ),
+            stdev_total_latency_ms=_optional_finite_float(
+                data, "stdev_total_latency_ms", context=context
+            ),
+            coefficient_of_variation=_optional_finite_float(
+                data, "coefficient_of_variation", context=context
+            ),
+            correct_cases_per_minute=_optional_finite_float(
+                data, "correct_cases_per_minute", context=context
+            ),
+            pass_rate=_optional_finite_float(data, "pass_rate", context=context),
+            mean_quality_score=_optional_finite_float(
+                data, "mean_quality_score", context=context
+            ),
+            quality_metric=_optional_str(data, "quality_metric", context=context),
+            mean_peak_memory_bytes=_optional_finite_float(
+                data, "mean_peak_memory_bytes", context=context
+            ),
+            max_peak_memory_bytes=_optional_finite_float(
+                data, "max_peak_memory_bytes", context=context
+            ),
+        )
+
 
 @dataclass(frozen=True)
 class RejectedCandidateReport:
@@ -94,6 +235,27 @@ class RejectedCandidateReport:
             "final_record_paths": list(self.final_record_paths),
             "reasons": list(self.reasons),
         }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> RejectedCandidateReport:
+        if not isinstance(data, dict):
+            raise TuneReportValidationError(
+                "rejected candidate report must be a JSON object"
+            )
+        context = "rejected candidate report"
+        return cls(
+            candidate_key=CandidateKey.from_dict(
+                _require(data, "candidate_key", context=context)
+            ),
+            run_ids=_string_tuple(data, "run_ids", context=context),
+            verification_paths=_string_tuple(
+                data, "verification_paths", context=context
+            ),
+            final_record_paths=_string_tuple(
+                data, "final_record_paths", context=context
+            ),
+            reasons=_string_tuple(data, "reasons", context=context),
+        )
 
 
 @dataclass(frozen=True)
@@ -117,6 +279,44 @@ class BaselineComparison:
             "delta_ms": self.report.delta_ms,
             "delta_pct": self.report.delta_pct,
         }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> BaselineComparison:
+        if not isinstance(data, dict):
+            raise TuneReportValidationError("baseline comparison must be a JSON object")
+        context = "baseline comparison"
+        raw_verdict = _require_str(data, "verdict", context=context)
+        try:
+            verdict = DoctorVerdict(raw_verdict)
+        except ValueError as exc:
+            raise TuneReportValidationError(
+                f"{context}.verdict has an invalid value: {exc}"
+            ) from exc
+        speculative_report = SpeculativeRegressionReport(
+            verdict=verdict,
+            reason=_require_str(data, "reason", context=context),
+            baseline_run_ids=_string_tuple(data, "baseline_run_ids", context=context),
+            speculative_run_ids=_string_tuple(
+                data, "speculative_run_ids", context=context
+            ),
+            baseline_mean_total_ms=_optional_finite_float(
+                data, "baseline_mean_total_ms", context=context
+            ),
+            speculative_mean_total_ms=_optional_finite_float(
+                data, "speculative_mean_total_ms", context=context
+            ),
+            delta_ms=_optional_finite_float(data, "delta_ms", context=context),
+            delta_pct=_optional_finite_float(data, "delta_pct", context=context),
+        )
+        return cls(
+            baseline_candidate_key=CandidateKey.from_dict(
+                _require(data, "baseline_candidate_key", context=context)
+            ),
+            speculative_candidate_key=CandidateKey.from_dict(
+                _require(data, "speculative_candidate_key", context=context)
+            ),
+            report=speculative_report,
+        )
 
 
 @dataclass(frozen=True)
@@ -149,6 +349,71 @@ class GroupReport:
             ),
         }
 
+    @classmethod
+    def from_dict(cls, data: Any) -> GroupReport:
+        if not isinstance(data, dict):
+            raise TuneReportValidationError("group report must be a JSON object")
+        context = "group report"
+
+        raw_outcome = _require_str(data, "outcome", context=context)
+        try:
+            outcome = GroupOutcome(raw_outcome)
+        except ValueError as exc:
+            raise TuneReportValidationError(
+                f"{context}.outcome has an invalid value: {exc}"
+            ) from exc
+
+        recommended_raw = data.get("recommended")
+        recommended = (
+            None
+            if recommended_raw is None
+            else CandidateReport.from_dict(recommended_raw)
+        )
+
+        accepted_raw = data.get("accepted", [])
+        if not isinstance(accepted_raw, list):
+            raise TuneReportValidationError(f"{context}.accepted must be a list")
+        accepted = tuple(CandidateReport.from_dict(item) for item in accepted_raw)
+
+        rejected_raw = data.get("rejected", [])
+        if not isinstance(rejected_raw, list):
+            raise TuneReportValidationError(f"{context}.rejected must be a list")
+        rejected = tuple(
+            RejectedCandidateReport.from_dict(item) for item in rejected_raw
+        )
+
+        baseline_comparison_raw = data.get("baseline_comparison")
+        baseline_comparison = (
+            None
+            if baseline_comparison_raw is None
+            else BaselineComparison.from_dict(baseline_comparison_raw)
+        )
+
+        group = cls(
+            group_key=GroupKey.from_dict(_require(data, "group_key", context=context)),
+            outcome=outcome,
+            recommended=recommended,
+            accepted=accepted,
+            rejected=rejected,
+            inconclusive_reason=_optional_str(
+                data, "inconclusive_reason", context=context
+            ),
+            baseline_comparison=baseline_comparison,
+        )
+        if group.outcome == GroupOutcome.RECOMMENDED and group.recommended is None:
+            raise TuneReportValidationError(
+                f"{context} has outcome 'recommended' but 'recommended' is null"
+            )
+        if (
+            group.outcome == GroupOutcome.INCONCLUSIVE
+            and group.inconclusive_reason is None
+        ):
+            raise TuneReportValidationError(
+                f"{context} has outcome 'inconclusive' but 'inconclusive_reason' "
+                "is null"
+            )
+        return group
+
 
 @dataclass(frozen=True)
 class TuneReport:
@@ -177,3 +442,57 @@ class TuneReport:
     @property
     def has_recommendation(self) -> bool:
         return any(group.outcome == GroupOutcome.RECOMMENDED for group in self.groups)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> TuneReport:
+        if not isinstance(data, dict):
+            raise TuneReportValidationError("tune report must be a JSON object")
+        context = "tune report"
+
+        schema_version = str(data.get("schema_version", TUNE_REPORT_SCHEMA_VERSION))
+        if schema_version != TUNE_REPORT_SCHEMA_VERSION:
+            raise TuneReportValidationError(
+                f"unsupported tune report schema_version {schema_version!r}, "
+                f"expected {TUNE_REPORT_SCHEMA_VERSION!r}"
+            )
+
+        policy_raw = _require(data, "policy", context=context)
+        try:
+            policy = TunePolicy.from_dict(policy_raw)
+        except TunePolicyError as exc:
+            raise TuneReportValidationError(
+                f"{context}.policy is invalid: {exc}"
+            ) from exc
+
+        groups_raw = data.get("groups", [])
+        if not isinstance(groups_raw, list):
+            raise TuneReportValidationError(f"{context}.groups must be a list")
+        groups = tuple(GroupReport.from_dict(item) for item in groups_raw)
+
+        excluded_raw = data.get("excluded_runs", [])
+        if not isinstance(excluded_raw, list):
+            raise TuneReportValidationError(f"{context}.excluded_runs must be a list")
+        excluded_runs = tuple(ExcludedRun.from_dict(item) for item in excluded_raw)
+
+        return cls(
+            schema_version=schema_version,
+            generated_at=_require_str(data, "generated_at", context=context),
+            results_dirs=_string_tuple(data, "results_dirs", context=context),
+            policy=policy,
+            groups=groups,
+            excluded_runs=excluded_runs,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> TuneReport:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TuneReportValidationError(
+                f"invalid JSON for tune report: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> TuneReport:
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))

--- a/llmtracefx/optimizer/tune/report_html.py
+++ b/llmtracefx/optimizer/tune/report_html.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import html
 import math
 from collections.abc import Iterable
+from itertools import zip_longest
 from pathlib import PurePosixPath
 
 from ..doctor.speculative import DoctorVerdict
@@ -48,25 +49,48 @@ def _esc(value: object) -> str:
     return html.escape(str(value), quote=True)
 
 
-def _redact_path(raw: str) -> str:
+def _redact_path(raw: str, *, run_id: str | None = None) -> str:
     """Replace a local artifact path with a stable, non-identifying label.
 
-    Every artifact this project ever links to lives under
-    ``<results_dir>/runs/<run_id>/...``; when that shape is recognizable the
-    label keeps the ``runs/<run_id>/<file>`` suffix (identifying which run
-    without leaking the absolute, possibly-home-directory-containing
-    prefix). Otherwise falls back to the final path component.
+    When ``run_id`` is known (the run this path belongs to), the label is
+    built by locating that exact run id as a path segment -- matching the
+    *last* occurrence, in case some unrelated ancestor directory happens to
+    share the run id string -- and keeping only that segment onward (plus
+    one leading ``runs`` segment when the run id is nested directly under
+    one, matching this project's own ``<results_dir>/runs/<run_id>/...``
+    layout). This never depends on guessing which occurrence of a literal
+    ``runs`` directory in the path is the canonical one, so it cannot leak
+    an intervening private project/experiment directory name even when the
+    path happens to contain more than one ``runs`` segment (e.g. because a
+    user's own directory tree is itself named ``runs`` somewhere above the
+    real results directory).
+
+    When no run id is given, or it is not found as an exact path segment,
+    falls back to the last ``runs`` segment (never the first, for the same
+    reason) or, failing that, to the final path component alone -- never
+    preserving any ancestor directory name.
     """
     posix_raw = raw.replace("\\", "/")
-    parts = PurePosixPath(posix_raw).parts
+    parts = tuple(p for p in PurePosixPath(posix_raw).parts if p not in ("/", ""))
+
+    if run_id:
+        matches = [index for index, part in enumerate(parts) if part == run_id]
+        if matches:
+            start = matches[-1]
+            if start > 0 and parts[start - 1] == "runs":
+                start -= 1
+            return "/".join(parts[start:])
+
     if "runs" in parts:
-        return "/".join(parts[parts.index("runs") :])
+        last_runs_index = len(parts) - 1 - parts[::-1].index("runs")
+        return "/".join(parts[last_runs_index:])
+
     name = PurePosixPath(posix_raw).name
     return name or raw
 
 
-def _path_label(raw: str, *, redact_paths: bool) -> str:
-    return raw if not redact_paths else _redact_path(raw)
+def _path_label(raw: str, *, redact_paths: bool, run_id: str | None = None) -> str:
+    return raw if not redact_paths else _redact_path(raw, run_id=run_id)
 
 
 def _fmt_number(value: float | None, *, digits: int = 4) -> str:
@@ -300,10 +324,18 @@ def _render_group_identity(group: GroupReport) -> str:
 def _candidate_evidence(candidate: CandidateReport, *, redact_paths: bool) -> str:
     run_ids = _list_items(candidate.run_ids)
     verification = _list_items(
-        _path_label(p, redact_paths=redact_paths) for p in candidate.verification_paths
+        _path_label(path, redact_paths=redact_paths, run_id=run_id)
+        for path, run_id in zip_longest(
+            candidate.verification_paths, candidate.run_ids, fillvalue=None
+        )
+        if path is not None
     )
     final_records = _list_items(
-        _path_label(p, redact_paths=redact_paths) for p in candidate.final_record_paths
+        _path_label(path, redact_paths=redact_paths, run_id=run_id)
+        for path, run_id in zip_longest(
+            candidate.final_record_paths, candidate.run_ids, fillvalue=None
+        )
+        if path is not None
     )
     return (
         "<details><summary>Source run IDs and artifact paths</summary>"
@@ -314,7 +346,9 @@ def _candidate_evidence(candidate: CandidateReport, *, redact_paths: bool) -> st
     )
 
 
-def _render_recommendation_rationale(group: GroupReport) -> str:
+def _render_recommendation_rationale(
+    group: GroupReport, *, ranked_accepted: tuple[CandidateReport, ...]
+) -> str:
     winner = group.recommended
     assert winner is not None
     parts = [
@@ -322,8 +356,10 @@ def _render_recommendation_rationale(group: GroupReport) -> str:
         f"<code>{_fmt_number(winner.objective_value)}</code>, backed by "
         f"{winner.evidence_count} accepted run(s)."
     ]
-    if len(group.accepted) > 1:
-        runner_up = group.accepted[1]
+    if len(ranked_accepted) > 1:
+        # ``ranked_accepted`` is sorted by rank, never by JSON/source list
+        # order, so index 1 is always the true rank-2 runner-up.
+        runner_up = ranked_accepted[1]
         parts.append(
             "Ranked ahead of runner-up "
             f"<code>{_esc(runner_up.candidate_key.label())}</code> "
@@ -349,7 +385,7 @@ def _render_accepted_table(
         "<th>Evidence</th><th>CV</th></tr>"
     )
     rows: list[str] = []
-    for candidate in accepted:
+    for candidate in sorted(accepted, key=lambda item: item.rank):
         row_class = (
             ' class="recommended-row"' if candidate.rank == recommended_rank else ""
         )
@@ -394,12 +430,18 @@ def _render_rejected(
         reasons = "".join(f"<li>{_esc(reason)}</li>" for reason in candidate.reasons)
         run_ids = _list_items(candidate.run_ids)
         verification = _list_items(
-            _path_label(p, redact_paths=redact_paths)
-            for p in candidate.verification_paths
+            _path_label(path, redact_paths=redact_paths, run_id=run_id)
+            for path, run_id in zip_longest(
+                candidate.verification_paths, candidate.run_ids, fillvalue=None
+            )
+            if path is not None
         )
         final_records = _list_items(
-            _path_label(p, redact_paths=redact_paths)
-            for p in candidate.final_record_paths
+            _path_label(path, redact_paths=redact_paths, run_id=run_id)
+            for path, run_id in zip_longest(
+                candidate.final_record_paths, candidate.run_ids, fillvalue=None
+            )
+            if path is not None
         )
         blocks.append(
             '<div class="panel panel-bad">'
@@ -443,13 +485,19 @@ def _render_group(group: GroupReport, *, redact_paths: bool) -> str:
     parts = [f"<h2>Group: {_esc(group.group_key.label())}</h2>"]
     parts.append(_render_group_identity(group))
 
+    # Rendering must always follow rank order, never whatever order the
+    # source JSON/list happened to be in -- computed once here and reused
+    # by both the recommendation rationale and the accepted table so a
+    # runner-up mention and its table row can never disagree.
+    ranked_accepted = tuple(sorted(group.accepted, key=lambda item: item.rank))
+
     if group.outcome == GroupOutcome.RECOMMENDED and group.recommended is not None:
         winner = group.recommended
         parts.append(
             '<div class="panel panel-good">'
             '<span class="badge badge-recommended">RECOMMENDED</span> '
             f"<strong>{_esc(winner.candidate_key.label())}</strong>"
-            f"<p>{_render_recommendation_rationale(group)}</p>"
+            f"<p>{_render_recommendation_rationale(group, ranked_accepted=ranked_accepted)}</p>"
             "</div>"
         )
     else:
@@ -464,7 +512,7 @@ def _render_group(group: GroupReport, *, redact_paths: bool) -> str:
     parts.append("<h3>Accepted candidate ranking</h3>")
     parts.append(
         _render_accepted_table(
-            group.accepted,
+            ranked_accepted,
             recommended_rank=recommended_rank,
             redact_paths=redact_paths,
         )
@@ -485,7 +533,7 @@ def _render_excluded_runs(report: TuneReport, *, redact_paths: bool) -> str:
     rows = "".join(
         "<tr>"
         f"<td><code>{_esc(run.run_id)}</code></td>"
-        f"<td><code>{_esc(_path_label(run.source_results_dir, redact_paths=redact_paths))}</code></td>"
+        f"<td><code>{_esc(_path_label(run.source_results_dir, redact_paths=redact_paths, run_id=run.run_id))}</code></td>"
         f"<td>{_esc(run.reason)}</td>"
         "</tr>"
         for run in report.excluded_runs

--- a/llmtracefx/optimizer/tune/report_html.py
+++ b/llmtracefx/optimizer/tune/report_html.py
@@ -1,0 +1,551 @@
+"""Self-contained static HTML rendering of a ``TuneReport``.
+
+This is a product surface over already-computed tuning evidence, not a new
+scoring system: every value rendered here comes straight from a validated
+``TuneReport`` (see ``report.py``) and nothing is recomputed or guessed. The
+output is a single portable HTML file with inline CSS and no JavaScript, so
+it opens directly in a browser (no server, no CDN, no network access) and is
+safe to attach to an issue, a chat message, or a shared drive.
+
+Two properties are deliberate:
+
+* **Determinism.** Rendering the same ``TuneReport`` twice produces
+  byte-identical HTML (the only "clock" in the document is the report's own
+  ``generated_at``, never a new timestamp taken at render time).
+* **Escaping.** Every string that ultimately originates from the report JSON
+  (policy name, reasons, model/candidate identity fields, artifact paths,
+  run ids) is passed through ``html.escape`` before being written into the
+  document, so a maliciously crafted report cannot inject markup or script
+  content into the rendered page.
+
+Local artifact paths are privacy-sensitive (they usually live under a
+user's home directory) and are redacted to a stable, non-identifying label
+by default -- see ``_redact_path``. Pass ``redact_paths=False`` to include
+the full path as plain text instead.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from collections.abc import Iterable
+from pathlib import PurePosixPath
+
+from ..doctor.speculative import DoctorVerdict
+from .policy import TuneConstraints, TunePolicy
+from .report import (
+    BaselineComparison,
+    CandidateReport,
+    GroupOutcome,
+    GroupReport,
+    RejectedCandidateReport,
+    TuneReport,
+)
+
+
+def _esc(value: object) -> str:
+    """HTML-escape any value by way of its string representation."""
+    return html.escape(str(value), quote=True)
+
+
+def _redact_path(raw: str) -> str:
+    """Replace a local artifact path with a stable, non-identifying label.
+
+    Every artifact this project ever links to lives under
+    ``<results_dir>/runs/<run_id>/...``; when that shape is recognizable the
+    label keeps the ``runs/<run_id>/<file>`` suffix (identifying which run
+    without leaking the absolute, possibly-home-directory-containing
+    prefix). Otherwise falls back to the final path component.
+    """
+    posix_raw = raw.replace("\\", "/")
+    parts = PurePosixPath(posix_raw).parts
+    if "runs" in parts:
+        return "/".join(parts[parts.index("runs") :])
+    name = PurePosixPath(posix_raw).name
+    return name or raw
+
+
+def _path_label(raw: str, *, redact_paths: bool) -> str:
+    return raw if not redact_paths else _redact_path(raw)
+
+
+def _fmt_number(value: float | None, *, digits: int = 4) -> str:
+    if value is None:
+        return "n/a"
+    if not math.isfinite(value):
+        # Defense in depth: TuneReport.from_dict already rejects non-finite
+        # values before a report ever reaches this renderer.
+        return "n/a"
+    return f"{value:.{digits}f}"
+
+
+def _fmt_bytes_mb(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value / (1024 * 1024):.1f} MB"
+
+
+def _fmt_percent(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def _list_items(values: Iterable[str]) -> str:
+    items = [f"<li><code>{_esc(value)}</code></li>" for value in values]
+    return (
+        '<ul class="evidence-list">' + "".join(items) + "</ul>"
+        if items
+        else '<p class="muted">none</p>'
+    )
+
+
+def _style() -> str:
+    return """
+    :root {
+      color-scheme: light;
+      --ink: #1b1f24;
+      --muted: #5b6472;
+      --border: #d7dce2;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --accent-good: #1a7f37;
+      --accent-good-bg: #ddf4e4;
+      --accent-bad: #b91c1c;
+      --accent-bad-bg: #fde2e1;
+      --accent-warn: #9a6700;
+      --accent-warn-bg: #fff3cd;
+    }
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg-alt);
+      margin: 0;
+      padding: 2rem 1rem 4rem;
+      line-height: 1.5;
+    }
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 2rem;
+    }
+    h1 { font-size: 1.6rem; margin-top: 0; }
+    h2 { font-size: 1.25rem; border-bottom: 1px solid var(--border); padding-bottom: 0.35rem; margin-top: 2.5rem; }
+    h3 { font-size: 1.05rem; margin-bottom: 0.4rem; }
+    h4 { font-size: 0.95rem; margin-bottom: 0.3rem; }
+    p { margin: 0.4rem 0; }
+    .muted { color: var(--muted); }
+    code { background: var(--bg-alt); padding: 0.05rem 0.3rem; border-radius: 4px; font-size: 0.85em; }
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+    .summary-card {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 0.8rem;
+      background: var(--bg-alt);
+      text-align: center;
+    }
+    .summary-card .value { font-size: 1.4rem; font-weight: 600; display: block; }
+    .summary-card .label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.03em; }
+    table { border-collapse: collapse; width: 100%; margin: 0.75rem 0; font-size: 0.9rem; }
+    th, td { border: 1px solid var(--border); padding: 0.4rem 0.55rem; text-align: left; vertical-align: top; }
+    th { background: var(--bg-alt); font-weight: 600; }
+    tr.recommended-row { background: var(--accent-good-bg); }
+    dl.identity { display: grid; grid-template-columns: max-content 1fr; gap: 0.15rem 1rem; margin: 0.5rem 0 1rem; }
+    dl.identity dt { color: var(--muted); font-size: 0.85rem; }
+    dl.identity dd { margin: 0; font-size: 0.9rem; }
+    .badge { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 999px; font-size: 0.78rem; font-weight: 600; }
+    .badge-recommended { background: var(--accent-good-bg); color: var(--accent-good); }
+    .badge-inconclusive { background: var(--accent-warn-bg); color: var(--accent-warn); }
+    .panel { border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; margin: 0.75rem 0; }
+    .panel-good { border-color: var(--accent-good); background: var(--accent-good-bg); }
+    .panel-warn { border-color: var(--accent-warn); background: var(--accent-warn-bg); }
+    .panel-bad { border-color: var(--accent-bad); background: var(--accent-bad-bg); }
+    ul.violations { margin: 0.3rem 0 0.6rem 1.1rem; padding: 0; }
+    ul.violations li { color: var(--accent-bad); }
+    ul.evidence-list { margin: 0.2rem 0; padding-left: 1.1rem; font-size: 0.85rem; }
+    details { margin: 0.4rem 0; }
+    details summary { cursor: pointer; color: var(--muted); font-size: 0.85rem; }
+    footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--muted); }
+    @media print {
+      body { background: var(--bg); padding: 0; }
+      main { border: none; padding: 0; }
+      details { display: block; }
+      details summary { display: none; }
+    }
+    """.strip()
+
+
+def _render_constraints(constraints: TuneConstraints) -> str:
+    rows: list[tuple[str, str]] = [
+        (
+            "Required row statuses",
+            ", ".join(sorted(status.value for status in constraints.required_statuses)),
+        ),
+        ("Minimum measured repetitions", str(constraints.min_measured_repetitions)),
+    ]
+    if constraints.min_pass_rate is not None:
+        rows.append(("Minimum pass rate", _fmt_percent(constraints.min_pass_rate)))
+    if constraints.min_quality_score is not None:
+        rows.append(
+            (
+                "Minimum quality score",
+                f"{_fmt_number(constraints.min_quality_score, digits=3)} "
+                f"({_esc(constraints.required_quality_metric)})",
+            )
+        )
+    if constraints.max_peak_memory_bytes is not None:
+        rows.append(
+            ("Maximum peak memory", _fmt_bytes_mb(constraints.max_peak_memory_bytes))
+        )
+    if constraints.max_total_latency_ms is not None:
+        rows.append(
+            (
+                "Maximum total latency",
+                f"{_fmt_number(constraints.max_total_latency_ms, digits=2)} ms",
+            )
+        )
+    if constraints.max_coefficient_of_variation is not None:
+        rows.append(
+            (
+                "Maximum coefficient of variation",
+                _fmt_number(constraints.max_coefficient_of_variation, digits=3),
+            )
+        )
+    if constraints.allowed_provenances is not None:
+        rows.append(
+            (
+                "Allowed metric provenances",
+                ", ".join(sorted(p.value for p in constraints.allowed_provenances)),
+            )
+        )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    return f'<dl class="identity">{items}</dl>'
+
+
+def _render_policy(policy: TunePolicy) -> str:
+    name = policy.name or "(unnamed policy)"
+    description = (
+        f'<p class="muted">{_esc(policy.description)}</p>' if policy.description else ""
+    )
+    return (
+        f"<h2>Policy</h2>"
+        f"<p><strong>{_esc(name)}</strong></p>"
+        f"{description}"
+        f"<p>Objective: <code>{_esc(policy.objective.value)}</code></p>"
+        f"<h3>Constraints</h3>"
+        f"{_render_constraints(policy.constraints)}"
+    )
+
+
+def _summary_card(value: int, label: str) -> str:
+    return (
+        '<div class="summary-card">'
+        f'<span class="value">{value}</span>'
+        f'<span class="label">{_esc(label)}</span>'
+        "</div>"
+    )
+
+
+def _render_summary(report: TuneReport) -> str:
+    recommended_groups = sum(
+        1 for group in report.groups if group.outcome == GroupOutcome.RECOMMENDED
+    )
+    inconclusive_groups = sum(
+        1 for group in report.groups if group.outcome == GroupOutcome.INCONCLUSIVE
+    )
+    accepted_total = sum(len(group.accepted) for group in report.groups)
+    rejected_total = sum(len(group.rejected) for group in report.groups)
+    cards = "".join(
+        [
+            _summary_card(len(report.groups), "Groups"),
+            _summary_card(recommended_groups, "Recommendations"),
+            _summary_card(inconclusive_groups, "Inconclusive"),
+            _summary_card(accepted_total, "Accepted candidates"),
+            _summary_card(rejected_total, "Rejected candidates"),
+            _summary_card(len(report.excluded_runs), "Excluded runs"),
+        ]
+    )
+    return f'<h2>Summary</h2><div class="summary-grid">{cards}</div>'
+
+
+def _render_group_identity(group: GroupReport) -> str:
+    key = group.group_key
+    rows = [
+        ("Workload", f"{key.workload_id} (v{key.workload_version})"),
+        ("Context tier", key.context_tier),
+        (
+            "Model",
+            key.model_id + (f" / {key.model_family}" if key.model_family else ""),
+        ),
+        ("Accelerator", key.accelerator or "unknown"),
+        (
+            "Runtime / backend",
+            f"{key.runtime_name} / {key.runtime_backend or 'unknown'}",
+        ),
+        ("Prompt hash", key.workload_prompt_hash),
+    ]
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    return f'<dl class="identity">{items}</dl>'
+
+
+def _candidate_evidence(candidate: CandidateReport, *, redact_paths: bool) -> str:
+    run_ids = _list_items(candidate.run_ids)
+    verification = _list_items(
+        _path_label(p, redact_paths=redact_paths) for p in candidate.verification_paths
+    )
+    final_records = _list_items(
+        _path_label(p, redact_paths=redact_paths) for p in candidate.final_record_paths
+    )
+    return (
+        "<details><summary>Source run IDs and artifact paths</summary>"
+        f"<h4>Run IDs</h4>{run_ids}"
+        f"<h4>Verification artifacts</h4>{verification}"
+        f"<h4>Final record artifacts</h4>{final_records}"
+        "</details>"
+    )
+
+
+def _render_recommendation_rationale(group: GroupReport) -> str:
+    winner = group.recommended
+    assert winner is not None
+    parts = [
+        f"Won on objective <code>{_esc(winner.objective_name)}</code> with value "
+        f"<code>{_fmt_number(winner.objective_value)}</code>, backed by "
+        f"{winner.evidence_count} accepted run(s)."
+    ]
+    if len(group.accepted) > 1:
+        runner_up = group.accepted[1]
+        parts.append(
+            "Ranked ahead of runner-up "
+            f"<code>{_esc(runner_up.candidate_key.label())}</code> "
+            f"(objective value <code>{_fmt_number(runner_up.objective_value)}</code>)."
+        )
+    else:
+        parts.append("It was the only candidate accepted in this group.")
+    return " ".join(parts)
+
+
+def _render_accepted_table(
+    accepted: tuple[CandidateReport, ...],
+    *,
+    recommended_rank: int | None,
+    redact_paths: bool,
+) -> str:
+    if not accepted:
+        return '<p class="muted">No accepted candidates.</p>'
+    header = (
+        "<tr><th>Rank</th><th>Candidate</th><th>Objective</th>"
+        "<th>Mean latency (ms)</th><th>Pass rate</th>"
+        "<th>Quality metric / score</th><th>Peak memory (mean / max)</th>"
+        "<th>Evidence</th><th>CV</th></tr>"
+    )
+    rows: list[str] = []
+    for candidate in accepted:
+        row_class = (
+            ' class="recommended-row"' if candidate.rank == recommended_rank else ""
+        )
+        quality = (
+            f"{_esc(candidate.quality_metric)} = "
+            f"{_fmt_number(candidate.mean_quality_score, digits=3)}"
+            if candidate.quality_metric is not None
+            else "n/a"
+        )
+        memory = (
+            f"{_fmt_bytes_mb(candidate.mean_peak_memory_bytes)} / "
+            f"{_fmt_bytes_mb(candidate.max_peak_memory_bytes)}"
+        )
+        rows.append(
+            f"<tr{row_class}>"
+            f"<td>#{candidate.rank}</td>"
+            f"<td>{_esc(candidate.candidate_key.label())}</td>"
+            f"<td>{_fmt_number(candidate.objective_value)}</td>"
+            f"<td>{_fmt_number(candidate.mean_total_latency_ms, digits=2)}</td>"
+            f"<td>{_fmt_percent(candidate.pass_rate)}</td>"
+            f"<td>{quality}</td>"
+            f"<td>{memory}</td>"
+            f"<td>{candidate.evidence_count}</td>"
+            f"<td>{_fmt_number(candidate.coefficient_of_variation, digits=4)}</td>"
+            "</tr>"
+        )
+        rows.append(
+            f'<tr{row_class}><td colspan="9">'
+            + _candidate_evidence(candidate, redact_paths=redact_paths)
+            + "</td></tr>"
+        )
+    return f"<table>{header}{''.join(rows)}</table>"
+
+
+def _render_rejected(
+    rejected: tuple[RejectedCandidateReport, ...], *, redact_paths: bool
+) -> str:
+    if not rejected:
+        return ""
+    blocks = []
+    for candidate in rejected:
+        reasons = "".join(f"<li>{_esc(reason)}</li>" for reason in candidate.reasons)
+        run_ids = _list_items(candidate.run_ids)
+        verification = _list_items(
+            _path_label(p, redact_paths=redact_paths)
+            for p in candidate.verification_paths
+        )
+        final_records = _list_items(
+            _path_label(p, redact_paths=redact_paths)
+            for p in candidate.final_record_paths
+        )
+        blocks.append(
+            '<div class="panel panel-bad">'
+            f"<strong>{_esc(candidate.candidate_key.label())}</strong>"
+            f'<ul class="violations">{reasons}</ul>'
+            "<details><summary>Source run IDs and artifact paths</summary>"
+            f"<h4>Run IDs</h4>{run_ids}"
+            f"<h4>Verification artifacts</h4>{verification}"
+            f"<h4>Final record artifacts</h4>{final_records}"
+            "</details>"
+            "</div>"
+        )
+    return f"<h3>Rejected candidates ({len(rejected)})</h3>" + "".join(blocks)
+
+
+def _render_baseline_comparison(comparison: BaselineComparison) -> str:
+    verdict = comparison.report.verdict
+    panel_class = {
+        DoctorVerdict.IMPROVEMENT: "panel-good",
+        DoctorVerdict.REGRESSION: "panel-bad",
+        DoctorVerdict.NO_SIGNIFICANT_DIFFERENCE: "panel-warn",
+        DoctorVerdict.INCONCLUSIVE: "panel-warn",
+    }.get(verdict, "panel-warn")
+    baseline_ms = _fmt_number(comparison.report.baseline_mean_total_ms, digits=2)
+    speculative_ms = _fmt_number(comparison.report.speculative_mean_total_ms, digits=2)
+    delta_ms = _fmt_number(comparison.report.delta_ms, digits=2)
+    delta_pct = _fmt_number(comparison.report.delta_pct, digits=2)
+    return (
+        f'<h3>Speculative baseline comparison</h3><div class="panel {panel_class}">'
+        f"<p><strong>Verdict:</strong> {_esc(verdict.value)} &mdash; {_esc(comparison.report.reason)}</p>"
+        f"<p>Baseline <code>{_esc(comparison.baseline_candidate_key.label())}</code>: "
+        f"{baseline_ms} ms mean total (run(s): {_esc(', '.join(comparison.report.baseline_run_ids))})</p>"
+        f"<p>Speculative <code>{_esc(comparison.speculative_candidate_key.label())}</code>: "
+        f"{speculative_ms} ms mean total (run(s): {_esc(', '.join(comparison.report.speculative_run_ids))})</p>"
+        f"<p>Delta: {delta_ms} ms ({delta_pct}%)</p>"
+        "</div>"
+    )
+
+
+def _render_group(group: GroupReport, *, redact_paths: bool) -> str:
+    parts = [f"<h2>Group: {_esc(group.group_key.label())}</h2>"]
+    parts.append(_render_group_identity(group))
+
+    if group.outcome == GroupOutcome.RECOMMENDED and group.recommended is not None:
+        winner = group.recommended
+        parts.append(
+            '<div class="panel panel-good">'
+            '<span class="badge badge-recommended">RECOMMENDED</span> '
+            f"<strong>{_esc(winner.candidate_key.label())}</strong>"
+            f"<p>{_render_recommendation_rationale(group)}</p>"
+            "</div>"
+        )
+    else:
+        parts.append(
+            '<div class="panel panel-warn">'
+            '<span class="badge badge-inconclusive">INCONCLUSIVE</span> '
+            f"<p>{_esc(group.inconclusive_reason or 'no reason recorded')}</p>"
+            "</div>"
+        )
+
+    recommended_rank = group.recommended.rank if group.recommended is not None else None
+    parts.append("<h3>Accepted candidate ranking</h3>")
+    parts.append(
+        _render_accepted_table(
+            group.accepted,
+            recommended_rank=recommended_rank,
+            redact_paths=redact_paths,
+        )
+    )
+
+    parts.append(_render_rejected(group.rejected, redact_paths=redact_paths))
+
+    if group.baseline_comparison is not None:
+        parts.append(_render_baseline_comparison(group.baseline_comparison))
+
+    return "".join(parts)
+
+
+def _render_excluded_runs(report: TuneReport, *, redact_paths: bool) -> str:
+    if not report.excluded_runs:
+        return ""
+    header = "<tr><th>Run ID</th><th>Source results directory</th><th>Reason</th></tr>"
+    rows = "".join(
+        "<tr>"
+        f"<td><code>{_esc(run.run_id)}</code></td>"
+        f"<td><code>{_esc(_path_label(run.source_results_dir, redact_paths=redact_paths))}</code></td>"
+        f"<td>{_esc(run.reason)}</td>"
+        "</tr>"
+        for run in report.excluded_runs
+    )
+    return (
+        f"<h2>Excluded runs ({len(report.excluded_runs)})</h2>"
+        '<p class="muted">Runs whose evidence could not be trusted at all '
+        "(never even considered as a rejected candidate).</p>"
+        f"<table>{header}{rows}</table>"
+    )
+
+
+def render_tune_report_html(report: TuneReport, *, redact_paths: bool = True) -> str:
+    """Render ``report`` as a single, self-contained, portable HTML page.
+
+    ``redact_paths`` (default ``True``) replaces every local artifact path
+    (results directories, verification/final-record paths) with a stable,
+    non-identifying label instead of the full path, so the report is safe
+    to share without leaking a user's home directory layout. Pass
+    ``redact_paths=False`` to include full paths as plain text.
+    """
+    title = report.policy.name or "Tune report"
+    body_parts = [
+        "<main>",
+        f"<h1>{_esc(title)}</h1>",
+        f'<p class="muted">Generated {_esc(report.generated_at)} '
+        f"&middot; schema version {_esc(report.schema_version)}</p>",
+        "<h2>Source results directories</h2>",
+        _list_items(
+            _path_label(d, redact_paths=redact_paths) for d in report.results_dirs
+        ),
+        _render_policy(report.policy),
+        _render_summary(report),
+        _render_excluded_runs(report, redact_paths=redact_paths),
+    ]
+
+    if not report.groups:
+        body_parts.append(
+            '<p class="muted">No comparable groups were found in the '
+            "provided results directories.</p>"
+        )
+    else:
+        for group in report.groups:
+            body_parts.append(_render_group(group, redact_paths=redact_paths))
+
+    body_parts.append(
+        "<footer>Generated by <code>llmtracefx-optimizer tune-report</code>. "
+        "This file is static HTML with no external references; open it "
+        "directly in a browser.</footer>"
+    )
+    body_parts.append("</main>")
+
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{_esc(title)} &mdash; LLMTraceFX tune report</title>\n"
+        f"<style>{_style()}</style>\n"
+        "</head>\n"
+        "<body>\n" + "".join(body_parts) + "\n</body>\n</html>\n"
+    )

--- a/tests/optimizer/test_tune_report_cli.py
+++ b/tests/optimizer/test_tune_report_cli.py
@@ -84,6 +84,24 @@ def test_tune_report_cli_exits_1_on_malformed_json(tmp_path):
     assert exit_code == 1
 
 
+def test_tune_report_cli_exits_1_on_non_utf8_input_without_traceback(tmp_path, capsys):
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_bytes(b"\xff\xfe")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(bad_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+    assert "Could not read tune report" in capsys.readouterr().err
+
+
 def test_tune_report_cli_exits_1_on_invalid_report_schema(tmp_path):
     bad_path = tmp_path / "bad_report.json"
     bad_path.write_text(json.dumps({"not": "a tune report"}), encoding="utf-8")

--- a/tests/optimizer/test_tune_report_cli.py
+++ b/tests/optimizer/test_tune_report_cli.py
@@ -101,6 +101,125 @@ def test_tune_report_cli_exits_1_on_invalid_report_schema(tmp_path):
     assert exit_code == 1
 
 
+def test_tune_report_cli_wraps_nested_validation_errors_without_traceback(
+    tmp_path, capsys
+):
+    report_path = _write_report(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    del payload["groups"][0]["group_key"]["workload_id"]
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(report_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "Invalid tune report" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_tune_report_cli_wraps_excluded_run_errors_without_traceback(tmp_path, capsys):
+    report_path = _write_report(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["excluded_runs"] = [{"run_id": "r1", "reason": "bad"}]
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(report_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "Invalid tune report" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_tune_report_cli_wraps_malformed_candidate_key_without_traceback(
+    tmp_path, capsys
+):
+    report_path = _write_report(tmp_path)
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    payload["groups"][0]["accepted"][0]["candidate_key"]["speculative_enabled"] = "yes"
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(report_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "Invalid tune report" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_tune_report_cli_wraps_malformed_baseline_comparison_identity_without_traceback(
+    tmp_path, capsys
+):
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "r-ar1", speculative_enabled=False, total_ms=2000.0)
+    write_run(results_dir, "r-ar2", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        results_dir,
+        "r-spec1",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    write_run(
+        results_dir,
+        "r-spec2",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    policy = TunePolicy(objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS)
+    report = tune(results_dirs=(results_dir,), policy=policy)
+    assert report.groups[0].baseline_comparison is not None
+
+    payload = report.to_dict()
+    payload["groups"][0]["baseline_comparison"]["baseline_candidate_key"][
+        "speculative_enabled"
+    ] = "yes"
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(report_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "Invalid tune report" in stderr
+    assert "Traceback" not in stderr
+
+
 def test_tune_report_cli_redacts_paths_by_default(tmp_path):
     report_path = _write_report(tmp_path)
     output_path = tmp_path / "report.html"

--- a/tests/optimizer/test_tune_report_cli.py
+++ b/tests/optimizer/test_tune_report_cli.py
@@ -1,0 +1,213 @@
+"""Tests for the `llmtracefx-optimizer tune-report` CLI subcommand.
+
+Covers file errors, exit codes, atomic output, the full synthetic example
+render, and that no network/CDN references leak into the generated HTML.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer.cli import build_parser
+from llmtracefx.optimizer.tune.policy import TuneObjective, TunePolicy
+from llmtracefx.optimizer.tune.tuner import tune
+
+EXAMPLE_REPORT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "optimizer"
+    / "tune-report-example.json"
+)
+
+
+def _run_cli(argv):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+def _write_report(tmp_path: Path) -> Path:
+    write_run(tmp_path / "results", "r1", total_ms=1000.0)
+    policy = TunePolicy(objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS)
+    report = tune(results_dirs=(tmp_path / "results",), policy=policy)
+    report_path = tmp_path / "report.json"
+    report_path.write_text(report.to_json(), encoding="utf-8")
+    return report_path
+
+
+def test_tune_report_cli_writes_html_and_exits_0(tmp_path):
+    report_path = _write_report(tmp_path)
+    output_path = tmp_path / "report.html"
+
+    exit_code = _run_cli(
+        ["tune-report", "--input", str(report_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    assert output_path.exists()
+    content = output_path.read_text(encoding="utf-8")
+    assert content.startswith("<!DOCTYPE html>")
+    assert "RECOMMENDED" in content
+
+
+def test_tune_report_cli_exits_1_on_missing_input_file(tmp_path):
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(tmp_path / "does-not-exist.json"),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_report_cli_exits_1_on_malformed_json(tmp_path):
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text("not json", encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(bad_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_report_cli_exits_1_on_invalid_report_schema(tmp_path):
+    bad_path = tmp_path / "bad_report.json"
+    bad_path.write_text(json.dumps({"not": "a tune report"}), encoding="utf-8")
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(bad_path),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+
+    assert exit_code == 1
+
+
+def test_tune_report_cli_redacts_paths_by_default(tmp_path):
+    report_path = _write_report(tmp_path)
+    output_path = tmp_path / "report.html"
+
+    _run_cli(["tune-report", "--input", str(report_path), "--output", str(output_path)])
+
+    content = output_path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in content
+
+
+def test_tune_report_cli_include_paths_flag_includes_full_paths(tmp_path):
+    report_path = _write_report(tmp_path)
+    output_path = tmp_path / "report.html"
+
+    _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(report_path),
+            "--output",
+            str(output_path),
+            "--include-paths",
+        ]
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+    assert str(tmp_path / "results") in content
+
+
+def test_tune_report_cli_writes_output_atomically(tmp_path):
+    report_path = _write_report(tmp_path)
+    output_path = tmp_path / "report.html"
+    output_path.write_text("stale content", encoding="utf-8")
+
+    exit_code = _run_cli(
+        ["tune-report", "--input", str(report_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    content = output_path.read_text(encoding="utf-8")
+    assert "stale content" not in content
+    # No leftover temp file from the atomic-write helper.
+    leftovers = [p for p in output_path.parent.iterdir() if p.name.startswith(".")]
+    assert leftovers == []
+
+
+def test_tune_report_cli_renders_full_synthetic_example(tmp_path):
+    output_path = tmp_path / "example.html"
+
+    exit_code = _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(EXAMPLE_REPORT_PATH),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    content = output_path.read_text(encoding="utf-8")
+    assert "RECOMMENDED" in content
+    assert "Rejected candidates" in content
+    assert "Speculative baseline comparison" in content
+    assert "Excluded runs" in content
+    assert "SYNTHETIC" in content
+
+
+def test_tune_report_cli_output_has_no_network_or_cdn_references(tmp_path):
+    output_path = tmp_path / "example.html"
+
+    _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(EXAMPLE_REPORT_PATH),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+    for token in ("http://", "https://", "<script", "cdn."):
+        assert token not in content
+
+
+def test_tune_report_cli_output_is_deterministic(tmp_path):
+    output_path_a = tmp_path / "a.html"
+    output_path_b = tmp_path / "b.html"
+
+    _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(EXAMPLE_REPORT_PATH),
+            "--output",
+            str(output_path_a),
+        ]
+    )
+    _run_cli(
+        [
+            "tune-report",
+            "--input",
+            str(EXAMPLE_REPORT_PATH),
+            "--output",
+            str(output_path_b),
+        ]
+    )
+
+    assert output_path_a.read_text() == output_path_b.read_text()

--- a/tests/optimizer/test_tune_report_html.py
+++ b/tests/optimizer/test_tune_report_html.py
@@ -169,6 +169,109 @@ def test_full_paths_included_when_redact_paths_is_false(tmp_path):
     assert str(tmp_path) in html_out
 
 
+def test_redaction_uses_last_runs_boundary_without_leaking_parent_segments():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    raw = (
+        "/Users/alice/runs/private-project/secret-experiment/"
+        "runs/run77/verification.json"
+    )
+
+    redacted = _redact_path(raw)
+
+    assert redacted == "runs/run77/verification.json"
+    assert "private-project" not in redacted
+    assert "secret-experiment" not in redacted
+
+
+def test_redaction_handles_windows_paths_and_escapes_labels():
+    from llmtracefx.optimizer.tune.report_html import _esc, _redact_path
+
+    raw = r"C:\Users\alice\runs\private\runs\run<script>\final_record.json"
+    redacted = _redact_path(raw)
+
+    assert redacted == "runs/run<script>/final_record.json"
+    assert "<script>" not in _esc(redacted)
+
+
+def test_redaction_falls_back_to_basename_without_runs_segment():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    assert _redact_path("/Users/alice/private/report.json") == "report.json"
+
+
+def test_redaction_prefers_known_run_id_over_ambiguous_runs_segments():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    # Two "runs" segments upstream of the real one; the run id itself is
+    # the ground truth and must never leave "secret-project"/"other-runs"
+    # in the label, regardless of which "runs" segment is "last".
+    raw = (
+        "/Users/alice/secret-project/runs/other-runs/results/"
+        "runs/run77/final_record.json"
+    )
+
+    assert _redact_path(raw, run_id="run77") == "runs/run77/final_record.json"
+
+
+def test_redaction_with_run_id_and_no_runs_segment_still_bounds_at_run_id():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    raw = "/Users/alice/private-project/custom-layout/run77/final_record.json"
+
+    assert _redact_path(raw, run_id="run77") == "run77/final_record.json"
+
+
+def test_redaction_with_unmatched_run_id_falls_back_to_last_runs_segment():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    raw = "/Users/alice/secret-project/runs/run1/final_record.json"
+
+    # The run id passed does not appear in the path at all (e.g. a
+    # verification/final-record path recorded under a different run than
+    # the one it is being rendered alongside); must not silently include
+    # the ancestor "secret-project" segment.
+    assert _redact_path(raw, run_id="some-other-run") == "runs/run1/final_record.json"
+
+
+def test_redaction_handles_traversal_like_segments_without_leaking_ancestors():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    raw = "/Users/alice/../alice/secret/runs/run1/final_record.json"
+
+    assert _redact_path(raw) == "runs/run1/final_record.json"
+    assert _redact_path(raw, run_id="run1") == "runs/run1/final_record.json"
+
+
+def test_redaction_windows_path_with_run_id():
+    from llmtracefx.optimizer.tune.report_html import _redact_path
+
+    raw = r"C:\Users\alice\secret-project\results\runs\run1\final_record.json"
+
+    assert _redact_path(raw, run_id="run1") == "runs/run1/final_record.json"
+
+
+def test_candidate_evidence_paths_use_run_id_aware_redaction(tmp_path):
+    write_run(
+        tmp_path / "secret-project" / "runs" / "duplicate-runs-dir",
+        "r1",
+        total_ms=1000.0,
+    )
+    report = tune(
+        results_dirs=(tmp_path / "secret-project" / "runs" / "duplicate-runs-dir",),
+        policy=LATENCY_POLICY,
+    )
+
+    html_out = render_tune_report_html(report)
+
+    # The ancestor "secret-project" directory name must never leak, whether
+    # via the results-directory listing or via any per-candidate artifact
+    # path (which is redacted using the known run id and always bounds at
+    # the "runs" segment immediately preceding it).
+    assert "secret-project" not in html_out
+    assert "runs/r1/final_record.json" in html_out
+
+
 # --- Section coverage --------------------------------------------------------
 
 

--- a/tests/optimizer/test_tune_report_html.py
+++ b/tests/optimizer/test_tune_report_html.py
@@ -1,0 +1,305 @@
+"""Tests for the `tune-report` HTML renderer: escaping, path redaction,
+section coverage, and determinism.
+
+Builds real ``TuneReport`` instances via ``tune()`` over fake
+``workloads run``-shaped artifact trees (see ``_tune_fixtures.write_run``)
+so the rendered HTML reflects the same shape a real report would have.
+"""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer.tune.policy import TuneObjective, TunePolicy
+from llmtracefx.optimizer.tune.report_html import render_tune_report_html
+from llmtracefx.optimizer.tune.tuner import tune
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+LATENCY_POLICY = TunePolicy(objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS)
+
+
+# --- Determinism ---------------------------------------------------------
+
+
+def test_render_is_byte_identical_across_calls(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    first = render_tune_report_html(report)
+    second = render_tune_report_html(report)
+
+    assert first == second
+
+
+def test_render_has_no_new_timestamp_beyond_generated_at(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert report.generated_at in html_out
+
+
+# --- Escaping / security --------------------------------------------------
+
+
+def test_script_tag_in_policy_name_is_escaped(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        name="<script>alert(1)</script>",
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    html_out = render_tune_report_html(report)
+
+    assert "<script>alert(1)</script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_script_tag_in_policy_description_is_escaped(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    policy = TunePolicy(
+        objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        description="<img src=x onerror=alert(1)>",
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    html_out = render_tune_report_html(report)
+
+    assert "<img src=x onerror=alert(1)>" not in html_out
+    assert "&lt;img" in html_out
+
+
+def test_script_tag_in_model_id_is_escaped(tmp_path):
+    write_run(
+        tmp_path, "r1", total_ms=1000.0, model_id="<script>alert('model')</script>"
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "<script>alert('model')</script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_script_tag_in_rejection_reason_is_escaped(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(
+        tmp_path,
+        "r2",
+        total_ms=1500.0,
+        seed=1,
+        quality_metric="<script>alert('metric')</script>",
+    )
+    policy = TunePolicy.from_dict(
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {"required_quality_metric": "trusted_metric"},
+        }
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    html_out = render_tune_report_html(report)
+
+    assert report.groups[0].rejected
+    assert any(
+        "<script>" in reason
+        for rejected in report.groups[0].rejected
+        for reason in rejected.reasons
+    )
+    assert "<script>" not in html_out
+
+
+def test_script_tag_in_excluded_run_id_is_escaped(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "run-<script>-excluded", corrupt_final_record=True)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert report.excluded_runs
+    assert "<script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_script_tag_in_candidate_run_id_is_escaped(tmp_path):
+    write_run(tmp_path, "run-<script>-runid", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "<script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_no_network_or_cdn_references_in_output(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    for token in ("http://", "https://", "<script", "cdn.", "googleapis"):
+        assert token not in html_out
+
+
+# --- Path redaction --------------------------------------------------------
+
+
+def test_paths_are_redacted_by_default(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report, redact_paths=True)
+
+    assert str(tmp_path) not in html_out
+    assert "runs/r1/final_record.json" in html_out
+
+
+def test_full_paths_included_when_redact_paths_is_false(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report, redact_paths=False)
+
+    assert str(tmp_path) in html_out
+
+
+# --- Section coverage --------------------------------------------------------
+
+
+def test_recommended_section_shows_winner_and_rationale(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "RECOMMENDED" in html_out
+    assert "runner-up" in html_out
+
+
+def test_inconclusive_section_shows_reason(tmp_path):
+    write_run(tmp_path, "r1", status=RowStatus.FAILED, success=False)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "INCONCLUSIVE" in html_out
+    assert report.groups[0].inconclusive_reason in html_out
+
+
+def test_rejected_section_lists_every_violation(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(
+        tmp_path,
+        "r2",
+        total_ms=10_000.0,
+        seed=1,
+        peak_bytes=25 * 1024**3,
+        status=RowStatus.FAILED,
+        success=False,
+    )
+    policy = TunePolicy.from_dict(
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {
+                "max_total_latency_ms": 1000,
+                "max_peak_memory_bytes": 20 * 1024**3,
+            },
+        }
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+
+    html_out = render_tune_report_html(report)
+
+    rejected = report.groups[0].rejected[0]
+    assert len(rejected.reasons) > 1
+    for reason in rejected.reasons:
+        assert html.escape(reason, quote=True) in html_out
+
+
+def test_excluded_runs_section_shows_reason(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", corrupt_final_record=True)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "Excluded runs" in html_out
+    assert report.excluded_runs[0].run_id in html_out
+
+
+def test_baseline_comparison_section_present_when_speculative_wins(tmp_path):
+    write_run(tmp_path, "r-ar1", speculative_enabled=False, total_ms=2000.0)
+    write_run(tmp_path, "r-ar2", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        tmp_path,
+        "r-spec1",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    write_run(
+        tmp_path,
+        "r-spec2",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "Speculative baseline comparison" in html_out
+    assert "improvement" in html_out
+
+
+def test_accepted_candidate_ranking_includes_required_metrics(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "Mean latency (ms)" in html_out
+    assert "Pass rate" in html_out
+    assert "Quality metric" in html_out
+    assert "Peak memory" in html_out
+    assert "Evidence" in html_out
+    assert "CV" in html_out
+
+
+def test_no_comparable_groups_message_when_no_groups(tmp_path):
+    results_dir = tmp_path / "empty"
+    results_dir.mkdir()
+    report = tune(results_dirs=(results_dir,), policy=LATENCY_POLICY)
+
+    html_out = render_tune_report_html(report)
+
+    assert "No comparable groups" in html_out
+
+
+def test_example_fixture_renders_every_section():
+    example_path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "optimizer"
+        / "tune-report-example.json"
+    )
+    from llmtracefx.optimizer.tune.report import TuneReport
+
+    report = TuneReport.read_json(example_path)
+
+    html_out = render_tune_report_html(report)
+
+    assert "RECOMMENDED" in html_out
+    assert "Rejected candidates" in html_out
+    assert "Speculative baseline comparison" in html_out
+    assert "Excluded runs" in html_out
+    assert "SYNTHETIC" in html_out

--- a/tests/optimizer/test_tune_report_schema.py
+++ b/tests/optimizer/test_tune_report_schema.py
@@ -1,0 +1,463 @@
+"""Tests for typed ``TuneReport`` loading: ``from_dict``/``from_json``/
+``read_json`` round-tripping, malformed-input rejection, and non-finite
+numeric rejection.
+
+Uses the real ``tune()`` engine over fake ``workloads run``-shaped
+artifact trees (see ``_tune_fixtures.write_run``) to build realistic
+reports to round-trip, plus hand-built minimal payloads to exercise
+specific validation failures in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer.tune.identity import (
+    CandidateKey,
+    GroupKey,
+    IdentityValidationError,
+)
+from llmtracefx.optimizer.tune.loader import ExcludedRun, TuneInputError
+from llmtracefx.optimizer.tune.policy import TuneObjective, TunePolicy
+from llmtracefx.optimizer.tune.report import TuneReport, TuneReportValidationError
+from llmtracefx.optimizer.tune.tuner import tune
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+LATENCY_POLICY = TunePolicy(objective=TuneObjective.MIN_MEAN_TOTAL_LATENCY_MS)
+
+
+def _minimal_report_dict() -> dict:
+    return {
+        "schema_version": "1",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "results_dirs": ["results"],
+        "policy": {"objective": "min_mean_total_latency_ms"},
+        "groups": [],
+        "excluded_runs": [],
+    }
+
+
+# --- Round-tripping ----------------------------------------------------------
+
+
+def test_recommended_report_round_trips_through_json(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    payload = report.to_json()
+    roundtripped = TuneReport.from_json(payload)
+
+    assert roundtripped.to_json() == payload
+    assert roundtripped.groups[0].recommended is not None
+    assert roundtripped.groups[0].recommended.candidate_key.label() == (
+        report.groups[0].recommended.candidate_key.label()
+    )
+
+
+def test_inconclusive_report_round_trips_through_json(tmp_path):
+    write_run(tmp_path, "r1", status=RowStatus.FAILED, success=False)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    payload = report.to_json()
+    roundtripped = TuneReport.from_json(payload)
+
+    assert roundtripped.to_json() == payload
+    assert roundtripped.groups[0].recommended is None
+    assert roundtripped.groups[0].inconclusive_reason is not None
+
+
+def test_report_with_excluded_runs_round_trips(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", corrupt_final_record=True)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert report.excluded_runs
+
+    payload = report.to_json()
+    roundtripped = TuneReport.from_json(payload)
+
+    assert roundtripped.to_json() == payload
+    assert len(roundtripped.excluded_runs) == len(report.excluded_runs)
+
+
+def test_report_with_baseline_comparison_round_trips(tmp_path):
+    write_run(tmp_path, "r-ar1", speculative_enabled=False, total_ms=2000.0)
+    write_run(tmp_path, "r-ar2", speculative_enabled=False, total_ms=2000.0)
+    write_run(
+        tmp_path,
+        "r-spec1",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    write_run(
+        tmp_path,
+        "r-spec2",
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_depth=2,
+        total_ms=1000.0,
+    )
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    assert report.groups[0].baseline_comparison is not None
+
+    payload = report.to_json()
+    roundtripped = TuneReport.from_json(payload)
+
+    assert roundtripped.to_json() == payload
+    assert roundtripped.groups[0].baseline_comparison is not None
+    assert (
+        roundtripped.groups[0].baseline_comparison.report.verdict
+        == report.groups[0].baseline_comparison.report.verdict
+    )
+
+
+def test_report_with_rejected_candidates_round_trips(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(
+        tmp_path,
+        "r2",
+        total_ms=1500.0,
+        seed=1,
+        peak_bytes=25 * 1024**3,
+    )
+    policy = TunePolicy.from_dict(
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {"max_peak_memory_bytes": 20 * 1024**3},
+        }
+    )
+    report = tune(results_dirs=(tmp_path,), policy=policy)
+    assert report.groups[0].rejected
+
+    payload = report.to_json()
+    roundtripped = TuneReport.from_json(payload)
+
+    assert roundtripped.to_json() == payload
+    assert roundtripped.groups[0].rejected[0].reasons
+
+
+def test_read_json_reads_from_file(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    report_path = tmp_path / "report.json"
+    report_path.write_text(report.to_json(), encoding="utf-8")
+
+    loaded = TuneReport.read_json(report_path)
+
+    assert loaded.to_json() == report.to_json()
+
+
+# --- Malformed input rejection ------------------------------------------------
+
+
+def test_from_dict_rejects_non_dict():
+    with pytest.raises(TuneReportValidationError, match="JSON object"):
+        TuneReport.from_dict(["not", "a", "dict"])
+
+
+def test_from_dict_rejects_missing_required_field():
+    data = _minimal_report_dict()
+    del data["policy"]
+    with pytest.raises(TuneReportValidationError, match="policy"):
+        TuneReport.from_dict(data)
+
+
+def test_from_dict_rejects_invalid_policy():
+    data = _minimal_report_dict()
+    data["policy"] = {"objective": "not-a-real-objective"}
+    with pytest.raises(TuneReportValidationError, match="policy"):
+        TuneReport.from_dict(data)
+
+
+def test_from_dict_rejects_unsupported_schema_version():
+    data = _minimal_report_dict()
+    data["schema_version"] = "999"
+    with pytest.raises(TuneReportValidationError, match="schema_version"):
+        TuneReport.from_dict(data)
+
+
+def test_from_json_rejects_invalid_json():
+    with pytest.raises(TuneReportValidationError, match="invalid JSON"):
+        TuneReport.from_json("not json")
+
+
+def test_from_dict_rejects_group_missing_group_key():
+    data = _minimal_report_dict()
+    data["groups"] = [{"outcome": "inconclusive", "inconclusive_reason": "x"}]
+    with pytest.raises(TuneReportValidationError, match="group_key"):
+        TuneReport.from_dict(data)
+
+
+def test_from_dict_rejects_recommended_outcome_without_recommended_candidate():
+    data = _minimal_report_dict()
+    data["groups"] = [
+        {
+            "group_key": {
+                "workload_id": "w",
+                "workload_version": "1",
+                "context_tier": "2k",
+                "model_id": "m",
+                "model_family": None,
+                "accelerator": None,
+                "runtime_name": "r",
+                "runtime_backend": None,
+                "workload_prompt_hash": "h",
+            },
+            "outcome": "recommended",
+            "recommended": None,
+            "accepted": [],
+            "rejected": [],
+            "inconclusive_reason": None,
+            "baseline_comparison": None,
+        }
+    ]
+    with pytest.raises(TuneReportValidationError, match="recommended"):
+        TuneReport.from_dict(data)
+
+
+def test_from_dict_rejects_inconclusive_outcome_without_reason():
+    data = _minimal_report_dict()
+    data["groups"] = [
+        {
+            "group_key": {
+                "workload_id": "w",
+                "workload_version": "1",
+                "context_tier": "2k",
+                "model_id": "m",
+                "model_family": None,
+                "accelerator": None,
+                "runtime_name": "r",
+                "runtime_backend": None,
+                "workload_prompt_hash": "h",
+            },
+            "outcome": "inconclusive",
+            "recommended": None,
+            "accepted": [],
+            "rejected": [],
+            "inconclusive_reason": None,
+            "baseline_comparison": None,
+        }
+    ]
+    with pytest.raises(TuneReportValidationError, match="inconclusive_reason"):
+        TuneReport.from_dict(data)
+
+
+def test_from_dict_rejects_excluded_run_missing_field():
+    data = _minimal_report_dict()
+    data["excluded_runs"] = [{"run_id": "r1", "reason": "x"}]
+    with pytest.raises(Exception, match="source_results_dir"):
+        TuneReport.from_dict(data)
+
+
+# --- Non-finite numeric rejection ---------------------------------------------
+
+
+def test_from_json_rejects_non_finite_objective_value():
+    data = _minimal_report_dict()
+    data["groups"] = [
+        {
+            "group_key": {
+                "workload_id": "w",
+                "workload_version": "1",
+                "context_tier": "2k",
+                "model_id": "m",
+                "model_family": None,
+                "accelerator": None,
+                "runtime_name": "r",
+                "runtime_backend": None,
+                "workload_prompt_hash": "h",
+            },
+            "outcome": "recommended",
+            "recommended": {
+                "candidate_key": {
+                    "decode_mode": "autoregressive",
+                    "runtime_version": None,
+                    "quantization": None,
+                    "model_revision": None,
+                    "tokenizer_revision": None,
+                    "speculative_enabled": False,
+                    "speculative_method": None,
+                    "speculative_configured_depth": None,
+                    "seed": None,
+                    "config_hash": None,
+                },
+                "rank": 1,
+                "run_ids": ["r1"],
+                "verification_paths": [],
+                "final_record_paths": [],
+                "evidence_count": 1,
+                "objective_name": "min_mean_total_latency_ms",
+                "objective_value": math.nan,
+                "mean_total_latency_ms": None,
+                "stdev_total_latency_ms": None,
+                "coefficient_of_variation": None,
+                "correct_cases_per_minute": None,
+                "pass_rate": None,
+                "mean_quality_score": None,
+                "quality_metric": None,
+                "mean_peak_memory_bytes": None,
+                "max_peak_memory_bytes": None,
+            },
+            "accepted": [],
+            "rejected": [],
+            "inconclusive_reason": None,
+            "baseline_comparison": None,
+        }
+    ]
+    payload = json.dumps(data, allow_nan=True)
+    assert "NaN" in payload
+
+    with pytest.raises(TuneReportValidationError, match="finite"):
+        TuneReport.from_json(payload)
+
+
+def test_from_dict_rejects_infinite_peak_memory():
+    data = _minimal_report_dict()
+    data["groups"] = [
+        {
+            "group_key": {
+                "workload_id": "w",
+                "workload_version": "1",
+                "context_tier": "2k",
+                "model_id": "m",
+                "model_family": None,
+                "accelerator": None,
+                "runtime_name": "r",
+                "runtime_backend": None,
+                "workload_prompt_hash": "h",
+            },
+            "outcome": "recommended",
+            "recommended": {
+                "candidate_key": {
+                    "decode_mode": "autoregressive",
+                    "runtime_version": None,
+                    "quantization": None,
+                    "model_revision": None,
+                    "tokenizer_revision": None,
+                    "speculative_enabled": False,
+                    "speculative_method": None,
+                    "speculative_configured_depth": None,
+                    "seed": None,
+                    "config_hash": None,
+                },
+                "rank": 1,
+                "run_ids": ["r1"],
+                "verification_paths": [],
+                "final_record_paths": [],
+                "evidence_count": 1,
+                "objective_name": "min_mean_total_latency_ms",
+                "objective_value": 1.0,
+                "mean_total_latency_ms": None,
+                "stdev_total_latency_ms": None,
+                "coefficient_of_variation": None,
+                "correct_cases_per_minute": None,
+                "pass_rate": None,
+                "mean_quality_score": None,
+                "quality_metric": None,
+                "mean_peak_memory_bytes": float("inf"),
+                "max_peak_memory_bytes": None,
+            },
+            "accepted": [],
+            "rejected": [],
+            "inconclusive_reason": None,
+            "baseline_comparison": None,
+        }
+    ]
+    with pytest.raises(TuneReportValidationError, match="finite"):
+        TuneReport.from_dict(data)
+
+
+# --- GroupKey / CandidateKey / ExcludedRun from_dict --------------------------
+
+
+def test_group_key_round_trips_through_dict():
+    key = GroupKey(
+        workload_id="w",
+        workload_version="1",
+        context_tier="2k",
+        model_id="m",
+        model_family="fam",
+        accelerator="acc",
+        runtime_name="rt",
+        runtime_backend="Metal",
+        workload_prompt_hash="sha256:abc",
+    )
+    assert GroupKey.from_dict(key.to_dict()) == key
+
+
+def test_group_key_from_dict_rejects_non_dict():
+    with pytest.raises(IdentityValidationError, match="JSON object"):
+        GroupKey.from_dict("not a dict")
+
+
+def test_group_key_from_dict_rejects_missing_field():
+    data = {
+        "workload_id": "w",
+        "workload_version": "1",
+        "context_tier": "2k",
+        "model_id": "m",
+        "model_family": None,
+        "accelerator": None,
+        "runtime_name": "rt",
+        "runtime_backend": None,
+        # workload_prompt_hash omitted
+    }
+    with pytest.raises(IdentityValidationError, match="workload_prompt_hash"):
+        GroupKey.from_dict(data)
+
+
+def test_candidate_key_round_trips_through_dict():
+    key = CandidateKey(
+        decode_mode="autoregressive",
+        runtime_version="1.0",
+        quantization="Q4",
+        model_revision=None,
+        tokenizer_revision=None,
+        speculative_enabled=True,
+        speculative_method="draft-model",
+        speculative_configured_depth=2,
+        seed=0,
+        config_hash="hash",
+    )
+    assert CandidateKey.from_dict(key.to_dict()) == key
+
+
+def test_candidate_key_from_dict_rejects_non_boolean_speculative_enabled():
+    data = CandidateKey(
+        decode_mode="autoregressive",
+        runtime_version=None,
+        quantization=None,
+        model_revision=None,
+        tokenizer_revision=None,
+        speculative_enabled=False,
+        speculative_method=None,
+        speculative_configured_depth=None,
+        seed=None,
+        config_hash=None,
+    ).to_dict()
+    data["speculative_enabled"] = "yes"
+    with pytest.raises(IdentityValidationError, match="speculative_enabled"):
+        CandidateKey.from_dict(data)
+
+
+def test_excluded_run_round_trips_through_dict():
+    excluded = ExcludedRun(run_id="r1", source_results_dir="results", reason="unusable")
+    assert ExcludedRun.from_dict(excluded.to_dict()) == excluded
+
+
+def test_excluded_run_from_dict_rejects_missing_field():
+    with pytest.raises(TuneInputError, match="reason"):
+        ExcludedRun.from_dict({"run_id": "r1", "source_results_dir": "results"})
+
+
+def test_excluded_run_from_dict_rejects_non_string_field():
+    with pytest.raises(TuneInputError, match="run_id"):
+        ExcludedRun.from_dict(
+            {"run_id": 123, "source_results_dir": "results", "reason": "x"}
+        )

--- a/tests/optimizer/test_tune_report_schema.py
+++ b/tests/optimizer/test_tune_report_schema.py
@@ -251,8 +251,80 @@ def test_from_dict_rejects_inconclusive_outcome_without_reason():
 def test_from_dict_rejects_excluded_run_missing_field():
     data = _minimal_report_dict()
     data["excluded_runs"] = [{"run_id": "r1", "reason": "x"}]
-    with pytest.raises(Exception, match="source_results_dir"):
+    with pytest.raises(TuneReportValidationError, match="source_results_dir"):
         TuneReport.from_dict(data)
+
+
+def test_group_report_canonicalizes_accepted_candidates_by_rank(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    data = report.to_dict()
+    data["groups"][0]["accepted"].reverse()
+
+    loaded = TuneReport.from_dict(data)
+
+    assert tuple(item.rank for item in loaded.groups[0].accepted) == (1, 2)
+    assert loaded.groups[0].recommended == loaded.groups[0].accepted[0]
+
+
+def test_group_report_canonicalization_round_trips_idempotently(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    data = report.to_dict()
+    data["groups"][0]["accepted"].reverse()
+
+    once = TuneReport.from_dict(data)
+    twice = TuneReport.from_json(once.to_json())
+
+    assert once.to_json() == twice.to_json()
+    assert tuple(item.rank for item in twice.groups[0].accepted) == (1, 2)
+
+
+@pytest.mark.parametrize("ranks", [(1, 1), (1, 3), (2, 3)])
+def test_group_report_rejects_invalid_accepted_rank_sequence(tmp_path, ranks):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    data = report.to_dict()
+    for item, rank in zip(data["groups"][0]["accepted"], ranks, strict=True):
+        item["rank"] = rank
+
+    with pytest.raises(TuneReportValidationError, match="ranks"):
+        TuneReport.from_dict(data)
+
+
+def test_group_report_rejects_recommended_candidate_that_is_not_rank_one(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    write_run(tmp_path, "r2", total_ms=2000.0, seed=1)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    data = report.to_dict()
+    data["groups"][0]["recommended"] = data["groups"][0]["accepted"][1]
+
+    with pytest.raises(TuneReportValidationError, match="rank 1"):
+        TuneReport.from_dict(data)
+
+
+def test_nested_identity_errors_are_wrapped_as_report_validation_errors(tmp_path):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+    for mutation in ("group", "candidate", "baseline"):
+        data = report.to_dict()
+        if mutation == "group":
+            del data["groups"][0]["group_key"]["workload_id"]
+        elif mutation == "candidate":
+            data["groups"][0]["accepted"][0]["candidate_key"][
+                "speculative_enabled"
+            ] = "yes"
+        else:
+            comparison = data["groups"][0]["baseline_comparison"]
+            if comparison is None:
+                continue
+            comparison["baseline_candidate_key"]["speculative_enabled"] = "yes"
+        with pytest.raises(TuneReportValidationError):
+            TuneReport.from_dict(data)
 
 
 # --- Non-finite numeric rejection ---------------------------------------------

--- a/tests/optimizer/test_tune_report_schema.py
+++ b/tests/optimizer/test_tune_report_schema.py
@@ -327,6 +327,57 @@ def test_nested_identity_errors_are_wrapped_as_report_validation_errors(tmp_path
             TuneReport.from_dict(data)
 
 
+def test_group_report_rejects_inconclusive_group_with_recommended_candidate(
+    tmp_path,
+):
+    write_run(tmp_path, "r1", total_ms=1000.0)
+    report = tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+    data = report.to_dict()
+    group = data["groups"][0]
+    group["outcome"] = "inconclusive"
+    group["inconclusive_reason"] = "forced contradiction"
+
+    with pytest.raises(TuneReportValidationError, match="recommended is set"):
+        TuneReport.from_dict(data)
+
+
+def _report_with_baseline_comparison(tmp_path):
+    write_run(tmp_path, "r-ar1", speculative_enabled=False, total_ms=2000.0)
+    write_run(tmp_path, "r-ar2", speculative_enabled=False, total_ms=2000.0)
+    for run_id in ("r-spec1", "r-spec2"):
+        write_run(
+            tmp_path,
+            run_id,
+            speculative_enabled=True,
+            speculative_method="draft-model",
+            speculative_depth=2,
+            total_ms=1000.0,
+        )
+    return tune(results_dirs=(tmp_path,), policy=LATENCY_POLICY)
+
+
+def test_group_report_rejects_inconclusive_group_with_baseline_comparison(
+    tmp_path,
+):
+    data = _report_with_baseline_comparison(tmp_path).to_dict()
+    group = data["groups"][0]
+    group["outcome"] = "inconclusive"
+    group["inconclusive_reason"] = "forced contradiction"
+    group["recommended"] = None
+
+    with pytest.raises(TuneReportValidationError, match="baseline_comparison"):
+        TuneReport.from_dict(data)
+
+
+def test_group_report_rejects_baseline_comparison_for_wrong_winner(tmp_path):
+    data = _report_with_baseline_comparison(tmp_path).to_dict()
+    comparison = data["groups"][0]["baseline_comparison"]
+    comparison["speculative_candidate_key"] = comparison["baseline_candidate_key"]
+
+    with pytest.raises(TuneReportValidationError, match="recommended candidate"):
+        TuneReport.from_dict(data)
+
+
 # --- Non-finite numeric rejection ---------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds `llmtracefx-optimizer tune-report`, which renders a validated tune report as one self-contained HTML file.

The viewer exposes recommendations, constraints, accepted evidence, rejected candidates, inconclusive groups, baseline comparisons, and excluded runs without executing models or changing tuning decisions.

```bash
llmtracefx-optimizer tune-report \
  --input artifacts/qwen38-tune-report.json \
  --output artifacts/qwen38-tune-report.html
```

## Rendering flow

```mermaid
flowchart LR
    J[Tune report JSON] --> V[Strict typed validation]
    V --> R[Privacy-safe HTML renderer]
    R --> H[Atomic offline HTML file]
```

## Report validation

Typed loaders reject:

- malformed report, group, candidate, comparison, and excluded-run objects
- unknown enums
- non-finite numeric values
- duplicate, missing, or non-contiguous accepted ranks
- a recommended candidate that is not the rank 1 accepted candidate
- inconclusive groups that still contain a recommendation or baseline comparison
- a baseline comparison whose speculative candidate is not the recommendation

Nested identity and evidence-loader failures are normalized to `TuneReportValidationError`, so malformed input produces a clean CLI error instead of an internal traceback.

## Privacy and security

Artifact paths are redacted by default. Labels use the known run ID when available, then the last `runs` boundary, then only the basename. Parent project names, usernames, and home-directory segments are not retained.

`--include-paths` explicitly opts into full local paths.

Every string originating from report JSON is HTML-escaped. The output contains inline CSS only, with no JavaScript, CDN, or network reference.

## Contents

The static report includes:

- policy objective and constraints
- recommendation and inconclusive counts
- comparable group identity
- recommended candidate and rationale
- rank-ordered accepted candidates
- rejected candidates with every violation
- quality, latency, memory, evidence count, and variation
- speculative baseline comparison
- excluded runs and source evidence labels

## Determinism

The same semantic report produces byte-identical HTML. Rendering adds no timestamp; it uses the tune report's existing `generated_at` value.

## Example

`examples/optimizer/tune-report-example.json` is synthetic and explicitly labeled non-benchmark data. It exercises every report section without making a claim about Qwen3.8 performance.

## Validation

- 591 tests pass
- Ruff passes on optimizer and optimizer tests
- Black and isort checks pass on changed surfaces
- mypy passes on the optimizer package

Tests cover typed round trips, malformed nested objects, report invariants, non-finite values, HTML injection, POSIX and Windows path shapes, multiple `runs` segments, default redaction, explicit path inclusion, deterministic output, atomic writes, non-UTF-8 input, and CLI errors without tracebacks.

## Scope boundaries

This PR does not add model execution, GPU dependencies, model downloads, new tuning logic, native counters, native MTP, or a Streamlit redesign.