### PR TITLE
Add end-to-end optimize command composing run, tune, and report

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,29 @@ share without leaking a machine's home-directory layout; pass
 `examples/optimizer/tune-report-example.json` for a synthetic (non-benchmark)
 example report that exercises every section of the viewer.
 
+The `optimize` command composes workload execution, verification, tuning, and
+optional HTML rendering without changing any phase's underlying logic:
+
+```bash
+uv run llmtracefx-optimizer optimize \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --model-path /existing/local/mlx/model \
+  --results artifacts/qwen3.8-run \
+  --policy examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json \
+  --report-json artifacts/qwen3.8-tune-report.json \
+  --report-html artifacts/qwen3.8-tune-report.html \
+  --mode autoregressive \
+  --context-tier 2k
+```
+
+It writes `optimize_summary.json` under `--results` by default. This atomic,
+machine-readable summary records every phase, row count, recommendation, and
+the final exit status. `--dry-run` writes the same summary with planning counts
+and marks execution, verification, tuning, and rendering as `not_run`; it does
+not load MLX or write tune reports. Existing unrelated runs under `--results`
+are excluded from tuning, while repeatable `--extra-results` paths explicitly
+opt additional evidence into the comparison.
+
 **Not yet included** (tracked as a follow-up PR): a genuinely capable
 native-MTP runtime adapter (none exists upstream today), native Metal/CUDA
 performance-counter ingestion, CUDA/vLLM/SGLang collectors, and any actual

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import sys
 from dataclasses import asdict
+from itertools import combinations
 from pathlib import Path
 
 from .collectors._shared import atomic_write_text
@@ -84,6 +85,7 @@ from .workloads.matrix import (
 )
 from .workloads.schema import ContextTier, WorkloadCategory, WorkloadSchemaError
 from .workloads.verify import (
+    RowPlan,
     RowSelection,
     RowStatus,
     RunBinding,
@@ -499,7 +501,6 @@ def _cmd_workloads_run(args: argparse.Namespace) -> int:
         if not plans:
             print("No matrix rows matched the selection filters", file=sys.stderr)
             return 1
-
         for plan in plans:
             label = (
                 "UNSUPPORTED"
@@ -587,7 +588,7 @@ def _cmd_workloads_summarize(args: argparse.Namespace) -> int:
 def _cmd_tune(args: argparse.Namespace) -> int:
     try:
         policy = TunePolicy.from_file(args.policy)
-    except TunePolicyError as exc:
+    except (OSError, UnicodeError, TunePolicyError) as exc:
         print(f"Invalid tune policy: {exc}", file=sys.stderr)
         return 1
 
@@ -665,6 +666,118 @@ def _combine_exit_codes(*codes: int) -> int:
     return max(codes, key=_exit_code_severity)
 
 
+def _resolve_optimize_paths(args: argparse.Namespace) -> dict[str, Path | None]:
+    output_dir = Path(args.results).expanduser().resolve(strict=False)
+    return {
+        "matrix": Path(args.matrix).expanduser().resolve(strict=False),
+        "policy": Path(args.policy).expanduser().resolve(strict=False),
+        "report-json": (
+            Path(args.report_json).expanduser().resolve(strict=False)
+            if args.report_json
+            else None
+        ),
+        "report-html": (
+            Path(args.report_html).expanduser().resolve(strict=False)
+            if args.report_html
+            else None
+        ),
+        "summary-json": (
+            Path(args.summary_json).expanduser().resolve(strict=False)
+            if args.summary_json
+            else output_dir / "optimize_summary.json"
+        ),
+        "results": output_dir,
+    }
+
+
+def _filesystem_is_case_insensitive(path: Path) -> bool:
+    """Detect case folding read-only using the nearest existing ancestor."""
+    probe = path
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    while probe != probe.parent:
+        name = probe.name
+        for index, character in enumerate(name):
+            if not character.isalpha():
+                continue
+            swapped = character.swapcase()
+            if swapped == character:
+                continue
+            alias = probe.with_name(name[:index] + swapped + name[index + 1 :])
+            try:
+                return alias.exists() and alias.samefile(probe)
+            except OSError:
+                return False
+        probe = probe.parent
+    return False
+
+
+def _paths_alias(left: Path, right: Path) -> bool:
+    left = left.expanduser().resolve(strict=False)
+    right = right.expanduser().resolve(strict=False)
+    if left == right:
+        return True
+    if left.exists() and right.exists():
+        try:
+            if left.samefile(right):
+                return True
+        except OSError:
+            pass
+    return str(left).casefold() == str(
+        right
+    ).casefold() and _filesystem_is_case_insensitive(left)
+
+
+def _validate_optimize_paths(paths: dict[str, Path | None]) -> str | None:
+    """Reject aliases that could overwrite optimize inputs or artifacts."""
+    configured: list[tuple[str, Path]] = []
+    for label in ("matrix", "policy", "report-json", "report-html", "summary-json"):
+        path = paths[label]
+        if path is not None:
+            configured.append((label, path))
+    for (left_label, left), (right_label, right) in combinations(configured, 2):
+        if _paths_alias(left, right):
+            return (
+                "optimize paths must be distinct; "
+                f"{left_label} and {right_label} alias {left}"
+            )
+    return None
+
+
+def _validate_optimize_plan_paths(
+    paths: dict[str, Path | None], plans: tuple[RowPlan, ...]
+) -> str | None:
+    """Prevent optimize inputs/outputs from aliasing selected-row artifacts."""
+    configured = [
+        (label, path)
+        for label in (
+            "matrix",
+            "policy",
+            "report-json",
+            "report-html",
+            "summary-json",
+        )
+        if (path := paths[label]) is not None
+    ]
+    for plan in plans:
+        artifacts = (
+            ("prompt", plan.prompt_path),
+            ("verification", plan.verification_path),
+            ("final record", plan.final_record_path),
+            ("collector record", plan.collection_dir / "record.json"),
+            ("response", plan.collection_dir / "response.txt"),
+            ("environment", plan.collection_dir / "environment.json"),
+        )
+        for label, path in configured:
+            for artifact_label, artifact_path in artifacts:
+                if _paths_alias(path, artifact_path):
+                    return (
+                        f"optimize {label} path aliases selected run "
+                        f"{plan.entry.run_id!r} {artifact_label} artifact: {path}"
+                    )
+    return None
+
+
 def _cmd_optimize(args: argparse.Namespace) -> int:
     """Compose row execution, offline tuning, and report rendering.
 
@@ -674,7 +787,22 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
     subcommands do; nothing here duplicates their collection, evaluation,
     tuning, or rendering logic.
     """
-    matrix_path = Path(args.matrix)
+    paths = _resolve_optimize_paths(args)
+    path_error = _validate_optimize_paths(paths)
+    if path_error is not None:
+        print(path_error, file=sys.stderr)
+        return 1
+
+    matrix_path = paths["matrix"]
+    policy_path = paths["policy"]
+    output_dir = paths["results"]
+    report_json_path = paths["report-json"]
+    report_html_path = paths["report-html"]
+    summary_path = paths["summary-json"]
+    assert matrix_path is not None
+    assert policy_path is not None
+    assert output_dir is not None
+    assert summary_path is not None
     try:
         manifest = MatrixManifest.read_json(matrix_path)
     except (OSError, MatrixSchemaError) as exc:
@@ -682,14 +810,13 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        policy = TunePolicy.from_file(args.policy)
-    except TunePolicyError as exc:
+        policy = TunePolicy.from_file(policy_path)
+    except (OSError, UnicodeError, TunePolicyError) as exc:
         print(f"Invalid tune policy: {exc}", file=sys.stderr)
         return 1
 
     selection = _row_selection_from_args(args)
     manifest_dir = matrix_path.parent
-    output_dir = Path(args.results)
 
     if args.dry_run:
         plans = plan_selected_rows(
@@ -701,6 +828,10 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         )
         if not plans:
             print("No matrix rows matched the selection filters", file=sys.stderr)
+            return 1
+        plan_path_error = _validate_optimize_plan_paths(paths, plans)
+        if plan_path_error is not None:
+            print(plan_path_error, file=sys.stderr)
             return 1
 
         for plan in plans:
@@ -728,19 +859,72 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
             f"{unsupported} unsupported"
         )
         print(
-            f"Planned tune policy objective: {policy.objective.value} ({args.policy})"
+            f"Planned tune policy objective: {policy.objective.value} ({policy_path})"
         )
-        if args.report_json:
-            print(f"Planned tune report JSON: {args.report_json}")
-        if args.report_html:
-            print(f"Planned tune report HTML: {args.report_html}")
+        if report_json_path is not None:
+            print(f"Planned tune report JSON: {report_json_path}")
+        if report_html_path is not None:
+            print(f"Planned tune report HTML: {report_html_path}")
+        exit_code = 0 if blocked == 0 else 2
+        overall_status = (
+            OverallStatus.SUCCESS if exit_code == 0 else OverallStatus.INCONCLUSIVE
+        )
+        planned_detail = (
+            f"{len(plans)} row(s) selected, {blocked} blocked, "
+            f"{unsupported} unsupported"
+        )
+        summary = OptimizeSummary(
+            schema_version=OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+            generated_at=utc_now_iso(),
+            dry_run=True,
+            matrix_path=str(matrix_path),
+            results_dir=str(output_dir),
+            extra_results_dirs=tuple(args.extra_results or ()),
+            policy_path=str(policy_path),
+            report_json_path=(
+                str(report_json_path) if report_json_path is not None else None
+            ),
+            report_html_path=(
+                str(report_html_path) if report_html_path is not None else None
+            ),
+            phases=(
+                PhaseReport(
+                    name=PhaseName.PLANNED,
+                    status=PhaseStatus.OK,
+                    detail=planned_detail,
+                ),
+                PhaseReport(name=PhaseName.EXECUTED, status=PhaseStatus.NOT_RUN),
+                PhaseReport(name=PhaseName.VERIFIED, status=PhaseStatus.NOT_RUN),
+                PhaseReport(name=PhaseName.TUNED, status=PhaseStatus.NOT_RUN),
+                PhaseReport(name=PhaseName.RENDERED, status=PhaseStatus.NOT_RUN),
+            ),
+            row_counts=RowStatusCounts(
+                total=len(plans),
+                ready=sum(1 for plan in plans if plan.ready and not plan.unsupported),
+                blocked=blocked,
+                unsupported=unsupported,
+            ),
+            recommendations=(),
+            overall_status=overall_status,
+            exit_code=exit_code,
+        )
+        try:
+            atomic_write_text(summary_path, summary.to_json() + "\n")
+            OptimizeSummary.read_json(summary_path)
+        except (OSError, OptimizeSummaryValidationError) as exc:
+            print(
+                f"Failed to write/validate orchestration summary: {exc}",
+                file=sys.stderr,
+            )
+            return 1
         print(
             "No model was loaded or downloaded, no results were tuned, and "
-            "no report was written (--dry-run)"
+            "no tune report was written (--dry-run)"
         )
-        return 0 if blocked == 0 else 2
+        print(f"Dry-run orchestration summary written to {summary_path}")
+        return exit_code
 
-    if not args.report_json:
+    if report_json_path is None:
         print("--report-json is required unless --dry-run is set", file=sys.stderr)
         return 1
     if not args.model_path:
@@ -758,6 +942,21 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         )
     except VerifyError as exc:
         print(f"Invalid model path binding: {exc}", file=sys.stderr)
+        return 1
+
+    plans = plan_selected_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        output_dir=output_dir,
+        selection=selection,
+        binding=binding,
+    )
+    if not plans:
+        print("No matrix rows matched the selection filters", file=sys.stderr)
+        return 1
+    plan_path_error = _validate_optimize_plan_paths(paths, plans)
+    if plan_path_error is not None:
+        print(plan_path_error, file=sys.stderr)
         return 1
 
     results = run_selected_rows(
@@ -781,6 +980,11 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
 
     counts = RowStatusCounts(
         total=len(results),
+        ready=sum(
+            1
+            for result in results
+            if result.verification.status != RowStatus.UNSUPPORTED
+        ),
         completed=sum(
             1 for r in results if r.verification.status == RowStatus.COMPLETED
         ),
@@ -817,7 +1021,11 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
     tune_report: TuneReport | None = None
     tune_detail: str | None = None
     try:
-        tune_report = tune(results_dirs=results_dirs, policy=policy)
+        tune_report = tune(
+            results_dirs=results_dirs,
+            policy=policy,
+            primary_run_ids=frozenset(result.entry.run_id for result in results),
+        )
     except TuneInputError as exc:
         tune_detail = str(exc)
         print(f"Invalid tuning input: {tune_detail}", file=sys.stderr)
@@ -856,9 +1064,6 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
 
     rendered_status = PhaseStatus.SKIPPED
     rendered_detail: str | None = None
-    report_json_path = Path(args.report_json)
-    report_html_path = Path(args.report_html) if args.report_html else None
-
     if tune_report is not None:
         try:
             atomic_write_text(report_json_path, tune_report.to_json() + "\n")
@@ -909,7 +1114,7 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         matrix_path=str(matrix_path),
         results_dir=str(output_dir),
         extra_results_dirs=tuple(str(path) for path in extra_results),
-        policy_path=str(args.policy),
+        policy_path=str(policy_path),
         report_json_path=str(report_json_path),
         report_html_path=str(report_html_path) if report_html_path else None,
         phases=(
@@ -929,11 +1134,6 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         exit_code=exit_code,
     )
 
-    summary_path = (
-        Path(args.summary_json)
-        if args.summary_json
-        else output_dir / "optimize_summary.json"
-    )
     try:
         atomic_write_text(summary_path, summary.to_json() + "\n")
         OptimizeSummary.read_json(summary_path)

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -14,6 +14,10 @@ Subcommands:
                      verified configuration for a workload/hardware target.
     tune-report      Render a `tune` JSON report as a self-contained, portable
                      HTML file for offline inspection (no Streamlit needed).
+    optimize         End-to-end: execute selected matrix rows, tune the
+                     resulting evidence, and render the JSON/HTML report,
+                     composing the above primitives without duplicating any
+                     of their logic.
 """
 
 from __future__ import annotations
@@ -39,6 +43,17 @@ from .collectors.native_mtp import (
 )
 from .doctor.speculative import diagnose_speculative_regression
 from .manifest import collect_environment_manifest
+from .optimize_summary import (
+    OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+    OptimizeSummary,
+    OptimizeSummaryValidationError,
+    OverallStatus,
+    PhaseName,
+    PhaseReport,
+    PhaseStatus,
+    RecommendedCandidate,
+    RowStatusCounts,
+)
 from .parsers.llama_cpp import LlamaCppParseError, build_experiment_record
 from .runner import ExperimentRunner, RunnerConfig, RunnerConfigError
 from .schema import (
@@ -53,7 +68,7 @@ from .schema import (
 from .tune.explain import format_report_text
 from .tune.loader import TuneInputError
 from .tune.policy import TunePolicy, TunePolicyError
-from .tune.report import TuneReport, TuneReportValidationError
+from .tune.report import GroupOutcome, TuneReport, TuneReportValidationError
 from .tune.report_html import render_tune_report_html
 from .tune.tuner import tune
 from .workloads.aggregate import summarize_results, write_summary
@@ -632,6 +647,307 @@ def _cmd_tune_report(args: argparse.Namespace) -> int:
     return 0
 
 
+def _exit_code_severity(code: int) -> int:
+    """Rank exit codes so a hard failure always outranks an inconclusive one.
+
+    Mirrors the precedence already implied by every other subcommand in
+    this CLI: ``1`` (invalid input / hard failure) is worse than ``2``
+    (evidence collected but inconclusive), which is worse than ``0``.
+    """
+    if code == 1:
+        return 2
+    if code == 2:
+        return 1
+    return 0
+
+
+def _combine_exit_codes(*codes: int) -> int:
+    return max(codes, key=_exit_code_severity)
+
+
+def _cmd_optimize(args: argparse.Namespace) -> int:
+    """Compose row execution, offline tuning, and report rendering.
+
+    Reuses ``workloads.verify.run_selected_rows``/``plan_selected_rows``,
+    ``tune.tuner.tune``, and ``tune.report_html.render_tune_report_html``
+    exactly as the standalone ``workloads run``/``tune``/``tune-report``
+    subcommands do; nothing here duplicates their collection, evaluation,
+    tuning, or rendering logic.
+    """
+    matrix_path = Path(args.matrix)
+    try:
+        manifest = MatrixManifest.read_json(matrix_path)
+    except (OSError, MatrixSchemaError) as exc:
+        print(f"Failed to load matrix manifest: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        policy = TunePolicy.from_file(args.policy)
+    except TunePolicyError as exc:
+        print(f"Invalid tune policy: {exc}", file=sys.stderr)
+        return 1
+
+    selection = _row_selection_from_args(args)
+    manifest_dir = matrix_path.parent
+    output_dir = Path(args.results)
+
+    if args.dry_run:
+        plans = plan_selected_rows(
+            manifest,
+            manifest_dir=manifest_dir,
+            output_dir=output_dir,
+            selection=selection,
+            binding=_optional_run_binding(args),
+        )
+        if not plans:
+            print("No matrix rows matched the selection filters", file=sys.stderr)
+            return 1
+
+        for plan in plans:
+            label = (
+                "UNSUPPORTED"
+                if plan.unsupported
+                else ("READY" if plan.ready else "BLOCKED")
+            )
+            print(
+                f"[{label}] {plan.entry.run_id} "
+                f"({plan.entry.decode_mode}, {plan.entry.context_tier})"
+            )
+            print(f"    prompt file: {plan.prompt_path}")
+            print(f"    collection dir: {plan.collection_dir}")
+            print(f"    final record: {plan.final_record_path}")
+            if plan.unsupported:
+                print(f"    unsupported reason: {plan.unsupported_reason}")
+            for blocker in plan.blockers:
+                print(f"    blocker: {blocker}")
+
+        blocked = sum(1 for plan in plans if not plan.unsupported and not plan.ready)
+        unsupported = sum(1 for plan in plans if plan.unsupported)
+        print(
+            f"{len(plans)} row(s) selected, {blocked} blocked, "
+            f"{unsupported} unsupported"
+        )
+        print(
+            f"Planned tune policy objective: {policy.objective.value} ({args.policy})"
+        )
+        if args.report_json:
+            print(f"Planned tune report JSON: {args.report_json}")
+        if args.report_html:
+            print(f"Planned tune report HTML: {args.report_html}")
+        print(
+            "No model was loaded or downloaded, no results were tuned, and "
+            "no report was written (--dry-run)"
+        )
+        return 0 if blocked == 0 else 2
+
+    if not args.report_json:
+        print("--report-json is required unless --dry-run is set", file=sys.stderr)
+        return 1
+    if not args.model_path:
+        print("--model-path is required unless --dry-run is set", file=sys.stderr)
+        return 1
+
+    try:
+        binding = RunBinding(
+            target_model_path=Path(args.model_path),
+            draft_model_path=(
+                Path(args.draft_model_path) if args.draft_model_path else None
+            ),
+            seed=args.seed,
+            num_draft_tokens=args.num_draft_tokens,
+        )
+    except VerifyError as exc:
+        print(f"Invalid model path binding: {exc}", file=sys.stderr)
+        return 1
+
+    results = run_selected_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        output_dir=output_dir,
+        selection=selection,
+        binding=binding,
+        resume=not args.no_resume,
+        runtime_factory=MLXLMRuntime,
+    )
+    if not results:
+        print("No matrix rows matched the selection filters", file=sys.stderr)
+        return 1
+
+    for result in results:
+        status = result.verification.status.value.upper()
+        suffix = f": {result.verification.reason}" if result.verification.reason else ""
+        print(f"[{status}] {result.entry.run_id}{suffix}")
+    print(f"Artifacts written to {output_dir}")
+
+    counts = RowStatusCounts(
+        total=len(results),
+        completed=sum(
+            1 for r in results if r.verification.status == RowStatus.COMPLETED
+        ),
+        skipped=sum(1 for r in results if r.verification.status == RowStatus.SKIPPED),
+        failed=sum(1 for r in results if r.verification.status == RowStatus.FAILED),
+        unsupported=sum(
+            1 for r in results if r.verification.status == RowStatus.UNSUPPORTED
+        ),
+        inconclusive=sum(
+            1 for r in results if r.verification.status == RowStatus.INCONCLUSIVE
+        ),
+    )
+
+    if counts.failed:
+        executed_status = PhaseStatus.FAILED
+    elif counts.inconclusive:
+        executed_status = PhaseStatus.INCONCLUSIVE
+    else:
+        executed_status = PhaseStatus.OK
+
+    trustable = counts.completed + counts.skipped
+    if counts.failed:
+        verified_status = PhaseStatus.FAILED
+    elif counts.inconclusive:
+        verified_status = PhaseStatus.INCONCLUSIVE
+    elif trustable == 0:
+        verified_status = PhaseStatus.UNSUPPORTED
+    else:
+        verified_status = PhaseStatus.OK
+
+    extra_results = tuple(Path(path) for path in (args.extra_results or ()))
+    results_dirs = (output_dir, *extra_results)
+
+    tune_report: TuneReport | None = None
+    tune_detail: str | None = None
+    try:
+        tune_report = tune(results_dirs=results_dirs, policy=policy)
+    except TuneInputError as exc:
+        tune_detail = str(exc)
+        print(f"Invalid tuning input: {tune_detail}", file=sys.stderr)
+
+    if tune_report is not None:
+        print(format_report_text(tune_report, verbose=args.explain))
+        if not tune_report.groups:
+            tuned_status = PhaseStatus.FAILED
+            tune_detail = (
+                "no comparable groups were found across the given results "
+                "directories"
+            )
+            print(f"\n{tune_detail}", file=sys.stderr)
+        elif not tune_report.has_recommendation:
+            tuned_status = PhaseStatus.INCONCLUSIVE
+        else:
+            tuned_status = PhaseStatus.OK
+    else:
+        tuned_status = PhaseStatus.FAILED
+
+    recommendations: list[RecommendedCandidate] = []
+    if tune_report is not None:
+        for group in tune_report.groups:
+            if (
+                group.outcome == GroupOutcome.RECOMMENDED
+                and group.recommended is not None
+            ):
+                recommendations.append(
+                    RecommendedCandidate(
+                        group_label=group.group_key.label(),
+                        run_ids=group.recommended.run_ids,
+                        objective_name=group.recommended.objective_name,
+                        objective_value=group.recommended.objective_value,
+                    )
+                )
+
+    rendered_status = PhaseStatus.SKIPPED
+    rendered_detail: str | None = None
+    report_json_path = Path(args.report_json)
+    report_html_path = Path(args.report_html) if args.report_html else None
+
+    if tune_report is not None:
+        try:
+            atomic_write_text(report_json_path, tune_report.to_json() + "\n")
+            TuneReport.read_json(report_json_path)
+        except (OSError, TuneReportValidationError) as exc:
+            rendered_status = PhaseStatus.FAILED
+            rendered_detail = f"failed to write/validate tune report JSON: {exc}"
+            print(rendered_detail, file=sys.stderr)
+        else:
+            print(f"Tune report JSON written to {report_json_path}")
+            rendered_status = PhaseStatus.OK
+
+        if rendered_status == PhaseStatus.OK and report_html_path is not None:
+            try:
+                html_document = render_tune_report_html(
+                    tune_report, redact_paths=not args.include_paths
+                )
+                atomic_write_text(report_html_path, html_document)
+            except OSError as exc:
+                rendered_status = PhaseStatus.FAILED
+                rendered_detail = f"failed to write tune report HTML: {exc}"
+                print(rendered_detail, file=sys.stderr)
+            else:
+                print(f"Tune report HTML written to {report_html_path}")
+    else:
+        rendered_detail = "tuning failed; nothing to render"
+
+    exec_code = 1 if counts.failed else (2 if counts.inconclusive else 0)
+    tune_code = (
+        1
+        if tuned_status == PhaseStatus.FAILED
+        else 2 if tuned_status == PhaseStatus.INCONCLUSIVE else 0
+    )
+    rendered_code = 1 if rendered_status == PhaseStatus.FAILED else 0
+    exit_code = _combine_exit_codes(exec_code, tune_code, rendered_code)
+
+    if exit_code == 0:
+        overall_status = OverallStatus.SUCCESS
+    elif exit_code == 2:
+        overall_status = OverallStatus.INCONCLUSIVE
+    else:
+        overall_status = OverallStatus.FAILED
+
+    summary = OptimizeSummary(
+        schema_version=OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+        generated_at=utc_now_iso(),
+        dry_run=False,
+        matrix_path=str(matrix_path),
+        results_dir=str(output_dir),
+        extra_results_dirs=tuple(str(path) for path in extra_results),
+        policy_path=str(args.policy),
+        report_json_path=str(report_json_path),
+        report_html_path=str(report_html_path) if report_html_path else None,
+        phases=(
+            PhaseReport(name=PhaseName.PLANNED, status=PhaseStatus.OK),
+            PhaseReport(name=PhaseName.EXECUTED, status=executed_status),
+            PhaseReport(name=PhaseName.VERIFIED, status=verified_status),
+            PhaseReport(name=PhaseName.TUNED, status=tuned_status, detail=tune_detail),
+            PhaseReport(
+                name=PhaseName.RENDERED,
+                status=rendered_status,
+                detail=rendered_detail,
+            ),
+        ),
+        row_counts=counts,
+        recommendations=tuple(recommendations),
+        overall_status=overall_status,
+        exit_code=exit_code,
+    )
+
+    summary_path = (
+        Path(args.summary_json)
+        if args.summary_json
+        else output_dir / "optimize_summary.json"
+    )
+    try:
+        atomic_write_text(summary_path, summary.to_json() + "\n")
+        OptimizeSummary.read_json(summary_path)
+    except (OSError, OptimizeSummaryValidationError) as exc:
+        print(f"Failed to write/validate orchestration summary: {exc}", file=sys.stderr)
+        # The summary itself is the source of truth for what happened; if it
+        # cannot be trusted on disk, the whole invocation must be reported
+        # as a hard failure regardless of how the individual phases went.
+        return 1
+
+    print(f"Orchestration summary written to {summary_path}")
+    return exit_code
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="llmtracefx-optimizer",
@@ -1059,6 +1375,149 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     tune_report_parser.set_defaults(func=_cmd_tune_report)
+
+    optimize_parser = subparsers.add_parser(
+        "optimize",
+        help=(
+            "End-to-end: execute selected `workloads generate-matrix` rows, "
+            "offline-tune the resulting evidence, and render the JSON/HTML "
+            "report in one invocation. Composes `workloads run`, `tune`, "
+            "and `tune-report` exactly as they already behave; never loads "
+            "a model, downloads weights, or writes a report until its own "
+            "phase's evidence exists and validates."
+        ),
+    )
+    optimize_parser.add_argument(
+        "--matrix",
+        required=True,
+        help="Path to a `workloads generate-matrix` manifest.json",
+    )
+    optimize_parser.add_argument(
+        "--model-path",
+        default=None,
+        help=(
+            "Existing local target MLX model directory; required unless "
+            "--dry-run (models are never downloaded)"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--draft-model-path",
+        default=None,
+        help=(
+            "Optional existing local MLX draft model; enables generic "
+            "draft-model speculation on selected autoregressive rows, "
+            "never on native-mtp rows"
+        ),
+    )
+    optimize_parser.add_argument("--num-draft-tokens", type=int, default=2)
+    optimize_parser.add_argument(
+        "--results",
+        required=True,
+        help=(
+            "The `workloads run` results directory for this invocation; "
+            "this is also the only results directory tuned unless "
+            "--extra-results explicitly opts in additional ones"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--extra-results",
+        nargs="+",
+        default=None,
+        help=(
+            "Opt-in: additional already-collected `workloads run` results "
+            "directories to include when tuning, alongside --results. "
+            "Omit to tune only the evidence produced by this invocation"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--run-id", nargs="+", default=None, help="Select specific run_id(s)"
+    )
+    optimize_parser.add_argument(
+        "--category",
+        nargs="+",
+        default=None,
+        choices=[category.value for category in WorkloadCategory],
+        help="Filter selected rows by workload category",
+    )
+    optimize_parser.add_argument(
+        "--context-tier",
+        nargs="+",
+        default=None,
+        choices=[tier.value for tier in ContextTier],
+        help="Filter selected rows by context tier",
+    )
+    optimize_parser.add_argument(
+        "--mode",
+        nargs="+",
+        default=None,
+        choices=[DECODE_MODE_AUTOREGRESSIVE, DECODE_MODE_NATIVE_MTP],
+        help=(
+            "Filter selected rows by decode mode; native-mtp rows are "
+            "always rejected as unsupported, never executed"
+        ),
+    )
+    optimize_parser.add_argument("--seed", type=int, default=0)
+    optimize_parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Re-run all selected rows even if a hash-matching completed artifact exists",
+    )
+    optimize_parser.add_argument(
+        "--policy",
+        required=True,
+        help="Path to a tune policy JSON/YAML file (objective + constraints)",
+    )
+    optimize_parser.add_argument(
+        "--report-json",
+        default=None,
+        help=(
+            "Atomically write the full tune report JSON to this path; "
+            "required unless --dry-run"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--report-html",
+        default=None,
+        help=(
+            "Atomically write a self-contained HTML tune report to this "
+            "path. Optional: omit to skip HTML rendering entirely"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--include-paths",
+        action="store_true",
+        help=(
+            "Include full local artifact paths in the HTML report. "
+            "Default: redact every path, same as `tune-report`"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--summary-json",
+        default=None,
+        help=(
+            "Path to atomically write the machine-readable orchestration "
+            "summary (phase statuses, run counts, recommendations, exit "
+            "status) to. Default: <--results>/optimize_summary.json"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Print every violated constraint for every rejected candidate "
+            "(same as `tune --explain`)"
+        ),
+    )
+    optimize_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print selected rows, required local model paths, expected "
+            "run/tune/report artifacts, unsupported rows, and blockers "
+            "without loading any model, tuning, or writing any report"
+        ),
+    )
+    optimize_parser.set_defaults(func=_cmd_optimize)
 
     return parser
 

--- a/llmtracefx/optimizer/optimize_summary.py
+++ b/llmtracefx/optimizer/optimize_summary.py
@@ -19,6 +19,7 @@ outcome of calling into it.
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -122,18 +123,40 @@ class PhaseReport:
 
 @dataclass(frozen=True)
 class RowStatusCounts:
-    """Per-``RowStatus`` counts across every row selected for this run."""
+    """Planning and result counts across every row selected for this run."""
 
     total: int = 0
+    ready: int = 0
+    blocked: int = 0
     completed: int = 0
     skipped: int = 0
     failed: int = 0
     unsupported: int = 0
     inconclusive: int = 0
 
+    def __post_init__(self) -> None:
+        for key in (
+            "total",
+            "ready",
+            "blocked",
+            "completed",
+            "skipped",
+            "failed",
+            "unsupported",
+            "inconclusive",
+        ):
+            value = getattr(self, key)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise OptimizeSummaryValidationError(
+                    f"row_counts.{key} must be a non-negative integer, "
+                    f"got {value!r}"
+                )
+
     def to_dict(self) -> dict[str, int]:
         return {
             "total": self.total,
+            "ready": self.ready,
+            "blocked": self.blocked,
             "completed": self.completed,
             "skipped": self.skipped,
             "failed": self.failed,
@@ -148,6 +171,8 @@ class RowStatusCounts:
         values: dict[str, int] = {}
         for key in (
             "total",
+            "ready",
+            "blocked",
             "completed",
             "skipped",
             "failed",
@@ -171,6 +196,16 @@ class RecommendedCandidate:
     run_ids: tuple[str, ...]
     objective_name: str
     objective_value: float
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.objective_value, bool)
+            or not isinstance(self.objective_value, (int, float))
+            or not math.isfinite(float(self.objective_value))
+        ):
+            raise OptimizeSummaryValidationError(
+                "recommended candidate.objective_value must be a finite number"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -205,11 +240,13 @@ class RecommendedCandidate:
                 f"{context}.objective_name must be a non-empty string"
             )
         objective_value = data.get("objective_value")
-        if isinstance(objective_value, bool) or not isinstance(
-            objective_value, (int, float)
+        if (
+            isinstance(objective_value, bool)
+            or not isinstance(objective_value, (int, float))
+            or not math.isfinite(float(objective_value))
         ):
             raise OptimizeSummaryValidationError(
-                f"{context}.objective_value must be a number"
+                f"{context}.objective_value must be a finite number"
             )
         return cls(
             group_label=group_label,
@@ -246,6 +283,12 @@ class OptimizeSummary:
     exit_code: int
     extra_results_dirs: tuple[str, ...] = field(default_factory=tuple)
 
+    def __post_init__(self) -> None:
+        if isinstance(self.exit_code, bool) or not isinstance(self.exit_code, int):
+            raise OptimizeSummaryValidationError(
+                "optimize summary.exit_code must be an integer"
+            )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": self.schema_version,
@@ -265,7 +308,12 @@ class OptimizeSummary:
         }
 
     def to_json(self, *, indent: int | None = 2) -> str:
-        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+        return json.dumps(
+            self.to_dict(),
+            indent=indent,
+            sort_keys=False,
+            allow_nan=False,
+        )
 
     def phase(self, name: PhaseName) -> PhaseReport | None:
         for phase in self.phases:

--- a/llmtracefx/optimizer/optimize_summary.py
+++ b/llmtracefx/optimizer/optimize_summary.py
@@ -1,0 +1,388 @@
+"""Machine-readable orchestration summary for the ``optimize`` command.
+
+``optimize`` composes four already-existing, independently tested phases
+(row planning/execution via ``workloads.verify``, offline tuning via
+``tune.tuner``, and report rendering via ``tune.report``/
+``tune.report_html``) into one invocation. This module defines the schema
+for the single artifact that records what actually happened across all of
+them, so a caller never has to guess whether a given JSON/HTML report on
+disk reflects a fully successful run, a partially failed one, or stale
+data from an earlier invocation.
+
+Every phase is reported with an explicit, typed status (see
+``PhaseStatus``); a phase is only ever recorded as ``OK`` once its own
+artifact has been produced and re-validated. Nothing here recomputes or
+duplicates the tuning/rendering logic itself -- it only records the
+outcome of calling into it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+OPTIMIZE_SUMMARY_SCHEMA_VERSION = "1"
+
+
+class OptimizeSummaryValidationError(ValueError):
+    """Raised when an ``OptimizeSummary`` loaded from JSON is malformed."""
+
+
+class PhaseName(str, Enum):
+    """The fixed, ordered set of phases one ``optimize`` invocation covers."""
+
+    PLANNED = "planned"
+    """Matrix/policy loaded and row selection resolved (dry-run's scope)."""
+
+    EXECUTED = "executed"
+    """``workloads.verify.run_selected_rows`` was invoked and returned."""
+
+    VERIFIED = "verified"
+    """Whether the executed rows produced trustworthy tunable evidence."""
+
+    TUNED = "tuned"
+    """``tune.tuner.tune`` was invoked against the results directory."""
+
+    RENDERED = "rendered"
+    """The tune report JSON (and, if requested, HTML) was written."""
+
+
+class PhaseStatus(str, Enum):
+    """Explicit, machine-readable outcome for one orchestration phase."""
+
+    OK = "ok"
+    """The phase completed and its artifact (if any) exists and validates."""
+
+    FAILED = "failed"
+    """The phase could not complete; see the phase's ``detail``."""
+
+    INCONCLUSIVE = "inconclusive"
+    """The phase completed but produced no actionable result."""
+
+    UNSUPPORTED = "unsupported"
+    """Every selected row was rejected as unsupported (e.g. native-mtp)."""
+
+    SKIPPED = "skipped"
+    """The phase was never attempted (e.g. no ``--report-html`` given)."""
+
+    NOT_RUN = "not_run"
+    """The phase was never reached (an earlier phase stopped the run)."""
+
+
+@dataclass(frozen=True)
+class PhaseReport:
+    """One phase's final status and an optional human-readable detail."""
+
+    name: PhaseName
+    status: PhaseStatus
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name.value,
+            "status": self.status.value,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> PhaseReport:
+        if not isinstance(data, dict):
+            raise OptimizeSummaryValidationError("phase report must be a JSON object")
+        context = "phase report"
+        try:
+            name = PhaseName(data["name"])
+        except KeyError as exc:
+            raise OptimizeSummaryValidationError(
+                f"{context} is missing required field: 'name'"
+            ) from exc
+        except ValueError as exc:
+            raise OptimizeSummaryValidationError(
+                f"{context}.name has an invalid value: {exc}"
+            ) from exc
+        try:
+            status = PhaseStatus(data["status"])
+        except KeyError as exc:
+            raise OptimizeSummaryValidationError(
+                f"{context} is missing required field: 'status'"
+            ) from exc
+        except ValueError as exc:
+            raise OptimizeSummaryValidationError(
+                f"{context}.status has an invalid value: {exc}"
+            ) from exc
+        detail = data.get("detail")
+        if detail is not None and not isinstance(detail, str):
+            raise OptimizeSummaryValidationError(
+                f"{context}.detail must be a string or null"
+            )
+        return cls(name=name, status=status, detail=detail)
+
+
+@dataclass(frozen=True)
+class RowStatusCounts:
+    """Per-``RowStatus`` counts across every row selected for this run."""
+
+    total: int = 0
+    completed: int = 0
+    skipped: int = 0
+    failed: int = 0
+    unsupported: int = 0
+    inconclusive: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "total": self.total,
+            "completed": self.completed,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "unsupported": self.unsupported,
+            "inconclusive": self.inconclusive,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> RowStatusCounts:
+        if not isinstance(data, dict):
+            raise OptimizeSummaryValidationError("row_counts must be a JSON object")
+        values: dict[str, int] = {}
+        for key in (
+            "total",
+            "completed",
+            "skipped",
+            "failed",
+            "unsupported",
+            "inconclusive",
+        ):
+            raw = data.get(key, 0)
+            if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+                raise OptimizeSummaryValidationError(
+                    f"row_counts.{key} must be a non-negative integer, got {raw!r}"
+                )
+            values[key] = raw
+        return cls(**values)
+
+
+@dataclass(frozen=True)
+class RecommendedCandidate:
+    """One tuned group's winning candidate, summarized for the orchestration."""
+
+    group_label: str
+    run_ids: tuple[str, ...]
+    objective_name: str
+    objective_value: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "group_label": self.group_label,
+            "run_ids": list(self.run_ids),
+            "objective_name": self.objective_name,
+            "objective_value": self.objective_value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> RecommendedCandidate:
+        if not isinstance(data, dict):
+            raise OptimizeSummaryValidationError(
+                "recommended candidate must be a JSON object"
+            )
+        context = "recommended candidate"
+        group_label = data.get("group_label")
+        if not isinstance(group_label, str) or not group_label:
+            raise OptimizeSummaryValidationError(
+                f"{context}.group_label must be a non-empty string"
+            )
+        run_ids_raw = data.get("run_ids")
+        if not isinstance(run_ids_raw, list) or not all(
+            isinstance(item, str) for item in run_ids_raw
+        ):
+            raise OptimizeSummaryValidationError(
+                f"{context}.run_ids must be a list of strings"
+            )
+        objective_name = data.get("objective_name")
+        if not isinstance(objective_name, str) or not objective_name:
+            raise OptimizeSummaryValidationError(
+                f"{context}.objective_name must be a non-empty string"
+            )
+        objective_value = data.get("objective_value")
+        if isinstance(objective_value, bool) or not isinstance(
+            objective_value, (int, float)
+        ):
+            raise OptimizeSummaryValidationError(
+                f"{context}.objective_value must be a number"
+            )
+        return cls(
+            group_label=group_label,
+            run_ids=tuple(run_ids_raw),
+            objective_name=objective_name,
+            objective_value=float(objective_value),
+        )
+
+
+class OverallStatus(str, Enum):
+    """The single, top-level verdict for one ``optimize`` invocation."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True)
+class OptimizeSummary:
+    """The complete, atomic record of one ``optimize`` invocation."""
+
+    schema_version: str
+    generated_at: str
+    dry_run: bool
+    matrix_path: str
+    results_dir: str | None
+    policy_path: str | None
+    report_json_path: str | None
+    report_html_path: str | None
+    phases: tuple[PhaseReport, ...]
+    row_counts: RowStatusCounts
+    recommendations: tuple[RecommendedCandidate, ...]
+    overall_status: OverallStatus
+    exit_code: int
+    extra_results_dirs: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "dry_run": self.dry_run,
+            "matrix_path": self.matrix_path,
+            "results_dir": self.results_dir,
+            "extra_results_dirs": list(self.extra_results_dirs),
+            "policy_path": self.policy_path,
+            "report_json_path": self.report_json_path,
+            "report_html_path": self.report_html_path,
+            "phases": [phase.to_dict() for phase in self.phases],
+            "row_counts": self.row_counts.to_dict(),
+            "recommendations": [rec.to_dict() for rec in self.recommendations],
+            "overall_status": self.overall_status.value,
+            "exit_code": self.exit_code,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    def phase(self, name: PhaseName) -> PhaseReport | None:
+        for phase in self.phases:
+            if phase.name == name:
+                return phase
+        return None
+
+    @classmethod
+    def from_dict(cls, data: Any) -> OptimizeSummary:
+        if not isinstance(data, dict):
+            raise OptimizeSummaryValidationError(
+                "optimize summary must be a JSON object"
+            )
+        context = "optimize summary"
+
+        schema_version = str(
+            data.get("schema_version", OPTIMIZE_SUMMARY_SCHEMA_VERSION)
+        )
+        if schema_version != OPTIMIZE_SUMMARY_SCHEMA_VERSION:
+            raise OptimizeSummaryValidationError(
+                f"unsupported optimize summary schema_version {schema_version!r}, "
+                f"expected {OPTIMIZE_SUMMARY_SCHEMA_VERSION!r}"
+            )
+
+        generated_at = data.get("generated_at")
+        if not isinstance(generated_at, str) or not generated_at:
+            raise OptimizeSummaryValidationError(
+                f"{context}.generated_at must be a non-empty string"
+            )
+        matrix_path = data.get("matrix_path")
+        if not isinstance(matrix_path, str) or not matrix_path:
+            raise OptimizeSummaryValidationError(
+                f"{context}.matrix_path must be a non-empty string"
+            )
+        dry_run = data.get("dry_run")
+        if not isinstance(dry_run, bool):
+            raise OptimizeSummaryValidationError(f"{context}.dry_run must be a boolean")
+
+        def _optional_str(key: str) -> str | None:
+            value = data.get(key)
+            if value is not None and not isinstance(value, str):
+                raise OptimizeSummaryValidationError(
+                    f"{context}.{key} must be a string or null"
+                )
+            return value
+
+        extra_results_raw = data.get("extra_results_dirs", [])
+        if not isinstance(extra_results_raw, list) or not all(
+            isinstance(item, str) for item in extra_results_raw
+        ):
+            raise OptimizeSummaryValidationError(
+                f"{context}.extra_results_dirs must be a list of strings"
+            )
+
+        phases_raw = data.get("phases", [])
+        if not isinstance(phases_raw, list):
+            raise OptimizeSummaryValidationError(f"{context}.phases must be a list")
+        phases = tuple(PhaseReport.from_dict(item) for item in phases_raw)
+        phase_names = tuple(phase.name for phase in phases)
+        if phase_names != tuple(PhaseName):
+            raise OptimizeSummaryValidationError(
+                f"{context}.phases must report exactly every phase "
+                f"{[p.value for p in PhaseName]!r} in order, got "
+                f"{[p.value for p in phase_names]!r}"
+            )
+
+        row_counts = RowStatusCounts.from_dict(data.get("row_counts", {}))
+
+        recommendations_raw = data.get("recommendations", [])
+        if not isinstance(recommendations_raw, list):
+            raise OptimizeSummaryValidationError(
+                f"{context}.recommendations must be a list"
+            )
+        recommendations = tuple(
+            RecommendedCandidate.from_dict(item) for item in recommendations_raw
+        )
+
+        try:
+            overall_status = OverallStatus(data.get("overall_status"))
+        except ValueError as exc:
+            raise OptimizeSummaryValidationError(
+                f"{context}.overall_status has an invalid value: {exc}"
+            ) from exc
+
+        exit_code = data.get("exit_code")
+        if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+            raise OptimizeSummaryValidationError(
+                f"{context}.exit_code must be an integer"
+            )
+
+        return cls(
+            schema_version=schema_version,
+            generated_at=generated_at,
+            dry_run=dry_run,
+            matrix_path=matrix_path,
+            results_dir=_optional_str("results_dir"),
+            extra_results_dirs=tuple(extra_results_raw),
+            policy_path=_optional_str("policy_path"),
+            report_json_path=_optional_str("report_json_path"),
+            report_html_path=_optional_str("report_html_path"),
+            phases=phases,
+            row_counts=row_counts,
+            recommendations=recommendations,
+            overall_status=overall_status,
+            exit_code=exit_code,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> OptimizeSummary:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise OptimizeSummaryValidationError(
+                f"invalid JSON for optimize summary: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> OptimizeSummary:
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))

--- a/llmtracefx/optimizer/tune/loader.py
+++ b/llmtracefx/optimizer/tune/loader.py
@@ -13,6 +13,7 @@ about it can be trusted enough to even place it in a comparable group.
 
 from __future__ import annotations
 
+from collections.abc import Set
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -209,7 +210,11 @@ def _load_one_run(
     )
 
 
-def load_evidence(results_dirs: tuple[Path, ...]) -> LoadedEvidence:
+def load_evidence(
+    results_dirs: tuple[Path, ...],
+    *,
+    primary_run_ids: Set[str] | None = None,
+) -> LoadedEvidence:
     """Load and identity-check every run under every given results directory.
 
     Raises ``TuneInputError`` if the same ``run_id`` appears more than once
@@ -222,11 +227,17 @@ def load_evidence(results_dirs: tuple[Path, ...]) -> LoadedEvidence:
     usable: dict[str, RunEvidence] = {}
     excluded: list[ExcludedRun] = []
 
-    for results_dir in results_dirs:
+    for index, results_dir in enumerate(results_dirs):
         runs_dir = results_dir / "runs"
         if not runs_dir.is_dir():
             continue
         for verification_path in sorted(runs_dir.glob("*/verification.json")):
+            if (
+                index == 0
+                and primary_run_ids is not None
+                and verification_path.parent.name not in primary_run_ids
+            ):
+                continue
             evidence, excluded_run = _load_one_run(
                 verification_path, results_dir=results_dir
             )

--- a/llmtracefx/optimizer/tune/tuner.py
+++ b/llmtracefx/optimizer/tune/tuner.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import math
 import statistics
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -595,9 +595,14 @@ def _build_groups(
     return groups, excluded
 
 
-def tune(*, results_dirs: Sequence[Path], policy: TunePolicy) -> TuneReport:
+def tune(
+    *,
+    results_dirs: Sequence[Path],
+    policy: TunePolicy,
+    primary_run_ids: Set[str] | None = None,
+) -> TuneReport:
     """Load, group, constrain, and rank evidence into a full ``TuneReport``."""
-    loaded = load_evidence(tuple(results_dirs))
+    loaded = load_evidence(tuple(results_dirs), primary_run_ids=primary_run_ids)
     groups, extra_excluded = _build_groups(loaded.usable)
 
     group_reports = tuple(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -184,6 +184,12 @@ class RunBinding:
     num_draft_tokens: int = 2
 
     def __post_init__(self) -> None:
+        if (
+            isinstance(self.num_draft_tokens, bool)
+            or not isinstance(self.num_draft_tokens, int)
+            or self.num_draft_tokens < 1
+        ):
+            raise VerifyError("num_draft_tokens must be a positive integer")
         if not self.target_model_path.exists():
             raise VerifyError(
                 f"target model path does not exist: {self.target_model_path}. "

--- a/tests/optimizer/test_optimize_cli.py
+++ b/tests/optimizer/test_optimize_cli.py
@@ -1,0 +1,875 @@
+"""End-to-end tests for the `llmtracefx-optimizer optimize` CLI subcommand.
+
+`optimize` composes `workloads run`, `tune`, and `tune-report` exactly as
+they already behave: every test here exercises the real
+``run_selected_rows``/``tune``/``render_tune_report_html`` code paths
+(never mocking the top-level `_cmd_optimize` function itself), faking only
+the outermost MLX runtime boundary the same way `test_workloads_cli.py`
+already does.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from _tune_fixtures import write_run
+
+from llmtracefx.optimizer import cli
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.optimize_summary import OptimizeSummary
+from llmtracefx.optimizer.tune.report import TuneReport
+from llmtracefx.optimizer.workloads.catalog import (
+    CODE_COMPLETION_PALINDROME,
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.matrix import generate_matrix, write_matrix
+from llmtracefx.optimizer.workloads.schema import ContextTier
+
+
+@dataclass
+class _FakeResponse:
+    text: str = '{"name": "Priya", "age": 34, "is_active": true}'
+    from_draft: bool = False
+    prompt_tokens: int = 3
+    generation_tokens: int = 1
+    finish_reason: str | None = None
+
+
+class _FakeTokenizer:
+    bos_token = None
+
+
+class _FakeMLXRuntime:
+    mlx_version = "0.32.0"
+    mlx_lm_version = "0.31.3"
+
+    def __init__(self, response_text: str | None = None) -> None:
+        self.response_text = response_text or _FakeResponse.text
+
+    def load_model(self, path):
+        return object(), _FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return MLXMemorySnapshot(active_bytes=1024, cache_bytes=256, peak_bytes=2048)
+
+    def accelerator_name(self):
+        return "Apple M5 Pro (test)"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        yield _FakeResponse(self.response_text)
+
+
+class _FailingRuntime(_FakeMLXRuntime):
+    def load_model(self, path):
+        raise RuntimeError("boom")
+
+
+def _sequenced_runtime_factory(*runtimes):
+    iterator = iter(runtimes)
+
+    def factory():
+        return next(iterator)
+
+    return factory
+
+
+def _never_call_runtime_factory():
+    def factory():
+        raise AssertionError(
+            "MLXLMRuntime must never be constructed for this invocation"
+        )
+
+    return factory
+
+
+def _build_matrix(tmp_path, workloads, *, context_tiers=(ContextTier.TIER_2K,)):
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        workloads=workloads,
+        context_tiers=context_tiers,
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+    return output_dir / "manifest.json"
+
+
+def _write_policy(tmp_path, payload, name="policy.json"):
+    policy_path = tmp_path / name
+    policy_path.write_text(json.dumps(payload), encoding="utf-8")
+    return policy_path
+
+
+def _run_optimize(argv):
+    parser = cli.build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+def _base_argv(
+    *,
+    matrix_path,
+    results_dir,
+    policy_path,
+    report_json,
+    model_path=None,
+    report_html=None,
+    extra=(),
+):
+    argv = [
+        "optimize",
+        "--matrix",
+        str(matrix_path),
+        "--results",
+        str(results_dir),
+        "--policy",
+        str(policy_path),
+    ]
+    if model_path is not None:
+        argv += ["--model-path", str(model_path)]
+    if report_json is not None:
+        argv += ["--report-json", str(report_json)]
+    if report_html is not None:
+        argv += ["--report-html", str(report_html)]
+    return argv + list(extra)
+
+
+# --- Full success ------------------------------------------------------
+
+
+def test_optimize_full_success_writes_json_html_and_summary(
+    tmp_path, monkeypatch, capsys
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    report_json = tmp_path / "report.json"
+    report_html = tmp_path / "report.html"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=report_json,
+            model_path=model_path,
+            report_html=report_html,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 0
+    assert report_json.exists()
+    assert report_html.exists()
+
+    tune_report = TuneReport.read_json(report_json)
+    assert tune_report.has_recommendation
+
+    summary_path = results_dir / "optimize_summary.json"
+    assert summary_path.exists()
+    summary = OptimizeSummary.read_json(summary_path)
+    assert summary.overall_status.value == "success"
+    assert summary.exit_code == 0
+    assert [phase.status.value for phase in summary.phases] == [
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+        "ok",
+    ]
+    assert summary.row_counts.completed == 1
+    assert len(summary.recommendations) == 1
+
+    out = capsys.readouterr().out
+    assert "Tune report JSON written" in out
+    assert "Tune report HTML written" in out
+    assert "Orchestration summary written" in out
+
+
+def test_optimize_default_redacts_paths_html_include_paths_opt_in(
+    tmp_path, monkeypatch
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    redacted_results = tmp_path / "results-redacted"
+    redacted_html = tmp_path / "redacted.html"
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=redacted_results,
+            policy_path=policy_path,
+            report_json=tmp_path / "redacted.json",
+            model_path=model_path,
+            report_html=redacted_html,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+    assert exit_code == 0
+    redacted_text = redacted_html.read_text(encoding="utf-8")
+    assert str(model_path) not in redacted_text
+    assert str(redacted_results) not in redacted_text
+
+    included_results = tmp_path / "results-included"
+    included_html = tmp_path / "included.html"
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=included_results,
+            policy_path=policy_path,
+            report_json=tmp_path / "included.json",
+            model_path=model_path,
+            report_html=included_html,
+            extra=["--mode", "autoregressive", "--include-paths"],
+        )
+    )
+    assert exit_code == 0
+    included_text = included_html.read_text(encoding="utf-8")
+    assert str(included_results) in included_text
+
+
+# --- Dry run -------------------------------------------------------------
+
+
+def test_optimize_dry_run_never_constructs_runtime_or_writes_reports(
+    tmp_path, monkeypatch
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    report_json = tmp_path / "report.json"
+    report_html = tmp_path / "report.html"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=report_json,
+            model_path=model_path,
+            report_html=report_html,
+            extra=["--mode", "autoregressive", "--dry-run"],
+        )
+    )
+
+    assert exit_code == 0  # ready: valid --model-path given, nothing blocked
+    assert not results_dir.exists()
+    assert not report_json.exists()
+    assert not report_html.exists()
+
+
+def test_optimize_dry_run_reports_blockers_without_model_path(tmp_path, capsys):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            extra=["--mode", "autoregressive", "--dry-run"],
+        )
+    )
+
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "BLOCKED" in out
+    assert "no model was loaded, no results were tuned" not in out  # printed once
+    assert "no report was written" in out
+
+
+def test_optimize_dry_run_reports_unsupported_rows(tmp_path, capsys):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            extra=["--mode", "native-mtp", "--dry-run"],
+        )
+    )
+
+    assert exit_code == 0  # unsupported rows never block
+    out = capsys.readouterr().out
+    assert "UNSUPPORTED" in out
+
+
+# --- Execution failure precedence ----------------------------------------
+
+
+def test_optimize_all_rows_failed_exits_1(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FailingRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 1
+    summary = OptimizeSummary.read_json(tmp_path / "results" / "optimize_summary.json")
+    assert summary.exit_code == 1
+    assert summary.overall_status.value == "failed"
+    assert summary.phase(cli.PhaseName.EXECUTED).status.value == "failed"
+    assert summary.row_counts.failed == 1
+
+
+def test_optimize_partial_failure_with_surviving_recommendation_retains_failure_exit(
+    tmp_path, monkeypatch
+):
+    # Two independent workloads (=> two independent tune groups): the first
+    # fails at execution, the second succeeds and is recommended. The
+    # overall command must still fail even though a recommendation exists.
+    matrix_path = _build_matrix(
+        tmp_path, (CODE_COMPLETION_PALINDROME, STRUCTURED_JSON_PROFILE_EXTRACTION)
+    )
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    report_json = tmp_path / "report.json"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(
+        cli,
+        "MLXLMRuntime",
+        _sequenced_runtime_factory(_FailingRuntime(), _FakeMLXRuntime()),
+    )
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=report_json,
+            model_path=model_path,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 1
+    tune_report = TuneReport.read_json(report_json)
+    assert tune_report.has_recommendation  # the surviving group did recommend
+
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.exit_code == 1
+    assert summary.overall_status.value == "failed"
+    assert summary.row_counts.failed == 1
+    assert summary.row_counts.completed == 1
+    assert len(summary.recommendations) == 1  # tuned eligible successful evidence
+
+
+def test_optimize_all_rows_unsupported_exits_1_consistently_with_tune(
+    tmp_path, monkeypatch
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "native-mtp"],
+        )
+    )
+
+    # Execution itself is a clean no-op (never touches MLX, no row failed),
+    # but there is zero tunable evidence: `tune` itself would report zero
+    # comparable groups (exit 1), so `optimize` mirrors that exactly.
+    assert exit_code == 1
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.phase(cli.PhaseName.EXECUTED).status.value == "ok"
+    assert summary.phase(cli.PhaseName.TUNED).status.value == "failed"
+    assert summary.row_counts.unsupported == 1
+    assert summary.row_counts.failed == 0
+
+
+def test_optimize_all_rows_inconclusive_exits_2(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    def _raising_evaluate_workload(workload, response_text):
+        raise RuntimeError("evaluator exploded")
+
+    import llmtracefx.optimizer.workloads.verify as verify_module
+
+    monkeypatch.setattr(verify_module, "evaluate_workload", _raising_evaluate_workload)
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 2
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.overall_status.value == "inconclusive"
+    assert summary.phase(cli.PhaseName.EXECUTED).status.value == "inconclusive"
+    assert summary.phase(cli.PhaseName.TUNED).status.value == "inconclusive"
+    assert summary.row_counts.inconclusive == 1
+
+
+# --- Setup/config errors ---------------------------------------------------
+
+
+def test_optimize_invalid_policy_fails_before_any_execution(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text("not json", encoding="utf-8")
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+        )
+    )
+
+    assert exit_code == 1
+    assert not results_dir.exists()
+
+
+def test_optimize_invalid_matrix_manifest_exits_1(tmp_path):
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=tmp_path / "missing-manifest.json",
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=tmp_path,
+        )
+    )
+    assert exit_code == 1
+
+
+def test_optimize_no_rows_selected_exits_1(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--run-id", "does-not-exist"],
+        )
+    )
+    assert exit_code == 1
+
+
+def test_optimize_requires_model_path_unless_dry_run(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+        )
+    )
+    assert exit_code == 1
+
+
+def test_optimize_requires_report_json_unless_dry_run(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=None,
+            model_path=model_path,
+        )
+    )
+    assert exit_code == 1
+
+
+def test_optimize_invalid_model_path_binding_exits_1(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=tmp_path / "does-not-exist",
+        )
+    )
+    assert exit_code == 1
+
+
+# --- Report write/read failures -------------------------------------------
+
+
+def test_optimize_report_json_write_failure_exits_1(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    # A directory at the report-json path makes the atomic write fail with
+    # an explicit OSError instead of silently succeeding.
+    report_json = tmp_path / "report-json-is-a-dir"
+    report_json.mkdir()
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=report_json,
+            model_path=model_path,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 1
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.phase(cli.PhaseName.RENDERED).status.value == "failed"
+
+
+def test_optimize_report_html_write_failure_exits_1(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    report_html = tmp_path / "report-html-is-a-dir"
+    report_html.mkdir()
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            report_html=report_html,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+
+    assert exit_code == 1
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.phase(cli.PhaseName.RENDERED).status.value == "failed"
+    # The JSON report itself was still written and validated successfully.
+    assert (tmp_path / "report.json").exists()
+
+
+def test_optimize_summary_write_failure_forces_exit_1(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    summary_path = tmp_path / "summary-is-a-dir"
+    summary_path.mkdir()
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "autoregressive", "--summary-json", str(summary_path)],
+        )
+    )
+
+    # Even though execution/tuning/rendering all otherwise succeeded, an
+    # untrustworthy orchestration summary must force a hard failure.
+    assert exit_code == 1
+
+
+def test_optimize_invalid_tuning_evidence_conflict_exits_1(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    # An --extra-results directory that conflicts (same run_id, different
+    # content) with what this invocation is about to produce.
+    conflicting_dir = tmp_path / "conflicting"
+    write_run(
+        conflicting_dir,
+        "structured-json-profile-extraction-2k-autoregressive",
+        total_ms=99999.0,
+    )
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=[
+                "--mode",
+                "autoregressive",
+                "--extra-results",
+                str(conflicting_dir),
+            ],
+        )
+    )
+
+    assert exit_code == 1
+    assert not (tmp_path / "report.json").exists()
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.phase(cli.PhaseName.TUNED).status.value == "failed"
+    assert summary.phase(cli.PhaseName.RENDERED).status.value == "skipped"
+
+
+# --- Opt-in extra-results (requirement 5) ---------------------------------
+
+
+def test_optimize_only_tunes_primary_results_dir_by_default(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    # An unrelated historical results directory with a *different* run_id
+    # so it never conflicts; only used to prove it's excluded by default.
+    unrelated_dir = tmp_path / "unrelated-history"
+    write_run(unrelated_dir, "some-other-historical-run")
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "autoregressive"],
+        )
+    )
+    assert exit_code == 0
+    report = TuneReport.read_json(tmp_path / "report.json")
+    assert str(unrelated_dir) not in report.results_dirs
+
+
+def test_optimize_extra_results_opt_in_includes_additional_directory(
+    tmp_path, monkeypatch
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    extra_dir = tmp_path / "extra-history"
+    write_run(extra_dir, "some-other-historical-run")
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=[
+                "--mode",
+                "autoregressive",
+                "--extra-results",
+                str(extra_dir),
+            ],
+        )
+    )
+    assert exit_code == 0
+    report = TuneReport.read_json(tmp_path / "report.json")
+    assert str(extra_dir) in report.results_dirs
+
+
+# --- Resume (requirement 4) ------------------------------------------------
+
+
+def test_optimize_resume_reuses_pr6_hash_matching_artifacts(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    first_argv = _base_argv(
+        matrix_path=matrix_path,
+        results_dir=results_dir,
+        policy_path=policy_path,
+        report_json=tmp_path / "report-1.json",
+        model_path=model_path,
+        extra=["--mode", "autoregressive"],
+    )
+    assert _run_optimize(first_argv) == 0
+
+    run_dir = next((results_dir / "runs").iterdir())
+    first_verification = json.loads((run_dir / "verification.json").read_text())
+    assert first_verification["status"] == "completed"
+
+    # A runtime that would fail if it were ever invoked again: resume must
+    # trust the hash-matching prior artifact instead of re-executing.
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+    second_argv = _base_argv(
+        matrix_path=matrix_path,
+        results_dir=results_dir,
+        policy_path=policy_path,
+        report_json=tmp_path / "report-2.json",
+        model_path=model_path,
+        extra=["--mode", "autoregressive"],
+    )
+    assert _run_optimize(second_argv) == 0
+    second_verification = json.loads((run_dir / "verification.json").read_text())
+    assert second_verification["status"] == "skipped"
+    assert second_verification["resumed"] is True
+
+
+def test_optimize_no_resume_forces_re_execution(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    argv = _base_argv(
+        matrix_path=matrix_path,
+        results_dir=results_dir,
+        policy_path=policy_path,
+        report_json=tmp_path / "report-1.json",
+        model_path=model_path,
+        extra=["--mode", "autoregressive"],
+    )
+    assert _run_optimize(argv) == 0
+
+    calls = {"count": 0}
+
+    def _counting_factory():
+        calls["count"] += 1
+        return _FakeMLXRuntime()
+
+    monkeypatch.setattr(cli, "MLXLMRuntime", _counting_factory)
+    no_resume_argv = _base_argv(
+        matrix_path=matrix_path,
+        results_dir=results_dir,
+        policy_path=policy_path,
+        report_json=tmp_path / "report-2.json",
+        model_path=model_path,
+        extra=["--mode", "autoregressive", "--no-resume"],
+    )
+    assert _run_optimize(no_resume_argv) == 0
+    assert calls["count"] == 1
+
+
+# --- Explain / row status printing ----------------------------------------
+
+
+def test_optimize_explain_flag_forwards_to_tune_explain(tmp_path, monkeypatch, capsys):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {"max_total_latency_ms": 0.0001},
+        },
+    )
+    monkeypatch.setattr(cli, "MLXLMRuntime", lambda: _FakeMLXRuntime())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "autoregressive", "--explain"],
+        )
+    )
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "total latency" in out

--- a/tests/optimizer/test_optimize_cli.py
+++ b/tests/optimizer/test_optimize_cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+import pytest
 from _tune_fixtures import write_run
 
 from llmtracefx.optimizer import cli
@@ -102,6 +103,10 @@ def _never_call_runtime_factory():
         )
 
     return factory
+
+
+def _never_call_phase(*args, **kwargs):
+    raise AssertionError("tune and render phases must not run during dry-run")
 
 
 def _build_matrix(tmp_path, workloads, *, context_tiers=(ContextTier.TIER_2K,)):
@@ -272,6 +277,8 @@ def test_optimize_dry_run_never_constructs_runtime_or_writes_reports(
     report_html = tmp_path / "report.html"
     policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
     monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+    monkeypatch.setattr(cli, "tune", _never_call_phase)
+    monkeypatch.setattr(cli, "render_tune_report_html", _never_call_phase)
 
     exit_code = _run_optimize(
         _base_argv(
@@ -286,9 +293,24 @@ def test_optimize_dry_run_never_constructs_runtime_or_writes_reports(
     )
 
     assert exit_code == 0  # ready: valid --model-path given, nothing blocked
-    assert not results_dir.exists()
+    assert not (results_dir / "runs").exists()
     assert not report_json.exists()
     assert not report_html.exists()
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.dry_run is True
+    assert summary.exit_code == 0
+    assert summary.row_counts.total == 1
+    assert summary.row_counts.ready == 1
+    assert summary.row_counts.blocked == 0
+    assert summary.row_counts.unsupported == 0
+    assert summary.phase(cli.PhaseName.PLANNED).status.value == "ok"
+    for phase_name in (
+        cli.PhaseName.EXECUTED,
+        cli.PhaseName.VERIFIED,
+        cli.PhaseName.TUNED,
+        cli.PhaseName.RENDERED,
+    ):
+        assert summary.phase(phase_name).status.value == "not_run"
 
 
 def test_optimize_dry_run_reports_blockers_without_model_path(tmp_path, capsys):
@@ -309,7 +331,15 @@ def test_optimize_dry_run_reports_blockers_without_model_path(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "BLOCKED" in out
     assert "no model was loaded, no results were tuned" not in out  # printed once
-    assert "no report was written" in out
+    assert "no tune report was written" in out
+    summary = OptimizeSummary.read_json(tmp_path / "results" / "optimize_summary.json")
+    assert summary.dry_run is True
+    assert summary.exit_code == 2
+    assert summary.overall_status.value == "inconclusive"
+    assert summary.row_counts.total == 1
+    assert summary.row_counts.ready == 0
+    assert summary.row_counts.blocked == 1
+    assert summary.row_counts.unsupported == 0
 
 
 def test_optimize_dry_run_reports_unsupported_rows(tmp_path, capsys):
@@ -329,6 +359,69 @@ def test_optimize_dry_run_reports_unsupported_rows(tmp_path, capsys):
     assert exit_code == 0  # unsupported rows never block
     out = capsys.readouterr().out
     assert "UNSUPPORTED" in out
+    summary = OptimizeSummary.read_json(tmp_path / "results" / "optimize_summary.json")
+    assert summary.row_counts.total == 1
+    assert summary.row_counts.ready == 0
+    assert summary.row_counts.blocked == 0
+    assert summary.row_counts.unsupported == 1
+    assert summary.phase(cli.PhaseName.EXECUTED).status.value == "not_run"
+
+
+def test_optimize_dry_run_writes_custom_summary_path(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    summary_path = tmp_path / "custom-summary.json"
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=[
+                "--mode",
+                "autoregressive",
+                "--dry-run",
+                "--summary-json",
+                str(summary_path),
+            ],
+        )
+    )
+
+    assert exit_code == 0
+    assert OptimizeSummary.read_json(summary_path).dry_run is True
+
+
+def test_optimize_dry_run_rejects_invalid_num_draft_tokens(tmp_path):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=[
+                "--mode",
+                "autoregressive",
+                "--dry-run",
+                "--num-draft-tokens",
+                "0",
+            ],
+        )
+    )
+
+    assert exit_code == 2
+    summary = OptimizeSummary.read_json(tmp_path / "results" / "optimize_summary.json")
+    assert summary.row_counts.ready == 0
+    assert summary.row_counts.blocked == 1
 
 
 # --- Execution failure precedence ----------------------------------------
@@ -435,6 +528,33 @@ def test_optimize_all_rows_unsupported_exits_1_consistently_with_tune(
     assert summary.row_counts.failed == 0
 
 
+def test_optimize_ignores_stale_unselected_primary_results(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    write_run(results_dir, "stale-successful-run")
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--mode", "native-mtp"],
+        )
+    )
+
+    assert exit_code == 1
+    report = TuneReport.read_json(tmp_path / "report.json")
+    assert report.groups == ()
+    summary = OptimizeSummary.read_json(results_dir / "optimize_summary.json")
+    assert summary.recommendations == ()
+
+
 def test_optimize_all_rows_inconclusive_exits_2(tmp_path, monkeypatch):
     matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
     model_path = tmp_path / "model"
@@ -472,6 +592,187 @@ def test_optimize_all_rows_inconclusive_exits_2(tmp_path, monkeypatch):
 # --- Setup/config errors ---------------------------------------------------
 
 
+def _assert_optimize_path_collision(
+    tmp_path,
+    monkeypatch,
+    *,
+    collision_flag,
+    collision_path,
+):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir(exist_ok=True)
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    report_json = tmp_path / "report.json"
+    report_html = tmp_path / "report.html"
+    summary_json = tmp_path / "summary.json"
+    paths = {
+        "--report-json": report_json,
+        "--report-html": report_html,
+        "--summary-json": summary_json,
+    }
+    paths[collision_flag] = collision_path(
+        matrix_path=matrix_path,
+        policy_path=policy_path,
+        report_json=report_json,
+        report_html=report_html,
+        summary_json=summary_json,
+    )
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+    policy_before = policy_path.read_bytes()
+    matrix_before = matrix_path.read_bytes()
+
+    argv = _base_argv(
+        matrix_path=matrix_path,
+        results_dir=results_dir,
+        policy_path=policy_path,
+        report_json=paths["--report-json"],
+        model_path=model_path,
+        report_html=paths["--report-html"],
+        extra=["--summary-json", str(paths["--summary-json"])],
+    )
+    exit_code = _run_optimize(argv)
+
+    assert exit_code == 1
+    assert policy_path.read_bytes() == policy_before
+    assert matrix_path.read_bytes() == matrix_before
+    assert not results_dir.exists()
+
+
+def test_optimize_rejects_report_json_report_html_collision(tmp_path, monkeypatch):
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--report-html",
+        collision_path=lambda **paths: paths["report_json"],
+    )
+
+
+def test_optimize_rejects_report_json_summary_collision(tmp_path, monkeypatch):
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--summary-json",
+        collision_path=lambda **paths: paths["report_json"],
+    )
+
+
+def test_optimize_rejects_report_json_default_summary_collision(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=results_dir / "optimize_summary.json",
+            model_path=model_path,
+        )
+    )
+
+    assert exit_code == 1
+    assert not results_dir.exists()
+
+
+def test_optimize_rejects_policy_report_collision(tmp_path, monkeypatch):
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--report-json",
+        collision_path=lambda **paths: paths["policy_path"],
+    )
+
+
+def test_optimize_rejects_matrix_summary_collision(tmp_path, monkeypatch):
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--summary-json",
+        collision_path=lambda **paths: paths["matrix_path"],
+    )
+
+
+def test_optimize_rejects_relative_path_aliases(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--report-html",
+        collision_path=lambda **paths: tmp_path
+        / "subdir"
+        / ".."
+        / paths["report_json"].name,
+    )
+
+
+def test_optimize_rejects_symlink_path_aliases(tmp_path, monkeypatch):
+    report_target = tmp_path / "report.json"
+    report_alias = tmp_path / "report-alias.json"
+    try:
+        report_alias.symlink_to(report_target)
+    except OSError:
+        pytest.skip("symlinks are not available")
+    _assert_optimize_path_collision(
+        tmp_path,
+        monkeypatch,
+        collision_flag="--report-html",
+        collision_path=lambda **paths: report_alias,
+    )
+
+
+def test_optimize_rejects_case_insensitive_path_aliases(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    if not cli._filesystem_is_case_insensitive(matrix_path):
+        pytest.skip("filesystem is case-sensitive")
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=matrix_path.with_name(matrix_path.name.swapcase()),
+            model_path=model_path,
+        )
+    )
+
+    assert exit_code == 1
+
+
+def test_optimize_rejects_selected_run_artifact_collision(tmp_path, monkeypatch):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+    run_id = "structured-json-profile-extraction-2k-autoregressive"
+    final_record_path = results_dir / "runs" / run_id / "final_record.json"
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+            extra=["--summary-json", str(final_record_path)],
+        )
+    )
+
+    assert exit_code == 1
+    assert not results_dir.exists()
+
+
 def test_optimize_invalid_policy_fails_before_any_execution(tmp_path, monkeypatch):
     matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
     model_path = tmp_path / "model"
@@ -492,6 +793,28 @@ def test_optimize_invalid_policy_fails_before_any_execution(tmp_path, monkeypatc
     )
 
     assert exit_code == 1
+    assert not results_dir.exists()
+
+
+def test_optimize_missing_policy_fails_without_traceback(tmp_path, monkeypatch, capsys):
+    matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(cli, "MLXLMRuntime", _never_call_runtime_factory())
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=results_dir,
+            policy_path=tmp_path / "missing-policy.json",
+            report_json=tmp_path / "report.json",
+            model_path=model_path,
+        )
+    )
+
+    assert exit_code == 1
+    assert "Invalid tune policy" in capsys.readouterr().err
     assert not results_dir.exists()
 
 

--- a/tests/optimizer/test_optimize_summary_schema.py
+++ b/tests/optimizer/test_optimize_summary_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 
 import pytest
 
@@ -120,6 +121,12 @@ def test_row_status_counts_rejects_non_integer_values():
         RowStatusCounts.from_dict({"total": "one"})
 
 
+@pytest.mark.parametrize("value", [True, -1, 1.5, "1"])
+def test_row_status_counts_rejects_invalid_direct_values(value):
+    with pytest.raises(OptimizeSummaryValidationError):
+        RowStatusCounts(blocked=value)
+
+
 def test_recommended_candidate_requires_group_label():
     with pytest.raises(OptimizeSummaryValidationError):
         RecommendedCandidate.from_dict(
@@ -129,6 +136,26 @@ def test_recommended_candidate_requires_group_label():
                 "objective_value": 1.0,
             }
         )
+
+
+@pytest.mark.parametrize("value", [True, math.nan, math.inf, -math.inf])
+def test_recommended_candidate_rejects_invalid_objective_value(value):
+    with pytest.raises(OptimizeSummaryValidationError, match="finite number"):
+        RecommendedCandidate(
+            group_label="g",
+            run_ids=("r1",),
+            objective_name="latency",
+            objective_value=value,
+        )
+
+
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_summary_json_rejects_non_finite_objective_value(token):
+    data = _make_summary().to_dict()
+    data["recommendations"][0]["objective_value"] = json.loads(token)
+    payload = json.dumps(data, allow_nan=True)
+    with pytest.raises(OptimizeSummaryValidationError, match="finite number"):
+        OptimizeSummary.from_json(payload)
 
 
 def test_rejects_invalid_overall_status():
@@ -145,6 +172,11 @@ def test_rejects_non_integer_exit_code():
     data["exit_code"] = "0"
     with pytest.raises(OptimizeSummaryValidationError):
         OptimizeSummary.from_dict(data)
+
+
+def test_rejects_boolean_exit_code_on_direct_construction():
+    with pytest.raises(OptimizeSummaryValidationError):
+        _make_summary(exit_code=True)
 
 
 def test_phase_lookup_helper_finds_named_phase():

--- a/tests/optimizer/test_optimize_summary_schema.py
+++ b/tests/optimizer/test_optimize_summary_schema.py
@@ -1,0 +1,163 @@
+"""Unit tests for the `optimize_summary` orchestration-summary schema."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from llmtracefx.optimizer.optimize_summary import (
+    OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+    OptimizeSummary,
+    OptimizeSummaryValidationError,
+    OverallStatus,
+    PhaseName,
+    PhaseReport,
+    PhaseStatus,
+    RecommendedCandidate,
+    RowStatusCounts,
+)
+
+
+def _make_summary(**overrides):
+    defaults = {
+        "schema_version": OPTIMIZE_SUMMARY_SCHEMA_VERSION,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "dry_run": False,
+        "matrix_path": "/tmp/matrix/manifest.json",
+        "results_dir": "/tmp/results",
+        "policy_path": "/tmp/policy.json",
+        "report_json_path": "/tmp/report.json",
+        "report_html_path": "/tmp/report.html",
+        "phases": (
+            PhaseReport(name=PhaseName.PLANNED, status=PhaseStatus.OK),
+            PhaseReport(name=PhaseName.EXECUTED, status=PhaseStatus.OK),
+            PhaseReport(name=PhaseName.VERIFIED, status=PhaseStatus.OK),
+            PhaseReport(name=PhaseName.TUNED, status=PhaseStatus.OK),
+            PhaseReport(name=PhaseName.RENDERED, status=PhaseStatus.OK),
+        ),
+        "row_counts": RowStatusCounts(total=1, completed=1),
+        "recommendations": (
+            RecommendedCandidate(
+                group_label="g",
+                run_ids=("r1",),
+                objective_name="min_mean_total_latency_ms",
+                objective_value=1.0,
+            ),
+        ),
+        "overall_status": OverallStatus.SUCCESS,
+        "exit_code": 0,
+    }
+    defaults.update(overrides)
+    return OptimizeSummary(**defaults)
+
+
+def test_round_trips_through_json():
+    summary = _make_summary()
+    restored = OptimizeSummary.from_json(summary.to_json())
+    assert restored == summary
+
+
+def test_write_and_read_json_file(tmp_path):
+    summary = _make_summary()
+    path = tmp_path / "summary.json"
+    path.write_text(summary.to_json() + "\n", encoding="utf-8")
+    restored = OptimizeSummary.read_json(path)
+    assert restored == summary
+
+
+def test_rejects_invalid_json():
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_json("not json")
+
+
+def test_rejects_non_object_payload():
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_json("[1, 2, 3]")
+
+
+def test_rejects_unsupported_schema_version():
+    summary = _make_summary()
+    data = summary.to_dict()
+    data["schema_version"] = "999"
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_dict(data)
+
+
+def test_requires_every_phase_present_in_order():
+    summary = _make_summary()
+    data = summary.to_dict()
+    data["phases"] = data["phases"][:-1]  # drop "rendered"
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_dict(data)
+
+
+def test_rejects_out_of_order_phases():
+    summary = _make_summary()
+    data = summary.to_dict()
+    data["phases"] = list(reversed(data["phases"]))
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_dict(data)
+
+
+def test_phase_report_rejects_unknown_status():
+    with pytest.raises(OptimizeSummaryValidationError):
+        PhaseReport.from_dict({"name": "planned", "status": "not-a-real-status"})
+
+
+def test_phase_report_rejects_unknown_name():
+    with pytest.raises(OptimizeSummaryValidationError):
+        PhaseReport.from_dict({"name": "not-a-real-phase", "status": "ok"})
+
+
+def test_row_status_counts_rejects_negative_values():
+    with pytest.raises(OptimizeSummaryValidationError):
+        RowStatusCounts.from_dict({"total": -1})
+
+
+def test_row_status_counts_rejects_non_integer_values():
+    with pytest.raises(OptimizeSummaryValidationError):
+        RowStatusCounts.from_dict({"total": "one"})
+
+
+def test_recommended_candidate_requires_group_label():
+    with pytest.raises(OptimizeSummaryValidationError):
+        RecommendedCandidate.from_dict(
+            {
+                "run_ids": ["r1"],
+                "objective_name": "x",
+                "objective_value": 1.0,
+            }
+        )
+
+
+def test_rejects_invalid_overall_status():
+    summary = _make_summary()
+    data = summary.to_dict()
+    data["overall_status"] = "somewhat_ok"
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_dict(data)
+
+
+def test_rejects_non_integer_exit_code():
+    summary = _make_summary()
+    data = summary.to_dict()
+    data["exit_code"] = "0"
+    with pytest.raises(OptimizeSummaryValidationError):
+        OptimizeSummary.from_dict(data)
+
+
+def test_phase_lookup_helper_finds_named_phase():
+    summary = _make_summary()
+    tuned = summary.phase(PhaseName.TUNED)
+    assert tuned is not None
+    assert tuned.status == PhaseStatus.OK
+
+
+def test_to_dict_is_json_serializable_directly():
+    summary = _make_summary()
+    # Never rely on to_json's json.dumps alone: to_dict must already be a
+    # plain, directly-serializable structure (no enums/dataclasses leaking
+    # through), the same contract every other schema module in this
+    # package upholds.
+    json.dumps(summary.to_dict())

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -190,6 +190,13 @@ def test_run_binding_accepts_existing_paths(tmp_path):
     assert binding.draft_model_path == draft
 
 
+@pytest.mark.parametrize("value", [True, 0, -1])
+def test_run_binding_rejects_invalid_num_draft_tokens(tmp_path, value):
+    target = make_target_model(tmp_path)
+    with pytest.raises(VerifyError, match="positive integer"):
+        RunBinding(target_model_path=target, num_draft_tokens=value)
+
+
 # --- Unsupported (native-mtp) rows -------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Adds `llmtracefx-optimizer optimize`, a single command that composes the existing workload execution, verification, offline tuning, JSON reporting, and privacy-safe HTML rendering APIs without duplicating collector, evaluator, tuner, or renderer logic.

```bash
uv run llmtracefx-optimizer optimize \
  --matrix artifacts/qwen3.8-matrix/manifest.json \
  --model-path /existing/local/mlx/model \
  --results artifacts/qwen3.8-run \
  --policy examples/optimizer/tune-policy-fastest-under-20gb-m5-pro.json \
  --report-json artifacts/qwen3.8-tune-report.json \
  --report-html artifacts/qwen3.8-tune-report.html \
  --mode autoregressive \
  --context-tier 2k
```

## Orchestration

1. Loads the matrix and policy before execution.
2. Selects and plans rows with the existing workload verifier.
3. Executes rows through the existing resumable MLX collection pipeline.
4. Tunes only selected runs from the primary `--results` directory. Repeatable `--extra-results` remains the explicit opt-in for historical evidence.
5. Writes and revalidates the tune JSON, optionally renders the path-redacted HTML report, and atomically persists `optimize_summary.json`.

The orchestration summary records planned, executed, verified, tuned, and rendered phase states, row counts, recommendations, the final status, and exit code.

## Exit behavior

- Exit `0`: execution and tuning produced at least one recommendation and all requested reports were written.
- Exit `1`: hard setup, execution, tuning-input, or report persistence failure.
- Exit `2`: the command completed but evidence was inconclusive.

A failed row keeps the overall result non-zero even when other valid rows still produce a recommendation.

## Dry run

`--dry-run` never constructs an MLX runtime, calls the tuner, or renders tune reports. It atomically writes and revalidates an orchestration summary with:

- `dry_run: true`
- planned phase `ok`
- executed, verified, tuned, and rendered phases `not_run`
- explicit selected, ready, blocked, and unsupported planning counts

## Data integrity hardening

- Resolves matrix, policy, report JSON, report HTML, results, and summary paths before use.
- Rejects pairwise aliases before reading inputs or writing artifacts, including relative, symlink, hardlink, and case-insensitive filesystem aliases.
- Rejects report or summary paths that alias selected prompts, verification files, final records, or collector artifacts.
- Preserves matrix and policy inputs on every collision failure.
- Rejects invalid draft-token depths during planning instead of reporting them as ready.
- Handles missing, unreadable, or invalidly encoded policy files without a traceback.
- Rejects boolean and non-finite recommendation objective values during construction and deserialization.
- Serializes orchestration JSON with `allow_nan=False`.

## Scope

No model download, native counter collection, native Qwen MTP adapter, new tuning objective, or network dependency is added. Generic draft-model speculation remains distinct from native MTP.

## Validation

- `uv run pytest tests/ -q`: 659 passed
- Ruff: clean
- Black: clean
- isort: clean
- mypy: clean across `llmtracefx/optimizer/` (30 source files)
- Independent final code review: no significant findings

Tests cover complete success, failure precedence, unsupported and inconclusive selections, resumable execution, explicit extra evidence, stale primary-result exclusion, dry-run summaries, path collisions and aliases, selected artifact protection, policy I/O errors, finite-number validation, and report persistence failures.