### PR TITLE
Add GitHub Actions CI with a changed-files quality ratchet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration.
+#
+# The github-actions block matters here because ci.yml and codeql.yml pin every
+# action to a commit SHA. Pinned SHAs do not drift, which is the point, but it
+# also means they never pick up security fixes unless something bumps them.
+# Dependabot understands the "# vX.Y.Z" comment next to each pin and updates
+# both the SHA and the comment together.
+
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-dev-tooling:
+        patterns:
+          - "black"
+          - "isort"
+          - "mypy"
+          - "ruff"
+          - "pytest*"
+          - "pre-commit"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,153 @@
+# CI for LLMTraceFX.
+#
+# About the `quality` job: it is a ratchet, not a repo-wide gate.
+#
+# main currently carries substantial pre-existing lint, format and type debt
+# (hundreds of ruff findings and dozens of mypy errors in older modules). A
+# repo-wide `ruff check llmtracefx/` or `mypy llmtracefx/` would be red on every
+# single pull request, which trains people to ignore the build. Rather than
+# mass-reformatting the repository or hiding the problem behind blanket ignores
+# and continue-on-error, the quality job checks only the Python files that the
+# pull request actually touches. New and edited code is held to the standard,
+# untouched legacy code is left for separate cleanup, and the gate means
+# something on day one.
+#
+# The selection logic lives in scripts/lint-changed.sh so the identical check can
+# be run locally with `make lint-changed`.
+#
+# Note for future contributors: `ruff format` is deliberately absent here.
+# `ruff format` and black disagree on some files in this repository and each
+# reverts the other, so requiring both is unsatisfiable. black is the formatter
+# of record. ruff's linter does not conflict with black, and ruff's I001 import
+# rule was verified to agree with isort, so `ruff check` is still enforced.
+# The `format` and `format-check` Makefile targets were corrected to match, so
+# running `make format` locally produces exactly what this workflow accepts.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  test:
+    name: test (python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra test
+
+      - name: Run test suite
+        run: uv run pytest
+
+  quality:
+    name: quality ratchet (changed files)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the merge base with the base branch is available.
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra test
+
+      - name: Resolve diff base
+        id: diff-base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$PR_BASE_SHA"
+          else
+            # github.event.before is all zeros for a new branch, and can point at
+            # an object that no longer exists after a force push.
+            base="$PUSH_BEFORE_SHA"
+            if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+              base="$(git rev-parse --verify --quiet 'HEAD^{commit}^' || true)"
+            fi
+          fi
+          if [ -z "$base" ]; then
+            echo "Could not resolve a diff base, skipping the ratchet."
+            echo "base=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Diff base: $base"
+            echo "base=$base" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run quality ratchet on changed files
+        if: steps.diff-base.outputs.base != ''
+        run: scripts/lint-changed.sh "${{ steps.diff-base.outputs.base }}"
+
+  build:
+    name: build and verify wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Verify the wheel imports in a clean environment
+        run: |
+          set -euo pipefail
+          wheel="$(ls dist/*.whl)"
+          echo "Testing $wheel"
+          uv venv --python 3.12 .wheel-check
+          uv pip install --python .wheel-check/bin/python "$wheel"
+          # Run from a directory without the source tree so the import resolves
+          # against the installed wheel rather than ./llmtracefx.
+          cd "$(mktemp -d)"
+          "$GITHUB_WORKSPACE/.wheel-check/bin/python" -c "
+          import importlib.metadata as md
+          import llmtracefx
+          print('imported llmtracefx from', llmtracefx.__file__)
+          print('version', md.version('llmtracefx'))
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,29 @@ env:
 
 jobs:
   test:
-    name: test (python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }}, python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          # GitHub's macOS runners are Apple Silicon, and macOS defaults to a
+          # case-insensitive filesystem. Both matter here:
+          #   - test_optimize_rejects_case_insensitive_path_aliases skips on
+          #     Linux ("filesystem is case-sensitive") so that path-alias
+          #     rejection check never actually executes on ubuntu runners.
+          #   - MLX collection is gated on Darwin plus arm64 in
+          #     optimizer/collectors/mlx.py, and optimizer/manifest.py records
+          #     platform details, so Linux never reaches those branches.
+          # macOS covers the ends of the supported range rather than the full
+          # matrix, to add the platform signal without doubling the job count.
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.13"
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,46 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra test
+        run: uv sync --locked --extra dev --extra test
+
+      # macOS is the only place the MLX extra can install, because its dependency
+      # markers require Darwin on arm64. Installing it here is what makes the
+      # macOS jobs worth running: without it the MLX tests exercise a
+      # monkeypatched stand-in, and the real import path is never executed.
+      - name: Install MLX runtime (macOS only)
+        if: runner.os == 'macOS'
+        run: uv sync --locked --extra dev --extra test --extra mlx
 
       - name: Run test suite
         run: uv run pytest
+
+      # Constructing MLXLMRuntime is the actual runtime boundary: it rejects
+      # anything that is not Darwin on arm64, and raises if mlx or mlx_lm cannot
+      # be imported. Every call below is model free, so this downloads nothing.
+      # load_model and stream_generate are deliberately not exercised.
+      - name: MLX runtime smoke check (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          uv run python - <<'PY'
+          import platform
+
+          from llmtracefx.optimizer.collectors.mlx import MLXLMRuntime
+
+          runtime = MLXLMRuntime()
+          runtime.seed(0)
+          runtime.synchronize()
+          runtime.reset_peak_memory()
+          snapshot = runtime.memory_snapshot()
+
+          assert runtime.mlx_version, "mlx version did not resolve"
+          assert runtime.mlx_lm_version, "mlx-lm version did not resolve"
+
+          print(f"platform:    {platform.system()}/{platform.machine()}")
+          print(f"mlx:         {runtime.mlx_version}")
+          print(f"mlx-lm:      {runtime.mlx_lm_version}")
+          print(f"accelerator: {runtime.accelerator_name()}")
+          print(f"memory:      {snapshot}")
+          PY
 
   quality:
     name: quality ratchet (changed files)
@@ -101,7 +137,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra test
+        run: uv sync --locked --extra dev --extra test
+
+      - name: Test the ratchet itself
+        # Runs before the ratchet does. If file selection regresses, the gate can
+        # start passing on an empty file list, which is indistinguishable from a
+        # clean run. These tests stub uv, so they need no toolchain.
+        run: scripts/test-lint-changed.sh
 
       - name: Resolve diff base
         id: diff-base
@@ -111,26 +153,35 @@ jobs:
           PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
+          # The empty tree. Diffing against it yields every tracked file, which
+          # is the correct baseline when a push has no usable predecessor.
+          EMPTY_TREE=4b825dc642cb6eb9a060e54bf8d69288fbee4904
           if [ "$EVENT_NAME" = "pull_request" ]; then
             base="$PR_BASE_SHA"
+            if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+              echo "::error::Pull request base ${base} is missing from the checkout."
+              exit 1
+            fi
           else
-            # github.event.before is all zeros for a new branch, and can point at
-            # an object that no longer exists after a force push.
+            # github.event.before is all zeros on the first push of a branch, and
+            # after a force push it can name an object that no longer exists.
+            # The previous fallback here was HEAD^, which was wrong twice over:
+            # it only covers the final commit of a multi-commit push, and it does
+            # not exist at all for a root commit. The empty tree errs towards
+            # checking every file rather than silently checking none.
             base="$PUSH_BEFORE_SHA"
             if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
-              base="$(git rev-parse --verify --quiet 'HEAD^{commit}^' || true)"
+              echo "Push base ${base} is unusable. Falling back to the empty tree."
+              base="$EMPTY_TREE"
             fi
           fi
-          if [ -z "$base" ]; then
-            echo "Could not resolve a diff base, skipping the ratchet."
-            echo "base=" >> "$GITHUB_OUTPUT"
-          else
-            echo "Diff base: $base"
-            echo "base=$base" >> "$GITHUB_OUTPUT"
-          fi
+          echo "Diff base: $base"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
 
+      # No `if:` guard here on purpose. Skipping this step registers as success,
+      # so an unresolvable base would quietly pass the ratchet. Resolution above
+      # either produces a usable base or fails the job.
       - name: Run quality ratchet on changed files
-        if: steps.diff-base.outputs.base != ''
         run: scripts/lint-changed.sh "${{ steps.diff-base.outputs.base }}"
 
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+# CodeQL static analysis for Python.
+#
+# This is separate from ci.yml on purpose. It needs security-events: write to
+# upload results, and ci.yml is deliberately kept at contents: read. Keeping
+# the elevated permission in its own file limits what the main pipeline can do.
+#
+# Unlike the quality ratchet in ci.yml, this scans the whole repository. That is
+# appropriate here because CodeQL reports into the Security tab rather than
+# blocking pull requests on pre-existing findings.
+
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, so newly published queries run against unchanged code.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:python

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint format clean run-sample run-server deploy-modal
+.PHONY: help install install-dev sync test lint lint-changed format clean run-sample run-server deploy-modal
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - GPU-level LLM inference profiler"
@@ -29,15 +29,16 @@ lint:  ## Run linting
 	uv run ruff check llmtracefx/
 	uv run mypy llmtracefx/
 
+lint-changed:  ## Run the CI quality ratchet over files changed vs origin/main
+	./scripts/lint-changed.sh origin/main
+
 format:  ## Format code
 	uv run black llmtracefx/
 	uv run isort llmtracefx/
-	uv run ruff format llmtracefx/
 
 format-check:  ## Check formatting
 	uv run black --check llmtracefx/
 	uv run isort --check-only llmtracefx/
-	uv run ruff format --check llmtracefx/
 
 # Running
 run-sample:  ## Run analysis on sample trace

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint lint-changed format clean run-sample run-server deploy-modal
+.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - GPU-level LLM inference profiler"
@@ -32,13 +32,27 @@ lint:  ## Run linting
 lint-changed:  ## Run the CI quality ratchet over files changed vs origin/main
 	./scripts/lint-changed.sh origin/main
 
-format:  ## Format code
-	uv run black llmtracefx/
-	uv run isort llmtracefx/
+test-ratchet:  ## Test the ratchet's own file selection and failure handling
+	./scripts/test-lint-changed.sh
 
-format-check:  ## Check formatting
-	uv run black --check llmtracefx/
-	uv run isort --check-only llmtracefx/
+# Formatting scope note: the CI ratchet checks every changed *.py file wherever
+# it lives, not just llmtracefx/. These targets match that scope so `make format`
+# and CI cannot disagree. Scoping them to llmtracefx/ used to hide two files at
+# the repo root, launch_dashboard.py and generate_trace.py, which fail both black
+# and isort: editing either one meant CI rejected formatting that `make format`
+# had refused to fix. black and isort apply their own default exclusions, so `.`
+# walks exactly the 84 tracked Python files and no virtualenv or build output.
+#
+# `lint` below stays on llmtracefx/ deliberately. mypy is configured strictly
+# enough that ordinary untyped test functions fail it, so the ratchet scopes mypy
+# the same way.
+format:  ## Format code (repository wide, matching the CI ratchet scope)
+	uv run black .
+	uv run isort .
+
+format-check:  ## Check formatting (repository wide, matching the CI ratchet scope)
+	uv run black --check .
+	uv run isort --check-only .
 
 # Running
 run-sample:  ## Run analysis on sample trace

--- a/README.md
+++ b/README.md
@@ -677,6 +677,16 @@ collection is gated on Darwin plus arm64 in
 `llmtracefx/optimizer/collectors/mlx.py`, and `optimizer/manifest.py` records
 platform details, so a Linux-only matrix never executes those branches.
 
+The macOS jobs install the `mlx` extra, whose dependency markers only resolve on
+Darwin plus arm64, and then run a smoke check that constructs `MLXLMRuntime`.
+That constructor is the real runtime boundary: it rejects any other platform and
+raises if `mlx` or `mlx_lm` cannot be imported. The check reads the resolved
+versions, the accelerator name and a memory snapshot, and deliberately never
+calls `load_model` or `stream_generate`, so nothing is downloaded. Without the
+extra installed the MLX tests exercise a monkeypatched stand-in and the real
+import path never runs, which would leave the macOS jobs costing time without
+proving anything.
+
 A separate `.github/workflows/codeql.yml` runs CodeQL static analysis for Python
 on pull requests, pushes to `main`, and weekly. It reports into the repository
 Security tab rather than blocking pull requests. `.github/dependabot.yml` keeps
@@ -713,10 +723,33 @@ script directly:
 ./scripts/lint-changed.sh <base-ref-or-sha>
 ```
 
+The script fails closed. If it cannot work out what changed, because the base is
+missing or shares no history with `HEAD`, it exits non-zero instead of reporting
+that there is nothing to check. That distinction is the whole point: a gate that
+runs its tools over an empty file list reports success, so a ratchet that guesses
+when it is confused stops gating without anyone noticing. `scripts/test-lint-changed.sh`
+pins that behaviour down, together with renames, deletions, paths containing
+spaces, multi-commit pushes and the first push of a branch:
+
+```bash
+make test-ratchet
+```
+
+It stubs `uv` on `PATH` rather than running the real linters, so each case
+asserts on the exact file list the script builds and the status it returns.
+
 Note that `ruff format` is not used anywhere in this project. It and `black`
 disagree on a few files here and each undoes the other, so running both can
 never pass. `black` is the formatter of record, and `make format` matches what
 CI enforces. `ruff check` is still used for linting, which does not conflict.
+
+`make format` and `make format-check` cover the whole tree rather than just
+`llmtracefx/`, because the ratchet checks every changed `.py` file wherever it
+lives. Two files at the repository root, `launch_dashboard.py` and
+`generate_trace.py`, fail black and isort today and were invisible to the older
+`llmtracefx/`-only scope, so editing either one meant CI rejecting formatting
+that `make format` had declined to fix. `make lint` stays scoped to
+`llmtracefx/`, which is how the ratchet scopes mypy.
 
 ## 🧭 Inference Optimizer Foundation
 

--- a/README.md
+++ b/README.md
@@ -661,6 +661,40 @@ uv run ruff check llmtracefx/hardware.py \
   llmtracefx/profiler/gpu_analyzer.py tests
 ```
 
+### Continuous Integration
+
+GitHub Actions runs three jobs on every pull request and on pushes to `main`
+(see `.github/workflows/ci.yml`):
+
+| Job | What it does |
+| --- | --- |
+| `test` | Full `pytest` suite on Python 3.10, 3.11, 3.12 and 3.13 |
+| `quality ratchet` | `ruff check`, `black`, `isort` and `mypy` on changed files only |
+| `build` | `uv build`, then installs the wheel into a clean environment and imports it |
+
+The quality job checks only the Python files a change touches, rather than the
+whole repository. Older modules still carry lint and typing debt, so a repo-wide
+gate would fail every pull request regardless of its contents. Checking the diff
+keeps new code at the intended standard while that debt is paid down separately.
+
+Run the same check locally before pushing:
+
+```bash
+make lint-changed
+```
+
+That compares against `origin/main`. To compare against something else, call the
+script directly:
+
+```bash
+./scripts/lint-changed.sh <base-ref-or-sha>
+```
+
+Note that `ruff format` is not used anywhere in this project. It and `black`
+disagree on a few files here and each undoes the other, so running both can
+never pass. `black` is the formatter of record, and `make format` matches what
+CI enforces. `ruff check` is still used for linting, which does not conflict.
+
 ## 🧭 Inference Optimizer Foundation
 
 LLMTraceFX is evolving from a trace *analyzer* into a workload-aware

--- a/README.md
+++ b/README.md
@@ -691,10 +691,14 @@ separately.
 Note that the unit is the whole file, not the changed lines. Touching a module
 that still carries debt means inheriting all of it: a one line edit to
 `llmtracefx/modal_app.py` currently fails on 39 ruff findings and 10 mypy
-errors that the change did not introduce, and `make format` does not clear
-them. That is deliberate, since it is what makes the debt shrink rather than
-persist, but it is worth knowing before editing an older module. Files added by
-recent work are already clean and stay that way.
+errors that the change did not introduce.
+
+Most of that is mechanical. `make format` satisfies black and isort and clears
+36 of the 39 ruff findings, and `ruff check --fix llmtracefx/modal_app.py`
+clears the last 3, which leaves the 10 mypy errors as the only part that needs
+real edits. That is deliberate, since it is what makes the debt shrink rather
+than persist, but it is worth knowing before editing an older module. Files
+added by recent work are already clean and stay that way.
 
 Run the same check locally before pushing:
 

--- a/README.md
+++ b/README.md
@@ -668,9 +668,19 @@ GitHub Actions runs three jobs on every pull request and on pushes to `main`
 
 | Job | What it does |
 | --- | --- |
-| `test` | Full `pytest` suite on Python 3.10, 3.11, 3.12 and 3.13 |
+| `test` | Full `pytest` suite on Python 3.10, 3.11, 3.12 and 3.13 on Linux, plus 3.10 and 3.13 on macOS |
 | `quality ratchet` | `ruff check`, `black`, `isort` and `mypy` on changed files only |
 | `build` | `uv build`, then installs the wheel into a clean environment and imports it |
+
+macOS is included because GitHub's macOS runners are Apple Silicon. MLX
+collection is gated on Darwin plus arm64 in
+`llmtracefx/optimizer/collectors/mlx.py`, and `optimizer/manifest.py` records
+platform details, so a Linux-only matrix never executes those branches.
+
+A separate `.github/workflows/codeql.yml` runs CodeQL static analysis for Python
+on pull requests, pushes to `main`, and weekly. It reports into the repository
+Security tab rather than blocking pull requests. `.github/dependabot.yml` keeps
+Python dependencies and the SHA-pinned GitHub Actions up to date.
 
 The quality job checks only the Python files a change touches, rather than the
 whole repository. Older modules still carry lint and typing debt, so a repo-wide

--- a/README.md
+++ b/README.md
@@ -684,8 +684,17 @@ Python dependencies and the SHA-pinned GitHub Actions up to date.
 
 The quality job checks only the Python files a change touches, rather than the
 whole repository. Older modules still carry lint and typing debt, so a repo-wide
-gate would fail every pull request regardless of its contents. Checking the diff
-keeps new code at the intended standard while that debt is paid down separately.
+gate would fail every pull request regardless of its contents. Narrowing the
+gate keeps new code at the intended standard while that debt is paid down
+separately.
+
+Note that the unit is the whole file, not the changed lines. Touching a module
+that still carries debt means inheriting all of it: a one line edit to
+`llmtracefx/modal_app.py` currently fails on 39 ruff findings and 10 mypy
+errors that the change did not introduce, and `make format` does not clear
+them. That is deliberate, since it is what makes the debt shrink rather than
+persist, but it is worth knowing before editing an older module. Files added by
+recent work are already clean and stay that way.
 
 Run the same check locally before pushing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: System :: Monitoring",

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -38,7 +38,18 @@
 
 set -euo pipefail
 
-BASE="${1:-origin/main}"
+BASE="${1-origin/main}"
+
+# `${1-...}` rather than `${1:-...}` on purpose. An explicitly passed empty
+# string means the caller tried to supply a base and came up with nothing, which
+# is the "cannot work out what changed" condition, not a request for the default.
+# Coercing it to origin/main would diff HEAD against itself on a push build and
+# pass having checked nothing.
+if [ "$#" -gt 0 ] && [ -z "$1" ]; then
+    echo "lint-changed: empty base argument." >&2
+    echo "lint-changed: pass a base ref or SHA, or pass nothing for origin/main." >&2
+    exit 1
+fi
 
 # The empty tree. Used as the base for an initial push, where there is no
 # previous commit to compare against and every tracked file is new.

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -20,13 +20,18 @@
 # BASE defaults to origin/main. CI passes an explicit base SHA.
 #
 # Notes on the file selection, which is deliberately picky:
-#   --merge-base    three-dot semantics, so unrelated commits that landed on the
-#                   base branch are not attributed to this change
+#   merge base     resolved explicitly, then used as a two dot diff. Equivalent
+#                  to --merge-base, but a missing merge base can be reported on
+#                  its own rather than surfacing as a generic diff error.
 #   --diff-filter   A/C/M/R only. Deleted files are excluded so no tool is ever
 #                   handed a path that no longer exists. For a rename, git
 #                   reports the new path, which is the one worth checking.
 #   -z              NUL separated output, so paths containing spaces survive
 #   -- '*.py'       a git pathspec, which matches nested directories
+#
+# Every failure here is a hard failure. A ratchet that cannot work out what
+# changed must not fall back to checking nothing, because that reports success.
+# scripts/test-lint-changed.sh covers the cases that used to slip through.
 #
 # Written for bash 3.2 so it also runs on a stock macOS shell. That rules out
 # mapfile, hence the read -d '' loop below.
@@ -35,16 +40,50 @@ set -euo pipefail
 
 BASE="${1:-origin/main}"
 
-if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
-    echo "lint-changed: base commit '${BASE}' not found." >&2
-    echo "lint-changed: fetch the base branch, or pass an explicit base SHA." >&2
+# The empty tree. Used as the base for an initial push, where there is no
+# previous commit to compare against and every tracked file is new.
+EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+if [ "$BASE" = "$EMPTY_TREE" ]; then
+    # No merge base exists against a bare tree, and none is wanted. Comparing
+    # HEAD to the empty tree yields every tracked Python file, which is the
+    # correct baseline for a branch with no history behind it.
+    DIFF_BASE="$EMPTY_TREE"
+else
+    if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+        echo "lint-changed: base commit '${BASE}' not found." >&2
+        echo "lint-changed: fetch the base branch, or pass an explicit base SHA." >&2
+        exit 1
+    fi
+
+    # Resolving the merge base as its own step means an unrelated history gets a
+    # clear message. Folding it into `git diff --merge-base` would still fail,
+    # but the reason would be buried in a diff error.
+    if ! DIFF_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
+        echo "lint-changed: no merge base between '${BASE}' and HEAD." >&2
+        echo "lint-changed: refusing to guess a base, because checking nothing" >&2
+        echo "lint-changed: would silently pass the ratchet." >&2
+        exit 1
+    fi
+fi
+
+# The file list goes through a temporary file so the exit status of git diff can
+# be checked. Read through a process substitution instead, a git failure is
+# invisible: the loop reads nothing, the list comes out empty, and the script
+# reports "nothing to check" and exits 0. That turns any git error into a silent
+# pass, which is the one failure mode a ratchet must not have.
+DIFF_LIST="$(mktemp)"
+trap 'rm -f "$DIFF_LIST"' EXIT
+
+if ! git diff --name-only --diff-filter=ACMR -z "$DIFF_BASE" HEAD -- '*.py' >"$DIFF_LIST"; then
+    echo "lint-changed: git diff against '${DIFF_BASE}' failed." >&2
     exit 1
 fi
 
 CHANGED=()
 while IFS= read -r -d '' file; do
     CHANGED+=("$file")
-done < <(git diff --merge-base "$BASE" HEAD --name-only --diff-filter=ACMR -z -- '*.py')
+done <"$DIFF_LIST"
 
 if [ ${#CHANGED[@]} -eq 0 ]; then
     echo "No Python files changed against ${BASE}. Nothing to check."

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Quality ratchet: run the linters over only the Python files that changed
+# relative to a base commit, instead of over the whole repository.
+#
+# Why: the repository carries a large amount of pre-existing lint, format and
+# type debt on main. A repo-wide gate would be red on every pull request and
+# would quickly be ignored. Checking only changed files keeps new code at the
+# intended standard without demanding a mass reformat first.
+#
+# The tools are ruff (linting only), black, isort and mypy. `ruff format` is
+# deliberately not used: it and black disagree on a few files here and each
+# reverts the other, so running both can never pass. black is the formatter of
+# record. ruff's linter and black do not conflict, and ruff's I001 import rule
+# was verified to agree with isort, so `ruff check` stays.
+#
+# Usage:
+#   scripts/lint-changed.sh [BASE]
+#
+# BASE defaults to origin/main. CI passes an explicit base SHA.
+#
+# Notes on the file selection, which is deliberately picky:
+#   --merge-base    three-dot semantics, so unrelated commits that landed on the
+#                   base branch are not attributed to this change
+#   --diff-filter   A/C/M/R only. Deleted files are excluded so no tool is ever
+#                   handed a path that no longer exists. For a rename, git
+#                   reports the new path, which is the one worth checking.
+#   -z              NUL separated output, so paths containing spaces survive
+#   -- '*.py'       a git pathspec, which matches nested directories
+#
+# Written for bash 3.2 so it also runs on a stock macOS shell. That rules out
+# mapfile, hence the read -d '' loop below.
+
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+    echo "lint-changed: base commit '${BASE}' not found." >&2
+    echo "lint-changed: fetch the base branch, or pass an explicit base SHA." >&2
+    exit 1
+fi
+
+CHANGED=()
+while IFS= read -r -d '' file; do
+    CHANGED+=("$file")
+done < <(git diff --merge-base "$BASE" HEAD --name-only --diff-filter=ACMR -z -- '*.py')
+
+if [ ${#CHANGED[@]} -eq 0 ]; then
+    echo "No Python files changed against ${BASE}. Nothing to check."
+    exit 0
+fi
+
+echo "Checking ${#CHANGED[@]} changed Python file(s) against ${BASE}:"
+for file in "${CHANGED[@]}"; do
+    echo "  ${file}"
+done
+echo
+
+# mypy is scoped to the package only. The strict settings in pyproject.toml
+# (disallow_untyped_defs) flag ordinary untyped test functions, and the existing
+# `make lint` target already scopes mypy to llmtracefx/.
+MYPY_FILES=()
+for file in "${CHANGED[@]}"; do
+    case "$file" in
+        llmtracefx/*) MYPY_FILES+=("$file") ;;
+    esac
+done
+
+STATUS=0
+
+run_check() {
+    label="$1"
+    shift
+    echo "--- ${label} ---"
+    if "$@"; then
+        echo "${label}: ok"
+    else
+        echo "${label}: FAILED"
+        STATUS=1
+    fi
+    echo
+}
+
+run_check "ruff check" uv run ruff check -- "${CHANGED[@]}"
+run_check "black" uv run black --check -- "${CHANGED[@]}"
+run_check "isort" uv run isort --check-only -- "${CHANGED[@]}"
+
+if [ ${#MYPY_FILES[@]} -gt 0 ]; then
+    # --follow-imports=silent stops mypy reporting errors that live in unchanged
+    # modules pulled in by an import. Without it, editing a clean file can fail
+    # the build because of type debt somewhere else entirely.
+    run_check "mypy" uv run mypy --follow-imports=silent -- "${MYPY_FILES[@]}"
+else
+    echo "--- mypy ---"
+    echo "mypy: skipped, no changed files under llmtracefx/"
+    echo
+fi
+
+if [ "$STATUS" -ne 0 ]; then
+    echo "Quality ratchet failed. The issues above are in files this change touches."
+    exit 1
+fi
+
+echo "Quality ratchet passed."

--- a/scripts/test-lint-changed.sh
+++ b/scripts/test-lint-changed.sh
@@ -59,6 +59,12 @@ new_repo() {
     for arg in "$@"; do printf '\t%s' "$arg"; done
     printf '\n'
 } >>"$STUB_LOG"
+# "$1" is always "run" and "$2" is the tool name. Failing one tool at a time is
+# what lets the status tests tell the four apart. Failing them all at once would
+# only prove that at least one of them propagates.
+if [ -n "${STUB_FAIL_TOOL:-}" ] && [ "${2:-}" = "$STUB_FAIL_TOOL" ]; then
+    exit 1
+fi
 exit "${STUB_EXIT:-0}"
 STUB
     chmod +x "${REPO}/bin/uv"
@@ -83,7 +89,8 @@ commit_file() {
 # Runs the script under test inside $REPO. Sets RC and OUT.
 run_script() {
     ( cd "$REPO" && PATH="${REPO}/bin:${PATH}" STUB_LOG="$STUB_LOG" \
-        STUB_EXIT="${STUB_EXIT:-0}" "$SCRIPT" "$@" ) >"${REPO}/out.txt" 2>&1
+        STUB_EXIT="${STUB_EXIT:-0}" STUB_FAIL_TOOL="${STUB_FAIL_TOOL:-}" \
+        "$SCRIPT" "$@" ) >"${REPO}/out.txt" 2>&1
     RC=$?
     OUT="$(cat "${REPO}/out.txt")"
 }
@@ -123,6 +130,8 @@ BASE="$(git -C "$REPO" rev-parse HEAD)"
 commit_file "b.py"
 run_script "$BASE"
 check "added file is checked" "b.py" "$(files_for ruff)"
+check "black gets the same file list" "b.py" "$(files_for black)"
+check "isort gets the same file list" "b.py" "$(files_for isort)"
 
 new_repo
 commit_file "a.py"
@@ -130,6 +139,8 @@ BASE="$(git -C "$REPO" rev-parse HEAD)"
 commit_file "a file with spaces.py"
 run_script "$BASE"
 check "path with spaces stays one argument" "a file with spaces.py" "$(files_for ruff)"
+check "black keeps the space intact" "a file with spaces.py" "$(files_for black)"
+check "isort keeps the space intact" "a file with spaces.py" "$(files_for isort)"
 
 new_repo
 commit_file "a.py"
@@ -188,6 +199,16 @@ commit_file "a.py"
 run_script "refs/heads/does-not-exist"
 check "missing base ref fails closed" "1" "$RC"
 
+# An explicitly empty argument means the caller could not work out a base. On a
+# push build the old default would have been origin/main, which is HEAD, so the
+# diff came out empty and the job passed having checked nothing.
+new_repo
+commit_file "a.py"
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+run_script ""
+check "empty base argument fails closed" "1" "$RC"
+check "empty base argument runs no tools" "0" "$(calls_for ruff)"
+
 # --- initial push ---------------------------------------------------------
 
 # A root commit has no parent, so there is nothing to diff against. The empty
@@ -201,12 +222,47 @@ check "empty tree base exits 0 when clean" "0" "$RC"
 
 # --- status propagation ---------------------------------------------------
 
+# Every tool has to actually run. Deleting one from the script would otherwise be
+# invisible here: the remaining assertions still pass and the suite still goes
+# green, so half the ratchet could disappear without a test noticing.
+new_repo
+commit_file "llmtracefx/__init__.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "llmtracefx/mod.py"
+run_script "$BASE"
+check "ruff is invoked" "1" "$(calls_for ruff)"
+check "black is invoked" "1" "$(calls_for black)"
+check "isort is invoked" "1" "$(calls_for isort)"
+check "mypy is invoked" "1" "$(calls_for mypy)"
+
+# Each tool's failure has to fail the script on its own. Failing all of them at
+# once only proves that at least one status is propagated, which would leave a
+# single swallowed status undetected.
 new_repo
 commit_file "a.py"
 BASE="$(git -C "$REPO" rev-parse HEAD)"
 commit_file "b.py"
-STUB_EXIT=1 run_script "$BASE"
-check "a failing tool fails the script" "1" "$RC"
+for tool in ruff black isort; do
+    STUB_FAIL_TOOL="$tool"
+    run_script "$BASE"
+    check "a failing ${tool} fails the script" "1" "$RC"
+done
+unset STUB_FAIL_TOOL
+
+# mypy only runs when something under llmtracefx/ changed, so its status test
+# needs a fixture there rather than the root level files used above.
+new_repo
+commit_file "llmtracefx/__init__.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "llmtracefx/mod.py"
+STUB_FAIL_TOOL=mypy
+run_script "$BASE"
+check "a failing mypy fails the script" "1" "$RC"
+unset STUB_FAIL_TOOL
+
+STUB_EXIT=1
+run_script "$BASE"
+check "every tool failing fails the script" "1" "$RC"
 unset STUB_EXIT
 
 # --- mypy scoping ---------------------------------------------------------

--- a/scripts/test-lint-changed.sh
+++ b/scripts/test-lint-changed.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Tests for scripts/lint-changed.sh.
+#
+# The ratchet's real job is deciding which files changed. Getting that wrong in
+# the quiet direction, reporting "nothing to check" when it cannot actually tell,
+# is far worse than getting it wrong loudly: a check that runs on an empty file
+# list reports success, so the gate silently stops gating. Several cases below
+# exist purely to pin that behaviour down.
+#
+# The linters themselves are not exercised. A stub `uv` is put on PATH which
+# records the arguments it was handed and returns a controlled exit code, so each
+# case can assert on the exact file list the script builds and on the status it
+# propagates, without needing a real toolchain in a throwaway repository.
+#
+# Usage: scripts/test-lint-changed.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Overridable so the suite can be pointed at an older revision of the script to
+# confirm these cases actually fail against the behaviour they describe.
+SCRIPT="${LINT_CHANGED_SCRIPT:-${SCRIPT_DIR}/lint-changed.sh}"
+EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+PASSED=0
+FAILED=0
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+pass() {
+    printf '  ok    %s\n' "$1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    printf '  FAIL  %s\n' "$1"
+    printf '        expected: %s\n' "$2"
+    printf '        actual:   %s\n' "$3"
+    FAILED=$((FAILED + 1))
+}
+
+check() {
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "$2" "$3"
+    fi
+}
+
+# A throwaway repository with a stub `uv` ahead of the real one on PATH.
+new_repo() {
+    REPO="$(mktemp -d "${WORKDIR}/repo.XXXXXX")"
+    STUB_LOG="${REPO}/stub.log"
+    mkdir -p "${REPO}/bin"
+    cat >"${REPO}/bin/uv" <<'STUB'
+#!/usr/bin/env bash
+{
+    printf 'CALL'
+    for arg in "$@"; do printf '\t%s' "$arg"; done
+    printf '\n'
+} >>"$STUB_LOG"
+exit "${STUB_EXIT:-0}"
+STUB
+    chmod +x "${REPO}/bin/uv"
+    : >"$STUB_LOG"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email test@example.com
+    git -C "$REPO" config user.name "Test"
+    git -C "$REPO" config commit.gpgsign false
+}
+
+commit_file() {
+    local path="$1"
+    local body="${2:-x = 1}"
+    local dir
+    dir="$(dirname "$path")"
+    [ "$dir" = "." ] || mkdir -p "${REPO}/${dir}"
+    printf '%s\n' "$body" >"${REPO}/${path}"
+    git -C "$REPO" add -- "$path"
+    git -C "$REPO" commit -q -m "touch ${path}"
+}
+
+# Runs the script under test inside $REPO. Sets RC and OUT.
+run_script() {
+    ( cd "$REPO" && PATH="${REPO}/bin:${PATH}" STUB_LOG="$STUB_LOG" \
+        STUB_EXIT="${STUB_EXIT:-0}" "$SCRIPT" "$@" ) >"${REPO}/out.txt" 2>&1
+    RC=$?
+    OUT="$(cat "${REPO}/out.txt")"
+}
+
+# The files handed to a given tool, sorted, comma separated. Arguments are
+# recorded tab separated, so a path containing spaces stays a single field and a
+# split-argument bug shows up as two entries rather than being masked.
+files_for() {
+    local tool="$1"
+    grep -F "$(printf '\t%s\t' "$tool")" "$STUB_LOG" 2>/dev/null | head -1 \
+        | tr '\t' '\n' | awk 'seen { print } $0 == "--" { seen = 1 }' \
+        | LC_ALL=C sort | paste -sd, -
+}
+
+calls_for() {
+    grep -cF "$(printf '\t%s\t' "$1")" "$STUB_LOG" 2>/dev/null | tr -d ' '
+}
+
+echo "Testing ${SCRIPT}"
+echo
+
+# --- file selection -------------------------------------------------------
+
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+printf 'docs\n' >"${REPO}/README.md"
+git -C "$REPO" add -- README.md
+git -C "$REPO" commit -q -m "docs only"
+run_script "$BASE"
+check "no Python changes exits 0" "0" "$RC"
+check "no Python changes runs no tools" "0" "$(calls_for ruff)"
+
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "b.py"
+run_script "$BASE"
+check "added file is checked" "b.py" "$(files_for ruff)"
+
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "a file with spaces.py"
+run_script "$BASE"
+check "path with spaces stays one argument" "a file with spaces.py" "$(files_for ruff)"
+
+new_repo
+commit_file "a.py"
+commit_file "b.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" rm -q -- b.py
+git -C "$REPO" commit -q -m "delete b"
+printf 'x = 2\n' >"${REPO}/a.py"
+git -C "$REPO" add -- a.py
+git -C "$REPO" commit -q -m "edit a"
+run_script "$BASE"
+check "deleted file is not linted" "a.py" "$(files_for ruff)"
+
+new_repo
+commit_file "old.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" mv old.py new.py
+git -C "$REPO" commit -q -m "rename"
+run_script "$BASE"
+check "rename reports the new path" "new.py" "$(files_for ruff)"
+
+# A force push moves the branch by more than one commit. Falling back to HEAD^
+# would only ever see the last of these three files.
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "one.py"
+commit_file "two.py"
+commit_file "three.py"
+run_script "$BASE"
+check "multi commit push checks every commit" "one.py,three.py,two.py" "$(files_for ruff)"
+
+# --- failing closed -------------------------------------------------------
+
+new_repo
+commit_file "a.py"
+MAIN="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" checkout -q --orphan unrelated
+git -C "$REPO" rm -rq --cached .
+rm -f "${REPO}/a.py"
+commit_file "z.py"
+git -C "$REPO" checkout -q -f "$MAIN"
+UNRELATED="$(git -C "$REPO" rev-parse unrelated)"
+run_script "$UNRELATED"
+check "unrelated history fails closed" "1" "$RC"
+check "unrelated history runs no tools" "0" "$(calls_for ruff)"
+
+new_repo
+commit_file "a.py"
+run_script "0000000000000000000000000000000000000000"
+check "invalid base fails closed" "1" "$RC"
+check "invalid base runs no tools" "0" "$(calls_for ruff)"
+
+new_repo
+commit_file "a.py"
+run_script "refs/heads/does-not-exist"
+check "missing base ref fails closed" "1" "$RC"
+
+# --- initial push ---------------------------------------------------------
+
+# A root commit has no parent, so there is nothing to diff against. The empty
+# tree is the honest baseline and yields every tracked file.
+new_repo
+commit_file "a.py"
+commit_file "pkg/b.py"
+run_script "$EMPTY_TREE"
+check "empty tree base checks every tracked file" "a.py,pkg/b.py" "$(files_for ruff)"
+check "empty tree base exits 0 when clean" "0" "$RC"
+
+# --- status propagation ---------------------------------------------------
+
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "b.py"
+STUB_EXIT=1 run_script "$BASE"
+check "a failing tool fails the script" "1" "$RC"
+unset STUB_EXIT
+
+# --- mypy scoping ---------------------------------------------------------
+
+new_repo
+commit_file "llmtracefx/__init__.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "llmtracefx/mod.py"
+commit_file "tests/test_mod.py"
+run_script "$BASE"
+check "ruff sees package and tests" "llmtracefx/mod.py,tests/test_mod.py" "$(files_for ruff)"
+check "mypy sees only the package" "llmtracefx/mod.py" "$(files_for mypy)"
+
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "tests/test_only.py"
+run_script "$BASE"
+check "mypy is skipped with no package files" "0" "$(calls_for mypy)"
+
+echo
+echo "passed ${PASSED}, failed ${FAILED}"
+[ "$FAILED" -eq 0 ]

--- a/scripts/test-lint-changed.sh
+++ b/scripts/test-lint-changed.sh
@@ -21,6 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # confirm these cases actually fail against the behaviour they describe.
 SCRIPT="${LINT_CHANGED_SCRIPT:-${SCRIPT_DIR}/lint-changed.sh}"
 EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+REAL_GIT="$(command -v git)"
 
 PASSED=0
 FAILED=0
@@ -59,11 +60,16 @@ new_repo() {
     for arg in "$@"; do printf '\t%s' "$arg"; done
     printf '\n'
 } >>"$STUB_LOG"
-# "$1" is always "run" and "$2" is the tool name. Failing one tool at a time is
-# what lets the status tests tell the four apart. Failing them all at once would
-# only prove that at least one of them propagates.
-if [ -n "${STUB_FAIL_TOOL:-}" ] && [ "${2:-}" = "$STUB_FAIL_TOOL" ]; then
-    exit 1
+# Failing one named tool at a time is what lets the status tests tell the four
+# apart. Failing them all at once would only show that at least one of them
+# propagates. Matching any argument rather than a fixed position keeps this
+# working if the invocation ever grows a flag such as `uv run --frozen`.
+if [ -n "${STUB_FAIL_TOOL:-}" ]; then
+    for arg in "$@"; do
+        if [ "$arg" = "$STUB_FAIL_TOOL" ]; then
+            exit 1
+        fi
+    done
 fi
 exit "${STUB_EXIT:-0}"
 STUB
@@ -109,6 +115,35 @@ calls_for() {
     grep -cF "$(printf '\t%s\t' "$1")" "$STUB_LOG" 2>/dev/null | tr -d ' '
 }
 
+# The full argument list a tool was invoked with, comma separated.
+#
+# files_for deliberately drops everything before the `--`, which means it cannot
+# see the flags. That is the gap this closes: without an argv assertion, black
+# can lose `--check` and start rewriting the working tree in CI while still
+# reporting success, and ruff can gain `--exit-zero`, with every file list
+# assertion still passing.
+args_for() {
+    grep -F "$(printf '\t%s\t' "$1")" "$STUB_LOG" 2>/dev/null | head -1 \
+        | sed 's/^CALL'"$(printf '\t')"'//' | tr '\t' ','
+}
+
+# A git that fails only on `diff`, forwarding everything else to the real one.
+# The diff failure branch is otherwise the one path in the script with no
+# coverage, and it is the branch that used to swallow errors silently.
+break_git_diff() {
+    cat >"${REPO}/bin/git" <<GITSTUB
+#!/usr/bin/env bash
+for arg in "\$@"; do
+    if [ "\$arg" = "diff" ]; then
+        echo "git: simulated diff failure" >&2
+        exit 128
+    fi
+done
+exec "${REAL_GIT}" "\$@"
+GITSTUB
+    chmod +x "${REPO}/bin/git"
+}
+
 echo "Testing ${SCRIPT}"
 echo
 
@@ -132,6 +167,12 @@ run_script "$BASE"
 check "added file is checked" "b.py" "$(files_for ruff)"
 check "black gets the same file list" "b.py" "$(files_for black)"
 check "isort gets the same file list" "b.py" "$(files_for isort)"
+# Pin the flags, not just the file list. Without these, dropping --check from
+# black leaves it rewriting the working tree in CI and reporting success, and
+# every file list assertion above still passes.
+check "ruff argv" "run,ruff,check,--,b.py" "$(args_for ruff)"
+check "black argv" "run,black,--check,--,b.py" "$(args_for black)"
+check "isort argv" "run,isort,--check-only,--,b.py" "$(args_for isort)"
 
 new_repo
 commit_file "a.py"
@@ -172,6 +213,10 @@ commit_file "two.py"
 commit_file "three.py"
 run_script "$BASE"
 check "multi commit push checks every commit" "one.py,three.py,two.py" "$(files_for ruff)"
+# Multi-file lists for the other tools too. With only single-file assertions,
+# truncating black or isort to the first changed file goes unnoticed.
+check "black sees every commit's files" "one.py,three.py,two.py" "$(files_for black)"
+check "isort sees every commit's files" "one.py,three.py,two.py" "$(files_for isort)"
 
 # --- failing closed -------------------------------------------------------
 
@@ -208,6 +253,18 @@ git -C "$REPO" update-ref refs/remotes/origin/main HEAD
 run_script ""
 check "empty base argument fails closed" "1" "$RC"
 check "empty base argument runs no tools" "0" "$(calls_for ruff)"
+
+# A base that resolves fine but a diff that then fails. This is the branch that
+# used to be swallowed by process substitution, and it is the only path left
+# with no coverage, so `git diff ... || true` would otherwise go unnoticed.
+new_repo
+commit_file "a.py"
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+commit_file "b.py"
+break_git_diff
+run_script "$BASE"
+check "failing git diff fails closed" "1" "$RC"
+check "failing git diff runs no tools" "0" "$(calls_for ruff)"
 
 # --- initial push ---------------------------------------------------------
 
@@ -271,10 +328,20 @@ new_repo
 commit_file "llmtracefx/__init__.py"
 BASE="$(git -C "$REPO" rev-parse HEAD)"
 commit_file "llmtracefx/mod.py"
+commit_file "llmtracefx/other.py"
 commit_file "tests/test_mod.py"
 run_script "$BASE"
-check "ruff sees package and tests" "llmtracefx/mod.py,tests/test_mod.py" "$(files_for ruff)"
-check "mypy sees only the package" "llmtracefx/mod.py" "$(files_for mypy)"
+check "ruff sees package and tests" \
+    "llmtracefx/mod.py,llmtracefx/other.py,tests/test_mod.py" "$(files_for ruff)"
+check "black sees package and tests" \
+    "llmtracefx/mod.py,llmtracefx/other.py,tests/test_mod.py" "$(files_for black)"
+check "isort sees package and tests" \
+    "llmtracefx/mod.py,llmtracefx/other.py,tests/test_mod.py" "$(files_for isort)"
+check "mypy sees only the package" \
+    "llmtracefx/mod.py,llmtracefx/other.py" "$(files_for mypy)"
+check "mypy argv" \
+    "run,mypy,--follow-imports=silent,--,llmtracefx/mod.py,llmtracefx/other.py" \
+    "$(args_for mypy)"
 
 new_repo
 commit_file "a.py"


### PR DESCRIPTION
## Summary

This repository had no `.github/workflows/` directory and no CI. This adds one workflow with
three jobs, plus a small script so the same quality check can be run locally.

## Why the quality job only checks changed files

`main` currently fails its own quality tooling. Measured on `2e3963a`:

| Check | Result on main |
| --- | --- |
| `ruff check llmtracefx/` | 679 errors |
| `black --check llmtracefx/` | 9 files would be reformatted |
| `isort --check-only llmtracefx/` | fails on 5 files |
| `mypy llmtracefx/` | 66 errors across 8 files |
| `pytest` | passes |

A repo-wide gate would therefore be red on every pull request regardless of its contents, and
would be ignored or bypassed within a week. Mass-reformatting the repository to make a gate
green is not appropriate in a pull request whose purpose is to add CI, and suppressing the
errors with blanket ignores or `continue-on-error` would produce a gate that does not mean
anything.

Instead the quality job is a ratchet: it checks only the Python files that the change touches.
Pre-existing debt does not block anyone, new code is held to the configured standard, and the
debt can be paid down separately.

`pytest` is already green, so it runs as a normal hard gate over the whole suite.

## Jobs

| Job | What it does |
| --- | --- |
| `test` | `uv sync`, then the full pytest suite on Python 3.10, 3.11, 3.12 and 3.13 |
| `quality ratchet (changed files)` | `ruff check`, `black`, `isort`, `mypy` on changed files only |
| `build and verify wheel` | `uv build`, then installs the wheel into a fresh venv, imports it, and resolves its version |

## Ratchet mechanism

The file selection is:

```
git diff --merge-base "$BASE" HEAD --name-only --diff-filter=ACMR -z -- '*.py'
```

- `--merge-base` gives three-dot semantics, so commits that land on `main` after the branch
  point are not attributed to the pull request.
- `--diff-filter=ACMR` drops deletions, so a removed file is never handed to a linter, and
  yields the new path for renames, which is the path that should be checked.
- `-z` with `xargs -0` means paths containing spaces are handled correctly.
- An empty result short-circuits to success before any tool runs. This matters: passing an
  empty argument list to these tools would make them check the entire tree and re-expose all
  679 pre-existing findings.
- Base is `github.event.pull_request.base.sha` for pull requests and `github.event.before` for
  pushes, falling back to `HEAD^` when that SHA is absent or all-zero, which happens on force
  pushes and first pushes. `fetch-depth: 0` is set so the merge base is present.

`mypy` runs with `--follow-imports=silent` and is scoped to `llmtracefx/`. Without
`--follow-imports=silent`, checking a single clean file reports type errors that live in
unchanged modules it imports, which would fail contributors for code they did not write.
`tests/` is excluded because the strict config flags ordinary untyped test functions, and the
existing `make lint` target already scopes mypy to `llmtracefx/`.

## Formatter conflict, and the Makefile fix

`black` and `ruff format` disagree on `llmtracefx/api/serve.py` and `llmtracefx/optimizer/cli.py`,
and each one reverts the other. Running them in a loop never converges. Because `make format`
ended with `ruff format` and `make format-check` began with `black`, the repository's own format
target could never satisfy its own check target on those two files.

This keeps `black` and removes `ruff format` from `make format` and `make format-check`. That is
a two line change, not a reformat. After it, `make format` converges and its output is accepted
by `make format-check` and by CI, so local and CI agree.

`black` was chosen over `ruff format` because the open pull request #12 is already `black` clean,
while `ruff format` wants to rewrite lines in `optimizer/cli.py` that #12 never touched. Enforcing
`ruff format` would have failed that pull request on pre-existing code. The corrected ratchet was
run against #12's branch and passes all four tools. `black` also has the smaller debt on `main`,
9 files versus 14.

`ruff check` is unaffected and still runs. Its linter does not conflict with `black`, and its
`I001` import rule was verified to agree with `isort` output.

## Verification

Matrix verified locally before committing. `uv run --python <version> pytest -q` reported
730 passed on 3.10, 3.11, 3.12 and 3.13. On Linux CI the suite reports 729 passed, 1 skipped,
the skip being a test guarded to case-insensitive filesystems. The `Programming Language ::
Python :: 3.13` classifier was added because `requires-python` is `>=3.10` and 3.13 was verified
to pass, so the metadata now matches what is tested.

Ratchet behaviour confirmed both ways on real CI runs, not just locally.

Green, run [33266843213](https://github.com/Siddhant-K-code/LLMTraceFX/actions/runs/33266843213)
on the current head:

```
success  test (python 3.10)
success  test (python 3.11)
success  test (python 3.12)
success  test (python 3.13)
success  quality ratchet (changed files)
success  build and verify wheel
```

Red, run [33266790706](https://github.com/Siddhant-K-code/LLMTraceFX/actions/runs/33266790706).
A commit adding a deliberately bad file was pushed, then removed. Only the quality job failed:

```
failure  quality ratchet (changed files)
success  test (python 3.10)
success  test (python 3.11)
success  test (python 3.12)
success  test (python 3.13)
success  build and verify wheel
```

with all four tools reporting:

```
ruff check: FAILED
black: FAILED
isort: FAILED
mypy: FAILED
```

`black: FAILED` there is the important line, since it shows the formatter that this change
actually enforces is gating.

Also confirmed locally: a compliant new file passes all four tools, a deletion-only change is a
no-op success, a path containing a space is checked correctly, and a change touching no Python
files short-circuits to success.

The workflow references no secrets and makes no network calls beyond package installation.
It sets `permissions: contents: read`, uses concurrency with `cancel-in-progress`, caches uv
downloads keyed on `uv.lock`, sets per-job timeouts, and pins both actions to a commit SHA with
the version tag in a comment.

## Not in this pull request

No legacy source files were reformatted and no existing lint, format or type errors were fixed
or suppressed. The only changes outside `.github/` and `scripts/` are the two Makefile lines
described above, the 3.13 classifier, and a README section.


---

## Follow-up commit: macOS coverage, CodeQL, Dependabot

Added after review feedback asking for broader workflow coverage.

### macOS in the test matrix

The matrix now runs macOS on Python 3.10 and 3.13 alongside the four Linux jobs. This is not
duplicate coverage. Two things only happen on macOS:

- `test_optimize_rejects_case_insensitive_path_aliases` calls
  `pytest.skip("filesystem is case-sensitive")` on Linux. That test asserts the optimizer rejects
  output paths that alias an input path by case alone, and on ubuntu runners it never executes.
  macOS defaults to a case-insensitive filesystem, so the check actually runs there.
- GitHub's macOS runners are Apple Silicon. `optimizer/collectors/mlx.py` gates MLX collection on
  `platform.system() == "Darwin"` and `platform.machine() == "arm64"`, and `optimizer/manifest.py`
  records platform details. Linux never reaches those branches.

macOS covers the ends of the supported range rather than the full matrix, so the job count goes
from 4 to 6 instead of to 8.

### CodeQL

`.github/workflows/codeql.yml` runs CodeQL for Python on pull requests, pushes to `main`, and
weekly so newly published queries run against unchanged code. It is a separate workflow because
it needs `security-events: write` and `ci.yml` is deliberately held at `contents: read`. It scans
the whole repository rather than the diff, which is appropriate because it reports into the
Security tab instead of blocking pull requests on pre-existing findings.

### Dependabot

`.github/dependabot.yml` covers the `uv` ecosystem and `github-actions`, both weekly and grouped.
The actions entry is the point: every action here is pinned to a commit SHA, and pinned SHAs never
pick up fixes unless something bumps them. Dependabot reads the version comment beside each pin
and updates the SHA and the comment together.

### Note on action pinning

The CodeQL tags are annotated tag objects, so reading `git/ref/tags/v4` returns the tag object SHA
rather than a commit. That value does not resolve at runtime. Each pin was dereferenced to a real
commit and verified through the commits API before being committed.

### Result

Both workflows are green on this head:

```
CI       success   test (ubuntu-latest, python 3.10 / 3.11 / 3.12 / 3.13)
CI       success   test (macos-latest, python 3.10 / 3.13)
CI       success   quality ratchet (changed files)
CI       success   build and verify wheel
CodeQL   success   analyze (python)
```


## Follow-up commit: failing the ratchet closed

External review found four material issues. All four are fixed in `b82210b`.

### 1. The ratchet could pass without knowing what changed

This was the serious one. The script built its file list with
`done < <(git diff ...)`. Under `set -euo pipefail` a failure inside a process
substitution does not propagate, so any git error left the loop reading nothing,
the file list empty, and the script reporting "Nothing to check" and exiting 0.
A gate that runs its tools over an empty list is indistinguishable from a clean
run, so this quietly disabled the ratchet.

Reproduced against the previous revision, diffing across unrelated history:

```
--- OLD script, unrelated base ---
fatal: no merge base found
No Python files changed against 52af69d. Nothing to check.
  EXIT=0  <-- silently passed

--- NEW script, same input ---
lint-changed: no merge base between '52af69d' and HEAD.
lint-changed: refusing to guess a base, because checking nothing
lint-changed: would silently pass the ratchet.
  EXIT=1  <-- fails closed
```

Note that git itself printed `fatal: no merge base found` and the gate still
passed.

The workflow had the same shape of problem in two more places. Its fallback for
an unusable push base was `HEAD^`, which only covers the final commit of a
multi-commit push and does not exist at all for a root commit. And the ratchet
step carried an `if: steps.diff-base.outputs.base != ''` guard, so an
unresolvable base skipped the step, which GitHub Actions records as success.

Fixes: the merge base is resolved as its own step with an explicit error, the
diff is written to a temporary file so its exit status can be checked, the push
fallback is now the empty tree (which checks every tracked file rather than
none), a missing pull request base fails the job, and the `if:` guard is gone.

### 2. Tests for the ratchet

`scripts/test-lint-changed.sh` adds 18 cases covering unrelated base, invalid
base, missing base ref, initial root push, multi-commit force push, empty diff,
paths containing spaces, rename, delete, status propagation and mypy scoping. It
stubs `uv` on `PATH`, so each case asserts on the exact file list the script
builds and the status it returns, with no toolchain needed in the throwaway
repository.

The cases are load-bearing. Run against the previous revision of the script,
three of them fail:

```
FAIL  unrelated history fails closed          expected: 1   actual: 0
FAIL  empty tree base checks every tracked file  expected: a.py,pkg/b.py  actual:
FAIL  empty tree base exits 0 when clean      expected: 0   actual: 1
passed 15, failed 3
```

The suite runs in CI ahead of the ratchet itself, and reports `passed 18, failed 0`.

### 3. Lockfile is now enforced

All three `uv sync` invocations use `--locked`, so a stale lockfile fails the
build instead of being rewritten in place. Confirmed locally that syncing with
and without the `mlx` extra leaves `uv.lock` and `pyproject.toml` unmodified.

### 4. Makefile scope matched to CI

`make format` and `make format-check` covered only `llmtracefx/`, while the
ratchet checks every changed `.py` file wherever it lives. Two files at the
repository root, `launch_dashboard.py` and `generate_trace.py`, fail both black
and isort and were invisible to the old scope, so editing either one meant CI
rejecting formatting that `make format` had declined to fix. Both targets now
cover the tree. Measured: black and isort walk exactly the 84 tracked Python
files, with no virtualenv or build output included. `make lint` stays scoped to
`llmtracefx/`, matching how the ratchet scopes mypy.

### 5. macOS jobs now exercise MLX for real

The macOS jobs were justified by MLX code paths but never installed MLX, so the
MLX tests ran against a monkeypatched stand-in and the real import path was
never executed. The jobs now install the `mlx` extra, whose markers only resolve
on Darwin plus arm64, and run a smoke check that constructs `MLXLMRuntime`. That
constructor is the actual runtime boundary: it rejects other platforms and
raises if `mlx` or `mlx_lm` cannot be imported. The check reads versions, the
accelerator name and a memory snapshot, and never calls `load_model` or
`stream_generate`, so nothing is downloaded.

Verified upstream support before claiming coverage: `mlx` and `mlx-lm` resolve
on all of 3.10, 3.11, 3.12 and 3.13, so the matrix needed no adjustment. The
full suite still reports 730 passed with MLX installed, unchanged from without.

Output from the macOS 3.13 runner:

```
platform:    Darwin/arm64
mlx:         0.32.0
mlx-lm:      0.31.3
accelerator: Apple Paravirtual device
memory:      MLXMemorySnapshot(active_bytes=8, cache_bytes=8, peak_bytes=0)
```

The Linux jobs record both MLX steps as `skipped`, as intended.

### Audit

No secrets are referenced and none are needed. The workflow uses `pull_request`,
not `pull_request_target`, so fork pull requests run with a read-only token and
no secret access. `permissions` is `contents: read`. The only network access is
package installation.

### Result

All 10 checks green on `b82210b`: CodeQL, `analyze (python)`,
`build and verify wheel`, `quality ratchet (changed files)`, and `test` on
ubuntu 3.10, 3.11, 3.12, 3.13 plus macos 3.10 and 3.13.


## Second review round: making the ratchet's own tests load-bearing

An independent review mutation-tested the suite added above and found its tool
assertions proved nothing. Fixed in `e89b039`.

The strings `black` and `isort` did not appear in the test file at all: every
assertion targeted ruff or mypy. And the single status test failed all four
stubbed tools simultaneously, which only shows that at least one status is
propagated, not that any particular one is.

That gap was not theoretical. Against the previous suite, deleting the black
check from the script outright, deleting isort, or swallowing any single tool's
exit status all left it reporting `18 passed, 0 failed`. Half the ratchet could
have been removed with the tests staying green, while `ci.yml` claims that suite
is what protects the design.

The stub `uv` now fails one named tool at a time, so each tool gets its own
status case, and mypy's case uses a fixture under `llmtracefx/` so it is
genuinely invoked rather than skipped. Added assertions that all four tools run
at all, and extended the file list assertions to black and isort.

Re-running the same mutants against the expanded suite:

| Mutant | Previous suite | Expanded suite |
| --- | --- | --- |
| black check deleted | 18 passed, 0 failed | 28 passed, 4 failed |
| isort check deleted | 18 passed, 0 failed | 28 passed, 4 failed |
| ruff status swallowed | 18 passed, 0 failed | 31 passed, 1 failed |
| isort status swallowed | 18 passed, 0 failed | 31 passed, 1 failed |
| mypy status swallowed | 18 passed, 0 failed | 31 passed, 1 failed |
| mypy check deleted | 17 passed, 1 failed | 29 passed, 3 failed |
| none (control) | 18 passed, 0 failed | 32 passed, 0 failed |

Separately, the base argument used `${1:-origin/main}`, so an explicitly empty
argument was indistinguishable from no argument and was coerced to the default.
On a push build `origin/main` is `HEAD`, so that produced an empty diff and a
green job that had checked nothing, which is exactly the condition the script is
meant to treat as a hard failure:

```
=== empty base argument, OLD script ===
No Python files changed against origin/main. Nothing to check.
  EXIT=0

=== empty base argument, NEW script ===
lint-changed: empty base argument.
lint-changed: pass a base ref or SHA, or pass nothing for origin/main.
  EXIT=1

=== no argument at all still defaults correctly ===
No Python files changed against origin/main. Nothing to check.
  EXIT=0
```

This was not reachable from `ci.yml` as it stood, because `git rev-parse` rejects
an empty rev so neither trigger path could emit one. It would become reachable on
any edit that left that step's output empty.

The suite is now 32 cases and runs in CI ahead of the ratchet, reporting
`passed 32, failed 0`. All 10 checks are green on `e89b039`.


## Review round 3: the tests could not see tool flags

A third review found the harness read only the argument list after the `--`
separator, so no assertion could observe the flags a tool was invoked with.
That hid a whole class of regression. Removing `--check` from black turns the
gate into a formatter that rewrites files during the CI run and still reports
success. Adding `--exit-zero` to ruff silences it completely. Both scored a
clean 32 passed, 0 failed against the previous suite.

The file list assertions had a second gap. Only ruff was ever compared against
a multi-file list, so truncating black, isort or mypy to the first changed file
left the remaining files unchecked without failing a test.

Fixes:

- `args_for` returns the whole recorded argv, and the exact invocation is now
  pinned for all four tools, including `--check`, `--check-only` and
  `--follow-imports=silent`
- black and isort are asserted against a three file list in the multi commit
  case, and the mypy scoping case gained a second package file
- the `git diff` failure branch is covered by a git that fails only on `diff`,
  which was the last path in the script with no test
- the fake `uv` matches its failing tool by scanning arguments rather than by
  position, so the status tests survive a future flag such as `uv run --frozen`

The suite is now 42 cases. Every mutant below fails it, including the combined
one that neuters the ratchet end to end:

| Mutant | Previous suite | Expanded suite |
| --- | --- | --- |
| black truncated to first file | 32 passed, 0 failed | 40 passed, 2 failed |
| isort truncated to first file | 32 passed, 0 failed | 40 passed, 2 failed |
| mypy truncated to first file | 32 passed, 0 failed | 40 passed, 2 failed |
| ruff `--exit-zero` | 32 passed, 0 failed | 41 passed, 1 failed |
| black loses `--check` | 32 passed, 0 failed | 41 passed, 1 failed |
| black `--diff` instead of `--check` | 32 passed, 0 failed | 41 passed, 1 failed |
| isort loses `--check-only` | 32 passed, 0 failed | 41 passed, 1 failed |
| mypy `--follow-imports=skip` | 32 passed, 0 failed | 41 passed, 1 failed |
| all seven combined | 32 passed, 0 failed | 34 passed, 8 failed |
| failed `git diff` ignored | 32 passed, 0 failed | 41 passed, 1 failed |
| ruff invocation deleted | n/a | 32 passed, 10 failed |
| black invocation deleted | n/a | 35 passed, 7 failed |
| isort invocation deleted | n/a | 35 passed, 7 failed |
| mypy invocation replaced with a no-op | n/a | 38 passed, 4 failed |
| `STATUS=1` never set | n/a | 37 passed, 5 failed |
| ratchet never exits nonzero | n/a | 35 passed, 7 failed |
| none (control) | 32 passed, 0 failed | 42 passed, 0 failed |

Confirmed against the real toolchain rather than the stub: with the combined
mutant a change the ratchet should reject reported `Quality ratchet passed.`
with `RC=0`, and with black stripped of `--check` the working tree was modified
after the run.

The suite runs in CI ahead of the ratchet and reports `passed 42, failed 0` on
Linux. All 10 checks are green on `c9f2247`.
