### PR TITLE
fix: report candidate cleanup permission denials

### DIFF
--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -96,6 +96,7 @@ _IS_POSIX = os.name == "posix"
 _MAX_CPU_SECONDS = 10
 _MAX_ADDRESS_SPACE_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
 _MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MiB
+_POST_TERMINATION_GRACE_SECONDS = 1.0
 
 _PROCESS_TERMINATION_PERMISSION_WARNING = (
     "warning: the operating system denied permission to terminate the candidate "
@@ -237,6 +238,7 @@ def _run_candidate(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        errors="replace",
         shell=False,
         start_new_session=_IS_POSIX,
         preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
@@ -253,7 +255,13 @@ def _run_candidate(
         cleanup_warning = _terminate_candidate_process(
             process, process_group_id=process_group_id
         )
-        process.communicate()
+        try:
+            process.communicate(timeout=_POST_TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            # A surviving candidate or descendant can keep the pipes open after
+            # cleanup. The configured evaluation timeout has already elapsed, so
+            # allow only a fixed termination grace and never block on another read.
+            pass
     finally:
         # A candidate can let its direct process exit while leaving detached
         # workers in the new process group. Clean up the whole group before

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -217,9 +217,7 @@ def _terminate_candidate_process(
                 continue
             except PermissionError:
                 permission_denied = True
-        return (
-            _PROCESS_TERMINATION_PERMISSION_WARNING if permission_denied else None
-        )
+        return _PROCESS_TERMINATION_PERMISSION_WARNING if permission_denied else None
     elif process.poll() is None:
         process.kill()
     return None
@@ -304,14 +302,14 @@ def evaluate_code_completion(
                 timeout_seconds=timeout_seconds,
             )
         except _CandidateTimeoutError as exc:
-            notes = f"candidate completion timed out after {timeout_seconds}s"
+            timeout_notes = f"candidate completion timed out after {timeout_seconds}s"
             if exc.cleanup_warning:
-                notes = f"{notes}; {exc.cleanup_warning}"
+                timeout_notes = f"{timeout_notes}; {exc.cleanup_warning}"
             return OutcomeInfo(
                 success=False,
                 quality_score=0.0,
                 quality_metric="unit_test_pass",
-                notes=notes,
+                notes=timeout_notes,
             )
 
     success = completed.returncode == 0

--- a/llmtracefx/optimizer/workloads/evaluators.py
+++ b/llmtracefx/optimizer/workloads/evaluators.py
@@ -97,6 +97,18 @@ _MAX_CPU_SECONDS = 10
 _MAX_ADDRESS_SPACE_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
 _MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MiB
 
+_PROCESS_TERMINATION_PERMISSION_WARNING = (
+    "warning: the operating system denied permission to terminate the candidate "
+    "process group; individual process cleanup was attempted"
+)
+
+
+class _CandidateTimeoutError(Exception):
+    """Internal timeout that preserves a process-cleanup warning."""
+
+    def __init__(self, cleanup_warning: str | None) -> None:
+        self.cleanup_warning = cleanup_warning
+
 
 def _minimal_subprocess_env() -> dict[str, str]:
     """Build a minimal, explicit environment for the candidate subprocess."""
@@ -183,21 +195,34 @@ def _process_ids_in_group(process_group_id: int) -> tuple[int, ...]:
 
 def _terminate_candidate_process(
     process: subprocess.Popen[str], *, process_group_id: int | None
-) -> None:
-    """Terminate the candidate and its descendants where the OS permits."""
+) -> str | None:
+    """Terminate the candidate and return any cleanup limitation."""
     if _IS_POSIX:
         if process_group_id is None:
-            return
+            return None
+        permission_denied = False
         try:
             os.killpg(process_group_id, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            for pid in _process_ids_in_group(process_group_id):
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
-                    continue
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            permission_denied = True
+        else:
+            return None
+
+        for pid in _process_ids_in_group(process_group_id):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                continue
+            except PermissionError:
+                permission_denied = True
+        return (
+            _PROCESS_TERMINATION_PERMISSION_WARNING if permission_denied else None
+        )
     elif process.poll() is None:
         process.kill()
+    return None
 
 
 def _run_candidate(
@@ -205,7 +230,7 @@ def _run_candidate(
     *,
     cwd: str,
     timeout_seconds: float,
-) -> subprocess.CompletedProcess[str]:
+) -> tuple[subprocess.CompletedProcess[str], str | None]:
     """Run candidate code while containing its process tree on POSIX."""
     process = subprocess.Popen(
         [sys.executable, str(program_path)],
@@ -219,23 +244,38 @@ def _run_candidate(
         preexec_fn=(_posix_preexec_resource_limits if _IS_POSIX else None),
     )
     process_group_id = process.pid if _IS_POSIX else None
+    cleanup_warning = None
+    timed_out = False
+    stdout = ""
+    stderr = ""
     try:
         stdout, stderr = process.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
-        _terminate_candidate_process(process, process_group_id=process_group_id)
+        timed_out = True
+        cleanup_warning = _terminate_candidate_process(
+            process, process_group_id=process_group_id
+        )
         process.communicate()
-        raise
     finally:
         # A candidate can let its direct process exit while leaving detached
         # workers in the new process group. Clean up the whole group before
         # returning from the evaluator.
-        _terminate_candidate_process(process, process_group_id=process_group_id)
+        final_cleanup_warning = _terminate_candidate_process(
+            process, process_group_id=process_group_id
+        )
+        cleanup_warning = cleanup_warning or final_cleanup_warning
 
-    return subprocess.CompletedProcess(
-        args=process.args,
-        returncode=process.returncode,
-        stdout=stdout,
-        stderr=stderr,
+    if timed_out:
+        raise _CandidateTimeoutError(cleanup_warning)
+
+    return (
+        subprocess.CompletedProcess(
+            args=process.args,
+            returncode=process.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        ),
+        cleanup_warning,
     )
 
 
@@ -258,21 +298,26 @@ def evaluate_code_completion(
         program_path = Path(tmp_dir) / "candidate.py"
         program_path.write_text(program, encoding="utf-8")
         try:
-            completed = _run_candidate(
+            completed, cleanup_warning = _run_candidate(
                 program_path,
                 cwd=tmp_dir,
                 timeout_seconds=timeout_seconds,
             )
-        except subprocess.TimeoutExpired:
+        except _CandidateTimeoutError as exc:
+            notes = f"candidate completion timed out after {timeout_seconds}s"
+            if exc.cleanup_warning:
+                notes = f"{notes}; {exc.cleanup_warning}"
             return OutcomeInfo(
                 success=False,
                 quality_score=0.0,
                 quality_metric="unit_test_pass",
-                notes=f"candidate completion timed out after {timeout_seconds}s",
+                notes=notes,
             )
 
     success = completed.returncode == 0
     notes = None if success else completed.stderr.strip()[-500:] or "non-zero exit"
+    if cleanup_warning:
+        notes = f"{notes}; {cleanup_warning}" if notes else cleanup_warning
     return OutcomeInfo(
         success=success,
         quality_score=1.0 if success else 0.0,

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -81,6 +81,21 @@ def test_evaluate_code_completion_times_out_on_infinite_loop():
     assert "timed out" in outcome.notes
 
 
+def test_evaluate_code_completion_timeout_survives_invalid_output():
+    invalid_output_then_hang = (
+        "import os\n" "import time\n" "os.write(1, b'\\xff')\n" "time.sleep(60)\n"
+    )
+
+    outcome = evaluate_code_completion(
+        CODE_COMPLETION_PALINDROME.spec,
+        invalid_output_then_hang,
+        timeout_seconds=0.2,
+    )
+
+    assert outcome.success is False
+    assert "timed out" in outcome.notes
+
+
 # --- Code completion sandboxing: cwd, environment, resource limits --------
 
 
@@ -194,16 +209,39 @@ def test_terminate_candidate_process_falls_back_when_killpg_is_not_permitted(
     assert warning == evaluators._PROCESS_TERMINATION_PERMISSION_WARNING
 
 
-def test_evaluate_code_completion_reports_process_cleanup_permission_denial(
+def test_evaluate_code_completion_bounds_held_pipes_after_permission_denial(
     monkeypatch,
 ):
-    def raise_timeout(*args, **kwargs):
-        raise evaluators._CandidateTimeoutError(
-            evaluators._PROCESS_TERMINATION_PERMISSION_WARNING
-        )
+    class HeldPipeProcess:
+        pid = 40
+        args = [sys.executable, "candidate.py"]
+        returncode = None
 
-    monkeypatch.setattr(evaluators, "_run_candidate", raise_timeout)
+        def __init__(self):
+            self.communicate_timeouts = []
 
+        def communicate(self, timeout=None):
+            self.communicate_timeouts.append(timeout)
+            raise subprocess.TimeoutExpired(self.args, timeout)
+
+    process = HeldPipeProcess()
+    monkeypatch.setattr(evaluators, "_IS_POSIX", True)
+    monkeypatch.setattr(evaluators.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(
+        evaluators.os,
+        "killpg",
+        lambda *_: (_ for _ in ()).throw(PermissionError),
+    )
+    monkeypatch.setattr(
+        evaluators, "_process_ids_in_group", lambda process_group_id: (41,)
+    )
+    monkeypatch.setattr(
+        evaluators.os,
+        "kill",
+        lambda *_: (_ for _ in ()).throw(PermissionError),
+    )
+
+    started = time.perf_counter()
     outcome = evaluate_code_completion(
         CodeCompletionSpec(
             function_stub="def f() -> None:\n    pass\n",
@@ -213,7 +251,14 @@ def test_evaluate_code_completion_reports_process_cleanup_permission_denial(
         "def f() -> None:\n    pass\n",
         timeout_seconds=0.5,
     )
+    elapsed = time.perf_counter() - started
 
+    assert process.communicate_timeouts == [
+        0.5,
+        evaluators._POST_TERMINATION_GRACE_SECONDS,
+    ]
+    assert elapsed < evaluators._POST_TERMINATION_GRACE_SECONDS
+    assert outcome.success is False
     assert outcome.notes == (
         "candidate completion timed out after 0.5s; "
         f"{evaluators._PROCESS_TERMINATION_PERMISSION_WARNING}"

--- a/tests/optimizer/test_workloads_evaluators.py
+++ b/tests/optimizer/test_workloads_evaluators.py
@@ -188,9 +188,36 @@ def test_terminate_candidate_process_falls_back_when_killpg_is_not_permitted(
         evaluators.os, "kill", lambda pid, signal: killed.append((pid, signal))
     )
 
-    evaluators._terminate_candidate_process(object(), process_group_id=40)
+    warning = evaluators._terminate_candidate_process(object(), process_group_id=40)
 
     assert killed == [(41, evaluators.signal.SIGKILL), (42, evaluators.signal.SIGKILL)]
+    assert warning == evaluators._PROCESS_TERMINATION_PERMISSION_WARNING
+
+
+def test_evaluate_code_completion_reports_process_cleanup_permission_denial(
+    monkeypatch,
+):
+    def raise_timeout(*args, **kwargs):
+        raise evaluators._CandidateTimeoutError(
+            evaluators._PROCESS_TERMINATION_PERMISSION_WARNING
+        )
+
+    monkeypatch.setattr(evaluators, "_run_candidate", raise_timeout)
+
+    outcome = evaluate_code_completion(
+        CodeCompletionSpec(
+            function_stub="def f() -> None:\n    pass\n",
+            test_code="",
+            entry_point="f",
+        ),
+        "def f() -> None:\n    pass\n",
+        timeout_seconds=0.5,
+    )
+
+    assert outcome.notes == (
+        "candidate completion timed out after 0.5s; "
+        f"{evaluators._PROCESS_TERMINATION_PERMISSION_WARNING}"
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- report process-group permission denials in code-completion outcomes
- bound the post-cleanup pipe drain to a fixed one-second grace so inaccessible candidates or descendants cannot hang evaluation
- preserve the original timeout result and cleanup warning when pipes remain held
- decode candidate output with replacement characters so invalid bytes cannot replace timeout handling with a decoding failure
- exercise the real `_run_candidate` path with mocked `Popen` behavior for permission denial and held pipes

## Validation
- `uv run pytest tests/optimizer/test_workloads_evaluators.py -k 'bounds_held_pipes or timeout_survives_invalid_output or terminate_candidate_process or timeout_kills_descendants or kills_descendants_after_parent_exits'`
- `uv run pytest` (733 passed)
- `make lint-changed`
- changed-file Black and isort checks
- `uv run mypy llmtracefx/optimizer/workloads/evaluators.py`
- `uv build --quiet`
- independent code review completed with no remaining findings