### PR TITLE
Add a budget-guarded Modal harness for self-hosting GLM-5.3-Flash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal
+.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - GPU-level LLM inference profiler"
@@ -74,14 +74,33 @@ generate-traces:  ## Generate various example trace files
 	@echo "✅ Generated example trace files in llmtracefx/test_traces/"
 
 # Modal deployment
+install-modal:  ## Install the optional Modal SDK extra
+	uv sync --extra modal
+
 deploy-modal:  ## Deploy to Modal
-	uv run modal deploy llmtracefx/modal_app.py
+	uv run --extra modal modal deploy llmtracefx/modal_app.py
 
 serve-modal:  ## Serve on Modal
-	uv run modal serve llmtracefx/modal_app.py::run_server
+	uv run --extra modal modal serve llmtracefx/modal_app.py::run_server
 
 test-modal:  ## Test Modal functions
-	uv run modal run llmtracefx/modal_app.py
+	uv run --extra modal modal run llmtracefx/modal_app.py
+
+# GLM-5.3-Flash self-hosting harness. `glm-recipe`, `glm-budget` and
+# `glm-plan` are offline: they need no Modal account and cannot spend.
+# See SELF_HOST_GLM_RUNBOOK.md for the full sequence.
+glm-recipe:  ## Print the pinned GLM-5.3-Flash facts and their sources
+	uv run llmtracefx-deploy recipe
+
+CREDIT ?= 30
+glm-budget:  ## Recommend a session spending cap (make glm-budget CREDIT=30)
+	uv run llmtracefx-deploy budget --credit-usd $(CREDIT)
+
+glm-plan:  ## Adjudicate a deployment plan (make glm-plan ARGS="--max-usd 10 ...")
+	uv run llmtracefx-deploy plan $(ARGS)
+
+test-deploy:  ## Run the offline deployment harness tests
+	uv run pytest tests/deploy
 
 # Documentation
 docs:  ## Build documentation

--- a/README.md
+++ b/README.md
@@ -604,6 +604,11 @@ patterns. This is causing the GPU to wait for memory operations.
 
 ## 🚀 Modal Deployment
 
+> **Modal is an optional extra.** It is no longer a runtime dependency of
+> `llmtracefx`, because nothing in the library imports it at module scope.
+> Install it with `uv sync --extra modal` (or `make install-modal`) before
+> running any `modal` command below.
+
 ### **🌐 Live Deployment**
 - **Web API**: https://siddhant-k-code--llmtracefx-web-app.modal.run
 - **Modal Dashboard**: https://modal.com/apps/siddhant-k-code/main/deployed/llmtracefx
@@ -642,6 +647,38 @@ uv run modal app logs llmtracefx
 # Stop deployment
 uv run modal app stop llmtracefx
 ```
+
+### Self-hosting GLM-5.3-Flash
+
+A separate, budget-guarded harness deploys the 320B-A18B FP8
+GLM-5.3-Flash checkpoint on rented accelerators for long enough to
+measure it with `collect-api`, then tears it down. Full sequence:
+[SELF_HOST_GLM_RUNBOOK.md](SELF_HOST_GLM_RUNBOOK.md).
+
+Start with the offline commands. They need no Modal account, make no
+network request and cannot spend anything:
+
+```bash
+# The pinned model facts and where each one came from
+uv run llmtracefx-deploy recipe
+
+# A conservative session cap that leaves a retry reserve
+uv run llmtracefx-deploy budget --credit-usd 30
+
+# Adjudicate a full deployment: worst-case cost, capacity check,
+# pinning, and every command it would take to run it
+uv run llmtracefx-deploy plan --help
+```
+
+`deploy plan` refuses and withholds every money-spending command unless
+you supply an explicit budget, GPU type and count, maximum runtime, and a
+GPU price with the date you read it. There are no defaults for any of
+those, so an incomplete invocation fails rather than assuming.
+
+Note that self-hosting is the *expensive* way to get GLM-5.3-Flash
+tokens. For anything about the model rather than about serving it, use
+the hosted `z-ai/glm-5.3-flash` endpoint on OpenRouter with `collect-api`
+instead; the runbook explains when each is appropriate.
 
 ## 🧪 Testing
 

--- a/SELF_HOST_GLM_RUNBOOK.md
+++ b/SELF_HOST_GLM_RUNBOOK.md
@@ -1,0 +1,501 @@
+# Self-hosting GLM-5.3-Flash on Modal: runbook
+
+A budget-guarded, pinned harness for standing GLM-5.3-Flash up on rented
+accelerators for long enough to measure it with the LLMTraceFX API
+collector, and then taking it down again.
+
+Read the next section before anything else. It is the one that decides
+whether you should be doing this at all.
+
+## Use OpenRouter first. Self-host only to answer what OpenRouter cannot
+
+Self-hosting a 320B model is not the cheap way to get GLM-5.3-Flash
+tokens. It is the expensive way, and it is only worth it for questions a
+hosted API cannot answer.
+
+Use the hosted route for anything about the model:
+
+```bash
+uv run llmtracefx-optimizer collect-api \
+  --run-id glm53flash-hosted \
+  --provider openrouter \
+  --endpoint https://openrouter.ai/api/v1/chat/completions \
+  --model-id z-ai/glm-5.3-flash \
+  --prompt-file prompts/smoke.txt \
+  --output-dir output/glm53flash-hosted \
+  --api-key-env OPENROUTER_API_KEY
+```
+
+Per-token pricing for `z-ai/glm-5.3-flash` is published on the OpenRouter
+model page (<https://openrouter.ai/z-ai/glm-5.3-flash>). Check it there
+rather than trusting a number written down here: it has changed at least
+once, and a stale figure in a runbook is worse than no figure.
+
+Self-host only when the question is about *serving*, and therefore cannot
+be asked of somebody else's endpoint:
+
+- how long this checkpoint takes to load onto a given accelerator count,
+- what tensor-parallel degree and context cap actually fit,
+- how the serving framework behaves under your own request shape,
+- whether the numbers a provider reports match your own measurement.
+
+Those are short experiments. Budget for an afternoon, not for a month.
+
+## What is pinned, what you must supply, and why
+
+The harness compiles in the facts that describe the checkpoint, because
+they cannot drift without the checkpoint changing:
+
+| Fact | Value | Source |
+| --- | --- | --- |
+| Repository | `zai-org/GLM-5.3-Flash` | <https://huggingface.co/zai-org/GLM-5.3-Flash> |
+| Parameters | 320B total, 18B active | model card |
+| Layers | 45 | `config.json` |
+| Experts | 288 routed, 8 per token | `config.json` |
+| Quantization | FP8, E4M3, dynamic activation scaling | `config.json` |
+| Attention | hybrid linear with periodic sparse layers | `config.json` |
+| Max context | 1,048,576 tokens | `config.json` |
+| Multimodal | yes | `config.json` |
+
+Run `llmtracefx-deploy recipe` to print these with their
+sources.
+
+Two notes on scope. The default `zai-org/GLM-5.3-Flash` repository *is*
+the FP8 checkpoint; there is no separate `-FP8` slug. And the harness
+refuses `zai-org/GLM-5.3-Flash-BF16` and full `zai-org/GLM-5.3` by name,
+because both are roughly twice the size and neither fits the budget this
+tool is built for.
+
+Everything mutable is *not* compiled in, and the harness will not run
+without it:
+
+| You supply | Flag | Why it is not a constant |
+| --- | --- | --- |
+| Model revision | `--model-revision` | A branch is not a revision. `main` moves. |
+| Serving image | `--image` | Tags can be repointed; `latest` is meaningless. |
+| Framework version | `--framework-version` | Records what actually served. |
+| GPU price and its date | `--usd-per-gpu-hour`, `--price-effective-date`, `--price-source` | Cloud prices change. A stale literal is a silently wrong cost. |
+| Budget, GPU type and count, runtime | `--max-usd`, `--gpu-type`, `--gpu-count`, `--max-runtime-seconds` | These are the spending authority. A default would be an assumption about your money. |
+
+Resolve the revision once and pin it:
+
+```bash
+curl -s https://huggingface.co/api/models/zai-org/GLM-5.3-Flash \
+  | python -c "import json,sys; print(json.load(sys.stdin)['sha'])"
+```
+
+### Why vLLM by default
+
+Both SGLang and vLLM are listed as supported on the GLM-5.3-Flash model
+card, and the harness supports both (`--framework vllm|sglang`). vLLM is
+the default, and the deciding reason is where each one puts your API key.
+
+vLLM reads it from the environment. `VLLM_API_KEY` is declared in
+`vllm/envs.py` and consumed by the authentication middleware in
+`vllm/entrypoints/serve/middleware/register.py`, so the value never
+appears on a command line.
+
+SGLang accepts it only as `--api-key` on argv, and its engine logs its
+own resolved configuration with
+`logger.info(f"server_args={server_args.resolved_dict()}")` in
+`python/sglang/srt/entrypoints/engine.py`, unredacted. The key therefore
+lands in the container's stdout, and from there in Modal's app logs, as
+well as being readable from `/proc/<pid>/cmdline`.
+
+So `--framework sglang` is refused unless you pass
+`--accept-argv-credential-exposure`, which records that you understood
+the trade. Both sources read 2026-08-30.
+
+SGLang does have one advantage worth knowing: the model card publishes a
+complete container recipe for it, including the image, shared-memory size
+and IPC mode, whereas the vLLM snippet is a bare `vllm serve`. If you
+take the SGLang route, expect to supply those container details
+yourself.
+
+Be aware of what is *not* published. As of 2026-08-30 the model card does
+not state a minimum SGLang or vLLM version, does not show multi-GPU or
+FP8 flags, and pins no image digest (it shows `lmsysorg/sglang:latest`).
+The `--tp` / `--tensor-parallel-size` and `--context-length` /
+`--max-model-len` flags this harness generates come from each framework's
+own general documentation, not from the GLM-5.3-Flash card. Verify the
+current recipe at <https://docs.sglang.io/cookbook/autoregressive/GLM/GLM-5.3-Flash>
+or <https://recipes.vllm.ai/zai-org/GLM-5.3-Flash> before you commit
+money to a version.
+
+### Whether 4x H200 is enough
+
+`deploy plan` computes it: roughly 306 GiB of weights against 4 x 141 GiB
+of advertised VRAM leaves about 258 GiB, or 45 percent, for KV cache and
+activations. The harness requires at least 20 percent and so approves it.
+
+This is arithmetic, not vendor guidance. No official hardware requirement
+for GLM-5.3-Flash was published on the model card or in
+<https://github.com/zai-org/GLM-5> as of 2026-08-30. The check can prove a
+configuration *cannot* work; it cannot prove one will. The smoke test
+settles that.
+
+## Budgeting on a small balance
+
+```bash
+uv run llmtracefx-deploy budget --credit-usd 30
+```
+
+On $30 this recommends a $10 cap and holds $20 back. The reserve is not
+timidity: it covers a start up that fails after the image is pulled and
+the GPUs are allocated, one full retry, and volume storage, which keeps
+billing after the GPUs stop and which Modal bills for up to four days
+after you delete the data.
+
+What $10 buys is a short window. Price the resources yourself, then
+divide.
+
+The total is not GPU-only. It is the sum of five mandatory charges, and
+`deploy plan` prints them as separate lines so you can check each:
+
+| Line | What it is |
+| --- | --- |
+| `serving-gpu` | the accelerators, for the whole deployment window |
+| `serving-compute` | the CPU and memory billed alongside them |
+| `staging` | the CPU-only download container, to its own timeout |
+| `verification` | the CPU-only inventory check, to its own timeout |
+| `storage` | the volume, for your retention plus four days |
+
+The accelerators are priced against `--max-deployment-seconds`, not
+against the container timeout. That matters: Modal's `timeout` bounds a
+Function's *execution*, and this server's function returns as soon as it
+has launched the framework, so the timeout alone would not stop a request
+arriving tomorrow from allocating accelerators again.
+
+What does stop it is an expiry. The deploy bakes an absolute instant into
+the container image, and the serving container refuses to start once it
+has passed. A container that starts a second before the expiry still runs
+its own lifetime afterwards, so one container timeout is added to the
+window rather than assuming a clean cut. That is what makes the number an
+upper bound rather than an estimate.
+
+Be precise about what the expiry does and does not do. It stops a
+container from *serving* past the window. It cannot stop one from being
+*started*, because the platform schedules a web server container before
+any of its code runs, so a request allocates accelerators first and is
+refused second. Proxy auth is what makes that bounded: without
+credentials the request never reaches the scheduler, and with them only
+you can trigger it. A request bearing your token after the expiry still
+cold-starts a container that refuses within seconds, and that residual is
+deliberately not priced.
+
+`min_containers` above zero is refused outright for a related reason: a
+warm container bills from deploy whether or not anything calls it, so the
+whole window is spent by definition rather than in the worst case.
+
+## The run
+
+### 0. Plan. This is free, offline and unauthenticated
+
+```bash
+uv run llmtracefx-deploy plan \
+  --max-usd 10.00 \
+  --gpu-type H200 --gpu-count 4 \
+  --max-runtime-seconds 1800 \
+  --max-deployment-seconds 3600 \
+  --usd-per-gpu-hour "<rate you read>" \
+  --usd-per-cpu-core-hour "<rate you read>" \
+  --usd-per-gib-memory-hour "<rate you read>" \
+  --storage-usd-per-gib-month "<rate you read>" \
+  --storage-retention-days 1 \
+  --price-effective-date "<YYYY-MM-DD you read them>" \
+  --price-source https://modal.com/pricing \
+  --model-revision "<40-character SHA>" \
+  --image "vllm/vllm-openai:<tag>@sha256:<digest>" \
+  --framework-version "<version>" \
+  --context-length 131072 \
+  --startup-timeout-seconds 900 \
+  --output output/glm-plan.json
+```
+
+This needs no Modal account, no token and no network. It prints the
+decision, the worst-case cost envelope, the capacity check and every
+command below, then exits non-zero if anything is blocking.
+
+Run it before you install the Modal CLI. If it refuses, nothing you do
+next can cost money, because the paid commands are withheld from the
+executable set rather than merely annotated.
+
+### 1. Authenticate
+
+```bash
+modal setup
+```
+
+Install the SDK first if you have not: `uv sync --extra modal`. It is an
+optional extra; the planner and the test suite do not need it.
+
+### 2. Create a proxy token, and store it as the secret
+
+The endpoint is served with Modal proxy auth on, and there is no flag to
+turn that off. The reason is a cost one rather than a security one: a web
+server container is scheduled by the platform *before* any of its code
+runs, so on a public URL every request from anyone allocates accelerators
+first and is refused second, without limit and including after the
+deployment expiry. Nothing in the cost envelope bounds that, so the
+harness will not configure it. With proxy auth on, Modal returns 401 at
+its edge and never schedules a container.
+
+Requiring it costs nothing, because Modal's token pair can be sent as a
+single `Authorization: Bearer` value, which is the scheme the OpenAI API
+uses. The collector and every OpenAI-compatible client work unchanged.
+
+Create a token in the dashboard under Proxy Auth Tokens, or with
+`modal workspace proxy-tokens`. Then join the pair with a period and
+store it:
+
+```bash
+export GLM_SELFHOST_API_KEY="wk-yourtokenid.ws-yourtokensecret"
+modal secret create glm-selfhost-api-key GLM_SELFHOST_API_KEY="$GLM_SELFHOST_API_KEY"
+```
+
+Creating the secret in the Modal dashboard instead keeps it out of shell
+history altogether. Either way, no plan, manifest, log line or generated
+command produced by this harness contains the value: they contain the
+string `$GLM_SELFHOST_API_KEY`.
+
+Check that the export actually took. Running the `modal secret create`
+line in a shell where `GLM_SELFHOST_API_KEY` is not set expands it to an
+empty value and creates a secret that exists but holds nothing. Modal's
+own `required_keys` assertion does not catch that, because it checks the
+variable is present, not that it contains anything. The server does: it
+refuses to start on an empty key rather than serving without
+authentication.
+
+If the repository is gated, create a Hugging Face token secret too and
+name it in `LLMTRACEFX_GLM_HF_SECRET_NAME`.
+
+### 3. Export the plan environment
+
+`modal run` and `modal deploy` import the app, and the app rebuilds the
+adjudicated plan from the environment. If any spending authority, price or
+pin is missing, or if the plan is refused, the import raises and nothing is
+registered. There is no configuration in which a default GPU count gets
+deployed.
+
+```bash
+export LLMTRACEFX_GLM_MAX_USD=10.00
+export LLMTRACEFX_GLM_GPU_TYPE=H200
+export LLMTRACEFX_GLM_GPU_COUNT=4
+export LLMTRACEFX_GLM_MAX_RUNTIME_SECONDS=1800
+export LLMTRACEFX_GLM_MAX_DEPLOYMENT_SECONDS=3600
+export LLMTRACEFX_GLM_USD_PER_GPU_HOUR="<rate you read>"
+export LLMTRACEFX_GLM_USD_PER_CPU_CORE_HOUR="<rate you read>"
+export LLMTRACEFX_GLM_USD_PER_GIB_MEMORY_HOUR="<rate you read>"
+export LLMTRACEFX_GLM_STORAGE_USD_PER_GIB_MONTH="<rate you read>"
+export LLMTRACEFX_GLM_STORAGE_RETENTION_DAYS=1
+export LLMTRACEFX_GLM_PRICE_EFFECTIVE_DATE="<YYYY-MM-DD>"
+export LLMTRACEFX_GLM_PRICE_SOURCE=https://modal.com/pricing
+export LLMTRACEFX_GLM_MODEL_REVISION="<40-character SHA>"
+export LLMTRACEFX_GLM_IMAGE="vllm/vllm-openai:<tag>@sha256:<digest>"
+export LLMTRACEFX_GLM_FRAMEWORK_VERSION="<version>"
+export LLMTRACEFX_GLM_CONTEXT_LENGTH=131072
+export LLMTRACEFX_GLM_STARTUP_TIMEOUT_SECONDS=900
+```
+
+Optional, all with safe defaults: `LLMTRACEFX_GLM_FRAMEWORK` (vllm),
+`LLMTRACEFX_GLM_MAX_CONTAINERS` (1), `LLMTRACEFX_GLM_MIN_CONTAINERS` (0),
+`LLMTRACEFX_GLM_SCALEDOWN_WINDOW_SECONDS` (300),
+`LLMTRACEFX_GLM_MAX_CONCURRENT_INPUTS` (1),
+`LLMTRACEFX_GLM_TENSOR_PARALLEL_SIZE` (the GPU count),
+`LLMTRACEFX_GLM_APP_NAME`, `LLMTRACEFX_GLM_VOLUME_NAME`,
+`LLMTRACEFX_GLM_API_KEY_ENV`, `LLMTRACEFX_GLM_MODAL_SECRET_NAME`,
+`LLMTRACEFX_GLM_STORED_GIB`.
+
+You do not have to re-export these for the containers. The deploy bakes
+the adjudicated configuration into both container images, so a remote
+worker rebuilds the same plan from the image rather than from a shell it
+has never seen. Nothing baked there is a secret: names, prices,
+revisions and limits only. The API key still travels separately, in the
+Modal Secret.
+
+### 4. Stage the weights on CPU
+
+```bash
+modal volume create llmtracefx-glm53flash-weights
+
+modal run llmtracefx/deploy/modal_glm_app.py::stage_weights \
+  --repo-id zai-org/GLM-5.3-Flash \
+  --revision "<40-character SHA>" \
+  --confirm "<the same SHA>" \
+  --volume-name llmtracefx-glm53flash-weights
+```
+
+This function has no `gpu=` argument at all, so several hundred GiB are
+never transferred while accelerators are billing. It is CPU and network
+only, and it takes a long time.
+
+`--confirm` repeats `--revision` rather than being a yes/no flag. A yes/no
+flag survives being copied onto a different command line and confirms
+whatever that line now says; restating the SHA means an edited command
+with a stale confirmation fails instead of fetching something nobody
+asked for.
+
+It writes `manifest.json` next to the weights recording the repository,
+the revision, every file and its size, and each file's sha256 where the
+repository published one. Hashes are not recomputed locally: hashing
+hundreds of GiB would double the container time you are billed for, and a
+locally computed digest proves the bytes are self-consistent, not that
+they are the bytes upstream published.
+
+Re-running with the same revision is a no-op. Inspect it any time:
+
+```bash
+modal run llmtracefx/deploy/modal_glm_app.py::read_manifest \
+  --volume-name llmtracefx-glm53flash-weights \
+  --revision "<40-character SHA>"
+```
+
+### 4b. Verify the staged inventory, still on CPU
+
+```bash
+modal run llmtracefx/deploy/modal_glm_app.py::verify_weights \
+  --volume-name llmtracefx-glm53flash-weights \
+  --revision "<40-character SHA>"
+```
+
+A manifest naming the right revision proves a download was started, not
+that it finished. An interruption near the end leaves the manifest and a
+short shard behind, and the only cheap place to find that is a CPU
+container. This re-checks every file's existence and size, and its
+published sha256 where the repository provided one, then records the
+result on the volume.
+
+The serving container requires that record. If verification has not
+passed for the revision it is configured with, it refuses to start, so a
+truncated volume is never discovered on four accelerators.
+
+### 5. Deploy
+
+```bash
+modal deploy llmtracefx/deploy/modal_glm_app.py
+```
+
+Deploying registers the app. Accelerators are allocated on the first
+request and released after the scaledown window, so nothing bills between
+step 5 and step 6.
+
+The server is pointed at the volume path, never at the repository id, so
+it cannot quietly fall back to downloading weights on GPUs. It verifies
+the staging manifest before launching the framework: if the weights are
+not staged you lose seconds of accelerator time, not an entire start up.
+
+The deploy prints the app URL. Feed it back in to get exact client
+commands:
+
+```bash
+uv run llmtracefx-deploy plan ... \
+  --endpoint-base-url https://<workspace>--llmtracefx-glm53flash-serve.modal.run
+```
+
+### 6. Health, readiness, one bounded smoke request
+
+```bash
+curl -fsS --max-time 30 "$URL/health"
+
+curl -fsS --max-time 60 \
+  -H "Authorization: Bearer $GLM_SELFHOST_API_KEY" "$URL/v1/models"
+
+curl -fsS --max-time 120 \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GLM_SELFHOST_API_KEY" \
+  -d '{"model":"zai-org/GLM-5.3-Flash","max_tokens":32,"stream":false,"messages":[{"role":"user","content":"Reply with the word: ready"}]}' \
+  "$URL/v1/chat/completions"
+```
+
+The first of these cold-starts the container and therefore allocates
+GPUs. The smoke request is capped at 32 output tokens so a misbehaving
+server cannot generate indefinitely.
+
+None of this is a benchmark. It proves the endpoint serves.
+
+### 7. Measure with the collector
+
+```bash
+uv run llmtracefx-optimizer collect-api \
+  --run-id glm53flash-selfhost \
+  --provider modal-selfhost \
+  --endpoint "$URL/v1/chat/completions" \
+  --model-id zai-org/GLM-5.3-Flash \
+  --model-revision "<40-character SHA>" \
+  --prompt-file prompts/smoke.txt \
+  --output-dir output/glm53flash-selfhost \
+  --api-key-env GLM_SELFHOST_API_KEY
+```
+
+Timing evidence is produced from outside, by the collector that already
+exists, and not by the server. A server that measures and grades itself
+produces numbers with no independent provenance. The server records only
+what it can honestly observe about its own configuration: GPU model and
+count, framework and version, model revision, quantization, tensor
+parallel degree, context cap, and start up duration, each marked as
+configured or observed. It makes no performance claim.
+
+### 8. Tear down. This is the step people skip
+
+```bash
+modal app stop llmtracefx-glm53flash
+modal volume delete llmtracefx-glm53flash-weights
+```
+
+Stop the app first: that is what prevents a request from starting a new
+GPU container.
+
+Then delete the volume. Storage is the charge that outlives the
+experiment, roughly 306 GiB of it, billed until deletion and for up to
+four days afterwards. Keep the volume only if you intend to serve again
+soon, because re-staging means transferring the whole checkpoint again.
+
+Both teardown commands stay available even when a plan is refused. They
+are the commands that make spending stop, so gating them on approval
+would withhold them exactly when they are most needed.
+
+## What the harness refuses, and how to proceed anyway
+
+| Refusal | Meaning | If you meant it |
+| --- | --- | --- |
+| Worst case exceeds budget | `gpu_count x containers x runtime x rate > --max-usd` | Lower the runtime or GPU count, or raise `--max-usd` |
+| Price quote is stale | Older than 90 days | Re-read the price, or `--accept-stale-price` |
+| Price is future dated | Data entry error | Fix the date. No override. |
+| Revision is not a SHA | `main` or a tag was passed | Resolve and pin the SHA |
+| Image tag is `latest` | Not reproducible | Pin a tag and digest. No override. |
+| Image has no digest | A tag can be repointed | `--accept-mutable-image` |
+| Accelerators too small | Under 20 percent left after weights | Add GPUs |
+| `min_containers` above zero | Warm GPUs bill from deploy whether or not anything calls them | Nothing. Set it to 0 and accept the cold start. |
+| Deployment window shorter than the container timeout | The window cannot be shorter than one container's life | Raise `--max-deployment-seconds` |
+| Weights not verified | The inventory check has not passed for this revision | Run the verify-weights step |
+| Deployment expired | The window baked at deploy has passed | `modal app stop`, then redeploy with a fresh window |
+| Framework takes the key on argv | SGLang logs its own config unredacted | `--accept-argv-credential-exposure` |
+
+## Safety properties, and where they are tested
+
+- Planning is pure. `deploy plan` opens no socket, reads no credential and
+  never imports the Modal SDK. `tests/deploy/test_deploy_cli.py` asserts
+  this by making `socket.socket` raise.
+- Nothing spends by default. Every spending parameter is required with no
+  default; omitting one is an error.
+- Downloads never touch a GPU. `tests/deploy/test_modal_app.py` imports
+  the real entrypoint against a fake Modal SDK and asserts the staging
+  function receives no `gpu` argument, and that serving receives exactly
+  the planned GPU string, timeout, container limits and concurrency.
+- No credential is ever persisted. Every field in a plan is a name by
+  construction, and on top of that the rendered document is scrubbed
+  against the resolved value of the variable you named, using the same
+  redactor `collect-api --dry-run` uses. `tests/deploy/test_deploy_cli.py`
+  plants a sentinel key and asserts it appears in neither stdout, stderr
+  nor the written artifact, on the success path, the JSON path, the
+  refusal path, and the path where the key was pasted where a name
+  belongs. Shape validation alone would not catch that last one: a
+  credential can be a well-formed Secret name.
+- Diagnostics repeat nothing the caller typed. A credential-shaped flag
+  is refused with a fixed message that does not name the offending
+  option, so no part of your argv can reach a log through it.
+- Modal is optional. The whole suite passes with the SDK uninstalled.
+
+```bash
+uv run pytest tests/deploy
+```

--- a/llmtracefx/deploy/__init__.py
+++ b/llmtracefx/deploy/__init__.py
@@ -1,0 +1,59 @@
+"""Budget-guarded, pinned self-hosting of GLM-5.3-Flash.
+
+The public surface is deliberately small and entirely offline:
+
+``plan``        adjudicate a deployment and render the commands for it.
+``budget``      worst-case cost arithmetic and the fail-closed gate.
+``recipe``      the pinned model facts and the serving configuration.
+``manifest``    what was staged, and what served.
+
+Importing this package does not import the Modal SDK. Modal is needed
+only by ``llmtracefx.deploy.modal_glm_app``, which is an entrypoint for
+``modal run`` and ``modal deploy`` rather than a library module, and is
+never imported by the planner, the CLI or the tests.
+"""
+
+from __future__ import annotations
+
+from .budget import (
+    BudgetRequest,
+    CostEnvelope,
+    assert_within_budget,
+    evaluate_budget,
+    recommended_session_budget_usd,
+)
+from .commands import CommandStep
+from .endpoint import EndpointConfig, collector_argv
+from .environment import REQUIRED_ENV_VARS, plan_from_environ
+from .errors import DeploymentPlanError
+from .manifest import ServerManifest, StagedFile, WeightStagingManifest
+from .plan import DeploymentPlan, RuntimeControls, assert_executable, build_plan
+from .pricing import GpuPriceQuote, StorageQuote
+from .recipe import GLM_53_FLASH, ServingRecipe, build_recipe, check_memory_fit
+
+__all__ = [
+    "GLM_53_FLASH",
+    "REQUIRED_ENV_VARS",
+    "BudgetRequest",
+    "CommandStep",
+    "CostEnvelope",
+    "DeploymentPlan",
+    "DeploymentPlanError",
+    "EndpointConfig",
+    "GpuPriceQuote",
+    "RuntimeControls",
+    "ServerManifest",
+    "ServingRecipe",
+    "StagedFile",
+    "StorageQuote",
+    "WeightStagingManifest",
+    "assert_executable",
+    "assert_within_budget",
+    "build_plan",
+    "build_recipe",
+    "check_memory_fit",
+    "collector_argv",
+    "evaluate_budget",
+    "plan_from_environ",
+    "recommended_session_budget_usd",
+]

--- a/llmtracefx/deploy/budget.py
+++ b/llmtracefx/deploy/budget.py
@@ -1,0 +1,495 @@
+"""Worst-case cost arithmetic and the fail-closed budget gate.
+
+Every number here is an upper bound, never an expectation. A plan is
+approved on the basis of what the deployment costs if it runs the whole
+way to its own timeout on every container it is allowed to start, because
+that is the only figure an operator can be held to: an average-case
+estimate approves a deployment that can still overspend, and the moment
+it does the money is already gone.
+
+Nothing in this module has a default that spends money. There is no
+default budget, no default GPU count, no default runtime and no default
+price. Each has to be stated by the caller, so an incomplete invocation
+fails closed instead of falling back to something plausible.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+from .errors import DeploymentPlanError
+from .pricing import ComputeQuote, GpuPriceQuote, StorageQuote, _require_finite
+from .resources import (
+    POST_DELETE_BILLING_DAYS,
+    SERVING_CPU_CORES,
+    SERVING_MEMORY_GIB,
+    STAGING_CPU_CORES,
+    STAGING_MEMORY_GIB,
+    STAGING_TIMEOUT_SECONDS,
+    VERIFY_CPU_CORES,
+    VERIFY_MEMORY_GIB,
+    VERIFY_TIMEOUT_SECONDS,
+)
+
+SECONDS_PER_HOUR = 3600.0
+DAYS_PER_MONTH = 30.0
+
+# This harness refuses to plan a run longer than a day regardless of what
+# the platform would accept. A self-host validation that needs more than
+# 24 hours of continuous GPU time is not the experiment this harness is
+# for, and the failure mode of an over-long timeout (a container nobody
+# is watching, billing until it hits the limit) is exactly what the
+# budget gate exists to prevent.
+MAX_RUNTIME_SECONDS_CEILING = 86_400
+
+# Modal documents up to 8 GPUs per container for H200 ("H200:8").
+# See https://modal.com/docs/guide/gpu (read 2026-08-30).
+MAX_GPU_COUNT_CEILING = 8
+
+# A ceiling on the autoscaling limit itself. This harness exists for a
+# short single-endpoint validation, so any three-digit container count is
+# a typo rather than an intention. It also keeps the worst-case product
+# inside the float range: without it a large integer count overflows
+# during the int-to-float conversion and raises OverflowError before the
+# finiteness guard below can turn it into a refusal.
+MAX_CONTAINERS_CEILING = 64
+
+# The wall-clock window during which the deployment may serve at all,
+# enforced by an expiry the serving container checks before it starts.
+# Seven days is the ceiling because this harness is for a short
+# validation and the whole point of the expiry is that it arrives.
+MAX_DEPLOYMENT_SECONDS_CEILING = 7 * 24 * 60 * 60
+
+# How long weights may be declared to stay on the volume. A year of
+# storage for a checkpoint this size is not a validation.
+MAX_RETENTION_DAYS_CEILING = 90.0
+
+# Fraction of remaining credit a single session is allowed to put at
+# risk, expressed as a divisor. One third leaves two thirds behind for
+# the things that are not in the GPU worst case: a startup that fails
+# after pulling the image and allocating GPUs, one retry of the whole
+# run, and volume storage, which keeps accruing after the GPU stops and
+# which Modal bills for up to four days after the data is deleted
+# (https://modal.com/docs/guide/volumes, read 2026-08-30).
+CREDIT_RESERVE_DIVISOR = 3.0
+
+
+def recommended_session_budget_usd(available_credit_usd: float) -> float:
+    """The largest budget this harness will suggest for one session.
+
+    Deliberately not "all of it". A harness that proposes spending the
+    entire balance leaves nothing for the second attempt, and the second
+    attempt is the likely one: the first run of an unfamiliar serving
+    stack is the run that discovers the flag it needed.
+
+    Rounded down to whole cents so the suggestion never exceeds the
+    fraction it claims to be.
+    """
+    credit = _require_finite(available_credit_usd, field="available_credit_usd")
+    if credit <= 0:
+        raise DeploymentPlanError("available_credit_usd must be greater than zero")
+    scaled = (credit / CREDIT_RESERVE_DIVISOR) * 100
+    # The input being finite does not make the scaled value finite, and
+    # math.floor raises on an infinity rather than returning one. Same
+    # hazard the worst-case product guards against in evaluate_budget.
+    if not math.isfinite(scaled):
+        raise DeploymentPlanError(
+            "available_credit_usd is too large to compute a recommendation from"
+        )
+    return math.floor(scaled) / 100
+
+
+def _require_positive_int(value: int, *, field: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DeploymentPlanError(f"{field} must be an integer")
+    if value < 1:
+        raise DeploymentPlanError(f"{field} must be at least 1, got {value}")
+    if maximum is not None and value > maximum:
+        raise DeploymentPlanError(f"{field} must not exceed {maximum}, got {value}")
+    return value
+
+
+@dataclass(frozen=True)
+class BudgetRequest:
+    """A fully specified, explicitly authorised spending envelope.
+
+    Every mandatory charge is represented, not just the largest one. The
+    accelerators dominate, but the staging container, the verification
+    container, the CPU and memory that bill alongside the accelerators,
+    and the volume that keeps billing after the run all cost money, and a
+    total that omits them is not a budget guard.
+
+    ``deployment_seconds`` is the wall-clock window the deployment may
+    serve at all, enforced by an expiry the serving container checks
+    before it starts. It is the term the accelerators are priced against,
+    because the per-container timeout does not bound spending: a served
+    request that arrives after a container exits simply starts another
+    one.
+    """
+
+    max_usd: float
+    gpu_type: str
+    gpu_count: int
+    max_runtime_seconds: int
+    deployment_seconds: int
+    price: GpuPriceQuote
+    compute: ComputeQuote
+    storage: StorageQuote
+    stored_gib: float
+    storage_retention_days: float
+    max_containers: int = 1
+
+    def __post_init__(self) -> None:
+        budget = _require_finite(self.max_usd, field="max_usd")
+        if budget <= 0:
+            raise DeploymentPlanError("max_usd must be greater than zero")
+        object.__setattr__(self, "max_usd", budget)
+
+        if not isinstance(self.gpu_type, str) or not self.gpu_type.strip():
+            raise DeploymentPlanError("gpu_type must be a non-empty string")
+        object.__setattr__(self, "gpu_type", self.gpu_type.strip())
+
+        object.__setattr__(
+            self,
+            "gpu_count",
+            _require_positive_int(
+                self.gpu_count, field="gpu_count", maximum=MAX_GPU_COUNT_CEILING
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_runtime_seconds",
+            _require_positive_int(
+                self.max_runtime_seconds,
+                field="max_runtime_seconds",
+                maximum=MAX_RUNTIME_SECONDS_CEILING,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "deployment_seconds",
+            _require_positive_int(
+                self.deployment_seconds,
+                field="deployment_seconds",
+                maximum=MAX_DEPLOYMENT_SECONDS_CEILING,
+            ),
+        )
+        if self.deployment_seconds < self.max_runtime_seconds:
+            raise DeploymentPlanError(
+                f"deployment_seconds {self.deployment_seconds} is shorter than "
+                f"max_runtime_seconds {self.max_runtime_seconds}; the window "
+                "the deployment may serve for cannot be shorter than one "
+                "container's own lifetime"
+            )
+        object.__setattr__(
+            self,
+            "max_containers",
+            _require_positive_int(
+                self.max_containers,
+                field="max_containers",
+                maximum=MAX_CONTAINERS_CEILING,
+            ),
+        )
+
+        # A quote for a different accelerator is the quietest way to
+        # underprice a run: the arithmetic all succeeds and the answer is
+        # simply wrong. The two names have to agree.
+        if self.price.gpu_type.casefold() != self.gpu_type.casefold():
+            raise DeploymentPlanError(
+                f"price quote is for {self.price.gpu_type!r} but the plan "
+                f"requests {self.gpu_type!r}; price the GPU you are booking"
+            )
+
+        size = _require_finite(self.stored_gib, field="stored_gib")
+        if size <= 0:
+            raise DeploymentPlanError("stored_gib must be greater than zero")
+        object.__setattr__(self, "stored_gib", size)
+
+        retention = _require_finite(
+            self.storage_retention_days, field="storage_retention_days"
+        )
+        if retention < 0:
+            raise DeploymentPlanError("storage_retention_days must not be negative")
+        if retention > MAX_RETENTION_DAYS_CEILING:
+            raise DeploymentPlanError(
+                "storage_retention_days must not exceed "
+                f"{MAX_RETENTION_DAYS_CEILING:.0f}"
+            )
+        object.__setattr__(self, "storage_retention_days", retention)
+
+
+@dataclass(frozen=True)
+class CostLine:
+    """One billable resource, priced, with its inputs carried through."""
+
+    name: str
+    detail: str
+    hours: float
+    usd_per_hour: float
+    usd: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "detail": self.detail,
+            "hours": round(self.hours, 6),
+            "usd_per_hour": round(self.usd_per_hour, 6),
+            "usd": round(self.usd, 6),
+        }
+
+
+@dataclass(frozen=True)
+class CostEnvelope:
+    """The upper bound on what a plan can cost, and how it was reached.
+
+    Every input is carried through to the output so the number can be
+    re-derived by hand from the record alone, without re-running the
+    planner or trusting it.
+    """
+
+    gpu_type: str
+    gpu_count: int
+    max_containers: int
+    max_runtime_seconds: int
+    deployment_seconds: int
+    billable_seconds: int
+    usd_per_gpu_hour: float
+    price_effective_date: str
+    price_source: str
+    compute_effective_date: str
+    compute_source: str
+    storage_effective_date: str
+    storage_source: str
+    stored_gib: float
+    storage_usd_per_gib_month: float
+    storage_retention_days: float
+    storage_billed_days: float
+    lines: tuple[CostLine, ...]
+    worst_case_usd: float
+    budget_usd: float
+    headroom_usd: float
+    within_budget: bool
+    bounded: bool = True
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def gpu_worst_case_usd(self) -> float:
+        return next(line.usd for line in self.lines if line.name == "serving-gpu")
+
+    def to_dict(self) -> dict[str, Any]:
+        def money(value: float) -> float:
+            return round(value, 6)
+
+        return {
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "max_containers": self.max_containers,
+            "max_runtime_seconds": self.max_runtime_seconds,
+            "deployment_seconds": self.deployment_seconds,
+            "billable_seconds": self.billable_seconds,
+            "usd_per_gpu_hour": money(self.usd_per_gpu_hour),
+            "price_effective_date": self.price_effective_date,
+            "price_source": self.price_source,
+            "compute_effective_date": self.compute_effective_date,
+            "compute_source": self.compute_source,
+            "storage_effective_date": self.storage_effective_date,
+            "storage_source": self.storage_source,
+            "stored_gib": round(self.stored_gib, 3),
+            "storage_usd_per_gib_month": money(self.storage_usd_per_gib_month),
+            "storage_retention_days": self.storage_retention_days,
+            "storage_billed_days": self.storage_billed_days,
+            "lines": [line.to_dict() for line in self.lines],
+            "worst_case_usd": money(self.worst_case_usd),
+            "budget_usd": money(self.budget_usd),
+            "headroom_usd": money(self.headroom_usd),
+            "within_budget": self.within_budget,
+            "bounded": self.bounded,
+            "covers": (
+                "Accelerators, the CPU and memory billed alongside them, the "
+                "staging and verification containers, and volume storage "
+                "including the period Modal bills after deletion."
+            ),
+            "does_not_cover": (
+                "Cold starts triggered by requests that reach the platform. A "
+                "web server function is scheduled before any code in the "
+                "container runs, so a request allocates accelerators first "
+                "and is refused second, including after the deployment "
+                "expiry. With proxy auth on, only a holder of a workspace "
+                "token can do this and the refusal takes seconds. With a "
+                "public endpoint anyone can, without limit, and no figure "
+                "here bounds it."
+            ),
+            "notes": list(self.notes),
+        }
+
+
+def evaluate_budget(request: BudgetRequest) -> CostEnvelope:
+    """Price the worst case for ``request``. Pure arithmetic, no I/O.
+
+    The serving term assumes every allowed container is occupied for the
+    whole deployment window, plus one container timeout, because a
+    container that starts just before the expiry still runs its full
+    lifetime afterwards.
+
+    This is the cost of the intended path, not an unconditional cap. The
+    platform schedules a web server container before any of this
+    project's code runs, so a request can allocate accelerators and be
+    refused afterwards; what stops that being unbounded is authentication
+    at the edge, which is a plan-level gate rather than a term in this
+    arithmetic. ``bounded`` records whether that gate is in place.
+    """
+    billable_seconds = request.deployment_seconds + request.max_runtime_seconds
+    serving_hours = request.max_containers * (billable_seconds / SECONDS_PER_HOUR)
+
+    gpu_rate = request.gpu_count * request.price.usd_per_gpu_hour
+    serving_compute_rate = request.compute.container_usd_per_hour(
+        cpu_cores=SERVING_CPU_CORES, memory_gib=SERVING_MEMORY_GIB
+    )
+    staging_hours = STAGING_TIMEOUT_SECONDS / SECONDS_PER_HOUR
+    staging_rate = request.compute.container_usd_per_hour(
+        cpu_cores=STAGING_CPU_CORES, memory_gib=STAGING_MEMORY_GIB
+    )
+    verify_hours = VERIFY_TIMEOUT_SECONDS / SECONDS_PER_HOUR
+    verify_rate = request.compute.container_usd_per_hour(
+        cpu_cores=VERIFY_CPU_CORES, memory_gib=VERIFY_MEMORY_GIB
+    )
+
+    storage_billed_days = request.storage_retention_days + POST_DELETE_BILLING_DAYS
+    storage_hours = storage_billed_days * 24.0
+    storage_rate = (
+        request.stored_gib * request.storage.usd_per_gib_month / (DAYS_PER_MONTH * 24.0)
+    )
+
+    lines = (
+        CostLine(
+            name="serving-gpu",
+            detail=(
+                f"{request.gpu_count} x {request.gpu_type} x "
+                f"{request.max_containers} container(s)"
+            ),
+            hours=serving_hours,
+            usd_per_hour=gpu_rate,
+            usd=serving_hours * gpu_rate,
+        ),
+        CostLine(
+            name="serving-compute",
+            detail=(
+                f"{SERVING_CPU_CORES:.0f} cores + {SERVING_MEMORY_GIB:.0f} GiB "
+                f"x {request.max_containers} container(s)"
+            ),
+            hours=serving_hours,
+            usd_per_hour=serving_compute_rate,
+            usd=serving_hours * serving_compute_rate,
+        ),
+        CostLine(
+            name="staging",
+            detail=(
+                f"{STAGING_CPU_CORES:.0f} cores + {STAGING_MEMORY_GIB:.0f} GiB, "
+                "CPU only, to its own timeout"
+            ),
+            hours=staging_hours,
+            usd_per_hour=staging_rate,
+            usd=staging_hours * staging_rate,
+        ),
+        CostLine(
+            name="verification",
+            detail=(
+                f"{VERIFY_CPU_CORES:.0f} cores + {VERIFY_MEMORY_GIB:.0f} GiB, "
+                "CPU only, to its own timeout"
+            ),
+            hours=verify_hours,
+            usd_per_hour=verify_rate,
+            usd=verify_hours * verify_rate,
+        ),
+        CostLine(
+            name="storage",
+            detail=(
+                f"{request.stored_gib:.0f} GiB for "
+                f"{request.storage_retention_days:.0f} day(s) plus "
+                f"{POST_DELETE_BILLING_DAYS:.0f} billed after deletion"
+            ),
+            hours=storage_hours,
+            usd_per_hour=storage_rate,
+            usd=storage_hours * storage_rate,
+        ),
+    )
+
+    worst_case = sum(line.usd for line in lines)
+
+    # Guarding the total as well as each input: the inputs are already
+    # finite, but a product of two large finite floats can still overflow
+    # to infinity, and an infinite worst case must not be allowed to
+    # reach the comparison below as a number.
+    if not math.isfinite(worst_case):
+        raise DeploymentPlanError(
+            "worst-case cost overflowed to a non-finite value; reduce "
+            "gpu_count, max_containers or the deployment window"
+        )
+
+    # Joined explicitly rather than written as adjacent string literals
+    # inside the list, which reads as a missing comma between two notes.
+    window_note = " ".join(
+        (
+            "The accelerator term is priced against the deployment window,",
+            "not the container timeout, because a request arriving after a",
+            "container exits simply starts another one. One container",
+            "timeout is added so a container starting just before the",
+            "expiry is still covered.",
+        )
+    )
+    storage_note = " ".join(
+        (
+            "Volume storage keeps billing after the GPUs stop, and Modal",
+            "bills deleted data for up to four days, so both are included.",
+        )
+    )
+    notes: list[str] = [window_note, storage_note]
+    if request.max_containers > 1:
+        notes.append(
+            f"max_containers is {request.max_containers}, so the worst case "
+            "is that many concurrent containers for the whole window."
+        )
+
+    return CostEnvelope(
+        gpu_type=request.gpu_type,
+        gpu_count=request.gpu_count,
+        max_containers=request.max_containers,
+        max_runtime_seconds=request.max_runtime_seconds,
+        deployment_seconds=request.deployment_seconds,
+        billable_seconds=billable_seconds,
+        usd_per_gpu_hour=request.price.usd_per_gpu_hour,
+        price_effective_date=request.price.effective_date,
+        price_source=request.price.source,
+        compute_effective_date=request.compute.effective_date,
+        compute_source=request.compute.source,
+        storage_effective_date=request.storage.effective_date,
+        storage_source=request.storage.source,
+        stored_gib=request.stored_gib,
+        storage_usd_per_gib_month=request.storage.usd_per_gib_month,
+        storage_retention_days=request.storage_retention_days,
+        storage_billed_days=storage_billed_days,
+        lines=lines,
+        worst_case_usd=worst_case,
+        budget_usd=request.max_usd,
+        headroom_usd=request.max_usd - worst_case,
+        within_budget=worst_case <= request.max_usd,
+        notes=tuple(notes),
+    )
+
+
+def assert_within_budget(envelope: CostEnvelope) -> None:
+    """Refuse an envelope whose worst case exceeds the stated budget."""
+    if envelope.within_budget:
+        return
+    raise DeploymentPlanError(
+        f"worst-case cost ${envelope.worst_case_usd:.2f} exceeds the "
+        f"authorised budget ${envelope.budget_usd:.2f} "
+        f"({envelope.gpu_count} x {envelope.gpu_type} x "
+        f"{envelope.max_containers} container(s) for "
+        f"{envelope.max_runtime_seconds}s at "
+        f"${envelope.usd_per_gpu_hour:.4f}/GPU-hour, priced "
+        f"{envelope.price_effective_date}). Lower --max-runtime-seconds or "
+        "--gpu-count, or raise --max-usd if you actually intend to spend it."
+    )

--- a/llmtracefx/deploy/cli.py
+++ b/llmtracefx/deploy/cli.py
@@ -1,0 +1,812 @@
+"""``llmtracefx-deploy``: plan a self-host without being able to run one.
+
+Three commands, none of which can spend anything:
+
+``recipe``   print the pinned model facts and their sources.
+``budget``   turn an available credit balance into a session cap.
+``plan``     adjudicate a full deployment and print the commands.
+
+``plan`` is the dry run. It needs no Modal authentication, opens no socket
+and allocates nothing, so it can be run before the operator has even
+installed the Modal CLI. What it prints is a decision plus the exact
+commands that would carry it out, and when the decision is negative the
+money-spending commands are withheld from the executable set rather than
+merely annotated.
+
+Every parameter that governs spending is required and has no default.
+Omitting one is an error, never an assumption.
+
+This is a separate console script rather than a subcommand of
+``llmtracefx-optimizer``, so that adding it changes no existing module.
+It does reuse that CLI's credential defences, which are the part worth
+sharing: the parser that never echoes a caller-supplied value back into a
+diagnostic, and the guard that refuses a credential-shaped flag before
+argparse can format its value into a message.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+from ..optimizer.cli import (
+    _CREDENTIAL_ARGUMENT_STEMS,
+    SecureArgumentParser,
+    _argument_scrub_scope,
+    _option_stem,
+)
+from ..optimizer.collectors._shared import atomic_write_text
+from ..optimizer.collectors.openai_api import redact_text_for_dry_run
+from .budget import (
+    MAX_GPU_COUNT_CEILING,
+    MAX_RUNTIME_SECONDS_CEILING,
+    BudgetRequest,
+    recommended_session_budget_usd,
+)
+from .commands import DEFAULT_APP_NAME, DEFAULT_VOLUME_NAME
+from .endpoint import (
+    DEFAULT_API_KEY_ENV_VAR,
+    DEFAULT_MODAL_SECRET_NAME,
+    EndpointConfig,
+)
+from .errors import DeploymentPlanError
+from .plan import (
+    DEFAULT_SCALEDOWN_WINDOW_SECONDS,
+    DeploymentPlan,
+    RuntimeControls,
+    build_plan,
+)
+from .pricing import (
+    DEFAULT_MAX_PRICE_AGE_DAYS,
+    ComputeQuote,
+    GpuPriceQuote,
+    StorageQuote,
+)
+from .recipe import (
+    DEFAULT_FRAMEWORK,
+    DEFAULT_SERVER_PORT,
+    DEFAULT_WEIGHTS_MOUNT_PATH,
+    GLM_53_FLASH,
+    SUPPORTED_FRAMEWORKS,
+    SUPPORTED_REPO_ID,
+    build_recipe,
+)
+
+PROG = "llmtracefx-deploy"
+
+
+def _parse_as_of(value: str | None) -> date:
+    if value is None:
+        return date.today()
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise DeploymentPlanError("--as-of must be an ISO date (YYYY-MM-DD)") from exc
+
+
+def render_plan_text(plan: DeploymentPlan) -> str:
+    """A human summary that leads with the decision and the money."""
+    envelope = plan.envelope
+    memory = plan.memory
+    recipe = plan.recipe
+    lines: list[str] = []
+
+    verdict = "APPROVED" if plan.approved else "REFUSED"
+    lines.append(f"Deployment plan: {verdict}")
+    lines.append("")
+    lines.append("This command allocated nothing, authenticated nowhere and")
+    lines.append("made no network request.")
+    lines.append("")
+
+    lines.append("Model")
+    lines.append(f"  repository        {recipe.model_repo_id}")
+    lines.append(f"  revision          {recipe.model_revision}")
+    lines.append(
+        f"  quantization      {recipe.facts.quantization} "
+        f"({recipe.facts.quantization_format}, "
+        f"{recipe.facts.activation_scheme} activation scaling)"
+    )
+    lines.append(
+        f"  parameters        {recipe.facts.total_parameters_b:.0f}B total, "
+        f"{recipe.facts.active_parameters_b:.0f}B active"
+    )
+    lines.append(f"  context cap       {recipe.context_length} tokens")
+    lines.append("")
+
+    lines.append("Serving")
+    lines.append(f"  framework         {recipe.framework} {recipe.framework_version}")
+    lines.append(f"  image             {recipe.image.reference}")
+    lines.append(
+        "  image pinned      "
+        + ("by digest" if recipe.image.is_digest_pinned else "by tag only")
+    )
+    lines.append(f"  accelerators      {recipe.gpu_count} x {recipe.gpu_type}")
+    lines.append(f"  tensor parallel   {recipe.tensor_parallel_size}")
+    lines.append(f"  server argv       {' '.join(recipe.launch_argv())}")
+    lines.append("")
+
+    lines.append("Limits")
+    lines.append(
+        f"  deployment expiry {plan.controls.deployment_seconds}s "
+        "after deploy (enforced: the container refuses to start)"
+    )
+    lines.append(f"  container timeout {plan.controls.timeout_seconds}s")
+    lines.append(f"  startup timeout   {plan.controls.startup_timeout_seconds}s")
+    lines.append(f"  scaledown window  {plan.controls.scaledown_window_seconds}s")
+    lines.append(
+        f"  containers        max {plan.controls.max_containers}, "
+        f"min {plan.controls.min_containers}"
+    )
+    lines.append(f"  concurrency       {plan.controls.max_concurrent_inputs}")
+    lines.append(
+        "  endpoint auth     "
+        + (
+            "Modal proxy auth (unauthenticated requests are rejected at the "
+            "edge, before a container is scheduled)"
+            if plan.controls.require_proxy_auth
+            else "PUBLIC (any request can allocate accelerators)"
+        )
+    )
+    lines.append("")
+
+    lines.append("Cost envelope (worst case, not an estimate)")
+    lines.append(
+        f"  billable window   {envelope.billable_seconds}s "
+        f"({envelope.deployment_seconds}s deployment expiry plus one "
+        f"{envelope.max_runtime_seconds}s container lifetime)"
+    )
+    for line in envelope.lines:
+        lines.append(
+            f"  {line.name:<17} ${line.usd:>8.2f}  "
+            f"({line.hours:.2f} h at ${line.usd_per_hour:.4f}/h: {line.detail})"
+        )
+    lines.append(
+        f"  rates read        {envelope.price_effective_date} from "
+        f"{envelope.price_source}"
+    )
+    lines.append(f"  total worst case  ${envelope.worst_case_usd:.2f}")
+    lines.append(
+        "  bounded           "
+        + (
+            "yes, for requests that get past the edge"
+            if envelope.bounded
+            else "NO: a public endpoint has no cost bound at all"
+        )
+    )
+    lines.append(f"  authorised budget ${envelope.budget_usd:.2f}")
+    lines.append(f"  headroom          ${envelope.headroom_usd:.2f}")
+    lines.append("")
+
+    lines.append("Capacity check")
+    lines.append(
+        f"  {memory.gpu_count} x {memory.gpu_type} = "
+        f"{memory.total_vram_gib:.0f} GiB against roughly "
+        f"{memory.weights_gib:.0f} GiB of weights"
+    )
+    lines.append(
+        f"  residual          {memory.residual_gib:.0f} GiB "
+        f"({memory.residual_fraction:.0%}, minimum "
+        f"{memory.required_headroom_fraction:.0%})"
+    )
+    lines.append(f"  caveat            {memory.caveat}")
+    lines.append("")
+
+    lines.append("Endpoint")
+    lines.append(f"  chat completions  {plan.endpoint.chat_completions_url}")
+    lines.append(f"  credential from   Modal Secret {plan.endpoint.modal_secret_name}")
+    lines.append(
+        f"  injected as       ${plan.endpoint.api_key_env_var} "
+        "(name only; no value is ever recorded)"
+    )
+    lines.append("")
+
+    if plan.blockers:
+        lines.append("Blockers (paid steps withheld until every one is cleared)")
+        for blocker in plan.blockers:
+            lines.append(f"  - {blocker}")
+        lines.append("")
+    if plan.warnings:
+        lines.append("Warnings")
+        for warning in plan.warnings:
+            lines.append(f"  - {warning}")
+        lines.append("")
+
+    lines.append("Steps")
+    executable = {step.name for step in plan.executable_steps}
+    for step in plan.steps:
+        marker = "  " if step.name in executable else "x "
+        cost = "$" if step.spends_money else " "
+        lines.append(f"{marker}{cost} {step.name}: {step.purpose}")
+        lines.append(f"      {step.rendered()}")
+    lines.append("")
+    lines.append("Legend: 'x' withheld by a blocker, '$' can spend money.")
+    if not plan.approved:
+        lines.append("")
+        lines.append("No paid step may be run while this plan is refused.")
+    return "\n".join(lines)
+
+
+def _cmd_deploy_recipe(args: argparse.Namespace) -> int:
+    facts = GLM_53_FLASH
+    if args.format == "json":
+        print(json.dumps(facts.to_dict(), indent=2, allow_nan=False))
+        return 0
+    print(f"Model            {facts.repo_id}")
+    print(
+        f"Parameters       {facts.total_parameters_b:.0f}B total, "
+        f"{facts.active_parameters_b:.0f}B active"
+    )
+    print(f"Layers           {facts.num_hidden_layers}")
+    print(
+        f"Experts          {facts.num_routed_experts} routed, "
+        f"{facts.num_experts_per_token} per token"
+    )
+    print(f"Attention        {facts.attention}")
+    print(
+        f"Quantization     {facts.quantization} ({facts.quantization_format}, "
+        f"{facts.activation_scheme})"
+    )
+    print(f"Max context      {facts.max_position_embeddings} tokens")
+    print(f"Multimodal       {'yes' if facts.multimodal else 'no'}")
+    print(
+        f"Checkpoint size  roughly {facts.approximate_checkpoint_gib:.0f} GiB "
+        "(approximate; the staging manifest records what actually landed)"
+    )
+    print(f"Config source    {facts.config_source}")
+    print(f"Model card       {facts.model_card}")
+    return 0
+
+
+def _cmd_deploy_budget(args: argparse.Namespace) -> int:
+    try:
+        recommended = recommended_session_budget_usd(args.credit_usd)
+    except (DeploymentPlanError, ValueError, OverflowError) as exc:
+        print(f"{PROG}: error: {exc}", file=sys.stderr)
+        return 1
+    reserve = args.credit_usd - recommended
+    payload = {
+        "kind": "llmtracefx.deploy.budget_recommendation",
+        "available_credit_usd": round(args.credit_usd, 2),
+        "recommended_session_budget_usd": recommended,
+        "reserve_usd": round(reserve, 2),
+        "rationale": (
+            "One session is capped at a third of the balance so a failed "
+            "start up, one retry and the volume storage that outlives the "
+            "run all remain affordable."
+        ),
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, allow_nan=False))
+        return 0
+    print(f"Available credit           ${args.credit_usd:.2f}")
+    print(f"Recommended session cap    ${recommended:.2f}")
+    print(f"Held in reserve            ${reserve:.2f}")
+    print()
+    print(payload["rationale"])
+    print()
+    print(f"Pass --max-usd {recommended:.2f} to `deploy plan`.")
+    return 0
+
+
+def _configured_credential(name: str | None) -> str | None:
+    """The value held by the variable named, if it is set.
+
+    Read so it can be scrubbed, never so it can be used. The planner has
+    no use for the credential itself; resolving it is what lets the
+    rendered document be checked against it before anything is printed.
+
+    The name is stripped, because ``require_env_var_name`` strips before
+    it validates and returns the stripped form. Looking up the raw
+    argument instead would mean a padded ``--api-key-env " NAME "`` was
+    accepted as a valid name everywhere else while this lookup missed and
+    silently returned ``None``, turning the scrub into a no-op with
+    nothing in the output to say so.
+    """
+    if not name:
+        return None
+    return os.environ.get(name.strip(), "").strip() or None
+
+
+def _build_plan_from_args(args: argparse.Namespace) -> DeploymentPlan:
+    price = GpuPriceQuote(
+        gpu_type=args.gpu_type,
+        usd_per_gpu_hour=args.usd_per_gpu_hour,
+        effective_date=args.price_effective_date,
+        source=args.price_source,
+    )
+    compute = ComputeQuote(
+        usd_per_cpu_core_hour=args.usd_per_cpu_core_hour,
+        usd_per_gib_memory_hour=args.usd_per_gib_memory_hour,
+        effective_date=args.price_effective_date,
+        source=args.price_source,
+    )
+    storage = StorageQuote(
+        usd_per_gib_month=args.storage_usd_per_gib_month,
+        effective_date=args.price_effective_date,
+        source=args.price_source,
+    )
+    stored_gib = (
+        GLM_53_FLASH.approximate_checkpoint_gib
+        if args.stored_gib is None
+        else args.stored_gib
+    )
+    budget = BudgetRequest(
+        max_usd=args.max_usd,
+        gpu_type=args.gpu_type,
+        gpu_count=args.gpu_count,
+        max_runtime_seconds=args.max_runtime_seconds,
+        deployment_seconds=args.max_deployment_seconds,
+        price=price,
+        compute=compute,
+        storage=storage,
+        stored_gib=stored_gib,
+        storage_retention_days=args.storage_retention_days,
+        max_containers=args.max_containers,
+    )
+    recipe = build_recipe(
+        framework=args.framework,
+        framework_version=args.framework_version,
+        image_reference=args.image,
+        model_revision=args.model_revision,
+        gpu_type=args.gpu_type,
+        gpu_count=args.gpu_count,
+        context_length=args.context_length,
+        weights_mount_path=args.weights_mount_path,
+        port=args.port,
+        served_model_name=args.served_model_name,
+        tensor_parallel_size=args.tensor_parallel_size,
+        accept_mutable_image=args.accept_mutable_image,
+    )
+    controls = RuntimeControls(
+        timeout_seconds=args.max_runtime_seconds,
+        deployment_seconds=args.max_deployment_seconds,
+        scaledown_window_seconds=args.scaledown_window_seconds,
+        startup_timeout_seconds=args.startup_timeout_seconds,
+        max_containers=args.max_containers,
+        min_containers=args.min_containers,
+        max_concurrent_inputs=args.max_concurrent_inputs,
+        allow_warm_containers=args.allow_warm_containers,
+    )
+    endpoint = EndpointConfig(
+        api_key_env_var=args.api_key_env,
+        modal_secret_name=args.modal_secret_name,
+        served_model_name=recipe.served_model_name,
+        base_url=args.endpoint_base_url,
+    )
+    return build_plan(
+        recipe=recipe,
+        controls=controls,
+        budget=budget,
+        endpoint=endpoint,
+        as_of=_parse_as_of(args.as_of),
+        app_name=args.app_name,
+        volume_name=args.volume_name,
+        smoke_max_output_tokens=args.smoke_max_output_tokens,
+        max_price_age_days=args.max_price_age_days,
+        accept_stale_price=args.accept_stale_price,
+        accept_argv_credential_exposure=args.accept_argv_credential_exposure,
+    )
+
+
+def _cmd_deploy_plan(args: argparse.Namespace) -> int:
+    # Resolved before the plan is built, so the scrub is available on the
+    # path where building the plan raised and there is no plan to read the
+    # validated name from.
+    credential = _configured_credential(getattr(args, "api_key_env", None))
+    try:
+        plan = _build_plan_from_args(args)
+    except (DeploymentPlanError, ValueError, OverflowError) as exc:
+        # Broader than DeploymentPlanError on purpose. Validation is
+        # thorough but not total, and an escaping exception would reach
+        # stderr as a traceback, which is the one output path that does
+        # not go through the scrub below.
+        print(
+            redact_text_for_dry_run(f"{PROG}: error: {exc}", credential),
+            file=sys.stderr,
+        )
+        return 1
+
+    # Re-resolved from the name the plan actually validated, so the value
+    # being scrubbed for cannot drift from the value the deployment will
+    # use. Falls back to the pre-plan resolution rather than replacing it.
+    credential = _configured_credential(plan.endpoint.api_key_env_var) or credential
+
+    document = json.dumps(plan.to_dict(), indent=2, allow_nan=False)
+    rendered = document if args.format == "json" else render_plan_text(plan)
+
+    # Defence in depth on the way to stdout and to disk. Every field in
+    # the plan is a name by construction and each is validated as one,
+    # but this is the same barrier `collect-api --dry-run` puts in front
+    # of its rendered plan: the document is checked against the resolved
+    # credential rather than each field being trusted individually.
+    text = redact_text_for_dry_run(rendered, credential)
+    print(text)
+
+    if args.output:
+        try:
+            atomic_write_text(
+                Path(args.output),
+                redact_text_for_dry_run(document, credential) + "\n",
+            )
+        except OSError as exc:
+            print(
+                redact_text_for_dry_run(f"Failed to write plan: {exc}", credential),
+                file=sys.stderr,
+            )
+            return 1
+
+    if not plan.approved:
+        print(
+            f"\n{PROG}: deployment refused; no paid step may be run.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def _reject_credential_arguments(raw_argv: list[str]) -> None:
+    """Refuse a credential-bearing flag before argparse can echo its value.
+
+    Shares the optimizer CLI's stem list and normalizer, which are the
+    parts worth reusing, but deliberately does not reuse its message.
+    That one names the offending flag to be helpful, which means a token
+    the caller typed reaches stderr. Here the diagnostic is a fixed
+    string: nothing derived from ``raw_argv`` reaches the output at all,
+    so there is no argument about whether the part that got echoed was
+    only the name.
+    """
+    for token in raw_argv:
+        if token == "--":
+            return
+        if not token.startswith("-"):
+            continue
+        if _option_stem(token) not in _CREDENTIAL_ARGUMENT_STEMS:
+            continue
+        print(
+            f"{PROG}: error: that option is not supported, and a credential "
+            "must never appear in a command line. Export the credential to "
+            "an environment variable and name that variable with "
+            "--api-key-env. The offending option is not repeated here so it "
+            "cannot reach your shell history or CI log through this message.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``llmtracefx-deploy`` parser.
+
+    ``SecureArgumentParser`` rather than a plain one, so a value the
+    caller typed can never be quoted back into a diagnostic. Several of
+    these flags sit next to a credential in an operator's shell history.
+    """
+    parser = SecureArgumentParser(
+        prog=PROG,
+        description=(
+            "Plan a budget-guarded, pinned self-host of GLM-5.3-Flash on "
+            "Modal. Never deploys, never authenticates, never spends."
+        ),
+    )
+    deploy_subparsers = parser.add_subparsers(dest="deploy_command")
+    deploy_subparsers.required = True
+
+    recipe_parser = deploy_subparsers.add_parser(
+        "recipe",
+        help="Print the pinned GLM-5.3-Flash facts and where they came from",
+    )
+    recipe_parser.add_argument("--format", choices=("text", "json"), default="text")
+    recipe_parser.set_defaults(func=_cmd_deploy_recipe)
+
+    budget_parser = deploy_subparsers.add_parser(
+        "budget",
+        help=(
+            "Recommend a conservative per-session spending cap from an "
+            "available credit balance"
+        ),
+    )
+    budget_parser.add_argument(
+        "--credit-usd",
+        type=float,
+        required=True,
+        help="Credit currently available, in US dollars",
+    )
+    budget_parser.add_argument("--format", choices=("text", "json"), default="text")
+    budget_parser.set_defaults(func=_cmd_deploy_budget)
+
+    plan_parser = deploy_subparsers.add_parser(
+        "plan",
+        help=(
+            "Dry run: adjudicate a deployment and print the exact commands. "
+            "Requires no Modal authentication and makes no network request; "
+            "refuses the paid steps unless every budget and pinning gate "
+            "passes."
+        ),
+        # Prefix matching would let a mistyped flag resolve to a different
+        # one, and several flags here are the difference between a ten
+        # dollar run and a hundred dollar one.
+        allow_abbrev=False,
+    )
+
+    money = plan_parser.add_argument_group(
+        "spending authority (all required; there are no defaults)"
+    )
+    money.add_argument(
+        "--max-usd",
+        type=float,
+        required=True,
+        help="Hard ceiling on the worst-case cost of this deployment",
+    )
+    money.add_argument(
+        "--gpu-type", required=True, help="Accelerator model, for example H200"
+    )
+    money.add_argument(
+        "--gpu-count",
+        type=int,
+        required=True,
+        help=f"Accelerators per container (1..{MAX_GPU_COUNT_CEILING})",
+    )
+    money.add_argument(
+        "--max-runtime-seconds",
+        type=int,
+        required=True,
+        help=(
+            "Container timeout, and the runtime the worst case is priced "
+            f"against (1..{MAX_RUNTIME_SECONDS_CEILING})"
+        ),
+    )
+    money.add_argument(
+        "--usd-per-gpu-hour",
+        type=float,
+        required=True,
+        help="Price you read for this accelerator, per GPU per hour",
+    )
+    money.add_argument(
+        "--max-deployment-seconds",
+        type=int,
+        required=True,
+        help=(
+            "Wall-clock window the deployment may serve at all. The serving "
+            "container refuses to start once it has passed, and this is what "
+            "the accelerator cost is priced against"
+        ),
+    )
+    money.add_argument(
+        "--usd-per-cpu-core-hour",
+        type=float,
+        required=True,
+        help="CPU rate; bills on every container, including the CPU-only ones",
+    )
+    money.add_argument(
+        "--usd-per-gib-memory-hour",
+        type=float,
+        required=True,
+        help="Memory rate; bills on every container",
+    )
+    money.add_argument(
+        "--storage-usd-per-gib-month",
+        type=float,
+        required=True,
+        help="Volume storage rate; the weights outlive the run",
+    )
+    money.add_argument(
+        "--storage-retention-days",
+        type=float,
+        required=True,
+        help=(
+            "How long you will keep the weights on the volume. Modal bills "
+            "deleted data for up to four more days, which is added for you"
+        ),
+    )
+    money.add_argument(
+        "--price-effective-date",
+        required=True,
+        help="ISO date (YYYY-MM-DD) on which you read these prices",
+    )
+    money.add_argument(
+        "--price-source",
+        required=True,
+        help="Where you read it, normally the pricing page URL",
+    )
+
+    pinning = plan_parser.add_argument_group("pinning")
+    pinning.add_argument(
+        "--model-revision",
+        required=True,
+        help=(
+            "Full 40-character commit SHA of the model repository. Branch "
+            "names are refused"
+        ),
+    )
+    pinning.add_argument(
+        "--image",
+        required=True,
+        help=(
+            "Serving container reference, ideally name:tag@sha256:<digest>. "
+            "'latest' is always refused"
+        ),
+    )
+    pinning.add_argument(
+        "--framework",
+        choices=SUPPORTED_FRAMEWORKS,
+        default=DEFAULT_FRAMEWORK,
+        help=(
+            "Serving framework. Default vllm, because it reads the endpoint "
+            "key from the environment; sglang takes it on the command line "
+            "and logs its own configuration unredacted (default: %(default)s)"
+        ),
+    )
+    pinning.add_argument(
+        "--framework-version",
+        required=True,
+        help="Version of the serving framework inside that image",
+    )
+    pinning.add_argument(
+        "--accept-mutable-image",
+        action="store_true",
+        help="Allow a tag-only image reference and record that you chose to",
+    )
+
+    serving = plan_parser.add_argument_group("serving")
+    serving.add_argument(
+        "--context-length",
+        type=int,
+        required=True,
+        help="Context cap to serve with; must not exceed the model maximum",
+    )
+    serving.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=None,
+        help="Tensor parallel degree (default: --gpu-count)",
+    )
+    serving.add_argument(
+        "--served-model-name",
+        default=SUPPORTED_REPO_ID,
+        help="Model id clients send (default: %(default)s)",
+    )
+    serving.add_argument("--port", type=int, default=DEFAULT_SERVER_PORT)
+    serving.add_argument("--weights-mount-path", default=DEFAULT_WEIGHTS_MOUNT_PATH)
+
+    limits = plan_parser.add_argument_group("runtime limits")
+    limits.add_argument(
+        "--max-containers",
+        type=int,
+        default=1,
+        help=(
+            "Autoscaling ceiling. Default 1: every extra container "
+            "multiplies the worst case (default: %(default)s)"
+        ),
+    )
+    limits.add_argument(
+        "--min-containers",
+        type=int,
+        default=0,
+        help=(
+            "Warm container floor. Default 0 so nothing bills while idle "
+            "(default: %(default)s)"
+        ),
+    )
+    limits.add_argument(
+        "--allow-warm-containers",
+        action="store_true",
+        help="Required before --min-containers may exceed zero",
+    )
+    limits.add_argument(
+        "--scaledown-window-seconds",
+        type=int,
+        default=DEFAULT_SCALEDOWN_WINDOW_SECONDS,
+        help="Idle seconds before accelerators are released (default: %(default)s)",
+    )
+    limits.add_argument(
+        "--startup-timeout-seconds",
+        type=int,
+        default=1800,
+        help="How long the server may take to become ready (default: %(default)s)",
+    )
+    limits.add_argument(
+        "--max-concurrent-inputs",
+        type=int,
+        default=1,
+        help=(
+            "Requests served concurrently per container. Default 1 so "
+            "measurements do not interfere (default: %(default)s)"
+        ),
+    )
+
+    storage = plan_parser.add_argument_group("volume storage")
+    storage.add_argument(
+        "--stored-gib",
+        type=float,
+        default=None,
+        help="GiB kept on the volume (default: the checkpoint size)",
+    )
+
+    freshness = plan_parser.add_argument_group("price freshness")
+    freshness.add_argument(
+        "--max-price-age-days",
+        type=int,
+        default=DEFAULT_MAX_PRICE_AGE_DAYS,
+        help="Refuse quotes older than this (default: %(default)s)",
+    )
+    freshness.add_argument(
+        "--accept-argv-credential-exposure",
+        action="store_true",
+        help=(
+            "Allow a framework that takes the endpoint key on its command "
+            "line and logs it. Only sglang needs this"
+        ),
+    )
+    freshness.add_argument(
+        "--accept-stale-price",
+        action="store_true",
+        help="Downgrade a stale GPU quote from a blocker to a warning",
+    )
+    freshness.add_argument(
+        "--as-of",
+        default=None,
+        help="ISO date to age quotes against (default: today)",
+    )
+
+    wiring = plan_parser.add_argument_group("endpoint and naming")
+    wiring.add_argument(
+        "--api-key-env",
+        default=DEFAULT_API_KEY_ENV_VAR,
+        help=(
+            "Name of the environment variable carrying the endpoint key. "
+            "Only the name is used or recorded (default: %(default)s)"
+        ),
+    )
+    wiring.add_argument(
+        "--modal-secret-name",
+        default=DEFAULT_MODAL_SECRET_NAME,
+        help="Modal Secret holding that variable (default: %(default)s)",
+    )
+    wiring.add_argument(
+        "--endpoint-base-url",
+        default=None,
+        help=(
+            "https base URL once deployed; omit before the first deploy and "
+            "the plan renders a placeholder"
+        ),
+    )
+    wiring.add_argument("--app-name", default=DEFAULT_APP_NAME)
+    wiring.add_argument("--volume-name", default=DEFAULT_VOLUME_NAME)
+    wiring.add_argument(
+        "--smoke-max-output-tokens",
+        type=int,
+        default=32,
+        help="Output cap on the single smoke request (default: %(default)s)",
+    )
+
+    plan_parser.add_argument("--format", choices=("text", "json"), default="text")
+    plan_parser.add_argument(
+        "--output",
+        default=None,
+        help="Atomically write the plan JSON to this path as well",
+    )
+    plan_parser.set_defaults(func=_cmd_deploy_plan)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point. Mirrors the optimizer CLI's credential handling.
+
+    The scrub scope wraps the credential guard as well as the parse, so
+    the one diagnostic argparse emits for an unrecognized argument cannot
+    echo a caller-supplied token either.
+    """
+    parser = build_parser()
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    with _argument_scrub_scope(parser, raw_argv):
+        _reject_credential_arguments(raw_argv)
+        args = parser.parse_args(raw_argv)
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/llmtracefx/deploy/commands.py
+++ b/llmtracefx/deploy/commands.py
@@ -1,0 +1,441 @@
+"""Command generation. Nothing in this module executes anything.
+
+The harness deliberately stops at printing the command an operator would
+run. Two reasons, and the second is the important one.
+
+The obvious reason is safety: a planner that can also launch is one
+mis-parsed flag away from launching, and the resource it would launch
+costs money per second.
+
+The less obvious reason is that a printed command is reviewable. The
+operator sees the GPU count, the timeout and the revision before anything
+starts, can paste the line into a review, and can re-run exactly it later.
+A function that internally calls the same API leaves no such artifact.
+
+Every step carries whether it can spend money and whether it needs
+authentication, so a plan can assert, rather than assume, that its
+default path does neither.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+from .endpoint import EndpointConfig, require_env_var_name
+from .errors import DeploymentPlanError
+
+APP_MODULE_PATH = "llmtracefx/deploy/modal_glm_app.py"
+DEFAULT_APP_NAME = "llmtracefx-glm53flash"
+DEFAULT_VOLUME_NAME = "llmtracefx-glm53flash-weights"
+
+STAGE_FUNCTION = "stage_weights"
+VERIFY_FUNCTION = "verify_weights"
+MANIFEST_FUNCTION = "read_manifest"
+
+# Characters that keep their meaning inside a double-quoted shell word.
+# Everything else is literal there, so escaping exactly these is what
+# makes an interpolated prefix or suffix inert.
+_DOUBLE_QUOTE_ESCAPES = str.maketrans(
+    {"\\": "\\\\", '"': '\\"', "$": "\\$", "`": "\\`"}
+)
+
+
+@dataclass(frozen=True)
+class EnvRef:
+    """A deliberate shell expansion, and the only one the renderer emits.
+
+    Every other token is quoted literally, so the single place a command
+    can still reach the shell is here. That is the point of making it a
+    type rather than a string: the name is validated as an environment
+    variable name, which excludes every metacharacter, and the literal
+    text around it is escaped for the double-quoted context it lands in.
+    An operator-supplied value therefore cannot become an expansion by
+    accident, and an expansion cannot carry an operator-supplied value.
+    """
+
+    name: str
+    prefix: str = ""
+    suffix: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "name", require_env_var_name(self.name, field="EnvRef name")
+        )
+
+    def display(self) -> str:
+        """The form recorded in artifacts: readable, and not a shell word."""
+        return f"{self.prefix}${self.name}{self.suffix}"
+
+    def rendered(self) -> str:
+        """The form pasted into a shell, with the literals made inert."""
+        prefix = self.prefix.translate(_DOUBLE_QUOTE_ESCAPES)
+        suffix = self.suffix.translate(_DOUBLE_QUOTE_ESCAPES)
+        return f'"{prefix}${{{self.name}}}{suffix}"'
+
+
+Token = str | EnvRef
+
+
+@dataclass(frozen=True)
+class CommandStep:
+    """One operator action, described rather than performed."""
+
+    name: str
+    purpose: str
+    argv: tuple[Token, ...]
+    requires_auth: bool
+    spends_money: bool
+    notes: tuple[str, ...] = ()
+
+    def rendered(self) -> str:
+        """A copy-pasteable rendering that cannot smuggle in a command.
+
+        Every literal token goes through ``shlex.quote``. The previous
+        rendering quoted only tokens containing whitespace, a quote or a
+        backslash, which left ``;``, ``|``, ``&``, ``$(...)`` and
+        backticks untouched: an app name or volume name chosen by whoever
+        supplied the plan would then execute when the operator pasted the
+        line. Quoting unconditionally costs some readability on unusual
+        tokens and removes that entirely.
+        """
+        return " ".join(
+            token.rendered() if isinstance(token, EnvRef) else shlex.quote(token)
+            for token in self.argv
+        )
+
+    def display_argv(self) -> tuple[str, ...]:
+        return tuple(
+            token.display() if isinstance(token, EnvRef) else token
+            for token in self.argv
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "purpose": self.purpose,
+            "argv": list(self.display_argv()),
+            "command": self.rendered(),
+            "requires_auth": self.requires_auth,
+            "spends_money": self.spends_money,
+            "notes": list(self.notes),
+        }
+
+
+def setup_step() -> CommandStep:
+    return CommandStep(
+        name="setup",
+        purpose="Authenticate the local Modal CLI against your workspace.",
+        argv=("modal", "setup"),
+        requires_auth=False,
+        spends_money=False,
+        notes=("Opens a browser and writes a token to ~/.modal.toml.",),
+    )
+
+
+def secret_step(endpoint: EndpointConfig) -> CommandStep:
+    """Create the Modal Secret without ever writing the value down.
+
+    The value is referenced as a shell variable, so the generated text
+    contains the variable's name and not its contents. The command can
+    therefore be printed, saved to a plan file and pasted into a review
+    with nothing to redact.
+    """
+    return CommandStep(
+        name="secret",
+        purpose=(
+            "Store the endpoint API key as a Modal Secret so the serving "
+            "container receives it as an environment variable."
+        ),
+        argv=(
+            "modal",
+            "secret",
+            "create",
+            endpoint.modal_secret_name,
+            EnvRef(endpoint.api_key_env_var, prefix=f"{endpoint.api_key_env_var}="),
+        ),
+        requires_auth=True,
+        spends_money=False,
+        notes=(
+            f"Export {endpoint.api_key_env_var} in your shell first; the "
+            "generated command references the variable and never contains "
+            "the value.",
+            "Creating the secret in the Modal dashboard instead keeps it out "
+            "of shell history entirely.",
+        ),
+    )
+
+
+def volume_step(volume_name: str) -> CommandStep:
+    return CommandStep(
+        name="volume",
+        purpose="Create the persistent volume that will hold the weights.",
+        argv=("modal", "volume", "create", volume_name),
+        requires_auth=True,
+        spends_money=False,
+        notes=(
+            "Creating an empty volume is free; storing weights on it is not. "
+            "Storage bills until the volume is deleted.",
+        ),
+    )
+
+
+def stage_weights_step(
+    *,
+    revision: str,
+    volume_name: str,
+    app_module: str = APP_MODULE_PATH,
+    repo_id: str = "zai-org/GLM-5.3-Flash",
+) -> CommandStep:
+    """Download weights on CPU only, with the revision stated twice.
+
+    ``--confirm`` repeats ``--revision`` rather than being a bare yes/no
+    flag. A yes/no flag can be carried unchanged from an older command
+    line and confirms whatever that line now says; restating the SHA
+    means confirmation is specific to the revision being fetched, so a
+    stale copy-paste fails instead of silently downloading something
+    else.
+    """
+    return CommandStep(
+        name="stage-weights",
+        purpose=(
+            "Download the pinned model revision onto the volume using CPU "
+            "and network only, then write a manifest of what landed."
+        ),
+        argv=(
+            "modal",
+            "run",
+            f"{app_module}::{STAGE_FUNCTION}",
+            "--repo-id",
+            repo_id,
+            "--revision",
+            revision,
+            "--confirm",
+            revision,
+            "--volume-name",
+            volume_name,
+        ),
+        requires_auth=True,
+        spends_money=True,
+        notes=(
+            "No GPU is attached to this step. Weights are never downloaded "
+            "on an accelerator.",
+            "This transfers hundreds of GiB and takes a long time; the cost "
+            "is CPU container time plus the storage it leaves behind.",
+            "Re-running with the same revision is a no-op once the manifest "
+            "matches.",
+        ),
+    )
+
+
+def verify_weights_step(
+    *, volume_name: str, revision: str, app_module: str = APP_MODULE_PATH
+) -> CommandStep:
+    """Check the staged inventory on CPU, before any accelerator exists.
+
+    A manifest that names the right revision does not prove the bytes
+    are there. A download interrupted near the end leaves a manifest and
+    a short file, and the only place that discrepancy is cheap to find
+    is a CPU container: discovering it after the serving container has
+    allocated four accelerators means paying for the discovery.
+    """
+    return CommandStep(
+        name="verify-weights",
+        purpose=(
+            "Re-check every staged file against the manifest, on CPU, and "
+            "record the result the serving container requires."
+        ),
+        argv=(
+            "modal",
+            "run",
+            f"{app_module}::{VERIFY_FUNCTION}",
+            "--volume-name",
+            volume_name,
+            "--revision",
+            revision,
+        ),
+        requires_auth=True,
+        spends_money=True,
+        notes=(
+            "CPU only. No accelerator is allocated to find a truncated " "download.",
+            "The serving container refuses to start until this has passed "
+            "for the revision it is configured with.",
+        ),
+    )
+
+
+def manifest_step(
+    *, volume_name: str, revision: str, app_module: str = APP_MODULE_PATH
+) -> CommandStep:
+    return CommandStep(
+        name="manifest",
+        purpose="Print the staging manifest recorded on the volume.",
+        argv=(
+            "modal",
+            "run",
+            f"{app_module}::{MANIFEST_FUNCTION}",
+            "--volume-name",
+            volume_name,
+            "--revision",
+            revision,
+        ),
+        requires_auth=True,
+        spends_money=True,
+        notes=("CPU only, seconds of container time.",),
+    )
+
+
+def deploy_step(*, app_module: str = APP_MODULE_PATH) -> CommandStep:
+    return CommandStep(
+        name="deploy",
+        purpose="Deploy the serving app and obtain its https URL.",
+        argv=("modal", "deploy", app_module),
+        requires_auth=True,
+        spends_money=True,
+        notes=(
+            "Deploying registers the app. GPUs are allocated on the first "
+            "request and released after the scaledown window.",
+            "Every budget parameter is read from the environment at deploy "
+            "time; the app refuses to build if any is missing.",
+        ),
+    )
+
+
+def health_step(endpoint: EndpointConfig) -> CommandStep:
+    return CommandStep(
+        name="health",
+        purpose="Liveness probe. Cheap, bounded, no model work.",
+        argv=(
+            "curl",
+            "-fsS",
+            "--max-time",
+            "30",
+            "-H",
+            # Carried even on the liveness probe, because proxy auth is
+            # enforced at the edge for every path. Without it this gets a
+            # 401 and never reaches the server, which would read as a
+            # broken deployment rather than a working one.
+            EnvRef(endpoint.api_key_env_var, prefix="Authorization: Bearer "),
+            endpoint.health_url,
+        ),
+        requires_auth=False,
+        spends_money=True,
+        notes=(
+            "The first authenticated call cold-starts the container and "
+            "therefore allocates GPUs.",
+        ),
+    )
+
+
+def readiness_step(endpoint: EndpointConfig) -> CommandStep:
+    return CommandStep(
+        name="readiness",
+        purpose=(
+            "Readiness probe: the model list is only served once weights " "are loaded."
+        ),
+        argv=(
+            "curl",
+            "-fsS",
+            "--max-time",
+            "60",
+            "-H",
+            EnvRef(endpoint.api_key_env_var, prefix="Authorization: Bearer "),
+            endpoint.readiness_url,
+        ),
+        requires_auth=False,
+        spends_money=True,
+        notes=(
+            "The header references a shell variable, so the command text "
+            "never contains the key.",
+        ),
+    )
+
+
+def smoke_step(
+    *,
+    endpoint: EndpointConfig,
+    max_output_tokens: int,
+) -> CommandStep:
+    """One bounded generation, sized so a hung server cannot run away."""
+    if max_output_tokens < 1:
+        raise DeploymentPlanError("max_output_tokens must be at least 1")
+    payload = json.dumps(
+        {
+            "model": endpoint.served_model_name,
+            "max_tokens": max_output_tokens,
+            "stream": False,
+            "messages": [{"role": "user", "content": "Reply with the word: ready"}],
+        },
+        separators=(",", ":"),
+    )
+    return CommandStep(
+        name="smoke",
+        purpose="One bounded chat completion proving the endpoint serves.",
+        argv=(
+            "curl",
+            "-fsS",
+            "--max-time",
+            "120",
+            "-H",
+            "Content-Type: application/json",
+            "-H",
+            EnvRef(endpoint.api_key_env_var, prefix="Authorization: Bearer "),
+            "-d",
+            payload,
+            endpoint.chat_completions_url,
+        ),
+        requires_auth=False,
+        spends_money=True,
+        notes=(
+            f"Capped at {max_output_tokens} output tokens so a misbehaving "
+            "server cannot generate indefinitely.",
+            "This proves the endpoint works. It is not a benchmark: timing "
+            "evidence comes from the collector step.",
+        ),
+    )
+
+
+def collect_step(argv: tuple[str, ...]) -> CommandStep:
+    return CommandStep(
+        name="collect",
+        purpose=(
+            "Measure the endpoint with the existing LLMTraceFX API "
+            "collector, which owns all timing evidence."
+        ),
+        argv=argv,
+        requires_auth=False,
+        spends_money=True,
+        notes=(
+            "Metrics are produced outside the server on purpose: the server "
+            "does not measure or grade itself.",
+        ),
+    )
+
+
+def stop_step(*, app_name: str) -> CommandStep:
+    return CommandStep(
+        name="stop",
+        purpose="Stop the app so no container can be started by a request.",
+        argv=("modal", "app", "stop", app_name),
+        requires_auth=True,
+        spends_money=False,
+        notes=("Do this first during teardown; it is what stops GPU spend.",),
+    )
+
+
+def delete_volume_step(*, volume_name: str) -> CommandStep:
+    return CommandStep(
+        name="delete-volume",
+        purpose="Delete the weights volume so storage stops accruing.",
+        argv=("modal", "volume", "delete", volume_name),
+        requires_auth=True,
+        spends_money=False,
+        notes=(
+            "Storage is the charge that outlives the experiment. Modal "
+            "bills deleted data for up to four days after deletion.",
+            "Skip this only if you intend to serve again soon; re-staging "
+            "means transferring the whole checkpoint again.",
+        ),
+    )

--- a/llmtracefx/deploy/endpoint.py
+++ b/llmtracefx/deploy/endpoint.py
@@ -1,0 +1,216 @@
+"""Wiring the deployed endpoint into the existing API collector.
+
+Two rules shape this module.
+
+The first is that a credential is referred to by the *name* of the
+environment variable that carries it and never by its value. That is the
+convention the API collector already follows, and it is what lets a plan,
+a manifest and a generated command all be written to disk and pasted into
+an issue without redacting anything.
+
+The second is that this harness does not measure anything itself. The
+collector already streams an OpenAI-compatible completion and records
+normalized timing evidence; duplicating that inside the server would
+produce a second set of numbers with no provenance and a server that has
+opinions about its own performance. So what this module produces is the
+collector invocation, not a benchmark.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from .errors import DeploymentPlanError
+
+# POSIX-ish environment variable name. Deliberately narrow: it excludes
+# every character an API key is likely to contain, so a key pasted into
+# this field is rejected on shape alone rather than being written down as
+# if it were a name.
+_ENV_VAR_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+# Modal secret names are lowercase, dash separated in practice; keep the
+# check loose enough to accept what Modal accepts and tight enough to
+# reject a pasted credential.
+_SECRET_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+DEFAULT_API_KEY_ENV_VAR = "GLM_SELFHOST_API_KEY"
+DEFAULT_MODAL_SECRET_NAME = "glm-selfhost-api-key"
+
+HEALTH_PATH = "/health"
+READINESS_PATH = "/v1/models"
+CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+
+
+def require_env_var_name(name: str, *, field: str = "api_key_env_var") -> str:
+    """Accept an environment variable name, reject anything key-shaped."""
+    if not isinstance(name, str) or not _ENV_VAR_PATTERN.match(name.strip()):
+        raise DeploymentPlanError(
+            f"{field} must be an environment variable NAME such as "
+            f"{DEFAULT_API_KEY_ENV_VAR}, not a credential value. Names match "
+            "[A-Za-z_][A-Za-z0-9_]* and are at most 64 characters."
+        )
+    return name.strip()
+
+
+def require_secret_name(name: str) -> str:
+    if not isinstance(name, str) or not _SECRET_NAME_PATTERN.match(name.strip()):
+        raise DeploymentPlanError(
+            "modal_secret_name must be a Modal Secret name such as "
+            f"{DEFAULT_MODAL_SECRET_NAME}, never the secret's value"
+        )
+    return name.strip()
+
+
+def require_endpoint_base_url(url: str) -> str:
+    """Require an https base URL with no credential embedded in it.
+
+    Userinfo in a URL is the classic way a key ends up in a log line, and
+    the collector refuses it downstream. Refusing it here as well means
+    the plan that is written to disk never contains it either.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise DeploymentPlanError("endpoint base URL must be a non-empty string")
+    candidate = url.strip().rstrip("/")
+    try:
+        parsed = urlparse(candidate)
+        # The netloc is parsed lazily, so a malformed bracketed host does
+        # not raise until something reads it. Forcing that here keeps the
+        # failure inside this guard, where it becomes a refusal, instead
+        # of surfacing later as a bare ValueError.
+        _ = parsed.netloc
+    except ValueError as exc:
+        raise DeploymentPlanError(f"endpoint base URL is not parseable: {exc}") from exc
+    if parsed.scheme != "https":
+        raise DeploymentPlanError(
+            f"endpoint base URL must use https, got {parsed.scheme or 'no scheme'}"
+        )
+    if not parsed.netloc:
+        raise DeploymentPlanError("endpoint base URL must include a host")
+    if "@" in parsed.netloc:
+        raise DeploymentPlanError(
+            "endpoint base URL must not embed credentials; pass the key "
+            "through an environment variable instead"
+        )
+    if parsed.query or parsed.fragment:
+        raise DeploymentPlanError(
+            "endpoint base URL must not carry a query string or fragment; "
+            "those are where a token gets smuggled in"
+        )
+    return candidate
+
+
+@dataclass(frozen=True)
+class EndpointConfig:
+    """How a client reaches the served model, names only.
+
+    ``base_url`` is optional because it does not exist until the app has
+    been deployed and Modal has assigned a URL. Planning therefore has to
+    be able to describe the endpoint before it can address it, which is
+    why the plan renders a placeholder rather than inventing a hostname.
+    """
+
+    api_key_env_var: str = DEFAULT_API_KEY_ENV_VAR
+    modal_secret_name: str = DEFAULT_MODAL_SECRET_NAME
+    served_model_name: str = "zai-org/GLM-5.3-Flash"
+    base_url: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "api_key_env_var", require_env_var_name(self.api_key_env_var)
+        )
+        object.__setattr__(
+            self, "modal_secret_name", require_secret_name(self.modal_secret_name)
+        )
+        if not isinstance(self.served_model_name, str) or not self.served_model_name:
+            raise DeploymentPlanError("served_model_name must be a non-empty string")
+        if self.base_url is not None:
+            object.__setattr__(
+                self, "base_url", require_endpoint_base_url(self.base_url)
+            )
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.base_url is not None
+
+    def _url(self, path: str) -> str:
+        if self.base_url is None:
+            return f"<deployed-url>{path}"
+        return f"{self.base_url}{path}"
+
+    @property
+    def health_url(self) -> str:
+        return self._url(HEALTH_PATH)
+
+    @property
+    def readiness_url(self) -> str:
+        return self._url(READINESS_PATH)
+
+    @property
+    def chat_completions_url(self) -> str:
+        return self._url(CHAT_COMPLETIONS_PATH)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "api_key_env_var": self.api_key_env_var,
+            "modal_secret_name": self.modal_secret_name,
+            "served_model_name": self.served_model_name,
+            "base_url": self.base_url,
+            "resolved": self.is_resolved,
+            "health_url": self.health_url,
+            "readiness_url": self.readiness_url,
+            "chat_completions_url": self.chat_completions_url,
+            "credential_handling": (
+                "The API key is stored in a Modal Secret and injected into "
+                "the serving container as an environment variable. Only the "
+                "secret name and the variable name are ever recorded."
+            ),
+        }
+
+
+def collector_argv(
+    *,
+    endpoint: EndpointConfig,
+    run_id: str,
+    prompt_file: str,
+    output_dir: str,
+    provider: str = "modal-selfhost",
+    max_output_tokens: int | None = None,
+    request_timeout_seconds: float = 120.0,
+    model_revision: str | None = None,
+) -> tuple[str, ...]:
+    """The exact ``collect-api`` invocation for the deployed endpoint.
+
+    Returned as a tuple so it is executed, if the operator chooses to
+    execute it, without a shell in between. There is no credential in it
+    by construction: the key is named, not passed.
+    """
+    if not run_id.strip():
+        raise DeploymentPlanError("run_id must be a non-empty string")
+    argv = [
+        "llmtracefx-optimizer",
+        "collect-api",
+        "--run-id",
+        run_id.strip(),
+        "--provider",
+        provider,
+        "--endpoint",
+        endpoint.chat_completions_url,
+        "--model-id",
+        endpoint.served_model_name,
+        "--prompt-file",
+        prompt_file,
+        "--output-dir",
+        output_dir,
+        "--api-key-env",
+        endpoint.api_key_env_var,
+        "--request-timeout",
+        str(request_timeout_seconds),
+    ]
+    if max_output_tokens is not None:
+        argv.extend(("--max-output-tokens", str(max_output_tokens)))
+    if model_revision is not None:
+        argv.extend(("--model-revision", model_revision))
+    return tuple(argv)

--- a/llmtracefx/deploy/environment.py
+++ b/llmtracefx/deploy/environment.py
@@ -1,0 +1,400 @@
+"""Reconstructing a plan from environment variables, and failing closed.
+
+The Modal app cannot take command line flags: it is imported by ``modal
+deploy``, which decides GPU count, timeout and autoscaling at build time
+from whatever the module says at import. So the same parameters that
+``deploy plan`` takes as flags have to reach the app some other way, and
+that way is the environment.
+
+The important property is what happens when a variable is missing. It is
+not "use a sensible default": a sensible default for a GPU count is still
+a GPU count, and the app would deploy. It is a refusal that names every
+missing variable at once, raised while the module is being imported, so
+``modal deploy`` fails before it registers anything.
+
+This module imports no Modal SDK. It is ordinary parsing and validation
+over a mapping, which is what lets the whole fail-closed contract be
+tested without Modal installed and without a network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+
+from .budget import BudgetRequest
+from .commands import DEFAULT_APP_NAME, DEFAULT_VOLUME_NAME
+from .endpoint import (
+    DEFAULT_API_KEY_ENV_VAR,
+    DEFAULT_MODAL_SECRET_NAME,
+    EndpointConfig,
+)
+from .errors import DeploymentPlanError
+from .plan import (
+    DEFAULT_SCALEDOWN_WINDOW_SECONDS,
+    DeploymentPlan,
+    RuntimeControls,
+    build_plan,
+)
+from .pricing import (
+    DEFAULT_MAX_PRICE_AGE_DAYS,
+    ComputeQuote,
+    GpuPriceQuote,
+    StorageQuote,
+)
+from .recipe import (
+    DEFAULT_FRAMEWORK,
+    DEFAULT_SERVER_PORT,
+    DEFAULT_WEIGHTS_MOUNT_PATH,
+    GLM_53_FLASH,
+    SUPPORTED_REPO_ID,
+    build_recipe,
+)
+
+PREFIX = "LLMTRACEFX_GLM_"
+
+MAX_USD = f"{PREFIX}MAX_USD"
+GPU_TYPE = f"{PREFIX}GPU_TYPE"
+GPU_COUNT = f"{PREFIX}GPU_COUNT"
+MAX_RUNTIME_SECONDS = f"{PREFIX}MAX_RUNTIME_SECONDS"
+USD_PER_GPU_HOUR = f"{PREFIX}USD_PER_GPU_HOUR"
+PRICE_EFFECTIVE_DATE = f"{PREFIX}PRICE_EFFECTIVE_DATE"
+PRICE_SOURCE = f"{PREFIX}PRICE_SOURCE"
+MODEL_REVISION = f"{PREFIX}MODEL_REVISION"
+IMAGE = f"{PREFIX}IMAGE"
+FRAMEWORK_VERSION = f"{PREFIX}FRAMEWORK_VERSION"
+CONTEXT_LENGTH = f"{PREFIX}CONTEXT_LENGTH"
+MAX_DEPLOYMENT_SECONDS = f"{PREFIX}MAX_DEPLOYMENT_SECONDS"
+USD_PER_CPU_CORE_HOUR = f"{PREFIX}USD_PER_CPU_CORE_HOUR"
+USD_PER_GIB_MEMORY_HOUR = f"{PREFIX}USD_PER_GIB_MEMORY_HOUR"
+STORAGE_RETENTION_DAYS = f"{PREFIX}STORAGE_RETENTION_DAYS"
+STORAGE_USD_PER_GIB_MONTH = f"{PREFIX}STORAGE_USD_PER_GIB_MONTH"
+
+# Every one of these has to be present. There is no default for any of
+# them because each is either a spending authority, a price, or the pin
+# that makes the deployment reproducible.
+REQUIRED_ENV_VARS: tuple[str, ...] = (
+    MAX_USD,
+    GPU_TYPE,
+    GPU_COUNT,
+    MAX_RUNTIME_SECONDS,
+    USD_PER_GPU_HOUR,
+    PRICE_EFFECTIVE_DATE,
+    PRICE_SOURCE,
+    MODEL_REVISION,
+    IMAGE,
+    FRAMEWORK_VERSION,
+    CONTEXT_LENGTH,
+    MAX_DEPLOYMENT_SECONDS,
+    USD_PER_CPU_CORE_HOUR,
+    USD_PER_GIB_MEMORY_HOUR,
+    STORAGE_USD_PER_GIB_MONTH,
+    STORAGE_RETENTION_DAYS,
+)
+
+FRAMEWORK = f"{PREFIX}FRAMEWORK"
+TENSOR_PARALLEL_SIZE = f"{PREFIX}TENSOR_PARALLEL_SIZE"
+SERVED_MODEL_NAME = f"{PREFIX}SERVED_MODEL_NAME"
+PORT = f"{PREFIX}PORT"
+WEIGHTS_MOUNT_PATH = f"{PREFIX}WEIGHTS_MOUNT_PATH"
+MAX_CONTAINERS = f"{PREFIX}MAX_CONTAINERS"
+MIN_CONTAINERS = f"{PREFIX}MIN_CONTAINERS"
+ALLOW_WARM_CONTAINERS = f"{PREFIX}ALLOW_WARM_CONTAINERS"
+SCALEDOWN_WINDOW_SECONDS = f"{PREFIX}SCALEDOWN_WINDOW_SECONDS"
+STARTUP_TIMEOUT_SECONDS = f"{PREFIX}STARTUP_TIMEOUT_SECONDS"
+MAX_CONCURRENT_INPUTS = f"{PREFIX}MAX_CONCURRENT_INPUTS"
+ACCEPT_MUTABLE_IMAGE = f"{PREFIX}ACCEPT_MUTABLE_IMAGE"
+ACCEPT_STALE_PRICE = f"{PREFIX}ACCEPT_STALE_PRICE"
+ACCEPT_ARGV_CREDENTIAL_EXPOSURE = f"{PREFIX}ACCEPT_ARGV_CREDENTIAL_EXPOSURE"
+MAX_PRICE_AGE_DAYS = f"{PREFIX}MAX_PRICE_AGE_DAYS"
+AS_OF = f"{PREFIX}AS_OF"
+APP_NAME = f"{PREFIX}APP_NAME"
+VOLUME_NAME = f"{PREFIX}VOLUME_NAME"
+API_KEY_ENV = f"{PREFIX}API_KEY_ENV"
+MODAL_SECRET_NAME = f"{PREFIX}MODAL_SECRET_NAME"
+ENDPOINT_BASE_URL = f"{PREFIX}ENDPOINT_BASE_URL"
+STORED_GIB = f"{PREFIX}STORED_GIB"
+
+_TRUE = frozenset({"1", "true", "yes", "on"})
+_FALSE = frozenset({"0", "false", "no", "off", ""})
+
+
+def _text(environ: Mapping[str, str], name: str) -> str | None:
+    value = environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _float(
+    environ: Mapping[str, str], name: str, default: float | None
+) -> float | None:
+    raw = _text(environ, name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        # The offending value is not echoed. These variables are set
+        # alongside credentials in the same deploy environment, and a
+        # message that quotes "the value of X" is one copy-paste mistake
+        # away from quoting a key.
+        raise DeploymentPlanError(f"{name} must be a number") from exc
+
+
+def _int(environ: Mapping[str, str], name: str, default: int | None) -> int | None:
+    raw = _text(environ, name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise DeploymentPlanError(f"{name} must be an integer") from exc
+
+
+def _int_with_default(environ: Mapping[str, str], name: str, default: int) -> int:
+    """Parse an optional integer, defaulting only when it is *absent*.
+
+    Deliberately not ``_int(...) or default``. That idiom cannot tell an
+    unset variable from a variable set to zero, so it silently rewrites
+    every zero into the default. For most of these settings that turns a
+    nonsense value into a plausible one instead of an error, and for
+    ``MAX_PRICE_AGE_DAYS`` it is worse than that: zero is the operator
+    asking for maximum strictness, and swallowing it hands back the
+    lenient default. Absence is the only thing that may produce a
+    default; a value that is present is passed through and validated.
+    """
+    value = _int(environ, name, default)
+    if value is None:  # pragma: no cover - default is not None
+        return default
+    return value
+
+
+def _bool(environ: Mapping[str, str], name: str, default: bool = False) -> bool:
+    raw = environ.get(name)
+    if raw is None:
+        return default
+    folded = raw.strip().casefold()
+    if folded in _TRUE:
+        return True
+    if folded in _FALSE:
+        return False
+    raise DeploymentPlanError(
+        f"{name} must be one of: " + ", ".join(sorted(_TRUE | {"false"}))
+    )
+
+
+def missing_required_env_vars(environ: Mapping[str, str]) -> tuple[str, ...]:
+    return tuple(name for name in REQUIRED_ENV_VARS if _text(environ, name) is None)
+
+
+def plan_from_environ(
+    environ: Mapping[str, str], *, as_of: date | None = None
+) -> DeploymentPlan:
+    """Rebuild the adjudicated plan the app must obey, or refuse to build.
+
+    Raises rather than returning an unapproved plan. At import time
+    inside ``modal deploy`` there is no operator to read a summary, so
+    the only useful outcome of a refused plan is a failed deploy.
+    """
+    missing = missing_required_env_vars(environ)
+    if missing:
+        raise DeploymentPlanError(
+            "refusing to configure a paid deployment: "
+            + ", ".join(missing)
+            + " must be set. Run `llmtracefx-deploy plan` first; it prints "
+            "the exact values to export."
+        )
+
+    max_usd = _float(environ, MAX_USD, None)
+    usd_per_gpu_hour = _float(environ, USD_PER_GPU_HOUR, None)
+    usd_per_cpu = _float(environ, USD_PER_CPU_CORE_HOUR, None)
+    usd_per_memory = _float(environ, USD_PER_GIB_MEMORY_HOUR, None)
+    storage_rate = _float(environ, STORAGE_USD_PER_GIB_MONTH, None)
+    retention_days = _float(environ, STORAGE_RETENTION_DAYS, None)
+    gpu_count = _int(environ, GPU_COUNT, None)
+    max_runtime = _int(environ, MAX_RUNTIME_SECONDS, None)
+    deployment_seconds = _int(environ, MAX_DEPLOYMENT_SECONDS, None)
+    context_length = _int(environ, CONTEXT_LENGTH, None)
+    # Narrowing for the type checker; the presence check above already
+    # guarantees each of these parsed from a non-empty string.
+    assert max_usd is not None
+    assert usd_per_gpu_hour is not None
+    assert usd_per_cpu is not None
+    assert usd_per_memory is not None
+    assert storage_rate is not None
+    assert retention_days is not None
+    assert gpu_count is not None
+    assert max_runtime is not None
+    assert deployment_seconds is not None
+    assert context_length is not None
+
+    gpu_type = environ[GPU_TYPE].strip()
+    effective_date = environ[PRICE_EFFECTIVE_DATE].strip()
+    price_source = environ[PRICE_SOURCE].strip()
+    max_containers = _int_with_default(environ, MAX_CONTAINERS, 1)
+    min_containers = _int_with_default(environ, MIN_CONTAINERS, 0)
+    stored_gib = _float(environ, STORED_GIB, None)
+    if stored_gib is None:
+        stored_gib = GLM_53_FLASH.approximate_checkpoint_gib
+
+    budget = BudgetRequest(
+        max_usd=max_usd,
+        gpu_type=gpu_type,
+        gpu_count=gpu_count,
+        max_runtime_seconds=max_runtime,
+        deployment_seconds=deployment_seconds,
+        price=GpuPriceQuote(
+            gpu_type=gpu_type,
+            usd_per_gpu_hour=usd_per_gpu_hour,
+            effective_date=effective_date,
+            source=price_source,
+        ),
+        compute=ComputeQuote(
+            usd_per_cpu_core_hour=usd_per_cpu,
+            usd_per_gib_memory_hour=usd_per_memory,
+            effective_date=effective_date,
+            source=price_source,
+        ),
+        storage=StorageQuote(
+            usd_per_gib_month=storage_rate,
+            effective_date=effective_date,
+            source=price_source,
+        ),
+        stored_gib=stored_gib,
+        storage_retention_days=retention_days,
+        max_containers=max_containers,
+    )
+    recipe = build_recipe(
+        framework=_text(environ, FRAMEWORK) or DEFAULT_FRAMEWORK,
+        framework_version=environ[FRAMEWORK_VERSION].strip(),
+        image_reference=environ[IMAGE].strip(),
+        model_revision=environ[MODEL_REVISION].strip(),
+        gpu_type=gpu_type,
+        gpu_count=gpu_count,
+        context_length=context_length,
+        weights_mount_path=_text(environ, WEIGHTS_MOUNT_PATH)
+        or DEFAULT_WEIGHTS_MOUNT_PATH,
+        port=_int_with_default(environ, PORT, DEFAULT_SERVER_PORT),
+        served_model_name=_text(environ, SERVED_MODEL_NAME) or SUPPORTED_REPO_ID,
+        tensor_parallel_size=_int(environ, TENSOR_PARALLEL_SIZE, None),
+        accept_mutable_image=_bool(environ, ACCEPT_MUTABLE_IMAGE),
+    )
+    controls = RuntimeControls(
+        timeout_seconds=max_runtime,
+        deployment_seconds=deployment_seconds,
+        scaledown_window_seconds=_int_with_default(
+            environ, SCALEDOWN_WINDOW_SECONDS, DEFAULT_SCALEDOWN_WINDOW_SECONDS
+        ),
+        startup_timeout_seconds=_int_with_default(
+            environ, STARTUP_TIMEOUT_SECONDS, 1800
+        ),
+        max_containers=max_containers,
+        min_containers=min_containers,
+        max_concurrent_inputs=_int_with_default(environ, MAX_CONCURRENT_INPUTS, 1),
+        allow_warm_containers=_bool(environ, ALLOW_WARM_CONTAINERS),
+    )
+    endpoint = EndpointConfig(
+        api_key_env_var=_text(environ, API_KEY_ENV) or DEFAULT_API_KEY_ENV_VAR,
+        modal_secret_name=_text(environ, MODAL_SECRET_NAME)
+        or DEFAULT_MODAL_SECRET_NAME,
+        served_model_name=recipe.served_model_name,
+        base_url=_text(environ, ENDPOINT_BASE_URL),
+    )
+
+    as_of_value = as_of
+    if as_of_value is None:
+        raw_as_of = _text(environ, AS_OF)
+        if raw_as_of is None:
+            as_of_value = date.today()
+        else:
+            try:
+                as_of_value = date.fromisoformat(raw_as_of)
+            except ValueError as exc:
+                raise DeploymentPlanError(f"{AS_OF} must be an ISO date") from exc
+
+    plan = build_plan(
+        recipe=recipe,
+        controls=controls,
+        budget=budget,
+        endpoint=endpoint,
+        as_of=as_of_value,
+        app_name=_text(environ, APP_NAME) or DEFAULT_APP_NAME,
+        volume_name=_text(environ, VOLUME_NAME) or DEFAULT_VOLUME_NAME,
+        max_price_age_days=_int_with_default(
+            environ, MAX_PRICE_AGE_DAYS, DEFAULT_MAX_PRICE_AGE_DAYS
+        ),
+        accept_stale_price=_bool(environ, ACCEPT_STALE_PRICE),
+        accept_argv_credential_exposure=_bool(environ, ACCEPT_ARGV_CREDENTIAL_EXPOSURE),
+    )
+    if not plan.approved:
+        raise DeploymentPlanError(
+            "refusing to configure a paid deployment:\n"
+            + "\n".join(f"  - {reason}" for reason in plan.blockers)
+        )
+    return plan
+
+
+def plan_environment(plan: DeploymentPlan, *, as_of: date) -> dict[str, str]:
+    """The environment a remote container needs to rebuild ``plan``.
+
+    This exists because the Modal entrypoint is imported twice: once
+    locally, where the operator has exported these variables, and once
+    inside every container, where nothing has. Baking the adjudicated
+    values into the container images is what makes the second import
+    reconstruct the same plan instead of failing on eleven missing
+    variables.
+
+    It is derived from the validated plan rather than copied from the
+    caller's environment, so what the container obeys is what the planner
+    approved, not whatever happened to be exported alongside it. Nothing
+    here is a secret: names, prices, revisions and limits only.
+    """
+    envelope = plan.envelope
+    values = {
+        MAX_USD: f"{envelope.budget_usd:.6f}",
+        GPU_TYPE: plan.recipe.gpu_type,
+        GPU_COUNT: str(plan.recipe.gpu_count),
+        MAX_RUNTIME_SECONDS: str(plan.controls.timeout_seconds),
+        MAX_DEPLOYMENT_SECONDS: str(plan.controls.deployment_seconds),
+        USD_PER_GPU_HOUR: f"{envelope.usd_per_gpu_hour:.6f}",
+        USD_PER_CPU_CORE_HOUR: f"{plan.budget.compute.usd_per_cpu_core_hour:.6f}",
+        USD_PER_GIB_MEMORY_HOUR: (f"{plan.budget.compute.usd_per_gib_memory_hour:.6f}"),
+        STORAGE_USD_PER_GIB_MONTH: f"{envelope.storage_usd_per_gib_month:.6f}",
+        STORAGE_RETENTION_DAYS: f"{envelope.storage_retention_days:.6f}",
+        STORED_GIB: f"{envelope.stored_gib:.6f}",
+        PRICE_EFFECTIVE_DATE: envelope.price_effective_date,
+        PRICE_SOURCE: envelope.price_source,
+        MODEL_REVISION: plan.recipe.model_revision,
+        IMAGE: plan.recipe.image.reference,
+        FRAMEWORK: plan.recipe.framework,
+        FRAMEWORK_VERSION: plan.recipe.framework_version,
+        CONTEXT_LENGTH: str(plan.recipe.context_length),
+        TENSOR_PARALLEL_SIZE: str(plan.recipe.tensor_parallel_size),
+        SERVED_MODEL_NAME: plan.recipe.served_model_name,
+        PORT: str(plan.recipe.port),
+        WEIGHTS_MOUNT_PATH: plan.recipe.weights_mount_path,
+        MAX_CONTAINERS: str(plan.controls.max_containers),
+        MIN_CONTAINERS: str(plan.controls.min_containers),
+        SCALEDOWN_WINDOW_SECONDS: str(plan.controls.scaledown_window_seconds),
+        STARTUP_TIMEOUT_SECONDS: str(plan.controls.startup_timeout_seconds),
+        MAX_CONCURRENT_INPUTS: str(plan.controls.max_concurrent_inputs),
+        APP_NAME: plan.app_name,
+        VOLUME_NAME: plan.volume_name,
+        API_KEY_ENV: plan.endpoint.api_key_env_var,
+        MODAL_SECRET_NAME: plan.endpoint.modal_secret_name,
+        ACCEPT_MUTABLE_IMAGE: str(not plan.recipe.image.is_digest_pinned).lower(),
+        ACCEPT_ARGV_CREDENTIAL_EXPOSURE: str(
+            plan.recipe.exposes_credential_on_argv
+        ).lower(),
+        ALLOW_WARM_CONTAINERS: str(plan.controls.allow_warm_containers).lower(),
+        # Pinned so the remote rebuild ages the quotes against the same
+        # day the local planner did. Without it a container starting after
+        # the freshness limit elapsed would refuse to boot on a price that
+        # was fresh when the deployment was approved.
+        AS_OF: as_of.isoformat(),
+        MAX_PRICE_AGE_DAYS: str(plan.max_price_age_days),
+        ACCEPT_STALE_PRICE: str(plan.accept_stale_price).lower(),
+    }
+    return values

--- a/llmtracefx/deploy/errors.py
+++ b/llmtracefx/deploy/errors.py
@@ -1,0 +1,19 @@
+"""Errors raised while planning a self-hosted deployment.
+
+A single error type keeps the failure mode uniform: every unsafe,
+unaffordable, unpinned or under-specified plan is refused the same way,
+before anything is launched, so a caller never has to distinguish
+"refused because it costs too much" from "refused because the model
+revision was not pinned" in order to know that nothing was spent.
+"""
+
+from __future__ import annotations
+
+
+class DeploymentPlanError(ValueError):
+    """A deployment plan is unsafe, unaffordable, unpinned or incomplete.
+
+    Raised only during planning, which is a pure, offline computation, so
+    receiving this exception is a positive guarantee that no paid resource
+    was allocated and no network call was made.
+    """

--- a/llmtracefx/deploy/manifest.py
+++ b/llmtracefx/deploy/manifest.py
@@ -1,0 +1,435 @@
+"""Manifests: what was staged, and what actually served the request.
+
+Two records, written at two different moments, for two different
+questions.
+
+The staging manifest answers "what is on the volume". It is written by
+the CPU staging step and records the repository, the revision and every
+file that landed, with sizes and with hashes where the source provided
+them. Sizes always exist because they are observed locally; hashes are
+optional because they depend on what the upstream metadata carried, and
+inventing one would be worse than admitting its absence.
+
+The server manifest answers "what served this". It is deliberately a
+description of configuration and observation, never of quality: it
+records that four H200s were requested and how long start up took, and it
+records nothing about tokens per second. Performance evidence belongs to
+the collector, which measures from outside.
+
+Neither record has a field capable of holding a credential. Environment
+variables appear as names, never as values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .errors import DeploymentPlanError
+
+MANIFEST_SCHEMA_VERSION = "1"
+
+CONFIGURED = "configured"
+OBSERVED = "observed"
+
+
+@dataclass(frozen=True)
+class StagedFile:
+    """One file present on the volume after staging."""
+
+    path: str
+    size_bytes: int
+    sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path.strip():
+            raise DeploymentPlanError("staged file path must be a non-empty string")
+        if isinstance(self.size_bytes, bool) or not isinstance(self.size_bytes, int):
+            raise DeploymentPlanError("staged file size_bytes must be an integer")
+        if self.size_bytes < 0:
+            raise DeploymentPlanError("staged file size_bytes must not be negative")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WeightStagingManifest:
+    """The inventory written next to the weights on the volume."""
+
+    schema_version: str
+    completed_at: str
+    repo_id: str
+    revision: str
+    mount_path: str
+    files: tuple[StagedFile, ...] = field(default_factory=tuple)
+    generator: str = "llmtracefx.deploy.manifest"
+
+    @property
+    def file_count(self) -> int:
+        return len(self.files)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(entry.size_bytes for entry in self.files)
+
+    @property
+    def hashed_file_count(self) -> int:
+        return sum(1 for entry in self.files if entry.sha256 is not None)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": "llmtracefx.deploy.weight_staging_manifest",
+            "completed_at": self.completed_at,
+            "repo_id": self.repo_id,
+            "revision": self.revision,
+            "mount_path": self.mount_path,
+            "file_count": self.file_count,
+            "total_bytes": self.total_bytes,
+            "total_gib": round(self.total_bytes / (1024**3), 3),
+            "hashed_file_count": self.hashed_file_count,
+            "files": [entry.to_dict() for entry in self.files],
+            "generator": self.generator,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> WeightStagingManifest:
+        try:
+            files = tuple(
+                StagedFile(
+                    path=str(entry["path"]),
+                    size_bytes=int(entry["size_bytes"]),
+                    sha256=entry.get("sha256"),
+                )
+                for entry in data.get("files", ())
+            )
+            return cls(
+                schema_version=str(data.get("schema_version", MANIFEST_SCHEMA_VERSION)),
+                completed_at=str(data["completed_at"]),
+                repo_id=str(data["repo_id"]),
+                revision=str(data["revision"]),
+                mount_path=str(data["mount_path"]),
+                files=files,
+                generator=str(data.get("generator", "llmtracefx.deploy.manifest")),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise DeploymentPlanError(
+                f"malformed weight staging manifest: {exc}"
+            ) from exc
+
+    def matches(self, *, repo_id: str, revision: str) -> bool:
+        """Whether this manifest describes exactly the requested weights.
+
+        Used to make re-staging idempotent. A manifest for a different
+        revision is not a partial match to be topped up; it describes
+        different weights, so the answer is simply no.
+        """
+        return self.repo_id == repo_id and self.revision == revision
+
+
+@dataclass(frozen=True)
+class ServerManifest:
+    """What was configured, and what was observed, for one served process.
+
+    ``provenance`` marks every substantive field as either configured (an
+    intent this harness expressed) or observed (something the container
+    reported at run time). Without that distinction a reader cannot tell
+    "we asked for four H200s" from "four H200s were present", and those
+    are different claims.
+    """
+
+    schema_version: str
+    collected_at: str
+    app_name: str
+    gpu_type: str
+    gpu_count: int
+    framework: str
+    framework_version: str
+    image_reference: str
+    image_digest: str | None
+    model_repo_id: str
+    model_revision: str
+    quantization: str
+    quantization_format: str
+    activation_scheme: str
+    tensor_parallel_size: int
+    context_length: int
+    expert_parallel_size: int | None = None
+    observed_gpus: tuple[str, ...] = field(default_factory=tuple)
+    observed_cuda_version: str | None = None
+    startup_seconds: float | None = None
+    credential_env_var_names_present: tuple[str, ...] = field(default_factory=tuple)
+    generator: str = "llmtracefx.deploy.manifest"
+
+    def provenance(self) -> dict[str, str]:
+        return {
+            "gpu_type": CONFIGURED,
+            "gpu_count": CONFIGURED,
+            "framework": CONFIGURED,
+            "framework_version": CONFIGURED,
+            "image_reference": CONFIGURED,
+            "image_digest": CONFIGURED,
+            "model_repo_id": CONFIGURED,
+            "model_revision": CONFIGURED,
+            "quantization": CONFIGURED,
+            "quantization_format": CONFIGURED,
+            "activation_scheme": CONFIGURED,
+            "tensor_parallel_size": CONFIGURED,
+            "expert_parallel_size": CONFIGURED,
+            "context_length": CONFIGURED,
+            "observed_gpus": OBSERVED,
+            "observed_cuda_version": OBSERVED,
+            "startup_seconds": OBSERVED,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": "llmtracefx.deploy.server_manifest",
+            "collected_at": self.collected_at,
+            "app_name": self.app_name,
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "framework": self.framework,
+            "framework_version": self.framework_version,
+            "image_reference": self.image_reference,
+            "image_digest": self.image_digest,
+            "image_digest_pinned": self.image_digest is not None,
+            "model_repo_id": self.model_repo_id,
+            "model_revision": self.model_revision,
+            "quantization": self.quantization,
+            "quantization_format": self.quantization_format,
+            "activation_scheme": self.activation_scheme,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "expert_parallel_size": self.expert_parallel_size,
+            "context_length": self.context_length,
+            "observed_gpus": list(self.observed_gpus),
+            "observed_cuda_version": self.observed_cuda_version,
+            "startup_seconds": (
+                None if self.startup_seconds is None else round(self.startup_seconds, 3)
+            ),
+            "credential_env_var_names_present": list(
+                self.credential_env_var_names_present
+            ),
+            "provenance": self.provenance(),
+            "performance_claims": (
+                "None. Throughput and latency evidence is produced by the "
+                "LLMTraceFX API collector against this endpoint, not by the "
+                "server describing itself."
+            ),
+            "generator": self.generator,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+
+def present_env_var_names(
+    environ: Mapping[str, str], names: Sequence[str]
+) -> tuple[str, ...]:
+    """Which of ``names`` are set and non-empty. Names only, never values.
+
+    This is the only function in the package that looks at an
+    environment mapping that may contain a credential, and it returns
+    keys. There is no code path by which a value reaches a manifest.
+    """
+    return tuple(name for name in names if (environ.get(name) or "").strip())
+
+
+VERIFICATION_FILENAME = "verification.json"
+
+MISSING = "missing"
+SIZE_MISMATCH = "size_mismatch"
+HASH_MISMATCH = "hash_mismatch"
+UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class VerificationIssue:
+    """One file that does not match what staging recorded."""
+
+    path: str
+    problem: str
+    expected: str | None = None
+    observed: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WeightVerification:
+    """Evidence that the staged bytes are still the bytes staging recorded.
+
+    Written by a CPU step and required by the serving container. A
+    manifest naming the right revision proves only that a download was
+    started for it: an interruption near the end leaves the manifest and
+    a short file behind. Finding that on CPU costs container seconds;
+    finding it after the serving container has allocated four
+    accelerators costs the whole start up.
+    """
+
+    schema_version: str
+    verified_at: str
+    repo_id: str
+    revision: str
+    mount_path: str
+    files_checked: int
+    bytes_checked: int
+    hashes_checked: int
+    hashes_available: int
+    issues: tuple[VerificationIssue, ...] = field(default_factory=tuple)
+    generator: str = "llmtracefx.deploy.manifest"
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": "llmtracefx.deploy.weight_verification",
+            "verified_at": self.verified_at,
+            "repo_id": self.repo_id,
+            "revision": self.revision,
+            "mount_path": self.mount_path,
+            "ok": self.ok,
+            "files_checked": self.files_checked,
+            "bytes_checked": self.bytes_checked,
+            "hashes_checked": self.hashes_checked,
+            "hashes_available": self.hashes_available,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "generator": self.generator,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> WeightVerification:
+        try:
+            issues = tuple(
+                VerificationIssue(
+                    path=str(entry["path"]),
+                    problem=str(entry["problem"]),
+                    expected=entry.get("expected"),
+                    observed=entry.get("observed"),
+                )
+                for entry in data.get("issues", ())
+            )
+            return cls(
+                schema_version=str(data.get("schema_version", MANIFEST_SCHEMA_VERSION)),
+                verified_at=str(data["verified_at"]),
+                repo_id=str(data["repo_id"]),
+                revision=str(data["revision"]),
+                mount_path=str(data["mount_path"]),
+                files_checked=int(data["files_checked"]),
+                bytes_checked=int(data["bytes_checked"]),
+                hashes_checked=int(data["hashes_checked"]),
+                hashes_available=int(data.get("hashes_available", 0)),
+                issues=issues,
+                generator=str(data.get("generator", "llmtracefx.deploy.manifest")),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise DeploymentPlanError(f"malformed weight verification: {exc}") from exc
+
+    def covers(self, *, repo_id: str, revision: str) -> bool:
+        return self.ok and self.repo_id == repo_id and self.revision == revision
+
+
+def _sha256_file(path: Path, *, chunk_bytes: int = 8 * 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_bytes):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_staged_weights(
+    manifest: WeightStagingManifest,
+    root: Path,
+    *,
+    now: Callable[[], str],
+    check_hashes: bool = True,
+) -> WeightVerification:
+    """Re-check a staged tree against its manifest. CPU and disk only.
+
+    Sizes are always checked because they are nearly free and catch the
+    common failure, a truncated or absent shard. Hashes are checked when
+    the repository published one and the caller asked for it; that reads
+    every byte, so it is the expensive half and the record says which
+    half ran rather than implying both did.
+    """
+    issues: list[VerificationIssue] = []
+    bytes_checked = 0
+    hashes_checked = 0
+    hashes_available = 0
+
+    for entry in manifest.files:
+        target = root / entry.path
+        if entry.sha256 is not None:
+            hashes_available += 1
+        try:
+            if not target.is_file():
+                issues.append(VerificationIssue(path=entry.path, problem=MISSING))
+                continue
+            observed_size = target.stat().st_size
+        except OSError as exc:
+            issues.append(
+                VerificationIssue(
+                    path=entry.path, problem=UNREADABLE, observed=type(exc).__name__
+                )
+            )
+            continue
+
+        if observed_size != entry.size_bytes:
+            issues.append(
+                VerificationIssue(
+                    path=entry.path,
+                    problem=SIZE_MISMATCH,
+                    expected=str(entry.size_bytes),
+                    observed=str(observed_size),
+                )
+            )
+            continue
+        bytes_checked += observed_size
+
+        if check_hashes and entry.sha256 is not None:
+            try:
+                observed_hash = _sha256_file(target)
+            except OSError as exc:
+                issues.append(
+                    VerificationIssue(
+                        path=entry.path,
+                        problem=UNREADABLE,
+                        observed=type(exc).__name__,
+                    )
+                )
+                continue
+            hashes_checked += 1
+            if observed_hash != entry.sha256:
+                # The digests themselves are not recorded in the issue.
+                # They are long, they are not actionable, and the answer
+                # is always the same: re-stage that file.
+                issues.append(VerificationIssue(path=entry.path, problem=HASH_MISMATCH))
+
+    return WeightVerification(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        verified_at=now(),
+        repo_id=manifest.repo_id,
+        revision=manifest.revision,
+        mount_path=manifest.mount_path,
+        files_checked=manifest.file_count,
+        bytes_checked=bytes_checked,
+        hashes_checked=hashes_checked,
+        hashes_available=hashes_available,
+        issues=tuple(issues),
+    )

--- a/llmtracefx/deploy/modal_glm_app.py
+++ b/llmtracefx/deploy/modal_glm_app.py
@@ -1,0 +1,668 @@
+"""Modal entrypoint for a budget-guarded GLM-5.3-Flash self-host.
+
+This module is run by ``modal run`` and ``modal deploy``. It is not a
+library: nothing else in the package imports it, and the tests never do,
+which is what allows the entire planning and budget contract to be tested
+with no Modal SDK installed.
+
+Three things happen at import, in this order, and the order matters:
+
+1. The Modal SDK is imported, with a message that says how to install it
+   rather than a bare ``ModuleNotFoundError``.
+2. The plan is rebuilt from the environment. If any spending authority,
+   price or pin is missing, or if the resulting plan is refused, this
+   raises and ``modal deploy`` fails before registering anything. There
+   is no configuration under which importing this module quietly yields
+   a deployable app with default GPU settings.
+3. Only then are the app, the volume and the images declared, every one
+   of them parameterised from the adjudicated plan rather than from a
+   literal written here.
+
+Staging and serving are separate functions with separate images and
+separate hardware. ``stage_weights`` has no ``gpu=`` argument at all, so
+there is no code path on which several hundred GiB are transferred while
+accelerators are allocated and billing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import threading
+import time
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import modal
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised only on Modal
+    raise SystemExit(
+        "The Modal SDK is required to run this entrypoint. It is an optional "
+        "dependency of llmtracefx: install it with `uv sync --extra modal` or "
+        "`pip install 'llmtracefx[modal]'`. Planning does not need it: "
+        "`llmtracefx-deploy plan` runs without Modal installed."
+    ) from exc
+
+from llmtracefx.deploy.environment import plan_environment, plan_from_environ
+from llmtracefx.deploy.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    VERIFICATION_FILENAME,
+    ServerManifest,
+    StagedFile,
+    WeightStagingManifest,
+    WeightVerification,
+    present_env_var_names,
+    verify_staged_weights,
+)
+from llmtracefx.deploy.recipe import (
+    SGLANG,
+    VLLM_API_KEY_ENV_VAR,
+    require_model_revision,
+    require_supported_repo,
+)
+from llmtracefx.deploy.resources import (
+    SERVING_CPU_CORES,
+    SERVING_MEMORY_GIB,
+    STAGING_CPU_CORES,
+    STAGING_MEMORY_GIB,
+    STAGING_TIMEOUT_SECONDS,
+    VERIFY_CPU_CORES,
+    VERIFY_MEMORY_GIB,
+    VERIFY_TIMEOUT_SECONDS,
+)
+
+# Resolved from PyPI on 2026-08-30. Pinned rather than floating because
+# the staging step's whole job is to produce a reproducible artifact, and
+# a resolver that picks a different client on a later run is one more way
+# for two stagings of the same revision to differ.
+DEFAULT_HF_HUB_PIN = "huggingface_hub==1.29.0"
+
+MANIFEST_FILENAME = "manifest.json"
+
+# Set on both images so a container rebuilds the same plan the local
+# deploy approved. Without it the remote import would look for eleven
+# variables that only ever existed in the operator's shell.
+DEPLOY_EXPIRES_AT_VAR = "LLMTRACEFX_GLM_DEPLOY_EXPIRES_AT"
+
+PLAN = plan_from_environ(os.environ)
+RECIPE = PLAN.recipe
+CONTROLS = PLAN.controls
+MOUNT_PATH = RECIPE.weights_mount_path
+
+# The wall-clock instant after which no container may start serving.
+#
+# This is what turns the priced window into an enforced one. Modal's
+# timeout bounds a Function's execution, and this server's function
+# returns as soon as it has launched the framework, so nothing in the
+# platform stops requests from starting fresh containers indefinitely.
+# An expiry does: once it passes, every cold start refuses, and the
+# accelerators cannot be allocated again by anyone, authenticated or not.
+#
+# Taken from the environment when already present so that a container
+# inherits the deploy-time value rather than extending its own window on
+# every cold start.
+DEPLOY_EXPIRES_AT = (os.environ.get(DEPLOY_EXPIRES_AT_VAR) or "").strip() or (
+    datetime.now(timezone.utc) + timedelta(seconds=CONTROLS.deployment_seconds)
+).isoformat(timespec="seconds")
+
+# Everything a remote container needs to rebuild this exact plan. No
+# credential appears here: names, prices, revisions and limits only.
+BAKED_ENVIRONMENT = {
+    **plan_environment(PLAN, as_of=date.today()),
+    DEPLOY_EXPIRES_AT_VAR: DEPLOY_EXPIRES_AT,
+}
+
+app = modal.App(PLAN.app_name)
+
+weights_volume = modal.Volume.from_name(PLAN.volume_name, create_if_missing=True)
+
+# The serving container receives the endpoint key through a Modal Secret.
+# ``required_keys`` makes Modal assert the variable exists at deploy
+# time, so a misnamed secret fails during deploy instead of producing a
+# server that starts on four accelerators and rejects every request.
+endpoint_secret = modal.Secret.from_name(
+    PLAN.endpoint.modal_secret_name,
+    required_keys=[PLAN.endpoint.api_key_env_var],
+)
+
+# Optional: a Hugging Face token, needed only if the repository is gated.
+_HF_SECRET_NAME = (os.environ.get("LLMTRACEFX_GLM_HF_SECRET_NAME") or "").strip()
+_staging_secrets = [modal.Secret.from_name(_HF_SECRET_NAME)] if _HF_SECRET_NAME else []
+
+staging_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(os.environ.get("LLMTRACEFX_GLM_HF_HUB_PIN") or DEFAULT_HF_HUB_PIN)
+    .env({**BAKED_ENVIRONMENT, "PYTHONPATH": "/opt/llmtracefx"})
+    .add_local_dir("llmtracefx", remote_path="/opt/llmtracefx/llmtracefx")
+)
+
+# The serving image is whatever the plan pinned. It already contains the
+# framework and its CUDA userspace; the local package is added only so
+# the container can build a manifest with the same code the rest of the
+# project uses.
+serving_image = (
+    modal.Image.from_registry(RECIPE.image.reference)
+    .env({**BAKED_ENVIRONMENT, "PYTHONPATH": "/opt/llmtracefx"})
+    .add_local_dir("llmtracefx", remote_path="/opt/llmtracefx/llmtracefx")
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _manifest_path(revision: str) -> Path:
+    return Path(MOUNT_PATH) / revision / MANIFEST_FILENAME
+
+
+def _read_manifest(revision: str) -> WeightStagingManifest | None:
+    path = _manifest_path(revision)
+    if not path.is_file():
+        return None
+    try:
+        return WeightStagingManifest.from_dict(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+    except (OSError, ValueError):
+        return None
+
+
+@app.function(
+    image=staging_image,
+    volumes={MOUNT_PATH: weights_volume},
+    secrets=_staging_secrets,
+    timeout=STAGING_TIMEOUT_SECONDS,
+    cpu=STAGING_CPU_CORES,
+    memory=int(STAGING_MEMORY_GIB * 1024),
+    retries=0,
+)
+def stage_weights(
+    repo_id: str,
+    revision: str,
+    confirm: str,
+    volume_name: str,
+) -> dict[str, Any]:
+    """Fetch one pinned revision onto the volume. CPU and network only.
+
+    ``confirm`` must repeat ``revision``. A bare yes/no flag would be
+    carried unchanged from a previous command line and would confirm
+    whatever that line now says; restating the SHA ties the confirmation
+    to the specific bytes being fetched, so an edited command with a
+    stale confirmation fails instead of downloading something nobody
+    asked for.
+
+    ``volume_name`` is checked rather than used. The volume is bound when
+    the app is built, so a mismatch means the operator believes they are
+    writing somewhere other than where the write will land, and that is
+    worth failing on.
+    """
+    from huggingface_hub import HfApi, snapshot_download
+
+    wanted = require_model_revision(revision)
+    confirmed = require_model_revision(confirm)
+    if wanted != confirmed:
+        raise ValueError(
+            "--confirm must repeat --revision exactly; refusing to download"
+        )
+    if wanted != RECIPE.model_revision:
+        raise ValueError(
+            "requested revision does not match the revision this app was "
+            f"configured with ({RECIPE.model_revision}); staging and serving "
+            "must agree or the served weights are not the ones recorded"
+        )
+    repository = require_supported_repo(repo_id)
+    if volume_name != PLAN.volume_name:
+        raise ValueError(
+            f"this app writes to volume {PLAN.volume_name!r}, not " f"{volume_name!r}"
+        )
+
+    existing = _read_manifest(wanted)
+    if existing is not None and existing.matches(repo_id=repository, revision=wanted):
+        print(
+            f"Revision {wanted} already staged: {existing.file_count} files, "
+            f"{existing.total_bytes / (1024 ** 3):.1f} GiB. Nothing to do."
+        )
+        return existing.to_dict()
+
+    target = Path(MOUNT_PATH) / wanted
+    target.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading {repository} at {wanted} into {target}")
+    started = time.monotonic()
+    snapshot_download(
+        repo_id=repository,
+        revision=wanted,
+        local_dir=str(target),
+    )
+    elapsed = time.monotonic() - started
+    print(f"Download finished in {elapsed / 60:.1f} minutes")
+
+    # Hashes come from the repository's own metadata where the upstream
+    # published them (large files are LFS/Xet tracked and carry a
+    # sha256). Files without published hashes are recorded with sizes
+    # only rather than with a hash computed here: hashing hundreds of
+    # GiB would double the container time this step is billed for, and a
+    # locally computed digest proves the bytes are self-consistent, not
+    # that they are the bytes upstream published.
+    hashes: dict[str, str] = {}
+    try:
+        info = HfApi().model_info(
+            repo_id=repository, revision=wanted, files_metadata=True
+        )
+        for sibling in info.siblings or ():
+            lfs = getattr(sibling, "lfs", None)
+            digest = getattr(lfs, "sha256", None) if lfs is not None else None
+            if digest:
+                hashes[sibling.rfilename] = str(digest)
+    except Exception as exc:  # noqa: BLE001 - metadata is a bonus, not a gate
+        print(f"File hashes unavailable from repository metadata: {type(exc).__name__}")
+
+    files: list[StagedFile] = []
+    for path in sorted(target.rglob("*")):
+        if not path.is_file() or path.name == MANIFEST_FILENAME:
+            continue
+        relative = path.relative_to(target).as_posix()
+        files.append(
+            StagedFile(
+                path=relative,
+                size_bytes=path.stat().st_size,
+                sha256=hashes.get(relative),
+            )
+        )
+
+    manifest = WeightStagingManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        completed_at=_utc_now_iso(),
+        repo_id=repository,
+        revision=wanted,
+        mount_path=MOUNT_PATH,
+        files=tuple(files),
+    )
+    _manifest_path(wanted).write_text(manifest.to_json(), encoding="utf-8")
+    weights_volume.commit()
+
+    print(
+        f"Staged {manifest.file_count} files, "
+        f"{manifest.total_bytes / (1024 ** 3):.1f} GiB, "
+        f"{manifest.hashed_file_count} with published hashes."
+    )
+    return manifest.to_dict()
+
+
+def _verification_path(revision: str) -> Path:
+    return Path(MOUNT_PATH) / revision / VERIFICATION_FILENAME
+
+
+def _read_verification(revision: str) -> WeightVerification | None:
+    path = _verification_path(revision)
+    if not path.is_file():
+        return None
+    try:
+        return WeightVerification.from_dict(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+    except (OSError, ValueError):
+        return None
+
+
+@app.function(
+    image=staging_image,
+    volumes={MOUNT_PATH: weights_volume},
+    timeout=VERIFY_TIMEOUT_SECONDS,
+    cpu=VERIFY_CPU_CORES,
+    memory=int(VERIFY_MEMORY_GIB * 1024),
+    retries=0,
+)
+def verify_weights(
+    volume_name: str, revision: str, check_hashes: bool = True
+) -> dict[str, Any]:
+    """Re-check the staged tree against its manifest. CPU and disk only.
+
+    A manifest that names the right revision proves a download was
+    started, not that it finished. An interruption near the end leaves
+    the manifest and a short shard, and the serving container would
+    discover that only after allocating four accelerators and loading
+    most of a checkpoint. Doing it here costs CPU seconds instead.
+    """
+    if volume_name != PLAN.volume_name:
+        raise ValueError(
+            f"this app verifies volume {PLAN.volume_name!r}, not {volume_name!r}"
+        )
+    wanted = require_model_revision(revision)
+    manifest = _read_manifest(wanted)
+    if manifest is None:
+        raise ValueError(
+            f"no manifest for revision {wanted} on {PLAN.volume_name}; run "
+            "the stage-weights step first"
+        )
+
+    verification = verify_staged_weights(
+        manifest,
+        Path(MOUNT_PATH) / wanted,
+        now=_utc_now_iso,
+        check_hashes=check_hashes,
+    )
+    _verification_path(wanted).write_text(verification.to_json(), encoding="utf-8")
+    weights_volume.commit()
+
+    print(verification.to_json())
+    if not verification.ok:
+        raise ValueError(
+            f"{len(verification.issues)} staged file(s) do not match the "
+            "manifest; re-run stage-weights before deploying"
+        )
+    print(
+        f"Verified {verification.files_checked} files, "
+        f"{verification.bytes_checked / (1024 ** 3):.1f} GiB, "
+        f"{verification.hashes_checked} of {verification.hashes_available} "
+        "published hashes."
+    )
+    return verification.to_dict()
+
+
+@app.function(
+    image=staging_image,
+    volumes={MOUNT_PATH: weights_volume},
+    timeout=300,
+    retries=0,
+)
+def read_manifest(volume_name: str, revision: str) -> dict[str, Any]:
+    """Print the staging manifest. CPU only, seconds of container time."""
+    if volume_name != PLAN.volume_name:
+        raise ValueError(
+            f"this app reads volume {PLAN.volume_name!r}, not {volume_name!r}"
+        )
+    manifest = _read_manifest(require_model_revision(revision))
+    if manifest is None:
+        raise ValueError(
+            f"no manifest for revision {revision} on {PLAN.volume_name}; "
+            "run the stage-weights step first"
+        )
+    print(manifest.to_json())
+    return manifest.to_dict()
+
+
+def _deploy_expiry() -> datetime:
+    """The instant after which no container may serve.
+
+    Parsed rather than trusted: a malformed value here would otherwise
+    become an exception in the middle of start up, on accelerators, when
+    the safe reading of an unparseable expiry is simply "expired".
+    """
+    raw = (os.environ.get(DEPLOY_EXPIRES_AT_VAR) or DEPLOY_EXPIRES_AT).strip()
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _stop_after(process: subprocess.Popen[bytes], seconds: float) -> None:
+    """End the container once its bounded lifetime is up.
+
+    Terminating the server is not enough on its own, because Modal keeps
+    the container while the web server port is bound. Exiting the process
+    is what actually releases the accelerators, so the wait is bounded
+    and then the exit is unconditional.
+    """
+    time.sleep(seconds)
+    print(
+        json.dumps({"event": "lifetime_reached", "seconds": round(seconds, 3)}),
+        flush=True,
+    )
+    try:
+        process.terminate()
+        process.wait(timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        # Deliberately swallowed. The server may already be gone, or may
+        # refuse to die politely; either way the next statement exits the
+        # process, which is what actually releases the accelerators.
+        # Re-raising here would skip that and leave them allocated.
+        pass
+    finally:
+        os._exit(0)
+
+
+def _observed_gpus() -> tuple[str, ...]:
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ()
+    return tuple(line.strip() for line in completed.stdout.splitlines() if line.strip())
+
+
+def _observed_cuda_version() -> str | None:
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query", "--display=COMPUTE"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in completed.stdout.splitlines():
+        if "CUDA" in line and ":" in line:
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _log_startup_when_ready(port: int, started: float, deadline_seconds: int) -> None:
+    """Record how long the server took to accept connections.
+
+    Startup time is one of the few things a serving container can
+    honestly observe about itself, and on a model this size it is the
+    number that dominates the cost of a short validation. It is recorded
+    as an observation, with no comparison and no target.
+    """
+    deadline = started + deadline_seconds
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(2.0)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                print(
+                    json.dumps(
+                        {
+                            "event": "server_ready",
+                            "startup_seconds": round(time.monotonic() - started, 3),
+                        }
+                    )
+                )
+                return
+        time.sleep(2.0)
+    print(
+        json.dumps(
+            {
+                "event": "server_not_ready",
+                "waited_seconds": deadline_seconds,
+            }
+        )
+    )
+
+
+@app.function(
+    image=serving_image,
+    gpu=f"{RECIPE.gpu_type.upper()}:{RECIPE.gpu_count}",
+    # Requested explicitly rather than left to the platform default,
+    # because the envelope prices these exact figures.
+    cpu=SERVING_CPU_CORES,
+    memory=int(SERVING_MEMORY_GIB * 1024),
+    volumes={MOUNT_PATH: weights_volume},
+    secrets=[endpoint_secret],
+    timeout=CONTROLS.timeout_seconds,
+    scaledown_window=CONTROLS.scaledown_window_seconds,
+    max_containers=CONTROLS.max_containers,
+    min_containers=CONTROLS.min_containers,
+    retries=0,
+)
+@modal.concurrent(max_inputs=CONTROLS.max_concurrent_inputs)
+@modal.web_server(
+    port=RECIPE.port,
+    startup_timeout=CONTROLS.startup_timeout_seconds,
+    # The only control that stops an unauthenticated request allocating
+    # accelerators. Everything this module checks runs after the platform
+    # has already scheduled the container, so refusing in Python bounds
+    # how long a container serves, not whether one is started. Modal
+    # rejects a request without proxy credentials at its edge with a 401
+    # (https://modal.com/docs/guide/webhook-proxy-auth, read 2026-08-30),
+    # and its token pair can be sent as a single `Authorization: Bearer`
+    # value, so the endpoint stays OpenAI-compatible for the collector.
+    requires_proxy_auth=CONTROLS.require_proxy_auth,
+)
+def serve() -> None:
+    """Start the OpenAI-compatible server against the staged weights.
+
+    The staged manifest is verified before the server is launched. That
+    check is cheap and it happens while the most expensive resource in
+    this deployment is already allocated, so failing here costs seconds
+    of accelerator time whereas letting the framework discover the
+    missing weights costs its entire start up sequence first.
+    """
+    # Checked first, and before anything else does work, because it is
+    # the gate that bounds total spend. Everything below this line costs
+    # accelerator time.
+    expiry = _deploy_expiry()
+    now = datetime.now(timezone.utc)
+    if now >= expiry:
+        raise RuntimeError(
+            f"this deployment expired at {expiry.isoformat(timespec='seconds')} "
+            f"and it is now {now.isoformat(timespec='seconds')}. Refusing to "
+            "start. The expiry is what makes the approved cost an upper "
+            "bound rather than an estimate: without it a request arriving "
+            "at any time in the future would allocate accelerators again. "
+            "Run `modal app stop` and redeploy with a fresh window if you "
+            "still need it."
+        )
+
+    manifest = _read_manifest(RECIPE.model_revision)
+    if manifest is None or not manifest.matches(
+        repo_id=RECIPE.model_repo_id, revision=RECIPE.model_revision
+    ):
+        raise RuntimeError(
+            f"weights for {RECIPE.model_repo_id} at {RECIPE.model_revision} "
+            f"are not staged on volume {PLAN.volume_name}. Run the "
+            "stage-weights step before deploying; the server will not "
+            "download weights on accelerators."
+        )
+
+    # A manifest says a download was attempted for this revision. It does
+    # not say the bytes are all there. The verification step establishes
+    # that on CPU, and requiring its result here is what keeps a
+    # truncated volume from being discovered on four accelerators.
+    verification = _read_verification(RECIPE.model_revision)
+    if verification is None or not verification.covers(
+        repo_id=RECIPE.model_repo_id, revision=RECIPE.model_revision
+    ):
+        raise RuntimeError(
+            f"weights for {RECIPE.model_revision} have not passed "
+            f"verification on volume {PLAN.volume_name}. Run the "
+            "verify-weights step, which is CPU only, before deploying."
+        )
+
+    # Resolved here, with the other precondition, because an absent key is
+    # a refusal rather than a degraded mode.
+    #
+    # Both frameworks install their authentication middleware only when a
+    # non-empty key is supplied, and this endpoint has no platform-level
+    # auth in front of it: `@modal.web_server` defaults to
+    # requires_proxy_auth=False, and turning it on is not an option
+    # because Modal's proxy expects its own headers while this endpoint
+    # has to stay OpenAI-compatible for the collector's bearer token. So
+    # an empty value would not weaken authentication, it would remove it,
+    # and publish four accelerators to the internet.
+    #
+    # Modal's `required_keys` does not cover this: it asserts that the
+    # variable is present, not that it holds anything, and `modal secret
+    # create NAME VAR="$VAR"` in a shell where the export was lost creates
+    # exactly that empty secret.
+    api_key = os.environ.get(PLAN.endpoint.api_key_env_var, "").strip()
+    if not api_key:
+        raise RuntimeError(
+            f"{PLAN.endpoint.api_key_env_var} is missing or empty in this "
+            f"container, so Modal Secret {PLAN.endpoint.modal_secret_name!r} "
+            "did not supply a value. Refusing to start: neither serving "
+            "framework installs authentication without a key, and this "
+            "endpoint has no other protection. Re-create the secret with a "
+            "non-empty value and deploy again."
+        )
+
+    server_manifest = ServerManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        collected_at=_utc_now_iso(),
+        app_name=PLAN.app_name,
+        gpu_type=RECIPE.gpu_type,
+        gpu_count=RECIPE.gpu_count,
+        framework=RECIPE.framework,
+        framework_version=RECIPE.framework_version,
+        image_reference=RECIPE.image.reference,
+        image_digest=RECIPE.image.digest,
+        model_repo_id=RECIPE.model_repo_id,
+        model_revision=RECIPE.model_revision,
+        quantization=RECIPE.facts.quantization,
+        quantization_format=RECIPE.facts.quantization_format,
+        activation_scheme=RECIPE.facts.activation_scheme,
+        tensor_parallel_size=RECIPE.tensor_parallel_size,
+        context_length=RECIPE.context_length,
+        observed_gpus=_observed_gpus(),
+        observed_cuda_version=_observed_cuda_version(),
+        credential_env_var_names_present=present_env_var_names(
+            os.environ, [PLAN.endpoint.api_key_env_var]
+        ),
+    )
+    # Safe operational metadata only: configuration, pins and observed
+    # hardware. There is no field here that can carry a credential.
+    print(server_manifest.to_json(indent=None))
+
+    argv = list(RECIPE.launch_argv())
+    print(json.dumps({"event": "server_argv", "argv": argv}))
+
+    environment = dict(os.environ)
+    if RECIPE.framework == SGLANG:
+        # Appended after the argv above has been logged, so the argv this
+        # module records stays credential free.
+        #
+        # That is the limit of what can be promised here. SGLang takes
+        # the key only on its command line, and its engine logs its own
+        # resolved configuration unredacted, so the value will appear in
+        # the container's stdout and in /proc/<pid>/cmdline regardless of
+        # what this module does. Reaching this branch at all requires the
+        # operator to have passed --accept-argv-credential-exposure,
+        # which the planner enforces; the default framework avoids the
+        # situation.
+        argv.extend(("--api-key", api_key))
+    else:
+        # vLLM reads the key from the environment, so it never reaches a
+        # command line or the server's config repr.
+        environment[VLLM_API_KEY_ENV_VAR] = api_key
+
+    started = time.monotonic()
+    threading.Thread(
+        target=_log_startup_when_ready,
+        args=(RECIPE.port, started, CONTROLS.startup_timeout_seconds),
+        daemon=True,
+    ).start()
+    process = subprocess.Popen(argv, env=environment)
+
+    # Modal's timeout does not stop this container: the function returns
+    # here, having only launched the server. The watchdog is what makes
+    # the per-container lifetime real, and it stops at whichever comes
+    # first, this container's own timeout or the deployment expiry, so a
+    # container started late cannot outlive the window that was priced.
+    remaining_to_expiry = (expiry - now).total_seconds()
+    lifetime = max(1.0, min(float(CONTROLS.timeout_seconds), remaining_to_expiry))
+    threading.Thread(
+        target=_stop_after,
+        args=(process, lifetime),
+        daemon=False,
+    ).start()

--- a/llmtracefx/deploy/plan.py
+++ b/llmtracefx/deploy/plan.py
@@ -1,0 +1,442 @@
+"""The deployment plan: one pure function from parameters to a decision.
+
+Planning is offline by construction. It reads no configuration file, opens
+no socket, imports no Modal SDK and consults no credential. Given the same
+inputs it produces the same document, which is what makes it safe to run
+before authenticating and useful to diff in review.
+
+The plan is also the gate. It does not merely describe what would happen;
+it decides whether the paid steps are allowed to be handed to the operator
+at all. When something is wrong (over budget, a stale price, an unpinned
+revision, accelerators that cannot hold the checkpoint) the plan still
+renders in full, because an operator needs to see why, but every step that
+can spend money is withheld from the executable set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import date
+from typing import Any
+
+from . import commands
+from .budget import BudgetRequest, CostEnvelope, evaluate_budget
+from .commands import CommandStep
+from .endpoint import EndpointConfig, collector_argv
+from .errors import DeploymentPlanError
+from .pricing import DEFAULT_MAX_PRICE_AGE_DAYS
+from .recipe import (
+    VLLM,
+    VLLM_API_KEY_ENV_VAR,
+    MemoryFit,
+    ServingRecipe,
+    check_memory_fit,
+)
+
+PLAN_SCHEMA_VERSION = "1"
+
+# Five minutes of idle before releasing the GPUs. Long enough that a
+# health check followed by a smoke request followed by a collector run
+# does not pay three cold starts, short enough that walking away from the
+# terminal does not quietly burn the budget.
+DEFAULT_SCALEDOWN_WINDOW_SECONDS = 300
+
+# An idle window beyond half an hour stops being "avoid a cold start" and
+# becomes "rent an idle accelerator", so it is refused.
+MAX_SCALEDOWN_WINDOW_SECONDS = 1800
+
+
+@dataclass(frozen=True)
+class RuntimeControls:
+    """The autoscaling and lifetime limits, all stated, none inherited.
+
+    Every field here is a multiplier or a duration on a billed resource.
+    Platform defaults are not used for any of them: a default that is
+    right for a cheap CPU function is the wrong default for four H200s,
+    and the difference is not visible until the invoice.
+    """
+
+    timeout_seconds: int
+    deployment_seconds: int
+    scaledown_window_seconds: int = DEFAULT_SCALEDOWN_WINDOW_SECONDS
+    startup_timeout_seconds: int = 1800
+    max_containers: int = 1
+    min_containers: int = 0
+    max_concurrent_inputs: int = 1
+    allow_warm_containers: bool = False
+    require_proxy_auth: bool = True
+
+    def __post_init__(self) -> None:
+        if self.timeout_seconds < 1:
+            raise DeploymentPlanError("timeout_seconds must be at least 1")
+        if self.deployment_seconds < 1:
+            raise DeploymentPlanError("deployment_seconds must be at least 1")
+        if self.deployment_seconds < self.timeout_seconds:
+            raise DeploymentPlanError(
+                f"deployment_seconds {self.deployment_seconds} is shorter than "
+                f"timeout_seconds {self.timeout_seconds}; the window the "
+                "deployment may serve for cannot be shorter than one "
+                "container's own lifetime"
+            )
+        if self.startup_timeout_seconds < 1:
+            raise DeploymentPlanError("startup_timeout_seconds must be at least 1")
+        if self.startup_timeout_seconds > self.timeout_seconds:
+            raise DeploymentPlanError(
+                f"startup_timeout_seconds {self.startup_timeout_seconds} "
+                f"exceeds timeout_seconds {self.timeout_seconds}; the "
+                "container would be killed while still starting"
+            )
+        if not (1 <= self.scaledown_window_seconds <= MAX_SCALEDOWN_WINDOW_SECONDS):
+            raise DeploymentPlanError(
+                "scaledown_window_seconds must be in "
+                f"1..{MAX_SCALEDOWN_WINDOW_SECONDS}, got "
+                f"{self.scaledown_window_seconds}"
+            )
+        if self.max_containers < 1:
+            raise DeploymentPlanError("max_containers must be at least 1")
+        if self.min_containers < 0:
+            raise DeploymentPlanError("min_containers must not be negative")
+        if self.min_containers > self.max_containers:
+            raise DeploymentPlanError("min_containers must not exceed max_containers")
+        if self.min_containers > 0 and not self.allow_warm_containers:
+            raise DeploymentPlanError(
+                "min_containers greater than zero keeps accelerators "
+                "allocated with no request in flight, which bills "
+                "continuously. Pass allow_warm_containers to state that you "
+                "mean it."
+            )
+        if self.max_concurrent_inputs < 1:
+            raise DeploymentPlanError("max_concurrent_inputs must be at least 1")
+        if not self.require_proxy_auth:
+            # Refused outright, with no flag to override it, because there
+            # is no honest number to put next to a public endpoint. A web
+            # server container is scheduled by the platform before any of
+            # this project's code runs, so on a public URL any request
+            # from anyone allocates accelerators first and is refused
+            # second, without limit and including after the deployment
+            # expiry. Nothing in the cost envelope bounds that, and this
+            # harness will not approve spending it cannot bound.
+            #
+            # Nothing is lost by requiring it. Modal's proxy token pair
+            # can be sent as a single `Authorization: Bearer` value, the
+            # same scheme the OpenAI API uses
+            # (https://modal.com/docs/guide/webhook-proxy-auth, read
+            # 2026-08-30), so the endpoint stays OpenAI-compatible and the
+            # collector needs no change.
+            raise DeploymentPlanError(
+                "require_proxy_auth cannot be turned off. Without it the "
+                "endpoint is public, and a web server container is "
+                "scheduled before any of its code runs, so every request "
+                "from anyone allocates accelerators and is refused "
+                "afterwards, without limit and including after the "
+                "expiry. That cost is unbounded, so it cannot be "
+                "approved. Modal's proxy token works as an ordinary "
+                "`Authorization: Bearer` value, so keeping it on costs "
+                "you nothing."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timeout_seconds": self.timeout_seconds,
+            "deployment_seconds": self.deployment_seconds,
+            "scaledown_window_seconds": self.scaledown_window_seconds,
+            "startup_timeout_seconds": self.startup_timeout_seconds,
+            "max_containers": self.max_containers,
+            "min_containers": self.min_containers,
+            "max_concurrent_inputs": self.max_concurrent_inputs,
+            "allow_warm_containers": self.allow_warm_containers,
+            "require_proxy_auth": self.require_proxy_auth,
+        }
+
+
+@dataclass(frozen=True)
+class DeploymentPlan:
+    """A rendered decision: what would run, what it could cost, and whether."""
+
+    schema_version: str
+    recipe: ServingRecipe
+    controls: RuntimeControls
+    budget: BudgetRequest
+    envelope: CostEnvelope
+    memory: MemoryFit
+    endpoint: EndpointConfig
+    app_name: str
+    volume_name: str
+    steps: tuple[CommandStep, ...]
+    max_price_age_days: int = DEFAULT_MAX_PRICE_AGE_DAYS
+    accept_stale_price: bool = False
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def approved(self) -> bool:
+        return not self.blockers
+
+    @property
+    def executable_steps(self) -> tuple[CommandStep, ...]:
+        """Steps the operator may run given the current decision.
+
+        When the plan is not approved this collapses to the steps that
+        cannot spend anything, so an operator who ignores the summary and
+        copies the command list still cannot start a paid resource.
+        """
+        if self.approved:
+            return self.steps
+        return tuple(step for step in self.steps if not step.spends_money)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": "llmtracefx.deploy.plan",
+            "approved": self.approved,
+            # Named the same way the API collector names its dry-run
+            # assertions, so "did this touch anything" reads identically
+            # across the two tools.
+            "network_request_performed": False,
+            "gpu_allocated": False,
+            "modal_authentication_used": False,
+            "app_name": self.app_name,
+            "volume_name": self.volume_name,
+            "recipe": self.recipe.to_dict(),
+            "server_argv": list(self.recipe.launch_argv()),
+            "runtime_controls": self.controls.to_dict(),
+            "cost_envelope": self.envelope.to_dict(),
+            "memory_fit": self.memory.to_dict(),
+            "endpoint": self.endpoint.to_dict(),
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "steps": [step.to_dict() for step in self.steps],
+            "executable_steps": [step.name for step in self.executable_steps],
+        }
+
+
+def build_plan(
+    *,
+    recipe: ServingRecipe,
+    controls: RuntimeControls,
+    budget: BudgetRequest,
+    endpoint: EndpointConfig,
+    as_of: date,
+    app_name: str = commands.DEFAULT_APP_NAME,
+    volume_name: str = commands.DEFAULT_VOLUME_NAME,
+    smoke_max_output_tokens: int = 32,
+    collector_run_id: str = "glm53flash-selfhost-smoke",
+    collector_prompt_file: str = "prompts/smoke.txt",
+    collector_output_dir: str = "output/glm53flash-selfhost",
+    max_price_age_days: int = DEFAULT_MAX_PRICE_AGE_DAYS,
+    accept_stale_price: bool = False,
+    accept_argv_credential_exposure: bool = False,
+) -> DeploymentPlan:
+    """Assemble and adjudicate a plan. Pure; performs no I/O."""
+    if budget.gpu_type.casefold() != recipe.gpu_type.casefold():
+        raise DeploymentPlanError(
+            f"budget prices {budget.gpu_type!r} but the recipe serves on "
+            f"{recipe.gpu_type!r}"
+        )
+    if budget.gpu_count != recipe.gpu_count:
+        raise DeploymentPlanError(
+            f"budget covers {budget.gpu_count} GPU(s) but the recipe "
+            f"requests {recipe.gpu_count}"
+        )
+    if budget.max_containers != controls.max_containers:
+        raise DeploymentPlanError(
+            f"budget prices {budget.max_containers} container(s) but the "
+            f"runtime controls allow {controls.max_containers}"
+        )
+    if budget.deployment_seconds != controls.deployment_seconds:
+        raise DeploymentPlanError(
+            f"budget prices a {budget.deployment_seconds}s deployment window "
+            f"but the controls declare {controls.deployment_seconds}s; the "
+            "window that is priced must be the window that is enforced"
+        )
+    if budget.max_runtime_seconds != controls.timeout_seconds:
+        raise DeploymentPlanError(
+            f"budget prices {budget.max_runtime_seconds}s but the container "
+            f"timeout is {controls.timeout_seconds}s; the priced window and "
+            "the configured window must be the same number or the envelope "
+            "describes a deployment other than the one being planned"
+        )
+
+    envelope = evaluate_budget(budget)
+    # The arithmetic cannot see the endpoint's auth posture, so the
+    # boundedness flag is set from the controls that decide it.
+    envelope = replace(envelope, bounded=controls.require_proxy_auth)
+    memory = check_memory_fit(
+        gpu_type=recipe.gpu_type, gpu_count=recipe.gpu_count, facts=recipe.facts
+    )
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    if not envelope.within_budget:
+        blockers.append(
+            f"Worst-case cost ${envelope.worst_case_usd:.2f} exceeds the "
+            f"authorised budget ${envelope.budget_usd:.2f}."
+        )
+    if not memory.fits:
+        blockers.append(
+            f"{recipe.gpu_count} x {recipe.gpu_type} provides "
+            f"{memory.total_vram_gib:.0f} GiB against roughly "
+            f"{memory.weights_gib:.0f} GiB of weights, leaving "
+            f"{memory.residual_fraction:.0%} for KV cache and activations; "
+            f"at least {memory.required_headroom_fraction:.0%} is required."
+        )
+
+    price_age = budget.price.age_days(as_of=as_of)
+    if price_age < 0:
+        blockers.append(
+            f"GPU price is dated {budget.price.effective_date}, which is in "
+            "the future relative to the planning date; correct the quote."
+        )
+    elif budget.price.is_stale(as_of=as_of, max_age_days=max_price_age_days):
+        message = (
+            f"GPU price quote is {price_age} days old (effective "
+            f"{budget.price.effective_date}, limit {max_price_age_days} "
+            "days). Cloud GPU prices change; re-read the current rate."
+        )
+        if accept_stale_price:
+            warnings.append(message + " Accepted explicitly.")
+        else:
+            blockers.append(message)
+
+    for label, quote in (
+        ("CPU and memory", budget.compute),
+        ("Storage", budget.storage),
+    ):
+        age = quote.age_days(as_of=as_of)
+        if age < 0:
+            blockers.append(
+                f"{label} price is dated {quote.effective_date}, which is in "
+                "the future relative to the planning date; correct the quote."
+            )
+        elif quote.is_stale(as_of=as_of, max_age_days=max_price_age_days):
+            message = (
+                f"{label} price quote is {age} days old (effective "
+                f"{quote.effective_date}, limit {max_price_age_days} days). "
+                "It is a mandatory part of the total, so a stale rate makes "
+                "the total wrong."
+            )
+            if accept_stale_price:
+                warnings.append(message + " Accepted explicitly.")
+            else:
+                blockers.append(message)
+
+    if not recipe.image.is_digest_pinned:
+        warnings.append(
+            f"Serving image {recipe.image.reference} is pinned by tag only. "
+            "A tag can be repointed, so this deployment is reproducible only "
+            "as long as the tag is not moved."
+        )
+
+    if recipe.exposes_credential_on_argv:
+        message = (
+            f"{recipe.framework} accepts the endpoint key only as a command "
+            "line argument, and its engine logs its own resolved server "
+            "configuration without redacting it, so the key will appear in "
+            "the container's logs and in /proc/<pid>/cmdline. "
+            f"{VLLM} reads {VLLM_API_KEY_ENV_VAR} from the environment "
+            "instead and does not have this problem."
+        )
+        if accept_argv_credential_exposure:
+            warnings.append(message + " Accepted explicitly.")
+        else:
+            blockers.append(message)
+
+    if controls.min_containers > 0:
+        # Not a warning. The envelope prices a window that begins at
+        # deploy and is closed by the expiry, but a warm container bills
+        # from deploy regardless of whether anyone calls it, so the whole
+        # window is spent by definition rather than in the worst case.
+        # This harness exists for a short validation; paying for idle
+        # accelerators is not one.
+        blockers.append(
+            f"min_containers is {controls.min_containers}: Modal keeps that "
+            "many containers running while the function is idle, so the "
+            "accelerators bill continuously from deploy whether or not "
+            "anything calls them. Set min_containers to 0 and accept the "
+            "cold start."
+        )
+    if controls.max_concurrent_inputs > 1:
+        warnings.append(
+            f"max_concurrent_inputs is {controls.max_concurrent_inputs}; "
+            "concurrent requests share one container and their measurements "
+            "will interfere with each other."
+        )
+
+    # The expiry stops a container from *serving* past the window, but it
+    # cannot stop one from being *started*: a web server function is
+    # scheduled by the platform before any of this module's code runs, so
+    # the refusal happens on an accelerator that has already been
+    # allocated and billed. On a public endpoint that is an unbounded
+    # cost, because anyone can keep triggering cold starts forever and
+    # each one bills. Proxy auth is the only thing that closes it, since
+    # Modal rejects an unauthenticated request at its edge with a 401
+    # before scheduling anything
+    # (https://modal.com/docs/guide/webhook-proxy-auth, read 2026-08-30).
+    warnings.append(
+        "Proxy auth is on, so Modal rejects unauthenticated requests at its "
+        "edge before scheduling a container and they cannot allocate "
+        "accelerators. A request bearing a valid workspace token still "
+        "cold-starts a container, including after the expiry, where it is "
+        "refused within seconds. That residual is operator-controlled and "
+        "is not priced above."
+    )
+
+    steps = (
+        commands.setup_step(),
+        commands.secret_step(endpoint),
+        commands.volume_step(volume_name),
+        commands.stage_weights_step(
+            revision=recipe.model_revision,
+            volume_name=volume_name,
+            repo_id=recipe.model_repo_id,
+        ),
+        commands.verify_weights_step(
+            volume_name=volume_name, revision=recipe.model_revision
+        ),
+        commands.manifest_step(volume_name=volume_name, revision=recipe.model_revision),
+        commands.deploy_step(),
+        commands.health_step(endpoint),
+        commands.readiness_step(endpoint),
+        commands.smoke_step(
+            endpoint=endpoint, max_output_tokens=smoke_max_output_tokens
+        ),
+        commands.collect_step(
+            collector_argv(
+                endpoint=endpoint,
+                run_id=collector_run_id,
+                prompt_file=collector_prompt_file,
+                output_dir=collector_output_dir,
+                model_revision=recipe.model_revision,
+            )
+        ),
+        commands.stop_step(app_name=app_name),
+        commands.delete_volume_step(volume_name=volume_name),
+    )
+
+    return DeploymentPlan(
+        schema_version=PLAN_SCHEMA_VERSION,
+        recipe=recipe,
+        controls=controls,
+        budget=budget,
+        envelope=envelope,
+        memory=memory,
+        endpoint=endpoint,
+        app_name=app_name,
+        volume_name=volume_name,
+        steps=steps,
+        max_price_age_days=max_price_age_days,
+        accept_stale_price=accept_stale_price,
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+    )
+
+
+def assert_executable(plan: DeploymentPlan) -> None:
+    """Raise unless every gate passed."""
+    if plan.approved:
+        return
+    raise DeploymentPlanError(
+        "deployment plan refused:\n"
+        + "\n".join(f"  - {reason}" for reason in plan.blockers)
+    )

--- a/llmtracefx/deploy/pricing.py
+++ b/llmtracefx/deploy/pricing.py
@@ -1,0 +1,231 @@
+"""Operator-supplied price quotes, with an effective date attached.
+
+Cloud GPU prices are mutable. A price literal compiled into this package
+would be a claim about the present that quietly decays into a false claim
+about the present, and the number it produces (a cost estimate the
+operator uses to decide whether to spend money) is exactly the kind of
+number that must not silently go stale.
+
+So there is deliberately no default price anywhere in this module. A
+quote has to be supplied by the caller together with the date it was
+read and where it was read from, and a quote older than the caller's
+tolerance is refused rather than used. The failure mode is "you must go
+and look up the current price", which costs a minute, instead of
+"budgeting silently used last quarter's price", which costs money.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import asdict, dataclass
+from datetime import date
+from typing import Any
+
+from .errors import DeploymentPlanError
+
+_ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# A ceiling well above any published accelerator rate. It exists to catch
+# a misplaced decimal point or a per-month figure pasted into a per-hour
+# field, not to express an opinion about what a GPU should cost.
+MAX_PLAUSIBLE_USD_PER_GPU_HOUR = 1000.0
+
+# The same idea for storage, per GiB-month.
+MAX_PLAUSIBLE_USD_PER_GIB_MONTH = 100.0
+
+# Per-core-hour and per-GiB-hour rates are small numbers; a three digit
+# one is a units mistake.
+MAX_PLAUSIBLE_USD_PER_CORE_HOUR = 100.0
+MAX_PLAUSIBLE_USD_PER_GIB_HOUR = 100.0
+
+# How old a quote may be before planning refuses it. Ninety days is long
+# enough that an operator is not re-reading a pricing page for every
+# invocation, and short enough that a quote cannot survive unnoticed
+# across a pricing change.
+DEFAULT_MAX_PRICE_AGE_DAYS = 90
+
+
+def _require_finite(value: float, *, field: str) -> float:
+    """Reject NaN and both infinities before they reach any arithmetic.
+
+    A NaN price propagates through every multiplication and comparison in
+    this package and comes out the other side as a cost that compares
+    False against every budget, which reads as "within budget" to any
+    naive check. Refusing it at the boundary is the only place where the
+    value is still recognisably wrong.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise DeploymentPlanError(f"{field} must be a real number")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise DeploymentPlanError(f"{field} must be a finite number, got {value!r}")
+    return numeric
+
+
+def _require_iso_date(value: str, *, field: str) -> date:
+    if not isinstance(value, str) or not _ISO_DATE_PATTERN.match(value):
+        raise DeploymentPlanError(f"{field} must be an ISO date (YYYY-MM-DD)")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise DeploymentPlanError(f"{field} is not a valid calendar date") from exc
+
+
+def _require_text(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DeploymentPlanError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+@dataclass(frozen=True)
+class GpuPriceQuote:
+    """One accelerator price, as read by a human on a stated date.
+
+    ``source`` is required and is free text (normally the URL of the
+    pricing page). It is what lets a reviewer re-check the number later
+    rather than having to trust it.
+    """
+
+    gpu_type: str
+    usd_per_gpu_hour: float
+    effective_date: str
+    source: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "gpu_type", _require_text(self.gpu_type, field="gpu_type")
+        )
+        object.__setattr__(
+            self, "source", _require_text(self.source, field="price source")
+        )
+        rate = _require_finite(self.usd_per_gpu_hour, field="usd_per_gpu_hour")
+        if rate <= 0:
+            raise DeploymentPlanError("usd_per_gpu_hour must be greater than zero")
+        if rate > MAX_PLAUSIBLE_USD_PER_GPU_HOUR:
+            raise DeploymentPlanError(
+                "usd_per_gpu_hour exceeds "
+                f"{MAX_PLAUSIBLE_USD_PER_GPU_HOUR:.0f}; check the units, this "
+                "field is dollars per GPU per hour"
+            )
+        object.__setattr__(self, "usd_per_gpu_hour", rate)
+        _require_iso_date(self.effective_date, field="price effective_date")
+
+    def age_days(self, *, as_of: date) -> int:
+        """Whole days between the quote's effective date and ``as_of``.
+
+        Negative when the quote is dated in the future, which is reported
+        rather than clamped: a future-dated quote is a data-entry error
+        worth surfacing, not something to round away to zero.
+        """
+        return (as_of - date.fromisoformat(self.effective_date)).days
+
+    def is_stale(
+        self, *, as_of: date, max_age_days: int = DEFAULT_MAX_PRICE_AGE_DAYS
+    ) -> bool:
+        return self.age_days(as_of=as_of) > max_age_days
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class StorageQuote:
+    """A persistent-volume storage price, per GiB-month.
+
+    Kept separate from :class:`GpuPriceQuote` because it bills on a
+    different clock. GPU time stops when the container stops; stored
+    weights keep costing money until the volume is deleted, which is the
+    charge an operator is most likely to forget.
+    """
+
+    usd_per_gib_month: float
+    effective_date: str
+    source: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "source", _require_text(self.source, field="storage source")
+        )
+        rate = _require_finite(self.usd_per_gib_month, field="usd_per_gib_month")
+        if rate <= 0:
+            raise DeploymentPlanError("usd_per_gib_month must be greater than zero")
+        if rate > MAX_PLAUSIBLE_USD_PER_GIB_MONTH:
+            raise DeploymentPlanError(
+                "usd_per_gib_month exceeds "
+                f"{MAX_PLAUSIBLE_USD_PER_GIB_MONTH:.0f}; check the units, this "
+                "field is dollars per GiB per month"
+            )
+        object.__setattr__(self, "usd_per_gib_month", rate)
+        _require_iso_date(self.effective_date, field="storage effective_date")
+
+    def age_days(self, *, as_of: date) -> int:
+        return (as_of - date.fromisoformat(self.effective_date)).days
+
+    def is_stale(
+        self, *, as_of: date, max_age_days: int = DEFAULT_MAX_PRICE_AGE_DAYS
+    ) -> bool:
+        return self.age_days(as_of=as_of) > max_age_days
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ComputeQuote:
+    """The CPU and memory rates that bill alongside every container.
+
+    Separate from :class:`GpuPriceQuote` because they apply to the
+    staging and verification containers too, which have no accelerator
+    at all and were previously priced at zero. A harness that calls
+    itself a budget guard cannot leave a mandatory charge out of the
+    total merely because it is the smaller one.
+    """
+
+    usd_per_cpu_core_hour: float
+    usd_per_gib_memory_hour: float
+    effective_date: str
+    source: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "source", _require_text(self.source, field="compute price source")
+        )
+        cpu = _require_finite(self.usd_per_cpu_core_hour, field="usd_per_cpu_core_hour")
+        memory = _require_finite(
+            self.usd_per_gib_memory_hour, field="usd_per_gib_memory_hour"
+        )
+        if cpu <= 0 or memory <= 0:
+            raise DeploymentPlanError(
+                "CPU and memory rates must both be greater than zero"
+            )
+        if cpu > MAX_PLAUSIBLE_USD_PER_CORE_HOUR:
+            raise DeploymentPlanError(
+                "usd_per_cpu_core_hour exceeds "
+                f"{MAX_PLAUSIBLE_USD_PER_CORE_HOUR:.0f}; check the units"
+            )
+        if memory > MAX_PLAUSIBLE_USD_PER_GIB_HOUR:
+            raise DeploymentPlanError(
+                "usd_per_gib_memory_hour exceeds "
+                f"{MAX_PLAUSIBLE_USD_PER_GIB_HOUR:.0f}; check the units"
+            )
+        object.__setattr__(self, "usd_per_cpu_core_hour", cpu)
+        object.__setattr__(self, "usd_per_gib_memory_hour", memory)
+        _require_iso_date(self.effective_date, field="compute effective_date")
+
+    def container_usd_per_hour(self, *, cpu_cores: float, memory_gib: float) -> float:
+        return (
+            cpu_cores * self.usd_per_cpu_core_hour
+            + memory_gib * self.usd_per_gib_memory_hour
+        )
+
+    def age_days(self, *, as_of: date) -> int:
+        return (as_of - date.fromisoformat(self.effective_date)).days
+
+    def is_stale(
+        self, *, as_of: date, max_age_days: int = DEFAULT_MAX_PRICE_AGE_DAYS
+    ) -> bool:
+        return self.age_days(as_of=as_of) > max_age_days
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/llmtracefx/deploy/recipe.py
+++ b/llmtracefx/deploy/recipe.py
@@ -1,0 +1,567 @@
+"""The pinned GLM-5.3-Flash serving recipe.
+
+Scope is deliberately one model. GLM-5.3-Flash is the 320B-A18B FP8
+checkpoint; the full GLM-5.3 is roughly twice the size and is out of
+scope for a credit-funded validation, as is the BF16 variant of Flash.
+Both are rejected by name rather than left to fail later against a VRAM
+limit, because by then the GPUs are already allocated and billing.
+
+What is pinned here and what is not is a deliberate split:
+
+* Architecture facts are compiled in. They were read from the published
+  ``config.json`` and they describe the checkpoint, so they cannot drift
+  without the checkpoint itself changing, which is what the revision pin
+  detects.
+* The model revision, the container digest and every price are *not*
+  compiled in. They are mutable, and a stale literal for any of them is
+  a silently wrong answer rather than a loud one. Each has to be supplied
+  by the caller and is validated for shape before it is used.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .errors import DeploymentPlanError
+
+MODEL_CARD_URL = "https://huggingface.co/zai-org/GLM-5.3-Flash"
+MODEL_CONFIG_URL = "https://huggingface.co/zai-org/GLM-5.3-Flash/raw/main/config.json"
+UPSTREAM_REPO_URL = "https://github.com/zai-org/GLM-5"
+
+SUPPORTED_REPO_ID = "zai-org/GLM-5.3-Flash"
+
+# Repositories refused by name, with the reason the operator needs.
+_REFUSED_REPO_IDS: dict[str, str] = {
+    "zai-org/GLM-5.3-Flash-BF16": (
+        "the BF16 variant is roughly twice the size of the FP8 checkpoint "
+        "this harness is scoped to and does not fit the budget it is "
+        "designed for"
+    ),
+    "zai-org/GLM-5.3": (
+        "full GLM-5.3 is roughly 704 GiB at FP8 and is out of scope for "
+        "this harness, which targets GLM-5.3-Flash only"
+    ),
+}
+
+_GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IMAGE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$")
+_IMAGE_TAG_PATTERN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]*$")
+
+SGLANG = "sglang"
+VLLM = "vllm"
+SUPPORTED_FRAMEWORKS = (SGLANG, VLLM)
+
+# How each framework accepts the endpoint credential.
+#
+# This is the deciding difference between them for this harness, and it
+# is why vLLM is the default. vLLM reads ``VLLM_API_KEY`` from the
+# environment (vllm/envs.py, and the auth middleware in
+# vllm/entrypoints/serve/middleware/register.py, read 2026-08-30), so the
+# value never appears on a command line. SGLang accepts the key only as
+# ``--api-key`` on argv, and its engine logs its own resolved
+# configuration with ``logger.info(f"server_args={server_args.resolved_dict()}")``
+# (python/sglang/srt/entrypoints/engine.py, read 2026-08-30) with no
+# redaction, so the key lands in the container's stdout and from there in
+# the platform's log store, as well as being readable from
+# /proc/<pid>/cmdline.
+CREDENTIAL_TRANSPORT_ENVIRONMENT = "environment"
+CREDENTIAL_TRANSPORT_ARGV = "argv"
+
+_CREDENTIAL_TRANSPORTS: dict[str, str] = {
+    VLLM: CREDENTIAL_TRANSPORT_ENVIRONMENT,
+    SGLANG: CREDENTIAL_TRANSPORT_ARGV,
+}
+
+VLLM_API_KEY_ENV_VAR = "VLLM_API_KEY"
+
+DEFAULT_FRAMEWORK = VLLM
+
+# Where the staged weights are mounted inside every container, and the
+# port the OpenAI-compatible server binds. Both live here rather than in
+# the CLI so the Modal app can read them without importing an argparse
+# module.
+DEFAULT_WEIGHTS_MOUNT_PATH = "/weights"
+DEFAULT_SERVER_PORT = 30000
+
+# Nameplate capacity per accelerator, in GiB, as advertised on Modal's
+# GPU guide (https://modal.com/docs/guide/gpu, read 2026-08-30). This is
+# advertised capacity, not usable capacity: the runtime, the CUDA
+# context and fragmentation all take a share before any weight is
+# loaded, which is why the fit check below demands headroom rather than
+# merely arithmetic sufficiency.
+GPU_VRAM_GIB: dict[str, float] = {
+    "H100": 80.0,
+    "H200": 141.0,
+    "B200": 180.0,
+}
+
+# Fraction of total VRAM that must remain after the weights are resident.
+# KV cache, activations and the CUDA context all come out of what is
+# left, and a plan that fits the weights but nothing else produces a
+# server that starts and then fails on the first long request, having
+# billed for the whole startup.
+MIN_VRAM_HEADROOM_FRACTION = 0.20
+
+
+@dataclass(frozen=True)
+class ModelFacts:
+    """Architecture facts read from the published model configuration.
+
+    ``approximate_checkpoint_gib`` is the one soft number here. It is
+    used to size the volume and to sanity-check the GPU fit, never to
+    make a claim about what was downloaded: the staging manifest records
+    the byte counts actually observed on the volume.
+    """
+
+    repo_id: str
+    total_parameters_b: float
+    active_parameters_b: float
+    num_hidden_layers: int
+    num_routed_experts: int
+    num_experts_per_token: int
+    max_position_embeddings: int
+    quantization: str
+    quantization_format: str
+    activation_scheme: str
+    multimodal: bool
+    attention: str
+    approximate_checkpoint_gib: float
+    config_source: str
+    model_card: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+GLM_53_FLASH = ModelFacts(
+    repo_id=SUPPORTED_REPO_ID,
+    total_parameters_b=320.0,
+    active_parameters_b=18.0,
+    num_hidden_layers=45,
+    num_routed_experts=288,
+    num_experts_per_token=8,
+    max_position_embeddings=1_048_576,
+    quantization="fp8",
+    quantization_format="e4m3",
+    activation_scheme="dynamic",
+    multimodal=True,
+    attention="hybrid linear attention with periodic sparse attention layers",
+    approximate_checkpoint_gib=306.0,
+    config_source=MODEL_CONFIG_URL,
+    model_card=MODEL_CARD_URL,
+)
+
+
+def require_model_revision(revision: str) -> str:
+    """Accept only a full commit SHA as a model revision.
+
+    A branch name is not a revision. ``main`` resolves to whatever was
+    pushed most recently, so staging weights at ``main`` produces an
+    artifact whose contents cannot be reconstructed later and a manifest
+    that records a name rather than a fact. A short SHA is refused for
+    the same reason a short hash is refused anywhere else: it is a prefix
+    that is not guaranteed to stay unique.
+    """
+    if not isinstance(revision, str):
+        raise DeploymentPlanError("model revision must be a string")
+    candidate = revision.strip().lower()
+    if not _GIT_SHA_PATTERN.match(candidate):
+        raise DeploymentPlanError(
+            "model revision must be a full 40-character commit SHA, not "
+            f"{revision!r}. Resolve it once and pin it, for example: "
+            "curl -s https://huggingface.co/api/models/"
+            f"{SUPPORTED_REPO_ID} | python -c "
+            "\"import json,sys; print(json.load(sys.stdin)['sha'])\""
+        )
+    return candidate
+
+
+def require_supported_repo(repo_id: str) -> str:
+    if not isinstance(repo_id, str) or not repo_id.strip():
+        raise DeploymentPlanError("repo_id must be a non-empty string")
+    candidate = repo_id.strip()
+    refusal = _REFUSED_REPO_IDS.get(candidate)
+    if refusal is not None:
+        raise DeploymentPlanError(f"{candidate} is not supported here: {refusal}")
+    if candidate != SUPPORTED_REPO_ID:
+        raise DeploymentPlanError(
+            f"this harness serves {SUPPORTED_REPO_ID} only, got {candidate!r}"
+        )
+    return candidate
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    """A container image reference, and whether it is actually pinned."""
+
+    reference: str
+    name: str
+    tag: str | None
+    digest: str | None
+
+    @property
+    def is_digest_pinned(self) -> bool:
+        return self.digest is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reference": self.reference,
+            "name": self.name,
+            "tag": self.tag,
+            "digest": self.digest,
+            "digest_pinned": self.is_digest_pinned,
+        }
+
+
+def _split_image_reference(candidate: str) -> tuple[str, str | None, str | None]:
+    """Split a reference into name, tag and digest, parsing right to left.
+
+    A single regex cannot do this correctly, because ``:`` is overloaded:
+    it separates a tag, and it also separates a registry host from its
+    port. ``registry.internal:5000/org/img`` has a colon and no tag at
+    all. The rule the OCI spec encodes, and the one applied here, is that
+    a colon introduces a tag only when no ``/`` follows it; otherwise it
+    belongs to the registry host.
+
+    Getting this wrong in the lenient direction would misread a port as a
+    version. Getting it wrong in the strict direction, as a naive pattern
+    does, refuses every private registry outright.
+    """
+    remainder, separator, digest_part = candidate.rpartition("@")
+    if separator:
+        digest: str | None = digest_part
+        if not remainder:
+            raise DeploymentPlanError(f"malformed image reference: {candidate!r}")
+    else:
+        digest = None
+        remainder = digest_part
+
+    name, colon, tail = remainder.rpartition(":")
+    if colon and "/" not in tail:
+        tag: str | None = tail
+    else:
+        name, tag = remainder, None
+
+    if not name:
+        raise DeploymentPlanError(f"malformed image reference: {candidate!r}")
+    return name, tag, digest
+
+
+def parse_image_reference(
+    reference: str, *, accept_mutable: bool = False
+) -> ImageReference:
+    """Parse and vet a registry reference.
+
+    ``latest`` is refused outright and with no override, because it is
+    not a version at all: two deploys a week apart can differ with
+    nothing in the record to show it. A concrete tag without a digest is
+    still mutable, since a tag can be repointed, so it is refused too,
+    but that refusal has an override for the case where the operator
+    knowingly accepts the risk and the plan then records that they did.
+
+    The published GLM-5.3-Flash model card itself shows
+    ``lmsysorg/sglang:latest``, so this check is expected to reject a
+    copy-pasted upstream command. That is the intended behaviour, not an
+    incompatibility: reproducibility is the whole point of the pin.
+    """
+    if not isinstance(reference, str) or not reference.strip():
+        raise DeploymentPlanError("image reference must be a non-empty string")
+    candidate = reference.strip()
+    if any(character.isspace() for character in candidate):
+        raise DeploymentPlanError(f"malformed image reference: {reference!r}")
+
+    name, tag, digest = _split_image_reference(candidate)
+
+    if not _IMAGE_NAME_PATTERN.match(name):
+        raise DeploymentPlanError(f"malformed image name in {reference!r}")
+    if tag is not None and not _IMAGE_TAG_PATTERN.match(tag):
+        raise DeploymentPlanError(f"malformed image tag in {reference!r}")
+    if digest is not None and not _DIGEST_PATTERN.match(digest):
+        raise DeploymentPlanError(f"malformed image digest in {reference!r}")
+
+    if tag == "latest":
+        raise DeploymentPlanError(
+            "image tag 'latest' is never reproducible; pin a concrete tag "
+            "and, preferably, an @sha256: digest"
+        )
+    if tag is None and digest is None:
+        raise DeploymentPlanError(
+            f"image reference {reference!r} has neither a tag nor a digest"
+        )
+    if digest is None and not accept_mutable:
+        raise DeploymentPlanError(
+            f"image reference {reference!r} is tag-only and a tag can be "
+            "repointed. Supply an @sha256: digest, or pass "
+            "--accept-mutable-image to record that you accepted a mutable "
+            "image on purpose"
+        )
+    return ImageReference(reference=candidate, name=name, tag=tag, digest=digest)
+
+
+@dataclass(frozen=True)
+class MemoryFit:
+    """Whether the requested accelerators can hold the checkpoint."""
+
+    gpu_type: str
+    gpu_count: int
+    vram_gib_per_gpu: float
+    total_vram_gib: float
+    weights_gib: float
+    residual_gib: float
+    residual_fraction: float
+    required_headroom_fraction: float
+    fits: bool
+    caveat: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "vram_gib_per_gpu": self.vram_gib_per_gpu,
+            "total_vram_gib": round(self.total_vram_gib, 2),
+            "weights_gib": round(self.weights_gib, 2),
+            "residual_gib": round(self.residual_gib, 2),
+            "residual_fraction": round(self.residual_fraction, 4),
+            "required_headroom_fraction": self.required_headroom_fraction,
+            "fits": self.fits,
+            "caveat": self.caveat,
+        }
+
+
+def check_memory_fit(
+    *,
+    gpu_type: str,
+    gpu_count: int,
+    facts: ModelFacts = GLM_53_FLASH,
+    vram_gib_per_gpu: float | None = None,
+) -> MemoryFit:
+    """A necessary, and explicitly not sufficient, capacity check.
+
+    No official hardware recommendation for GLM-5.3-Flash was found on
+    the model card or in the upstream repository, so this is arithmetic
+    over the published checkpoint size and the advertised VRAM, not a
+    restatement of vendor guidance. It can prove that a configuration
+    cannot work. It cannot prove that one will, which is what the caveat
+    on the result says and what the smoke test exists to settle.
+    """
+    resolved_type = gpu_type.strip()
+    if vram_gib_per_gpu is None:
+        known = GPU_VRAM_GIB.get(resolved_type.upper())
+        if known is None:
+            raise DeploymentPlanError(
+                f"unknown GPU type {gpu_type!r}; pass an explicit "
+                "vram_gib_per_gpu or use one of: " + ", ".join(sorted(GPU_VRAM_GIB))
+            )
+        vram = known
+    else:
+        vram = float(vram_gib_per_gpu)
+        if vram <= 0:
+            raise DeploymentPlanError("vram_gib_per_gpu must be greater than zero")
+
+    total = vram * gpu_count
+    weights = facts.approximate_checkpoint_gib
+    residual = total - weights
+    fraction = residual / total if total > 0 else 0.0
+    return MemoryFit(
+        gpu_type=resolved_type,
+        gpu_count=gpu_count,
+        vram_gib_per_gpu=vram,
+        total_vram_gib=total,
+        weights_gib=weights,
+        residual_gib=residual,
+        residual_fraction=fraction,
+        required_headroom_fraction=MIN_VRAM_HEADROOM_FRACTION,
+        fits=residual > 0 and fraction >= MIN_VRAM_HEADROOM_FRACTION,
+        caveat=(
+            "Advertised VRAM against an approximate checkpoint size. "
+            "Passing this check does not prove the model serves at the "
+            "requested context length; no official hardware requirement "
+            "for GLM-5.3-Flash was published on the model card or in "
+            f"{UPSTREAM_REPO_URL} as of 2026-08-30."
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class ServingRecipe:
+    """A fully resolved, reproducible description of how to serve.
+
+    Holds no credential and no price. It is the "what runs" half of a
+    plan; the "what may it cost" half lives in the cost envelope.
+    """
+
+    framework: str
+    framework_version: str
+    image: ImageReference
+    model_repo_id: str
+    model_revision: str
+    facts: ModelFacts
+    gpu_type: str
+    gpu_count: int
+    tensor_parallel_size: int
+    context_length: int
+    served_model_name: str
+    port: int
+    weights_mount_path: str
+    extra_server_args: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def credential_transport(self) -> str:
+        """How this framework will receive the endpoint key.
+
+        Recorded and adjudicated rather than assumed, because the two
+        supported frameworks differ in a way that matters: one takes the
+        key from the environment and one takes it on its command line and
+        then logs its own configuration.
+        """
+        return _CREDENTIAL_TRANSPORTS[self.framework]
+
+    @property
+    def exposes_credential_on_argv(self) -> bool:
+        return self.credential_transport == CREDENTIAL_TRANSPORT_ARGV
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "framework": self.framework,
+            "framework_version": self.framework_version,
+            "credential_transport": self.credential_transport,
+            "image": self.image.to_dict(),
+            "model_repo_id": self.model_repo_id,
+            "model_revision": self.model_revision,
+            "model_facts": self.facts.to_dict(),
+            "gpu_type": self.gpu_type,
+            "gpu_count": self.gpu_count,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "context_length": self.context_length,
+            "served_model_name": self.served_model_name,
+            "port": self.port,
+            "weights_mount_path": self.weights_mount_path,
+            "extra_server_args": list(self.extra_server_args),
+        }
+
+    def local_model_path(self) -> str:
+        """Where the staged weights are read from inside the container.
+
+        The server is always pointed at the volume, never at the
+        repository id. Passing the repository id would let the serving
+        container fall back to downloading over the network at start up,
+        on GPUs, which is precisely the expensive mistake the separate
+        CPU staging step exists to prevent.
+        """
+        return f"{self.weights_mount_path.rstrip('/')}/{self.model_revision}"
+
+    def launch_argv(self) -> tuple[str, ...]:
+        """The exact server process argv, as a tuple, never a shell string."""
+        if self.framework == SGLANG:
+            return (
+                "python3",
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                self.local_model_path(),
+                "--served-model-name",
+                self.served_model_name,
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(self.port),
+                "--tp",
+                str(self.tensor_parallel_size),
+                "--context-length",
+                str(self.context_length),
+                *self.extra_server_args,
+            )
+        return (
+            "vllm",
+            "serve",
+            self.local_model_path(),
+            "--served-model-name",
+            self.served_model_name,
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(self.port),
+            "--tensor-parallel-size",
+            str(self.tensor_parallel_size),
+            "--max-model-len",
+            str(self.context_length),
+            *self.extra_server_args,
+        )
+
+
+def build_recipe(
+    *,
+    framework: str,
+    framework_version: str,
+    image_reference: str,
+    model_revision: str,
+    gpu_type: str,
+    gpu_count: int,
+    context_length: int,
+    weights_mount_path: str,
+    port: int,
+    repo_id: str = SUPPORTED_REPO_ID,
+    served_model_name: str = SUPPORTED_REPO_ID,
+    tensor_parallel_size: int | None = None,
+    extra_server_args: tuple[str, ...] = (),
+    accept_mutable_image: bool = False,
+    facts: ModelFacts = GLM_53_FLASH,
+) -> ServingRecipe:
+    """Validate every field and assemble a recipe, or refuse.
+
+    ``tensor_parallel_size`` defaults to ``gpu_count`` because a
+    tensor-parallel degree below the number of allocated GPUs leaves
+    accelerators idle and billing, which is a costly default to get
+    wrong silently.
+    """
+    if framework not in SUPPORTED_FRAMEWORKS:
+        raise DeploymentPlanError(
+            f"framework must be one of {', '.join(SUPPORTED_FRAMEWORKS)}, "
+            f"got {framework!r}"
+        )
+    if not isinstance(framework_version, str) or not framework_version.strip():
+        raise DeploymentPlanError(
+            "framework_version must be stated so the record says which "
+            "build served the request"
+        )
+    if context_length < 1:
+        raise DeploymentPlanError("context_length must be at least 1")
+    if context_length > facts.max_position_embeddings:
+        raise DeploymentPlanError(
+            f"context_length {context_length} exceeds the model's "
+            f"max_position_embeddings {facts.max_position_embeddings}"
+        )
+    if not (1 <= port <= 65535):
+        raise DeploymentPlanError(f"port must be in 1..65535, got {port}")
+    if not weights_mount_path.startswith("/"):
+        raise DeploymentPlanError("weights_mount_path must be an absolute path")
+
+    parallel = gpu_count if tensor_parallel_size is None else tensor_parallel_size
+    if parallel < 1:
+        raise DeploymentPlanError("tensor_parallel_size must be at least 1")
+    if parallel > gpu_count:
+        raise DeploymentPlanError(
+            f"tensor_parallel_size {parallel} exceeds gpu_count {gpu_count}"
+        )
+
+    return ServingRecipe(
+        framework=framework,
+        framework_version=framework_version.strip(),
+        image=parse_image_reference(
+            image_reference, accept_mutable=accept_mutable_image
+        ),
+        model_repo_id=require_supported_repo(repo_id),
+        model_revision=require_model_revision(model_revision),
+        facts=facts,
+        gpu_type=gpu_type.strip(),
+        gpu_count=gpu_count,
+        tensor_parallel_size=parallel,
+        context_length=context_length,
+        served_model_name=served_model_name,
+        port=port,
+        weights_mount_path=weights_mount_path,
+        extra_server_args=tuple(extra_server_args),
+    )

--- a/llmtracefx/deploy/resources.py
+++ b/llmtracefx/deploy/resources.py
@@ -1,0 +1,41 @@
+"""The container shapes the harness actually asks Modal for.
+
+These live in one module because two different things need to agree on
+them and the cost of disagreement is a wrong number rather than an
+error: the Modal entrypoint requests these resources, and the budget
+prices them. If the entrypoint asked for sixteen cores while the
+envelope priced eight, the plan would approve a deployment that costs
+more than it said, and nothing would fail until the invoice.
+
+Every value here is therefore imported by both sides. None of them is
+configurable, because a knob that changes what is billed without
+changing what is priced is the same bug with more steps.
+"""
+
+from __future__ import annotations
+
+# The staging container. CPU and network only; sized for parallel
+# downloads of a few hundred GiB rather than for compute.
+STAGING_CPU_CORES = 8.0
+STAGING_MEMORY_GIB = 32.0
+STAGING_TIMEOUT_SECONDS = 6 * 60 * 60
+
+# The verification container. Reads the staged tree back and hashes it,
+# so it wants throughput rather than cores.
+VERIFY_CPU_CORES = 4.0
+VERIFY_MEMORY_GIB = 16.0
+VERIFY_TIMEOUT_SECONDS = 6 * 60 * 60
+
+# The serving container, alongside its accelerators. Requested
+# explicitly rather than left to the platform default, because a default
+# is a number nobody wrote down and therefore a number the envelope
+# cannot price.
+SERVING_CPU_CORES = 16.0
+SERVING_MEMORY_GIB = 64.0
+
+# Modal bills volume storage for a period after deletion:
+# "When you delete data, you may still be billed for that storage for up
+# to four days" (https://modal.com/docs/guide/volumes, read 2026-08-30).
+# The worst case adds this to whatever retention the operator declares,
+# because it is charged whether or not they remember it.
+POST_DELETE_BILLING_DAYS = 4.0

--- a/llmtracefx/requirements.txt
+++ b/llmtracefx/requirements.txt
@@ -5,5 +5,4 @@ plotly==5.17.0
 pandas==2.1.3
 numpy==1.25.2
 python-multipart==0.0.32
-modal==0.57.0
 streamlit>=1.28.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,25 @@ dependencies = [
     "pandas>=2.1.3",
     "numpy>=1.25.2",
     "python-multipart>=0.0.6",
-    "modal>=0.57.0",
     "streamlit>=1.28.0",
 ]
 
 [project.optional-dependencies]
+# Modal is an optional extra, not a runtime dependency. Nothing in the
+# library imports it at module scope: `llmtracefx.api.serve` guards its
+# import, and the deployment planner (`llmtracefx.deploy`) is pure Python
+# so `llmtracefx-deploy plan` and the whole test suite run with Modal
+# absent. Only the `modal run`/`modal deploy` entrypoints need it.
+#
+# The floor is 1.0.5 because that is the version whose API surface the
+# GLM entrypoint was written against: `@modal.web_server`,
+# `@modal.concurrent`, and the `max_containers`/`min_containers`/
+# `scaledown_window` parameters. The newer `@app.server()` decorator does
+# not exist at this floor and is deliberately not used.
+modal = [
+    "modal>=1.0.5",
+]
+
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -78,6 +92,7 @@ llmtracefx = "llmtracefx.main:main"
 llmtracefx-serve = "llmtracefx.api.serve:main"
 llmtracefx-dashboard = "llmtracefx.realtime_dashboard:main"
 llmtracefx-optimizer = "llmtracefx.optimizer.cli:main"
+llmtracefx-deploy = "llmtracefx.deploy.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -136,10 +151,21 @@ module = [
     "pandas.*",
     "numpy.*",
     "modal.*",
+    "huggingface_hub.*",
     "uvicorn.*",
     "streamlit.*",
 ]
 ignore_missing_imports = true
+
+# The Modal entrypoint is decorated by an optional dependency. When the
+# `modal` extra is not installed the decorators resolve to Any, which
+# `disallow_untyped_decorators` reports on every decorated function. That
+# check cannot say anything useful about a module whose decorators come
+# from a package the type checker was not given, and the rest of the
+# strict settings still apply here.
+[[tool.mypy.overrides]]
+module = ["llmtracefx.deploy.modal_glm_app"]
+disallow_untyped_decorators = false
 
 # Pytest configuration
 [tool.pytest.ini_options]

--- a/tests/deploy/_fakes.py
+++ b/tests/deploy/_fakes.py
@@ -1,0 +1,237 @@
+"""Fakes and fixtures shared by the deployment tests.
+
+The point of the fake Modal module is to let the real entrypoint be
+imported and inspected without the Modal SDK, without authentication and
+without a network. What the entrypoint decides at import (how many GPUs,
+what timeout, whether the staging function gets an accelerator at all) is
+exactly what has to be asserted, and those decisions are only observable
+by watching the decorators receive them.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any
+
+VALID_REVISION = "0123456789abcdef0123456789abcdef01234567"
+OTHER_REVISION = "fedcba9876543210fedcba9876543210fedcba98"
+VALID_DIGEST = "sha256:" + "a" * 64
+PINNED_IMAGE = f"lmsysorg/sglang:v0.5.6@{VALID_DIGEST}"
+TAG_ONLY_IMAGE = "lmsysorg/sglang:v0.5.6"
+
+
+def valid_environ(**overrides: str) -> dict[str, str]:
+    """A complete, approvable deployment environment.
+
+    Sized so the worst case lands under the budget with room for the
+    CPU, memory and storage terms as well as the accelerators.
+    """
+    environ = {
+        "LLMTRACEFX_GLM_MAX_USD": "40.00",
+        "LLMTRACEFX_GLM_GPU_TYPE": "H200",
+        "LLMTRACEFX_GLM_GPU_COUNT": "4",
+        "LLMTRACEFX_GLM_MAX_RUNTIME_SECONDS": "1800",
+        "LLMTRACEFX_GLM_MAX_DEPLOYMENT_SECONDS": "3600",
+        "LLMTRACEFX_GLM_USD_PER_GPU_HOUR": "1.00",
+        "LLMTRACEFX_GLM_USD_PER_CPU_CORE_HOUR": "0.01",
+        "LLMTRACEFX_GLM_USD_PER_GIB_MEMORY_HOUR": "0.005",
+        "LLMTRACEFX_GLM_STORAGE_USD_PER_GIB_MONTH": "0.02",
+        "LLMTRACEFX_GLM_STORAGE_RETENTION_DAYS": "1",
+        "LLMTRACEFX_GLM_PRICE_EFFECTIVE_DATE": "2026-08-01",
+        "LLMTRACEFX_GLM_PRICE_SOURCE": "https://modal.com/pricing",
+        "LLMTRACEFX_GLM_MODEL_REVISION": VALID_REVISION,
+        "LLMTRACEFX_GLM_IMAGE": PINNED_IMAGE,
+        "LLMTRACEFX_GLM_FRAMEWORK_VERSION": "0.5.6",
+        "LLMTRACEFX_GLM_CONTEXT_LENGTH": "131072",
+        "LLMTRACEFX_GLM_STARTUP_TIMEOUT_SECONDS": "900",
+        "LLMTRACEFX_GLM_AS_OF": "2026-08-30",
+    }
+    environ.update(overrides)
+    return environ
+
+
+class FakeImage:
+    """Records the chained image builder calls without building anything."""
+
+    def __init__(self, label: str, **kwargs: Any) -> None:
+        self.label = label
+        self.kwargs = kwargs
+        self.pip_packages: list[str] = []
+        self.env_vars: dict[str, str] = {}
+        self.local_dirs: list[tuple[str, str]] = []
+
+    def pip_install(self, *packages: str, **_: Any) -> FakeImage:
+        self.pip_packages.extend(packages)
+        return self
+
+    def env(self, mapping: Mapping[str, str]) -> FakeImage:
+        self.env_vars.update(mapping)
+        return self
+
+    def add_local_dir(
+        self, local_path: str, *, remote_path: str, **_: Any
+    ) -> FakeImage:
+        self.local_dirs.append((local_path, remote_path))
+        return self
+
+
+class FakeVolume:
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self.kwargs = kwargs
+        self.commits = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeSecret:
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        self.name = name
+        self.required_keys = tuple(kwargs.get("required_keys", ()))
+
+
+class FakeRegistration:
+    """One decorated function and every decorator argument it received."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.function_kwargs: dict[str, Any] = {}
+        self.concurrent_kwargs: dict[str, Any] = {}
+        self.web_server_args: tuple[Any, ...] = ()
+        self.web_server_kwargs: dict[str, Any] = {}
+
+
+class FakeApp:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.registrations: dict[str, FakeRegistration] = {}
+
+    def _registration(self, func: Any) -> FakeRegistration:
+        name = getattr(func, "_fake_name", None) or func.__name__
+        return self.registrations.setdefault(name, FakeRegistration(name))
+
+    def function(self, **kwargs: Any) -> Any:
+        def decorator(func: Any) -> Any:
+            registration = self._registration(func)
+            registration.function_kwargs = kwargs
+            func._fake_name = registration.name
+            return func
+
+        return decorator
+
+
+def build_fake_modal() -> types.ModuleType:
+    """A stand-in ``modal`` module with just the surface the app uses."""
+    module = types.ModuleType("modal")
+    apps: list[FakeApp] = []
+    images: list[FakeImage] = []
+    volumes: list[FakeVolume] = []
+    secrets: list[FakeSecret] = []
+
+    def make_app(name: str) -> FakeApp:
+        app = FakeApp(name)
+        apps.append(app)
+        return app
+
+    class Image:
+        @staticmethod
+        def debian_slim(**kwargs: Any) -> FakeImage:
+            image = FakeImage("debian_slim", **kwargs)
+            images.append(image)
+            return image
+
+        @staticmethod
+        def from_registry(tag: str, **kwargs: Any) -> FakeImage:
+            image = FakeImage("from_registry", tag=tag, **kwargs)
+            images.append(image)
+            return image
+
+    class Volume:
+        @staticmethod
+        def from_name(name: str, **kwargs: Any) -> FakeVolume:
+            volume = FakeVolume(name, **kwargs)
+            volumes.append(volume)
+            return volume
+
+    class Secret:
+        @staticmethod
+        def from_name(name: str, **kwargs: Any) -> FakeSecret:
+            secret = FakeSecret(name, **kwargs)
+            secrets.append(secret)
+            return secret
+
+    def concurrent(**kwargs: Any) -> Any:
+        def decorator(func: Any) -> Any:
+            name = getattr(func, "_fake_name", None) or func.__name__
+            for app in apps:
+                app.registrations.setdefault(name, FakeRegistration(name))
+                app.registrations[name].concurrent_kwargs = kwargs
+            func._fake_name = name
+            return func
+
+        return decorator
+
+    def web_server(*args: Any, **kwargs: Any) -> Any:
+        def decorator(func: Any) -> Any:
+            name = getattr(func, "_fake_name", None) or func.__name__
+            for app in apps:
+                app.registrations.setdefault(name, FakeRegistration(name))
+                app.registrations[name].web_server_args = args
+                app.registrations[name].web_server_kwargs = kwargs
+            func._fake_name = name
+            return func
+
+        return decorator
+
+    module.App = make_app  # type: ignore[attr-defined]
+    module.Image = Image  # type: ignore[attr-defined]
+    module.Volume = Volume  # type: ignore[attr-defined]
+    module.Secret = Secret  # type: ignore[attr-defined]
+    module.concurrent = concurrent  # type: ignore[attr-defined]
+    module.web_server = web_server  # type: ignore[attr-defined]
+    module.__version__ = "1.0.5-fake"  # type: ignore[attr-defined]
+    module._fake_apps = apps  # type: ignore[attr-defined]
+    module._fake_images = images  # type: ignore[attr-defined]
+    module._fake_volumes = volumes  # type: ignore[attr-defined]
+    module._fake_secrets = secrets  # type: ignore[attr-defined]
+    return module
+
+
+APP_MODULE = "llmtracefx.deploy.modal_glm_app"
+
+
+@contextmanager
+def imported_app(environ: Mapping[str, str]) -> Iterator[tuple[Any, types.ModuleType]]:
+    """Import the Modal entrypoint against a fake SDK and a given environment.
+
+    Both the fake module and the imported entrypoint are removed
+    afterwards so one test cannot observe another's registrations, and so
+    a real ``modal`` install (or its absence) is irrelevant to the result.
+    """
+    import importlib
+    import os
+
+    fake = build_fake_modal()
+    saved_modal = sys.modules.get("modal")
+    saved_app = sys.modules.pop(APP_MODULE, None)
+    saved_environ = dict(os.environ)
+    sys.modules["modal"] = fake
+    os.environ.clear()
+    os.environ.update(environ)
+    try:
+        module = importlib.import_module(APP_MODULE)
+        yield module, fake
+    finally:
+        sys.modules.pop(APP_MODULE, None)
+        if saved_app is not None:
+            sys.modules[APP_MODULE] = saved_app
+        if saved_modal is not None:
+            sys.modules["modal"] = saved_modal
+        else:
+            sys.modules.pop("modal", None)
+        os.environ.clear()
+        os.environ.update(saved_environ)

--- a/tests/deploy/test_budget.py
+++ b/tests/deploy/test_budget.py
@@ -1,0 +1,331 @@
+"""Budget arithmetic, and the ways it is allowed to refuse."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from llmtracefx.deploy.budget import (
+    MAX_CONTAINERS_CEILING,
+    MAX_GPU_COUNT_CEILING,
+    MAX_RUNTIME_SECONDS_CEILING,
+    BudgetRequest,
+    assert_within_budget,
+    evaluate_budget,
+    recommended_session_budget_usd,
+)
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.pricing import ComputeQuote, GpuPriceQuote, StorageQuote
+
+
+def quote(rate: float = 1.0, gpu_type: str = "H200") -> GpuPriceQuote:
+    return GpuPriceQuote(
+        gpu_type=gpu_type,
+        usd_per_gpu_hour=rate,
+        effective_date="2026-08-01",
+        source="https://modal.com/pricing",
+    )
+
+
+def compute(cpu: float = 0.0, memory: float = 0.0) -> ComputeQuote:
+    """Zero-cost by default so a test can isolate one term at a time.
+
+    A rate of exactly zero is refused, so the defaults are the smallest
+    positive value that still rounds away in the assertions below.
+    """
+    return ComputeQuote(
+        usd_per_cpu_core_hour=cpu or 1e-9,
+        usd_per_gib_memory_hour=memory or 1e-9,
+        effective_date="2026-08-01",
+        source="https://modal.com/pricing",
+    )
+
+
+def storage_quote(rate: float = 1e-9) -> StorageQuote:
+    return StorageQuote(
+        usd_per_gib_month=rate,
+        effective_date="2026-08-01",
+        source="https://modal.com/pricing",
+    )
+
+
+def request(**overrides: object) -> BudgetRequest:
+    kwargs: dict[str, object] = {
+        "max_usd": 10.0,
+        "gpu_type": "H200",
+        "gpu_count": 4,
+        "max_runtime_seconds": 1800,
+        "deployment_seconds": 1800,
+        "price": quote(),
+        "compute": compute(),
+        "storage": storage_quote(),
+        "stored_gib": 306.0,
+        "storage_retention_days": 0.0,
+    }
+    kwargs.update(overrides)
+    return BudgetRequest(**kwargs)  # type: ignore[arg-type]
+
+
+def test_accelerators_are_priced_against_the_deployment_window() -> None:
+    """One container timeout is added to the window on purpose.
+
+    A container that starts a second before the expiry still runs its
+    whole lifetime afterwards, so a bound that stopped at the expiry
+    would be beatable by a single well-timed request.
+    """
+    envelope = evaluate_budget(
+        request(max_runtime_seconds=3600, deployment_seconds=7200, gpu_count=4)
+    )
+    assert envelope.billable_seconds == 7200 + 3600
+    gpu = next(line for line in envelope.lines if line.name == "serving-gpu")
+    assert gpu.hours == pytest.approx(3.0)
+    assert gpu.usd == pytest.approx(12.0)
+    assert envelope.gpu_worst_case_usd == pytest.approx(12.0)
+
+
+def test_every_mandatory_resource_appears_in_the_total() -> None:
+    """Each line must contribute, and the total must be their sum.
+
+    Deliberately priced with rates large enough that dropping any one
+    line moves the total well outside tolerance. The earlier version of
+    this test used the near-zero default rates, so removing the CPU-only
+    containers from the sum changed nothing it could measure and the
+    assertion passed against a total that was missing them.
+    """
+    envelope = evaluate_budget(
+        request(
+            compute=compute(cpu=0.5, memory=0.25),
+            storage=storage_quote(0.5),
+            max_usd=10_000.0,
+        )
+    )
+    names = [line.name for line in envelope.lines]
+    assert names == [
+        "serving-gpu",
+        "serving-compute",
+        "staging",
+        "verification",
+        "storage",
+    ]
+    for line in envelope.lines:
+        assert line.usd > 1.0, f"{line.name} contributes nothing measurable"
+    assert envelope.worst_case_usd == pytest.approx(
+        sum(line.usd for line in envelope.lines)
+    )
+    # Dropping any single line has to be detectable in the total.
+    for line in envelope.lines:
+        assert envelope.worst_case_usd - line.usd != pytest.approx(
+            envelope.worst_case_usd
+        )
+
+
+def test_the_cpu_only_containers_are_a_material_part_of_the_total() -> None:
+    """Staging and verification are not rounding error.
+
+    They have no accelerator, which is exactly why an earlier version of
+    the cost model left them out entirely.
+    """
+    envelope = evaluate_budget(
+        request(compute=compute(cpu=0.5, memory=0.25), max_usd=10_000.0)
+    )
+    cpu_only = sum(
+        line.usd for line in envelope.lines if line.name in {"staging", "verification"}
+    )
+    assert cpu_only > 0
+    assert envelope.worst_case_usd - cpu_only == pytest.approx(
+        sum(
+            line.usd
+            for line in envelope.lines
+            if line.name not in {"staging", "verification"}
+        )
+    )
+
+
+def test_cpu_and_memory_bill_on_the_cpu_only_containers_too() -> None:
+    """Staging and verification have no accelerator and still cost money."""
+    free = evaluate_budget(request())
+    priced = evaluate_budget(request(compute=compute(cpu=1.0, memory=0.5)))
+    for name in ("staging", "verification"):
+        before = next(line for line in free.lines if line.name == name).usd
+        after = next(line for line in priced.lines if line.name == name).usd
+        assert after > before
+    assert priced.worst_case_usd > free.worst_case_usd
+
+
+def test_storage_is_billed_past_deletion() -> None:
+    envelope = evaluate_budget(
+        request(
+            storage=storage_quote(1.0), stored_gib=300.0, storage_retention_days=6.0
+        )
+    )
+    assert envelope.storage_billed_days == pytest.approx(10.0)
+    storage = next(line for line in envelope.lines if line.name == "storage")
+    # 300 GiB at $1/GiB-month for ten of a thirty day month.
+    assert storage.usd == pytest.approx(100.0)
+    assert any("after deletion" in note for note in envelope.notes) or any(
+        "after deletion" in line.detail for line in envelope.lines
+    )
+
+
+def test_extra_containers_multiply_the_worst_case() -> None:
+    one = evaluate_budget(request(max_containers=1))
+    three = evaluate_budget(request(max_containers=3, max_usd=100.0))
+    assert three.gpu_worst_case_usd == pytest.approx(one.gpu_worst_case_usd * 3)
+    assert any("max_containers is 3" in note for note in three.notes)
+
+
+def test_over_budget_is_reported_and_then_refused() -> None:
+    envelope = evaluate_budget(
+        request(max_usd=1.0, max_runtime_seconds=3600, deployment_seconds=3600)
+    )
+    assert envelope.within_budget is False
+    assert envelope.headroom_usd < 0
+    with pytest.raises(DeploymentPlanError, match="exceeds the authorised budget"):
+        assert_within_budget(envelope)
+
+
+def test_exactly_on_budget_is_allowed() -> None:
+    """The boundary is inclusive, and compared before rounding."""
+    envelope = evaluate_budget(request())
+    on_the_nose = evaluate_budget(request(max_usd=envelope.worst_case_usd))
+    assert on_the_nose.within_budget is True
+    assert on_the_nose.headroom_usd == pytest.approx(0.0)
+    assert_within_budget(on_the_nose)
+
+    just_under = evaluate_budget(request(max_usd=envelope.worst_case_usd * 0.999999))
+    assert just_under.within_budget is False
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_budget_is_refused(bad: float) -> None:
+    with pytest.raises(DeploymentPlanError, match="finite"):
+        request(max_usd=bad)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_non_finite_price_is_refused(bad: float) -> None:
+    with pytest.raises(DeploymentPlanError, match="finite"):
+        quote(rate=bad)
+
+
+def test_nan_budget_cannot_slip_through_as_within_budget() -> None:
+    """A NaN compares False against everything, which reads as 'fine'.
+
+    The guard has to be at construction, because by the time the
+    comparison happens a NaN looks exactly like an over-budget plan that
+    somehow passed.
+    """
+    with pytest.raises(DeploymentPlanError):
+        request(max_usd=math.nan)
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_non_positive_budget_is_refused(bad: float) -> None:
+    with pytest.raises(DeploymentPlanError, match="greater than zero"):
+        request(max_usd=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1, MAX_GPU_COUNT_CEILING + 1])
+def test_gpu_count_bounds(bad: int) -> None:
+    with pytest.raises(DeploymentPlanError, match="gpu_count"):
+        request(gpu_count=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1, MAX_RUNTIME_SECONDS_CEILING + 1])
+def test_runtime_bounds(bad: int) -> None:
+    with pytest.raises(DeploymentPlanError, match="max_runtime_seconds"):
+        request(max_runtime_seconds=bad)
+
+
+def test_booleans_are_not_accepted_as_counts() -> None:
+    with pytest.raises(DeploymentPlanError, match="integer"):
+        request(gpu_count=True)
+
+
+def test_price_for_a_different_gpu_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="price the GPU you are booking"):
+        request(gpu_type="H200", price=quote(gpu_type="H100"))
+
+
+def test_storage_size_and_retention_are_validated() -> None:
+    with pytest.raises(DeploymentPlanError, match="stored_gib"):
+        request(stored_gib=0.0)
+    with pytest.raises(DeploymentPlanError, match="storage_retention_days"):
+        request(storage_retention_days=-1.0)
+    with pytest.raises(DeploymentPlanError, match="storage_retention_days"):
+        request(storage_retention_days=10_000.0)
+
+
+def test_a_deployment_window_shorter_than_a_container_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="shorter than"):
+        request(max_runtime_seconds=3600, deployment_seconds=1800)
+
+
+def test_envelope_records_every_input_needed_to_recheck_it() -> None:
+    payload = evaluate_budget(request()).to_dict()
+    for field in (
+        "gpu_type",
+        "gpu_count",
+        "max_containers",
+        "max_runtime_seconds",
+        "usd_per_gpu_hour",
+        "price_effective_date",
+        "price_source",
+        "worst_case_usd",
+        "budget_usd",
+    ):
+        assert payload[field] is not None, field
+
+
+def test_recommended_budget_holds_two_thirds_in_reserve() -> None:
+    assert recommended_session_budget_usd(30.0) == pytest.approx(10.0)
+    assert recommended_session_budget_usd(30.0) < 30.0
+
+
+def test_recommended_budget_rounds_down_so_it_never_exceeds_its_fraction() -> None:
+    assert recommended_session_budget_usd(10.0) == pytest.approx(3.33)
+
+
+@pytest.mark.parametrize("bad", [0.0, -5.0, float("nan")])
+def test_recommended_budget_refuses_nonsense_credit(bad: float) -> None:
+    with pytest.raises(DeploymentPlanError):
+        recommended_session_budget_usd(bad)
+
+
+def test_container_count_is_capped_so_the_product_cannot_overflow() -> None:
+    """A large integer count overflows on int-to-float conversion.
+
+    Without a ceiling the multiplication raises OverflowError before the
+    finiteness guard can turn it into a refusal, so the guard's own
+    advice to reduce max_containers could never be reached for the input
+    it names.
+    """
+    with pytest.raises(DeploymentPlanError, match="max_containers"):
+        request(max_containers=10**308)
+    with pytest.raises(DeploymentPlanError, match="max_containers"):
+        request(max_containers=MAX_CONTAINERS_CEILING + 1)
+
+
+def test_the_finiteness_guard_is_reachable_for_an_overflowing_product() -> None:
+    """Every accepted input must still be priced without raising."""
+    envelope = evaluate_budget(
+        request(
+            max_containers=MAX_CONTAINERS_CEILING,
+            max_runtime_seconds=MAX_RUNTIME_SECONDS_CEILING,
+            deployment_seconds=MAX_RUNTIME_SECONDS_CEILING,
+            max_usd=1e12,
+        )
+    )
+    assert math.isfinite(envelope.worst_case_usd)
+
+
+def test_a_credit_too_large_to_scale_is_refused_not_raised() -> None:
+    """The input being finite does not make the scaled value finite.
+
+    `math.floor` raises on an infinity rather than returning one, so the
+    guard has to sit on the product, exactly as it does for the
+    worst-case cost.
+    """
+    with pytest.raises(DeploymentPlanError, match="too large"):
+        recommended_session_budget_usd(1e307)

--- a/tests/deploy/test_commands.py
+++ b/tests/deploy/test_commands.py
@@ -1,0 +1,155 @@
+"""Generated commands, and what they are allowed to contain."""
+
+from __future__ import annotations
+
+import json
+import shlex
+
+import pytest
+from _fakes import VALID_REVISION
+
+from llmtracefx.deploy import commands
+from llmtracefx.deploy.commands import EnvRef
+from llmtracefx.deploy.endpoint import EndpointConfig, collector_argv
+from llmtracefx.deploy.errors import DeploymentPlanError
+
+ENDPOINT = EndpointConfig(base_url="https://ws--app-serve.modal.run")
+
+
+def test_staging_states_the_revision_twice() -> None:
+    step = commands.stage_weights_step(revision=VALID_REVISION, volume_name="vol")
+    argv = step.argv
+    assert argv[argv.index("--revision") + 1] == VALID_REVISION
+    assert argv[argv.index("--confirm") + 1] == VALID_REVISION
+    assert "stage_weights" in argv[2]
+
+
+def test_staging_never_requests_an_accelerator_on_the_command_line() -> None:
+    step = commands.stage_weights_step(revision=VALID_REVISION, volume_name="vol")
+    joined = " ".join(step.argv).casefold()
+    assert "gpu" not in joined
+    assert any("No GPU is attached" in note for note in step.notes)
+
+
+def test_secret_creation_references_a_variable_and_not_a_value() -> None:
+    step = commands.secret_step(ENDPOINT)
+    assignment = step.argv[-1]
+    assert isinstance(assignment, EnvRef)
+    assert assignment.display() == "GLM_SELFHOST_API_KEY=$GLM_SELFHOST_API_KEY"
+    assert step.rendered().endswith('"GLM_SELFHOST_API_KEY=${GLM_SELFHOST_API_KEY}"')
+    assert step.spends_money is False
+
+
+def test_probes_pass_the_key_by_shell_reference() -> None:
+    header = next(
+        token
+        for token in commands.readiness_step(ENDPOINT).argv
+        if isinstance(token, EnvRef)
+    )
+    assert header.display() == "Authorization: Bearer $GLM_SELFHOST_API_KEY"
+    assert header.rendered() == '"Authorization: Bearer ${GLM_SELFHOST_API_KEY}"'
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "app; rm -rf /",
+        "app$(id)",
+        "app`id`",
+        "app|cat /etc/passwd",
+        "app > /tmp/pwned",
+        "app && curl evil.example",
+        "app'''; id; '''",
+        'app"; id; "',
+        "app\nid",
+    ],
+)
+def test_a_hostile_name_cannot_escape_the_rendered_command(hostile: str) -> None:
+    """The rendered line is what an operator pastes into a shell.
+
+    Quoting only tokens containing whitespace left ``;``, ``|``, ``$()``
+    and backticks bare, so a name chosen by whoever supplied the plan
+    executed on paste. Every literal token is quoted now.
+    """
+    rendered = commands.stop_step(app_name=hostile).rendered()
+    assert shlex.split(rendered) == ["modal", "app", "stop", hostile]
+
+    rendered = commands.delete_volume_step(volume_name=hostile).rendered()
+    assert shlex.split(rendered) == ["modal", "volume", "delete", hostile]
+
+
+def test_a_hostile_endpoint_url_cannot_escape_either() -> None:
+    endpoint = EndpointConfig(base_url="https://ws--app-serve.modal.run")
+    step = commands.smoke_step(endpoint=endpoint, max_output_tokens=8)
+    # shlex round-trips it, so nothing in the payload is a shell operator.
+    assert shlex.split(step.rendered())[-1] == endpoint.chat_completions_url
+
+
+def test_smoke_request_is_bounded() -> None:
+    step = commands.smoke_step(endpoint=ENDPOINT, max_output_tokens=16)
+    payload = step.argv[step.argv.index("-d") + 1]
+    assert '"max_tokens":16' in payload
+    assert '"stream":false' in payload
+    assert "--max-time" in step.argv
+
+
+def test_smoke_request_rejects_an_unbounded_token_budget() -> None:
+    with pytest.raises(DeploymentPlanError, match="at least 1"):
+        commands.smoke_step(endpoint=ENDPOINT, max_output_tokens=0)
+
+
+def test_teardown_steps_cannot_spend() -> None:
+    assert commands.stop_step(app_name="app").spends_money is False
+    assert commands.delete_volume_step(volume_name="vol").spends_money is False
+
+
+def test_steps_declare_whether_they_can_spend() -> None:
+    assert commands.setup_step().spends_money is False
+    assert commands.volume_step("vol").spends_money is False
+    assert commands.deploy_step().spends_money is True
+    assert (
+        commands.stage_weights_step(
+            revision=VALID_REVISION, volume_name="vol"
+        ).spends_money
+        is True
+    )
+
+
+def test_rendering_round_trips_through_a_shell_lexer() -> None:
+    step = commands.smoke_step(endpoint=ENDPOINT, max_output_tokens=8)
+    tokens = shlex.split(step.rendered())
+    assert tokens[0] == "curl"
+    payload = json.loads(tokens[tokens.index("-d") + 1])
+    assert payload["max_tokens"] == 8
+
+
+def test_collector_command_names_the_variable_holding_the_key() -> None:
+    argv = collector_argv(
+        endpoint=ENDPOINT,
+        run_id="smoke",
+        prompt_file="prompts/smoke.txt",
+        output_dir="output/smoke",
+        model_revision=VALID_REVISION,
+    )
+    assert argv[:2] == ("llmtracefx-optimizer", "collect-api")
+    assert argv[argv.index("--api-key-env") + 1] == "GLM_SELFHOST_API_KEY"
+    assert argv[argv.index("--model-revision") + 1] == VALID_REVISION
+    assert "--api-key" not in argv
+
+
+def test_collector_targets_the_chat_completions_path() -> None:
+    argv = collector_argv(
+        endpoint=ENDPOINT,
+        run_id="smoke",
+        prompt_file="p.txt",
+        output_dir="out",
+    )
+    endpoint = argv[argv.index("--endpoint") + 1]
+    assert endpoint == "https://ws--app-serve.modal.run/v1/chat/completions"
+
+
+def test_collector_refuses_an_empty_run_id() -> None:
+    with pytest.raises(DeploymentPlanError, match="run_id"):
+        collector_argv(
+            endpoint=ENDPOINT, run_id="  ", prompt_file="p.txt", output_dir="out"
+        )

--- a/tests/deploy/test_deploy_cli.py
+++ b/tests/deploy/test_deploy_cli.py
@@ -1,0 +1,421 @@
+"""The ``deploy`` CLI: exit codes, artifacts, and what it refuses to touch."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+from _fakes import PINNED_IMAGE, TAG_ONLY_IMAGE, VALID_REVISION
+
+from llmtracefx.deploy.cli import main
+
+BASE_ARGS = [
+    "plan",
+    "--gpu-type",
+    "H200",
+    "--gpu-count",
+    "4",
+    "--max-runtime-seconds",
+    "1800",
+    "--max-deployment-seconds",
+    "3600",
+    "--usd-per-cpu-core-hour",
+    "0.01",
+    "--usd-per-gib-memory-hour",
+    "0.005",
+    "--storage-usd-per-gib-month",
+    "0.02",
+    "--storage-retention-days",
+    "1",
+    "--price-effective-date",
+    "2026-08-01",
+    "--price-source",
+    "https://modal.com/pricing",
+    "--model-revision",
+    VALID_REVISION,
+    "--image",
+    PINNED_IMAGE,
+    "--framework-version",
+    "0.5.6",
+    "--context-length",
+    "131072",
+    "--startup-timeout-seconds",
+    "900",
+    "--as-of",
+    "2026-08-30",
+]
+
+
+def plan_args(*extra: str, max_usd: str = "40.00", rate: str = "1.00") -> list[str]:
+    return [*BASE_ARGS, "--max-usd", max_usd, "--usd-per-gpu-hour", rate, *extra]
+
+
+def run(argv: list[str]) -> int:
+    with pytest.raises(SystemExit) as excinfo:
+        main(argv)
+    return int(excinfo.value.code or 0)
+
+
+def test_a_sound_plan_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(plan_args()) == 0
+    assert "Deployment plan: APPROVED" in capsys.readouterr().out
+
+
+def test_an_over_budget_plan_exits_non_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(plan_args(max_usd="1.00", rate="10.00")) == 1
+    captured = capsys.readouterr()
+    assert "Deployment plan: REFUSED" in captured.out
+    assert "no paid step may be run" in captured.err
+
+
+def test_refusal_marks_the_paid_steps_as_withheld(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run(plan_args("--format", "json", max_usd="1.00", rate="10.00"))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["approved"] is False
+    assert "deploy" not in payload["executable_steps"]
+    assert "stop" in payload["executable_steps"]
+
+
+@pytest.mark.parametrize(
+    "omit",
+    [
+        "--max-usd",
+        "--gpu-type",
+        "--gpu-count",
+        "--max-runtime-seconds",
+        "--max-deployment-seconds",
+        "--usd-per-gpu-hour",
+        "--usd-per-cpu-core-hour",
+        "--usd-per-gib-memory-hour",
+        "--storage-usd-per-gib-month",
+        "--storage-retention-days",
+        "--price-effective-date",
+        "--price-source",
+        "--model-revision",
+        "--image",
+        "--framework-version",
+        "--context-length",
+    ],
+)
+def test_every_spending_and_pinning_flag_is_required(
+    omit: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    argv = plan_args()
+    index = argv.index(omit)
+    del argv[index : index + 2]
+    assert run(argv) == 2
+    assert omit in capsys.readouterr().err
+
+
+def test_the_plan_command_makes_no_network_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail loudly if planning ever grows a network dependency."""
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("planning must not open a socket")
+
+    monkeypatch.setattr(socket, "socket", forbidden)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+    assert run(plan_args()) == 0
+
+
+def test_the_plan_command_never_imports_the_modal_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, "modal", raising=False)
+    assert run(plan_args()) == 0
+    assert "modal" not in sys.modules
+
+
+def test_the_plan_command_does_not_read_modal_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A missing Modal config must be irrelevant to planning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    assert run(plan_args()) == 0
+
+
+def test_plan_json_can_be_written_atomically(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    destination = tmp_path / "nested" / "plan.json"
+    assert run(plan_args("--output", str(destination))) == 0
+    capsys.readouterr()
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    assert payload["kind"] == "llmtracefx.deploy.plan"
+    assert payload["approved"] is True
+    assert payload["gpu_allocated"] is False
+    assert not list(destination.parent.glob(".*tmp*"))
+
+
+def test_generated_commands_are_present_and_credential_free(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    destination = tmp_path / "plan.json"
+    run(plan_args("--output", str(destination)))
+    capsys.readouterr()
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    names = [step["name"] for step in payload["steps"]]
+    assert names == [
+        "setup",
+        "secret",
+        "volume",
+        "stage-weights",
+        "verify-weights",
+        "manifest",
+        "deploy",
+        "health",
+        "readiness",
+        "smoke",
+        "collect",
+        "stop",
+        "delete-volume",
+    ]
+    document = json.dumps(payload)
+    assert "--api-key " not in document
+    assert "Bearer $GLM_SELFHOST_API_KEY" in document
+
+
+def test_endpoint_url_is_substituted_once_it_is_known(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    destination = tmp_path / "plan.json"
+    run(
+        plan_args(
+            "--endpoint-base-url",
+            "https://ws--llmtracefx-glm53flash-serve.modal.run",
+            "--output",
+            str(destination),
+        )
+    )
+    capsys.readouterr()
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    assert payload["endpoint"]["resolved"] is True
+    collect = next(s for s in payload["steps"] if s["name"] == "collect")
+    assert (
+        "https://ws--llmtracefx-glm53flash-serve.modal.run/v1/chat/completions"
+        in collect["argv"]
+    )
+
+
+def test_an_http_endpoint_is_refused(capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(plan_args("--endpoint-base-url", "http://insecure.example")) == 1
+    assert "must use https" in capsys.readouterr().err
+
+
+def test_a_tag_only_image_needs_the_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    argv = plan_args()
+    argv[argv.index("--image") + 1] = TAG_ONLY_IMAGE
+    assert run(argv) == 1
+    assert "accept-mutable-image" in capsys.readouterr().err
+    assert run([*argv, "--accept-mutable-image"]) == 0
+
+
+def test_a_credential_flag_is_rejected_before_argparse_sees_its_value(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The existing credential guard covers the new subcommand too."""
+    secret = "sk-live-should-never-be-echoed"
+    with pytest.raises(SystemExit) as excinfo:
+        main([*plan_args(), "--api-key", secret])
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert secret not in captured.err + captured.out
+    # Not even the flag name is repeated, so there is nothing derived
+    # from the caller's argv in the diagnostic at all.
+    assert "--api-key" not in captured.err.replace("--api-key-env", "")
+    assert "--api-key-env" in captured.err
+
+
+def test_budget_command_recommends_a_reserve(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(["budget", "--credit-usd", "30", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommended_session_budget_usd"] == pytest.approx(10.0)
+    assert payload["reserve_usd"] == pytest.approx(20.0)
+
+
+def test_recipe_command_prints_the_pinned_facts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(["recipe", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repo_id"] == "zai-org/GLM-5.3-Flash"
+    assert payload["num_hidden_layers"] == 45
+
+
+def test_a_deployment_window_shorter_than_a_container_is_refused(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    argv = plan_args()
+    argv[argv.index("--max-deployment-seconds") + 1] = "600"
+    assert run(argv) == 1
+    assert "shorter than" in capsys.readouterr().err
+
+
+# A value that is not a plausible env var name, so any appearance of it in
+# output means a credential value escaped rather than a name being echoed.
+SENTINEL = "sk-live-SENTINEL-6f2b91c4e7a0d3"
+
+
+def _no_sentinel(*streams: str) -> None:
+    for stream in streams:
+        assert SENTINEL not in stream
+
+
+def test_success_path_never_emits_the_credential_value(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """The key is in the environment where the harness expects it to be."""
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    destination = tmp_path / "plan.json"
+    assert run(plan_args("--output", str(destination))) == 0
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err, destination.read_text(encoding="utf-8"))
+    assert "GLM_SELFHOST_API_KEY" in captured.out
+
+
+def test_json_format_never_emits_the_credential_value(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    assert run(plan_args("--format", "json")) == 0
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err)
+
+
+def test_refusal_path_never_emits_the_credential_value(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    assert run(plan_args(max_usd="1.00", rate="10.00")) == 1
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err)
+
+
+def test_validation_error_path_never_emits_the_credential_value(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An error message that genuinely quotes the offending value.
+
+    The image parser reports the reference it refused, so pasting the key
+    there puts it directly into the diagnostic. That is what makes this
+    test load-bearing: remove the scrub and it fails. A flag whose
+    validator never quotes its input would pass either way and prove
+    nothing.
+    """
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    argv = plan_args()
+    argv[argv.index("--image") + 1] = SENTINEL
+    assert run(argv) == 1
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err)
+    assert "neither a tag nor a digest" in captured.err
+
+
+def test_a_padded_variable_name_still_resolves_the_credential_to_scrub(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Padding must not silently disable the scrub.
+
+    `require_env_var_name` strips before validating, so a padded name is
+    accepted everywhere else and appears stripped in the plan. If the
+    lookup that resolves the value to scrub for used the raw argument it
+    would miss, return None, and turn the redaction into a no-op with
+    nothing in the output to indicate it.
+    """
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    assert (
+        run(
+            plan_args(
+                "--api-key-env",
+                "  GLM_SELFHOST_API_KEY  ",
+                "--price-source",
+                SENTINEL,
+            )
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err)
+    assert "GLM_SELFHOST_API_KEY" in captured.out
+
+
+def test_an_absurd_container_count_is_refused_not_raised(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A typo must produce a refusal, not a traceback.
+
+    Multiplying a very large integer container count reaches an
+    int-to-float conversion that raises OverflowError, which would escape
+    as a traceback on the one output path the design routes through the
+    scrub.
+    """
+    assert run(plan_args("--max-containers", str(10**308))) == 1
+    assert "max_containers" in capsys.readouterr().err
+
+
+def test_a_malformed_endpoint_host_is_refused_not_raised(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """urlsplit raises on a malformed bracketed host; that must be caught."""
+    assert run(plan_args("--endpoint-base-url", "https://[bad")) == 1
+    captured = capsys.readouterr()
+    assert "endpoint base URL" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_a_credential_pasted_where_a_secret_name_belongs_is_scrubbed(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A credential can be a well-formed Modal Secret name.
+
+    Shape validation cannot save us here: this sentinel is alphanumeric
+    with dashes and inside the length limit, so it passes as a name and
+    the plan is built. What keeps it out of the output is the scrub,
+    which compares the rendered document against the resolved value of
+    the variable the caller named. The plan is therefore approved and the
+    value still never appears.
+    """
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    assert run(plan_args("--modal-secret-name", SENTINEL)) == 0
+    captured = capsys.readouterr()
+    _no_sentinel(captured.out, captured.err)
+
+
+def test_the_plan_never_contains_a_bearer_value_only_a_variable_reference(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GLM_SELFHOST_API_KEY", SENTINEL)
+    destination = tmp_path / "plan.json"
+    run(plan_args("--output", str(destination)))
+    capsys.readouterr()
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    for step in payload["steps"]:
+        for token in step["argv"]:
+            assert SENTINEL not in token
+            if "Authorization" in token:
+                assert token.endswith("$GLM_SELFHOST_API_KEY")
+
+
+def test_budget_command_refuses_an_unscalable_credit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run(["budget", "--credit-usd", "1e307"]) == 1
+    captured = capsys.readouterr()
+    assert "too large" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/deploy/test_deploy_manifest.py
+++ b/tests/deploy/test_deploy_manifest.py
@@ -1,0 +1,264 @@
+"""Staging and server manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from _fakes import OTHER_REVISION, VALID_REVISION
+
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    OBSERVED,
+    ServerManifest,
+    StagedFile,
+    WeightStagingManifest,
+    WeightVerification,
+    present_env_var_names,
+    verify_staged_weights,
+)
+
+
+def staging(**overrides: object) -> WeightStagingManifest:
+    kwargs: dict[str, object] = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "completed_at": "2026-08-30T00:00:00+00:00",
+        "repo_id": "zai-org/GLM-5.3-Flash",
+        "revision": VALID_REVISION,
+        "mount_path": "/weights",
+        "files": (
+            StagedFile(path="config.json", size_bytes=4096),
+            StagedFile(
+                path="model-00001-of-00002.safetensors",
+                size_bytes=8 * 1024**3,
+                sha256="b" * 64,
+            ),
+        ),
+    }
+    kwargs.update(overrides)
+    return WeightStagingManifest(**kwargs)  # type: ignore[arg-type]
+
+
+def test_staging_manifest_totals_sizes_and_counts_published_hashes() -> None:
+    payload = staging().to_dict()
+    assert payload["file_count"] == 2
+    assert payload["total_bytes"] == 4096 + 8 * 1024**3
+    assert payload["hashed_file_count"] == 1
+    assert payload["total_gib"] == pytest.approx(8.0, abs=0.01)
+
+
+def test_a_file_without_a_published_hash_records_none_rather_than_a_guess() -> None:
+    entry = staging().files[0]
+    assert entry.sha256 is None
+
+
+def test_staging_manifest_round_trips() -> None:
+    original = staging()
+    restored = WeightStagingManifest.from_dict(json.loads(original.to_json()))
+    assert restored.revision == original.revision
+    assert restored.total_bytes == original.total_bytes
+    assert restored.files[1].sha256 == "b" * 64
+
+
+def test_a_manifest_for_another_revision_is_not_a_partial_match() -> None:
+    manifest = staging()
+    assert manifest.matches(repo_id="zai-org/GLM-5.3-Flash", revision=VALID_REVISION)
+    assert not manifest.matches(
+        repo_id="zai-org/GLM-5.3-Flash", revision=OTHER_REVISION
+    )
+    assert not manifest.matches(
+        repo_id="zai-org/GLM-5.3-Flash-BF16", revision=VALID_REVISION
+    )
+
+
+def test_malformed_manifests_are_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="malformed"):
+        WeightStagingManifest.from_dict({"revision": VALID_REVISION})
+
+
+@pytest.mark.parametrize("bad", [-1, True, "4096"])
+def test_file_sizes_must_be_non_negative_integers(bad: object) -> None:
+    with pytest.raises(DeploymentPlanError, match="size_bytes"):
+        StagedFile(path="x", size_bytes=bad)  # type: ignore[arg-type]
+
+
+def server(**overrides: object) -> ServerManifest:
+    kwargs: dict[str, object] = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "collected_at": "2026-08-30T00:00:00+00:00",
+        "app_name": "llmtracefx-glm53flash",
+        "gpu_type": "H200",
+        "gpu_count": 4,
+        "framework": "sglang",
+        "framework_version": "0.5.6",
+        "image_reference": "lmsysorg/sglang:v0.5.6@sha256:" + "a" * 64,
+        "image_digest": "sha256:" + "a" * 64,
+        "model_repo_id": "zai-org/GLM-5.3-Flash",
+        "model_revision": VALID_REVISION,
+        "quantization": "fp8",
+        "quantization_format": "e4m3",
+        "activation_scheme": "dynamic",
+        "tensor_parallel_size": 4,
+        "context_length": 131072,
+    }
+    kwargs.update(overrides)
+    return ServerManifest(**kwargs)  # type: ignore[arg-type]
+
+
+def test_server_manifest_captures_the_required_environment_facts() -> None:
+    payload = server(
+        observed_gpus=("NVIDIA H200", "NVIDIA H200"),
+        observed_cuda_version="12.9",
+        startup_seconds=612.5,
+    ).to_dict()
+    assert payload["gpu_type"] == "H200"
+    assert payload["gpu_count"] == 4
+    assert payload["framework_version"] == "0.5.6"
+    assert payload["model_revision"] == VALID_REVISION
+    assert payload["quantization"] == "fp8"
+    assert payload["tensor_parallel_size"] == 4
+    assert payload["expert_parallel_size"] is None
+    assert payload["context_length"] == 131072
+    assert payload["startup_seconds"] == pytest.approx(612.5)
+    assert payload["image_digest_pinned"] is True
+
+
+def test_observed_fields_are_distinguished_from_configured_ones() -> None:
+    provenance = server().to_dict()["provenance"]
+    assert provenance["gpu_count"] == "configured"
+    assert provenance["observed_gpus"] == OBSERVED
+    assert provenance["startup_seconds"] == OBSERVED
+
+
+def test_unobservable_values_stay_none_rather_than_being_invented() -> None:
+    payload = server().to_dict()
+    assert payload["observed_gpus"] == []
+    assert payload["observed_cuda_version"] is None
+    assert payload["startup_seconds"] is None
+
+
+def test_the_server_makes_no_performance_claim_about_itself() -> None:
+    claims = server().to_dict()["performance_claims"]
+    assert "None." in claims
+    assert "collector" in claims
+
+
+def test_environment_lookup_returns_names_and_never_values() -> None:
+    environ = {"GLM_SELFHOST_API_KEY": "sk-live-secret", "EMPTY": "  "}
+    assert present_env_var_names(environ, ["GLM_SELFHOST_API_KEY"]) == (
+        "GLM_SELFHOST_API_KEY",
+    )
+    assert present_env_var_names(environ, ["EMPTY"]) == ()
+    assert present_env_var_names(environ, ["ABSENT"]) == ()
+
+
+def test_no_credential_value_can_reach_a_server_manifest() -> None:
+    manifest = server(credential_env_var_names_present=("GLM_SELFHOST_API_KEY",))
+    document = manifest.to_json()
+    assert "GLM_SELFHOST_API_KEY" in document
+    assert "sk-" not in document
+
+
+def _write_tree(root: Path, files: dict[str, bytes]) -> None:
+    for name, payload in files.items():
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+
+
+def _manifest_for(
+    root: Path, files: dict[str, bytes], *, hashed: set[str]
+) -> WeightStagingManifest:
+    return WeightStagingManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        completed_at="2026-08-30T00:00:00+00:00",
+        repo_id="zai-org/GLM-5.3-Flash",
+        revision=VALID_REVISION,
+        mount_path=str(root),
+        files=tuple(
+            StagedFile(
+                path=name,
+                size_bytes=len(payload),
+                sha256=(
+                    hashlib.sha256(payload).hexdigest() if name in hashed else None
+                ),
+            )
+            for name, payload in files.items()
+        ),
+    )
+
+
+def _now() -> str:
+    return "2026-08-30T00:00:00+00:00"
+
+
+def test_a_complete_tree_verifies(tmp_path: Path) -> None:
+    files = {"config.json": b"{}", "shard-0.safetensors": b"weights"}
+    _write_tree(tmp_path, files)
+    manifest = _manifest_for(tmp_path, files, hashed={"shard-0.safetensors"})
+    result = verify_staged_weights(manifest, tmp_path, now=_now)
+    assert result.ok is True
+    assert result.files_checked == 2
+    assert result.hashes_checked == 1
+    assert result.hashes_available == 1
+    assert result.covers(repo_id="zai-org/GLM-5.3-Flash", revision=VALID_REVISION)
+
+
+def test_a_truncated_shard_is_caught_by_size_alone(tmp_path: Path) -> None:
+    """The common failure: an interrupted download leaves a short file.
+
+    A manifest naming the right revision does not catch this, which is
+    why the serving container is not allowed to rely on the manifest.
+    """
+    files = {"shard-0.safetensors": b"weights"}
+    manifest = _manifest_for(tmp_path, files, hashed=set())
+    _write_tree(tmp_path, {"shard-0.safetensors": b"wei"})
+    result = verify_staged_weights(manifest, tmp_path, now=_now, check_hashes=False)
+    assert result.ok is False
+    assert result.issues[0].problem == "size_mismatch"
+    assert result.issues[0].expected == "7"
+    assert result.issues[0].observed == "3"
+    assert not result.covers(repo_id="zai-org/GLM-5.3-Flash", revision=VALID_REVISION)
+
+
+def test_a_missing_file_is_caught(tmp_path: Path) -> None:
+    files = {"present.json": b"{}", "absent.safetensors": b"gone"}
+    manifest = _manifest_for(tmp_path, files, hashed=set())
+    _write_tree(tmp_path, {"present.json": b"{}"})
+    result = verify_staged_weights(manifest, tmp_path, now=_now)
+    assert [issue.problem for issue in result.issues] == ["missing"]
+
+
+def test_corruption_that_preserves_size_needs_the_hash(tmp_path: Path) -> None:
+    """Same length, different bytes. Only the published hash sees it."""
+    files = {"shard-0.safetensors": b"weights"}
+    manifest = _manifest_for(tmp_path, files, hashed={"shard-0.safetensors"})
+    _write_tree(tmp_path, {"shard-0.safetensors": b"corrupt"})
+
+    without = verify_staged_weights(manifest, tmp_path, now=_now, check_hashes=False)
+    assert without.ok is True
+
+    with_hashes = verify_staged_weights(manifest, tmp_path, now=_now)
+    assert with_hashes.ok is False
+    assert with_hashes.issues[0].problem == "hash_mismatch"
+    # The digests are not repeated into the issue; they are long and the
+    # remedy is the same either way.
+    assert with_hashes.issues[0].observed is None
+
+
+def test_a_verification_round_trips(tmp_path: Path) -> None:
+    files = {"config.json": b"{}"}
+    _write_tree(tmp_path, files)
+    manifest = _manifest_for(tmp_path, files, hashed=set())
+    original = verify_staged_weights(manifest, tmp_path, now=_now)
+    restored = WeightVerification.from_dict(json.loads(original.to_json()))
+    assert restored.ok is True
+    assert restored.revision == VALID_REVISION
+
+
+def test_a_malformed_verification_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="malformed"):
+        WeightVerification.from_dict({"revision": VALID_REVISION})

--- a/tests/deploy/test_endpoint.py
+++ b/tests/deploy/test_endpoint.py
@@ -1,0 +1,98 @@
+"""Endpoint wiring: names, never values."""
+
+from __future__ import annotations
+
+import pytest
+
+from llmtracefx.deploy.endpoint import (
+    DEFAULT_API_KEY_ENV_VAR,
+    EndpointConfig,
+    require_endpoint_base_url,
+    require_env_var_name,
+)
+from llmtracefx.deploy.errors import DeploymentPlanError
+
+
+def test_an_unresolved_endpoint_renders_a_placeholder_rather_than_a_guess() -> None:
+    endpoint = EndpointConfig()
+    assert endpoint.is_resolved is False
+    assert endpoint.chat_completions_url == "<deployed-url>/v1/chat/completions"
+    assert endpoint.health_url == "<deployed-url>/health"
+
+
+def test_a_resolved_endpoint_builds_absolute_paths() -> None:
+    endpoint = EndpointConfig(base_url="https://ws--app-serve.modal.run/")
+    assert endpoint.base_url == "https://ws--app-serve.modal.run"
+    assert endpoint.readiness_url == "https://ws--app-serve.modal.run/v1/models"
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "sk-abcdef0123456789abcdef0123456789",
+        "Bearer abc",
+        "my key",
+        "",
+        "a" * 65,
+        "1LEADING_DIGIT",
+        "has-dashes",
+    ],
+)
+def test_key_shaped_values_are_refused_where_a_name_belongs(candidate: str) -> None:
+    with pytest.raises(DeploymentPlanError, match="NAME"):
+        require_env_var_name(candidate)
+
+
+def test_ordinary_variable_names_are_accepted() -> None:
+    assert require_env_var_name(DEFAULT_API_KEY_ENV_VAR) == DEFAULT_API_KEY_ENV_VAR
+    assert require_env_var_name("_PRIVATE") == "_PRIVATE"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://ws--app.modal.run",
+        "ftp://ws--app.modal.run",
+        "https://user:secret@ws--app.modal.run",
+        "https://ws--app.modal.run/v1?api_key=abc",
+        "https://ws--app.modal.run/v1#token",
+        "https://",
+        "",
+    ],
+)
+def test_unsafe_base_urls_are_refused(url: str) -> None:
+    with pytest.raises(DeploymentPlanError):
+        require_endpoint_base_url(url)
+
+
+def test_a_secret_name_is_not_allowed_to_be_a_secret_value() -> None:
+    with pytest.raises(DeploymentPlanError, match="never the secret's value"):
+        EndpointConfig(modal_secret_name="sk-live-" + "x" * 80)
+
+
+def test_serialised_endpoint_carries_names_and_an_explanation_only() -> None:
+    payload = EndpointConfig().to_dict()
+    assert payload["api_key_env_var"] == DEFAULT_API_KEY_ENV_VAR
+    assert payload["modal_secret_name"] == "glm-selfhost-api-key"
+    assert "Only the secret name" in payload["credential_handling"]
+    assert set(payload) == {
+        "api_key_env_var",
+        "modal_secret_name",
+        "served_model_name",
+        "base_url",
+        "resolved",
+        "health_url",
+        "readiness_url",
+        "chat_completions_url",
+        "credential_handling",
+    }
+
+
+def test_a_malformed_bracketed_host_is_refused_not_raised() -> None:
+    """urlsplit defers netloc parsing, so the ValueError arrives late.
+
+    Left unguarded it escapes as a bare ValueError rather than the
+    refusal every other bad URL produces.
+    """
+    with pytest.raises(DeploymentPlanError, match="not parseable"):
+        require_endpoint_base_url("https://[bad")

--- a/tests/deploy/test_environment.py
+++ b/tests/deploy/test_environment.py
@@ -1,0 +1,228 @@
+"""The environment contract, and what happens when it is incomplete."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+from _fakes import PINNED_IMAGE, VALID_REVISION, valid_environ
+
+from llmtracefx.deploy.environment import (
+    REQUIRED_ENV_VARS,
+    missing_required_env_vars,
+    plan_from_environ,
+)
+from llmtracefx.deploy.errors import DeploymentPlanError
+
+AS_OF = date(2026, 8, 30)
+
+PLANTED_SECRET = "sk-live-do-not-persist-4f9a2c7e1b"
+
+
+def test_a_complete_environment_produces_an_approved_plan() -> None:
+    plan = plan_from_environ(valid_environ(), as_of=AS_OF)
+    assert plan.approved is True
+    assert plan.recipe.model_revision == VALID_REVISION
+    assert plan.recipe.image.reference == PINNED_IMAGE
+    assert plan.controls.max_containers == 1
+    assert plan.controls.min_containers == 0
+
+
+def test_an_empty_environment_refuses_and_names_everything_missing() -> None:
+    with pytest.raises(DeploymentPlanError) as excinfo:
+        plan_from_environ({}, as_of=AS_OF)
+    message = str(excinfo.value)
+    assert "refusing to configure a paid deployment" in message
+    for name in REQUIRED_ENV_VARS:
+        assert name in message
+
+
+@pytest.mark.parametrize("name", REQUIRED_ENV_VARS)
+def test_every_required_variable_is_individually_required(name: str) -> None:
+    environ = valid_environ()
+    del environ[name]
+    assert missing_required_env_vars(environ) == (name,)
+    with pytest.raises(DeploymentPlanError, match=name):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+@pytest.mark.parametrize("name", REQUIRED_ENV_VARS)
+def test_a_blank_variable_counts_as_missing(name: str) -> None:
+    environ = valid_environ(**{name: "   "})
+    assert missing_required_env_vars(environ) == (name,)
+
+
+def test_a_refused_plan_raises_rather_than_being_returned() -> None:
+    """At deploy time nobody reads a summary, so a refusal must be fatal."""
+    environ = valid_environ(
+        LLMTRACEFX_GLM_MAX_USD="0.01", LLMTRACEFX_GLM_USD_PER_GPU_HOUR="50"
+    )
+    with pytest.raises(DeploymentPlanError, match="exceeds the authorised budget"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+def test_an_unpinned_revision_is_refused_at_deploy_time() -> None:
+    environ = valid_environ(LLMTRACEFX_GLM_MODEL_REVISION="main")
+    with pytest.raises(DeploymentPlanError, match="40-character commit SHA"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+def test_a_latest_image_is_refused_at_deploy_time() -> None:
+    environ = valid_environ(LLMTRACEFX_GLM_IMAGE="lmsysorg/sglang:latest")
+    with pytest.raises(DeploymentPlanError, match="never reproducible"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+def test_warm_containers_are_refused_at_deploy_time() -> None:
+    """Refused twice, for two different reasons, and neither is skippable.
+
+    RuntimeControls refuses an unacknowledged warm floor outright; the
+    plan then refuses an acknowledged one as well, because a container
+    that bills while idle is not bounded by the window the envelope
+    prices.
+    """
+    with pytest.raises(DeploymentPlanError, match="bills continuously"):
+        plan_from_environ(valid_environ(LLMTRACEFX_GLM_MIN_CONTAINERS="1"), as_of=AS_OF)
+    with pytest.raises(DeploymentPlanError, match="bill continuously"):
+        plan_from_environ(
+            valid_environ(
+                LLMTRACEFX_GLM_MIN_CONTAINERS="1",
+                LLMTRACEFX_GLM_ALLOW_WARM_CONTAINERS="true",
+                LLMTRACEFX_GLM_MAX_USD="20.00",
+            ),
+            as_of=AS_OF,
+        )
+
+
+def test_the_default_framework_needs_no_credential_exposure_waiver() -> None:
+    plan = plan_from_environ(valid_environ(), as_of=AS_OF)
+    assert plan.recipe.framework == "vllm"
+    assert plan.approved is True
+
+
+def test_sglang_is_refused_at_deploy_time_unless_acknowledged() -> None:
+    with pytest.raises(DeploymentPlanError, match="command line argument"):
+        plan_from_environ(valid_environ(LLMTRACEFX_GLM_FRAMEWORK="sglang"), as_of=AS_OF)
+    approved = plan_from_environ(
+        valid_environ(
+            LLMTRACEFX_GLM_FRAMEWORK="sglang",
+            LLMTRACEFX_GLM_ACCEPT_ARGV_CREDENTIAL_EXPOSURE="true",
+        ),
+        as_of=AS_OF,
+    )
+    assert approved.recipe.framework == "sglang"
+
+
+def test_extra_containers_multiply_the_serving_terms() -> None:
+    one = plan_from_environ(valid_environ(), as_of=AS_OF)
+    four = plan_from_environ(
+        valid_environ(
+            LLMTRACEFX_GLM_MAX_CONTAINERS="4", LLMTRACEFX_GLM_MAX_USD="200.00"
+        ),
+        as_of=AS_OF,
+    )
+    for name in ("serving-gpu", "serving-compute"):
+        single = next(line for line in one.envelope.lines if line.name == name).usd
+        quadruple = next(line for line in four.envelope.lines if line.name == name).usd
+        assert quadruple == pytest.approx(single * 4)
+    with pytest.raises(DeploymentPlanError, match="exceeds the authorised budget"):
+        plan_from_environ(
+            valid_environ(
+                LLMTRACEFX_GLM_MAX_CONTAINERS="8", LLMTRACEFX_GLM_MAX_USD="10.00"
+            ),
+            as_of=AS_OF,
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "LLMTRACEFX_GLM_MAX_USD",
+        "LLMTRACEFX_GLM_USD_PER_GPU_HOUR",
+    ],
+)
+def test_unparseable_numbers_are_refused_without_echoing_the_value(name: str) -> None:
+    environ = valid_environ(**{name: "not-a-number-but-secret-ish"})
+    with pytest.raises(DeploymentPlanError) as excinfo:
+        plan_from_environ(environ, as_of=AS_OF)
+    assert "not-a-number-but-secret-ish" not in str(excinfo.value)
+    assert name in str(excinfo.value)
+
+
+def test_unparseable_integers_are_refused() -> None:
+    environ = valid_environ(LLMTRACEFX_GLM_GPU_COUNT="four")
+    with pytest.raises(DeploymentPlanError, match="must be an integer"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+def test_a_bad_boolean_is_refused_rather_than_read_as_false() -> None:
+    environ = valid_environ(LLMTRACEFX_GLM_ACCEPT_MUTABLE_IMAGE="maybe")
+    with pytest.raises(DeploymentPlanError, match="ACCEPT_MUTABLE_IMAGE"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+def test_a_zero_freshness_limit_is_honoured_and_not_read_as_absent() -> None:
+    """Zero means "only a quote read today", which is the strictest setting.
+
+    Defaulting it away would hand back the lenient ninety day limit to
+    the one operator who explicitly asked for the opposite.
+    """
+    environ = valid_environ(LLMTRACEFX_GLM_MAX_PRICE_AGE_DAYS="0")
+    with pytest.raises(DeploymentPlanError, match="limit 0 days"):
+        plan_from_environ(environ, as_of=AS_OF)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("LLMTRACEFX_GLM_MAX_CONTAINERS", "max_containers"),
+        ("LLMTRACEFX_GLM_SCALEDOWN_WINDOW_SECONDS", "scaledown_window_seconds"),
+        ("LLMTRACEFX_GLM_STARTUP_TIMEOUT_SECONDS", "startup_timeout_seconds"),
+        ("LLMTRACEFX_GLM_MAX_CONCURRENT_INPUTS", "max_concurrent_inputs"),
+    ],
+)
+def test_an_explicit_zero_is_validated_rather_than_replaced(
+    name: str, expected: str
+) -> None:
+    """A present value must reach its validator, not the default.
+
+    `_int(...) or default` cannot tell "unset" from "set to zero", so it
+    rewrites every zero into a plausible default and the validator that
+    exists to reject zero never runs.
+    """
+    with pytest.raises(DeploymentPlanError, match=expected):
+        plan_from_environ(valid_environ(**{name: "0"}), as_of=AS_OF)
+
+
+def test_an_explicit_port_of_zero_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="port"):
+        plan_from_environ(valid_environ(LLMTRACEFX_GLM_PORT="0"), as_of=AS_OF)
+
+
+def test_storage_size_defaults_to_the_checkpoint() -> None:
+    plan = plan_from_environ(valid_environ(), as_of=AS_OF)
+    assert plan.envelope.stored_gib == pytest.approx(306.0)
+    assert plan.envelope.storage_billed_days == pytest.approx(5.0)
+
+
+def test_no_credential_value_reaches_the_serialised_plan() -> None:
+    """A key sitting in the deploy environment must not be written down.
+
+    The planner reads its own prefixed variables and nothing else, so a
+    credential exported alongside them has no route into the document.
+    This asserts that end to end rather than by inspection.
+    """
+    environ = valid_environ()
+    environ["GLM_SELFHOST_API_KEY"] = PLANTED_SECRET
+    environ["HF_TOKEN"] = PLANTED_SECRET
+    plan = plan_from_environ(environ, as_of=AS_OF)
+    document = json.dumps(plan.to_dict())
+    assert PLANTED_SECRET not in document
+    assert "GLM_SELFHOST_API_KEY" in document
+
+
+def test_the_plan_still_reports_that_it_touched_nothing() -> None:
+    payload = plan_from_environ(valid_environ(), as_of=AS_OF).to_dict()
+    assert payload["network_request_performed"] is False
+    assert payload["gpu_allocated"] is False

--- a/tests/deploy/test_modal_app.py
+++ b/tests/deploy/test_modal_app.py
@@ -1,0 +1,532 @@
+"""The Modal entrypoint, imported against a fake SDK.
+
+What this module decides at import is the whole safety story: how many
+accelerators the serving function asks for, how long it may run, whether
+it scales, and above all that the staging function asks for no
+accelerator at all. Those decisions are only visible where the decorators
+receive them, so the entrypoint is imported here with a stand-in ``modal``
+module that records its arguments.
+
+Nothing here authenticates, connects, or needs the real SDK installed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from _fakes import OTHER_REVISION, VALID_REVISION, imported_app, valid_environ
+
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    StagedFile,
+    VerificationIssue,
+    WeightStagingManifest,
+    WeightVerification,
+)
+from llmtracefx.deploy.resources import (
+    SERVING_CPU_CORES,
+    SERVING_MEMORY_GIB,
+    STAGING_CPU_CORES,
+    VERIFY_CPU_CORES,
+)
+
+
+def test_the_staging_function_is_never_given_an_accelerator() -> None:
+    with imported_app(valid_environ()) as (_, fake):
+        staging = fake._fake_apps[0].registrations["stage_weights"]
+        assert "gpu" not in staging.function_kwargs
+        assert staging.function_kwargs["cpu"] == 8.0
+        assert staging.function_kwargs["retries"] == 0
+
+
+def test_staging_and_serving_use_different_images() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        registrations = fake._fake_apps[0].registrations
+        staging_image = registrations["stage_weights"].function_kwargs["image"]
+        serving_image = registrations["serve"].function_kwargs["image"]
+        assert staging_image is not serving_image
+        assert staging_image.label == "debian_slim"
+        assert serving_image.label == "from_registry"
+        assert serving_image.kwargs["tag"] == module.RECIPE.image.reference
+
+
+def test_the_serving_function_requests_exactly_the_planned_accelerators() -> None:
+    with imported_app(valid_environ()) as (_, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["gpu"] == "H200:4"
+
+
+def test_gpu_count_follows_the_environment() -> None:
+    with imported_app(
+        valid_environ(LLMTRACEFX_GLM_GPU_COUNT="8", LLMTRACEFX_GLM_MAX_USD="20.00")
+    ) as (_, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["gpu"] == "H200:8"
+
+
+def test_the_serving_function_carries_the_timeout_that_was_priced() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["timeout"] == 1800
+        assert (
+            serve.function_kwargs["timeout"] == module.PLAN.envelope.max_runtime_seconds
+        )
+
+
+def test_serving_does_not_scale_or_stay_warm_by_default() -> None:
+    with imported_app(valid_environ()) as (_, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["max_containers"] == 1
+        assert serve.function_kwargs["min_containers"] == 0
+        assert serve.function_kwargs["scaledown_window"] == 300
+        assert serve.concurrent_kwargs == {"max_inputs": 1}
+
+
+def test_the_web_server_port_and_startup_budget_match_the_recipe() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.web_server_kwargs["port"] == module.RECIPE.port
+        assert serve.web_server_kwargs["startup_timeout"] == 900
+
+
+def test_the_secret_is_referenced_by_name_with_a_required_key() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        secret = fake._fake_secrets[0]
+        assert secret.name == "glm-selfhost-api-key"
+        assert secret.required_keys == ("GLM_SELFHOST_API_KEY",)
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["secrets"] == [secret]
+        assert module.PLAN.endpoint.api_key_env_var == "GLM_SELFHOST_API_KEY"
+
+
+def test_both_functions_mount_the_same_weights_volume() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        volume = fake._fake_volumes[0]
+        assert volume.name == module.PLAN.volume_name
+        assert volume.kwargs["create_if_missing"] is True
+        registrations = fake._fake_apps[0].registrations
+        for name in ("stage_weights", "serve"):
+            mounts = registrations[name].function_kwargs["volumes"]
+            assert mounts == {module.MOUNT_PATH: volume}
+
+
+def test_the_app_is_named_from_the_plan() -> None:
+    with imported_app(valid_environ(LLMTRACEFX_GLM_APP_NAME="custom-app")) as (
+        module,
+        fake,
+    ):
+        assert fake._fake_apps[0].name == "custom-app"
+        assert module.PLAN.app_name == "custom-app"
+
+
+def test_the_staging_client_is_pinned() -> None:
+    with imported_app(valid_environ()) as (module, fake):
+        staging_image = (
+            fake._fake_apps[0].registrations["stage_weights"].function_kwargs["image"]
+        )
+        assert staging_image.pip_packages == [module.DEFAULT_HF_HUB_PIN]
+        assert "==" in module.DEFAULT_HF_HUB_PIN
+
+
+def test_the_serving_image_gets_the_local_package_for_manifest_building() -> None:
+    with imported_app(valid_environ()) as (_, fake):
+        serving_image = (
+            fake._fake_apps[0].registrations["serve"].function_kwargs["image"]
+        )
+        assert serving_image.env_vars["PYTHONPATH"] == "/opt/llmtracefx"
+        assert serving_image.local_dirs == [
+            ("llmtracefx", "/opt/llmtracefx/llmtracefx")
+        ]
+
+
+def test_importing_without_the_spending_authority_fails_before_anything_registers() -> (
+    None
+):
+    environ = valid_environ()
+    del environ["LLMTRACEFX_GLM_MAX_USD"]
+    with pytest.raises(DeploymentPlanError, match="LLMTRACEFX_GLM_MAX_USD"):
+        with imported_app(environ):
+            pass
+
+
+def test_importing_an_over_budget_configuration_fails() -> None:
+    environ = valid_environ(
+        LLMTRACEFX_GLM_MAX_USD="0.01", LLMTRACEFX_GLM_USD_PER_GPU_HOUR="50"
+    )
+    with pytest.raises(DeploymentPlanError, match="exceeds the authorised budget"):
+        with imported_app(environ):
+            pass
+
+
+def test_importing_with_an_unpinned_revision_fails() -> None:
+    environ = valid_environ(LLMTRACEFX_GLM_MODEL_REVISION="main")
+    with pytest.raises(DeploymentPlanError, match="commit SHA"):
+        with imported_app(environ):
+            pass
+
+
+def test_the_module_exposes_the_adjudicated_plan_it_was_built_from() -> None:
+    with imported_app(valid_environ()) as (module, _):
+        assert module.PLAN.approved is True
+        assert module.RECIPE.model_revision == VALID_REVISION
+        assert module.MOUNT_PATH == "/weights"
+
+
+def test_the_entrypoint_is_not_imported_by_the_package() -> None:
+    """Importing the library must never pull in the Modal SDK."""
+    import sys
+
+    sys.modules.pop("llmtracefx.deploy.modal_glm_app", None)
+    sys.modules.pop("modal", None)
+    import importlib
+
+    importlib.reload(importlib.import_module("llmtracefx.deploy"))
+    assert "modal" not in sys.modules
+    assert "llmtracefx.deploy.modal_glm_app" not in sys.modules
+
+
+def _serve_harness(module: Any, monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Neutralise everything in ``serve`` except the decisions under test.
+
+    The manifest is made to match so the staging gate passes, hardware
+    probes and the readiness thread are stubbed out because they shell
+    out and poll a socket, and Popen is replaced by a recorder so the
+    question "did this start a server" has a direct answer.
+    """
+    launched: list[list[str]] = []
+
+    manifest = WeightStagingManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        completed_at="2026-08-30T00:00:00+00:00",
+        repo_id=module.RECIPE.model_repo_id,
+        revision=module.RECIPE.model_revision,
+        mount_path=module.MOUNT_PATH,
+        files=(StagedFile(path="config.json", size_bytes=1024),),
+    )
+    verification = WeightVerification(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        verified_at="2026-08-30T00:00:00+00:00",
+        repo_id=module.RECIPE.model_repo_id,
+        revision=module.RECIPE.model_revision,
+        mount_path=module.MOUNT_PATH,
+        files_checked=1,
+        bytes_checked=1024,
+        hashes_checked=0,
+        hashes_available=0,
+    )
+    monkeypatch.setattr(module, "_read_manifest", lambda revision: manifest)
+    monkeypatch.setattr(module, "_read_verification", lambda revision: verification)
+    monkeypatch.setattr(module, "_observed_gpus", lambda: ("NVIDIA H200",))
+    monkeypatch.setattr(module, "_observed_cuda_version", lambda: "12.9")
+    monkeypatch.setattr(module.threading, "Thread", lambda **kwargs: _NoThread())
+    monkeypatch.setattr(
+        module.subprocess,
+        "Popen",
+        lambda argv, env=None: launched.append(list(argv)),
+    )
+    return launched
+
+
+class _NoThread:
+    def start(self) -> None:
+        return None
+
+
+def test_serve_refuses_to_start_without_a_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty key must be a refusal, not an unauthenticated endpoint.
+
+    Neither framework installs authentication middleware without a
+    non-empty key, and this endpoint has no platform auth in front of it,
+    so serving anyway would publish the accelerators openly. Modal's
+    `required_keys` does not cover it: it asserts presence, not content,
+    and `modal secret create NAME VAR="$VAR"` with the export lost
+    creates exactly this.
+    """
+    for value in ("", "   "):
+        with imported_app(valid_environ(GLM_SELFHOST_API_KEY=value)) as (module, _):
+            launched = _serve_harness(module, monkeypatch)
+            with pytest.raises(RuntimeError, match="Refusing to start"):
+                module.serve()
+            assert launched == []
+
+
+def test_serve_refuses_when_the_variable_is_absent_entirely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with imported_app(valid_environ()) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        with pytest.raises(RuntimeError, match="GLM_SELFHOST_API_KEY"):
+            module.serve()
+        assert launched == []
+
+
+def test_serve_refuses_when_the_weights_are_not_staged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY="k")) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        monkeypatch.setattr(module, "_read_manifest", lambda revision: None)
+        with pytest.raises(RuntimeError, match="are not staged"):
+            module.serve()
+        assert launched == []
+
+
+def test_serve_keeps_the_key_out_of_the_argv_on_the_default_framework(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    secret = "sk-live-SERVE-SENTINEL-2f7c"
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY=secret)) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        module.serve()
+        assert len(launched) == 1
+        assert secret not in " ".join(launched[0])
+        assert "--api-key" not in launched[0]
+        # vLLM takes it from the environment, so nothing printed by this
+        # module can carry it either.
+        assert secret not in capsys.readouterr().out
+
+
+def test_serve_logs_the_argv_before_sglang_gets_the_key(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The recorded argv must be credential free even for sglang."""
+    secret = "sk-live-SERVE-SENTINEL-9a1b"
+    environ = valid_environ(
+        LLMTRACEFX_GLM_FRAMEWORK="sglang",
+        LLMTRACEFX_GLM_ACCEPT_ARGV_CREDENTIAL_EXPOSURE="true",
+        GLM_SELFHOST_API_KEY=secret,
+    )
+    with imported_app(environ) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        module.serve()
+        printed = capsys.readouterr().out
+        assert secret not in printed
+        # The framework really does receive it; the guarantee is only
+        # that this module did not write it down.
+        assert launched[0][-2:] == ["--api-key", secret]
+
+
+def test_a_remote_container_can_rebuild_the_plan_from_the_image_alone() -> None:
+    """The decisive test for the remote import path.
+
+    The entrypoint is imported twice: locally by `modal deploy`, where
+    the operator has exported the configuration, and again inside every
+    container, where nothing has. Baking the adjudicated values into both
+    images is what makes the second import work. This simulates it by
+    importing with *only* what the image sets plus the secret, which is
+    exactly what a worker sees.
+    """
+    with imported_app(valid_environ()) as (module, fake):
+        baked = dict(module.BAKED_ENVIRONMENT)
+        local_plan = module.PLAN
+        images = {
+            registration.function_kwargs["image"]
+            for registration in fake._fake_apps[0].registrations.values()
+        }
+        # Every image carries it, so no function can be scheduled onto a
+        # container that lacks the configuration.
+        for image in images:
+            assert "LLMTRACEFX_GLM_MAX_USD" in image.env_vars
+
+    # A worker's environment: the image env, plus the Secret, and none of
+    # the operator's shell.
+    remote_environ = {**baked, "GLM_SELFHOST_API_KEY": "secret-value"}
+    assert not any(
+        key.startswith("LLMTRACEFX_GLM_")
+        for key in valid_environ()
+        if key not in remote_environ
+    )
+    with imported_app(remote_environ) as (module, _):
+        remote_plan = module.PLAN
+        assert remote_plan.approved is True
+        assert remote_plan.recipe.model_revision == local_plan.recipe.model_revision
+        assert remote_plan.recipe.gpu_count == local_plan.recipe.gpu_count
+        assert remote_plan.controls.timeout_seconds == (
+            local_plan.controls.timeout_seconds
+        )
+        assert remote_plan.controls.deployment_seconds == (
+            local_plan.controls.deployment_seconds
+        )
+        assert remote_plan.envelope.worst_case_usd == pytest.approx(
+            local_plan.envelope.worst_case_usd
+        )
+
+
+def test_the_baked_configuration_carries_no_credential() -> None:
+    secret = "sk-live-BAKED-SENTINEL-3c8d"
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY=secret)) as (module, _):
+        baked = module.BAKED_ENVIRONMENT
+        assert secret not in json.dumps(baked)
+        # The name is there, so the container knows which variable to read.
+        assert baked["LLMTRACEFX_GLM_API_KEY_ENV"] == "GLM_SELFHOST_API_KEY"
+
+
+def test_an_expired_deployment_refuses_to_allocate_accelerators(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The expiry is what makes the priced window an upper bound.
+
+    Modal's timeout bounds a Function's execution, and this one returns
+    as soon as it has launched the server, so without an expiry a request
+    arriving at any future time would allocate accelerators again.
+    """
+    past = "2020-01-01T00:00:00+00:00"
+    environ = valid_environ(
+        GLM_SELFHOST_API_KEY="k", LLMTRACEFX_GLM_DEPLOY_EXPIRES_AT=past
+    )
+    with imported_app(environ) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        with pytest.raises(RuntimeError, match="expired"):
+            module.serve()
+        assert launched == []
+
+
+def test_an_unparseable_expiry_reads_as_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The safe reading of a corrupt expiry is 'do not start'."""
+    environ = valid_environ(
+        GLM_SELFHOST_API_KEY="k", LLMTRACEFX_GLM_DEPLOY_EXPIRES_AT="not-a-date"
+    )
+    with imported_app(environ) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        with pytest.raises(RuntimeError, match="expired"):
+            module.serve()
+        assert launched == []
+
+
+def test_a_container_inherits_the_deploy_expiry_rather_than_extending_it() -> None:
+    """A cold start must not restart the clock.
+
+    If each container computed its own expiry from its own start time,
+    the window would renew on every request and bound nothing.
+    """
+    future = "2099-01-01T00:00:00+00:00"
+    with imported_app(valid_environ(LLMTRACEFX_GLM_DEPLOY_EXPIRES_AT=future)) as (
+        module,
+        _,
+    ):
+        assert module.DEPLOY_EXPIRES_AT == future
+        assert module.BAKED_ENVIRONMENT["LLMTRACEFX_GLM_DEPLOY_EXPIRES_AT"] == future
+
+
+def test_serving_requests_the_cpu_and_memory_the_envelope_prices() -> None:
+    with imported_app(valid_environ()) as (_, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.function_kwargs["cpu"] == SERVING_CPU_CORES
+        assert serve.function_kwargs["memory"] == int(SERVING_MEMORY_GIB * 1024)
+        staging = fake._fake_apps[0].registrations["stage_weights"]
+        assert staging.function_kwargs["cpu"] == STAGING_CPU_CORES
+        verify = fake._fake_apps[0].registrations["verify_weights"]
+        assert "gpu" not in verify.function_kwargs
+        assert verify.function_kwargs["cpu"] == VERIFY_CPU_CORES
+
+
+def test_serve_refuses_when_the_weights_were_never_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The manifest alone must not be enough to reach the accelerators.
+
+    The other serve tests stub a passing verification so they can reach
+    the code past this gate, which means none of them exercises the gate
+    itself. This one removes the record entirely.
+    """
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY="k")) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        monkeypatch.setattr(module, "_read_verification", lambda revision: None)
+        with pytest.raises(RuntimeError, match="have not passed verification"):
+            module.serve()
+        assert launched == []
+
+
+def test_serve_refuses_a_verification_that_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record that exists but records issues must not satisfy the gate."""
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY="k")) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        broken = WeightVerification(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            verified_at="2026-08-30T00:00:00+00:00",
+            repo_id=module.RECIPE.model_repo_id,
+            revision=module.RECIPE.model_revision,
+            mount_path=module.MOUNT_PATH,
+            files_checked=1,
+            bytes_checked=0,
+            hashes_checked=0,
+            hashes_available=0,
+            issues=(VerificationIssue(path="shard.safetensors", problem="missing"),),
+        )
+        monkeypatch.setattr(module, "_read_verification", lambda revision: broken)
+        with pytest.raises(RuntimeError, match="have not passed verification"):
+            module.serve()
+        assert launched == []
+
+
+def test_serve_refuses_a_verification_for_another_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A passing record for different weights must not be reused."""
+    with imported_app(valid_environ(GLM_SELFHOST_API_KEY="k")) as (module, _):
+        launched = _serve_harness(module, monkeypatch)
+        foreign = WeightVerification(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            verified_at="2026-08-30T00:00:00+00:00",
+            repo_id=module.RECIPE.model_repo_id,
+            revision=OTHER_REVISION,
+            mount_path=module.MOUNT_PATH,
+            files_checked=1,
+            bytes_checked=1024,
+            hashes_checked=0,
+            hashes_available=0,
+        )
+        monkeypatch.setattr(module, "_read_verification", lambda revision: foreign)
+        with pytest.raises(RuntimeError, match="have not passed verification"):
+            module.serve()
+        assert launched == []
+
+
+def test_unauthenticated_requests_cannot_schedule_a_gpu_container() -> None:
+    """The decisive control, asserted where the platform reads it.
+
+    Everything this module checks runs after Modal has already scheduled
+    the container, so a Python-side refusal bounds how long a container
+    serves, not whether one starts. Proxy auth is enforced at Modal's
+    edge, which rejects a request without credentials with a 401 before
+    scheduling anything, so this decorator argument is the only thing
+    standing between a public request and an allocated accelerator.
+    """
+    with imported_app(valid_environ()) as (_, fake):
+        serve = fake._fake_apps[0].registrations["serve"]
+        assert serve.web_server_kwargs["requires_proxy_auth"] is True
+        # And it really is the GPU function that carries it.
+        assert serve.function_kwargs["gpu"].startswith("H200:")
+
+
+def test_a_public_endpoint_cannot_be_configured_at_all() -> None:
+    """There is deliberately no flag that turns the edge off.
+
+    A public endpoint has no cost bound: any request from anyone
+    allocates accelerators before any refusal can run. Rather than offer
+    an override, the harness refuses the configuration outright.
+    """
+    from llmtracefx.deploy.plan import RuntimeControls
+
+    with pytest.raises(DeploymentPlanError, match="cannot be turned off"):
+        RuntimeControls(
+            timeout_seconds=1800,
+            deployment_seconds=1800,
+            require_proxy_auth=False,
+        )
+
+
+def test_the_envelope_states_what_it_does_not_cover() -> None:
+    with imported_app(valid_environ()) as (module, _):
+        payload = module.PLAN.envelope.to_dict()
+        assert payload["bounded"] is True
+        assert "scheduled before any code" in payload["does_not_cover"]

--- a/tests/deploy/test_plan.py
+++ b/tests/deploy/test_plan.py
@@ -1,0 +1,361 @@
+"""Plan adjudication: what blocks a deployment, and what that withholds."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from _fakes import PINNED_IMAGE, TAG_ONLY_IMAGE, VALID_REVISION
+
+from llmtracefx.deploy.budget import BudgetRequest
+from llmtracefx.deploy.endpoint import EndpointConfig
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.plan import (
+    MAX_SCALEDOWN_WINDOW_SECONDS,
+    RuntimeControls,
+    assert_executable,
+    build_plan,
+)
+from llmtracefx.deploy.pricing import ComputeQuote, GpuPriceQuote, StorageQuote
+from llmtracefx.deploy.recipe import SGLANG, VLLM, build_recipe
+
+AS_OF = date(2026, 8, 30)
+
+
+def _compute(effective_date: str = "2026-08-01") -> ComputeQuote:
+    return ComputeQuote(
+        usd_per_cpu_core_hour=1e-9,
+        usd_per_gib_memory_hour=1e-9,
+        effective_date=effective_date,
+        source="https://modal.com/pricing",
+    )
+
+
+def _storage(effective_date: str = "2026-08-01") -> StorageQuote:
+    return StorageQuote(
+        usd_per_gib_month=1e-9,
+        effective_date=effective_date,
+        source="https://modal.com/pricing",
+    )
+
+
+def make_recipe(**overrides: object):  # type: ignore[no-untyped-def]
+    kwargs: dict[str, object] = {
+        "framework": VLLM,
+        "framework_version": "0.5.6",
+        "image_reference": PINNED_IMAGE,
+        "model_revision": VALID_REVISION,
+        "gpu_type": "H200",
+        "gpu_count": 4,
+        "context_length": 131072,
+        "weights_mount_path": "/weights",
+        "port": 30000,
+    }
+    kwargs.update(overrides)
+    return build_recipe(**kwargs)  # type: ignore[arg-type]
+
+
+def make_plan(
+    *,
+    recipe_overrides: dict[str, object] | None = None,
+    max_usd: float = 10.0,
+    rate: float = 1.0,
+    price_date: str = "2026-08-01",
+    timeout: int = 1800,
+    max_containers: int = 1,
+    controls_overrides: dict[str, object] | None = None,
+    **plan_kwargs: object,
+):  # type: ignore[no-untyped-def]
+    recipe = make_recipe(**(recipe_overrides or {}))
+    controls_kwargs: dict[str, object] = {
+        "timeout_seconds": timeout,
+        "deployment_seconds": timeout,
+        "startup_timeout_seconds": 900,
+        "max_containers": max_containers,
+    }
+    controls_kwargs.update(controls_overrides or {})
+    budget = BudgetRequest(
+        max_usd=max_usd,
+        gpu_type=recipe.gpu_type,
+        gpu_count=recipe.gpu_count,
+        max_runtime_seconds=timeout,
+        deployment_seconds=controls_kwargs["deployment_seconds"],  # type: ignore[arg-type]
+        price=GpuPriceQuote(
+            gpu_type=recipe.gpu_type,
+            usd_per_gpu_hour=rate,
+            effective_date=price_date,
+            source="https://modal.com/pricing",
+        ),
+        compute=_compute(price_date),
+        storage=_storage(price_date),
+        stored_gib=306.0,
+        storage_retention_days=0.0,
+        max_containers=max_containers,
+    )
+    return build_plan(
+        recipe=recipe,
+        controls=RuntimeControls(**controls_kwargs),  # type: ignore[arg-type]
+        budget=budget,
+        endpoint=EndpointConfig(),
+        as_of=AS_OF,
+        **plan_kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_a_sound_plan_is_approved_and_every_step_is_executable() -> None:
+    plan = make_plan()
+    assert plan.approved is True
+    assert plan.blockers == ()
+    assert len(plan.executable_steps) == len(plan.steps)
+    assert_executable(plan)
+
+
+def test_the_plan_asserts_it_touched_nothing() -> None:
+    payload = make_plan().to_dict()
+    assert payload["network_request_performed"] is False
+    assert payload["gpu_allocated"] is False
+    assert payload["modal_authentication_used"] is False
+
+
+def test_over_budget_withholds_every_paid_step() -> None:
+    plan = make_plan(max_usd=1.0, rate=10.0)
+    assert plan.approved is False
+    assert any("exceeds the authorised budget" in b for b in plan.blockers)
+
+    withheld = {step.name for step in plan.steps} - {
+        step.name for step in plan.executable_steps
+    }
+    assert {"stage-weights", "deploy", "smoke", "collect"} <= withheld
+    assert all(not step.spends_money for step in plan.executable_steps)
+    with pytest.raises(DeploymentPlanError, match="refused"):
+        assert_executable(plan)
+
+
+def test_teardown_stays_available_while_a_plan_is_refused() -> None:
+    """Stopping and deleting must never be gated on approval.
+
+    They are the actions that make spending stop, so a plan that
+    withheld them would be at its most restrictive exactly when an
+    operator most needs to shut something down.
+    """
+    plan = make_plan(max_usd=1.0, rate=10.0)
+    available = {step.name for step in plan.executable_steps}
+    assert {"stop", "delete-volume"} <= available
+
+
+def test_insufficient_accelerators_block_the_plan() -> None:
+    plan = make_plan(recipe_overrides={"gpu_count": 2}, max_usd=100.0)
+    assert plan.approved is False
+    assert any("KV cache and activations" in b for b in plan.blockers)
+
+
+def test_a_stale_price_blocks_until_it_is_explicitly_accepted() -> None:
+    stale = make_plan(price_date="2025-01-01")
+    assert stale.approved is False
+    assert any("days old" in b for b in stale.blockers)
+
+    accepted = make_plan(price_date="2025-01-01", accept_stale_price=True)
+    assert accepted.approved is True
+    assert any("Accepted explicitly" in w for w in accepted.warnings)
+
+
+def test_a_future_dated_price_blocks_and_cannot_be_accepted_away() -> None:
+    plan = make_plan(price_date="2027-01-01", accept_stale_price=True)
+    assert plan.approved is False
+    assert any("in the future" in b for b in plan.blockers)
+
+
+def test_a_tighter_freshness_limit_can_be_requested() -> None:
+    plan = make_plan(price_date="2026-08-01", max_price_age_days=7)
+    assert plan.approved is False
+    assert any("limit 7 days" in b for b in plan.blockers)
+
+
+def test_a_tag_only_image_warns_but_does_not_block() -> None:
+    plan = make_plan(
+        recipe_overrides={
+            "image_reference": TAG_ONLY_IMAGE,
+            "accept_mutable_image": True,
+        }
+    )
+    assert plan.approved is True
+    assert any("pinned by tag only" in w for w in plan.warnings)
+
+
+def test_storage_is_a_mandatory_part_of_the_total() -> None:
+    """It cannot be omitted, and the envelope says what it covers."""
+    envelope = make_plan().envelope.to_dict()
+    assert any(line["name"] == "storage" for line in envelope["lines"])
+    assert "after deletion" in envelope["covers"]
+
+
+def test_budget_and_recipe_must_describe_the_same_deployment() -> None:
+    recipe = make_recipe()
+    controls = RuntimeControls(
+        timeout_seconds=1800, deployment_seconds=1800, startup_timeout_seconds=900
+    )
+    price = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=1.0,
+        effective_date="2026-08-01",
+        source="pricing",
+    )
+    mismatched = BudgetRequest(
+        max_usd=100.0,
+        gpu_type="H200",
+        gpu_count=2,
+        max_runtime_seconds=1800,
+        deployment_seconds=1800,
+        price=price,
+        compute=_compute(),
+        storage=_storage(),
+        stored_gib=306.0,
+        storage_retention_days=0.0,
+    )
+    with pytest.raises(DeploymentPlanError, match="budget covers 2 GPU"):
+        build_plan(
+            recipe=recipe,
+            controls=controls,
+            budget=mismatched,
+            endpoint=EndpointConfig(),
+            as_of=AS_OF,
+        )
+
+
+def test_budget_runtime_must_equal_the_configured_window() -> None:
+    recipe = make_recipe()
+    price = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=1.0,
+        effective_date="2026-08-01",
+        source="pricing",
+    )
+    budget = BudgetRequest(
+        max_usd=100.0,
+        gpu_type="H200",
+        gpu_count=4,
+        max_runtime_seconds=600,
+        deployment_seconds=1800,
+        price=price,
+        compute=_compute(),
+        storage=_storage(),
+        stored_gib=306.0,
+        storage_retention_days=0.0,
+    )
+    with pytest.raises(DeploymentPlanError, match="same number"):
+        build_plan(
+            recipe=recipe,
+            controls=RuntimeControls(
+                timeout_seconds=1800,
+                deployment_seconds=1800,
+                startup_timeout_seconds=900,
+            ),
+            budget=budget,
+            endpoint=EndpointConfig(),
+            as_of=AS_OF,
+        )
+
+
+def test_default_controls_do_not_keep_a_container_warm() -> None:
+    controls = RuntimeControls(timeout_seconds=1800, deployment_seconds=1800)
+    assert controls.min_containers == 0
+    assert controls.max_containers == 1
+    assert controls.max_concurrent_inputs == 1
+
+
+def test_warm_containers_require_an_explicit_acknowledgement() -> None:
+    with pytest.raises(DeploymentPlanError, match="bills continuously"):
+        RuntimeControls(timeout_seconds=1800, deployment_seconds=1800, min_containers=1)
+    allowed = RuntimeControls(
+        timeout_seconds=1800,
+        deployment_seconds=1800,
+        min_containers=1,
+        allow_warm_containers=True,
+    )
+    assert allowed.min_containers == 1
+
+
+def test_warm_containers_block_because_the_window_cannot_price_them() -> None:
+    """A warm container ignores the priced window entirely.
+
+    Modal keeps min_containers running while the function is idle, so the
+    accelerators bill from deploy until the app is stopped with no
+    relation to max_runtime_seconds. Approving that on the strength of a
+    window it ignores would turn the envelope into an estimate.
+    """
+    plan = make_plan(
+        controls_overrides={"min_containers": 1, "allow_warm_containers": True}
+    )
+    assert plan.approved is False
+    assert any("bill continuously" in b for b in plan.blockers)
+    assert all(not step.spends_money for step in plan.executable_steps)
+
+
+def test_the_cold_start_residual_is_stated_plainly() -> None:
+    """Auth is at the edge now, but an authenticated caller still churns.
+
+    A Python-side refusal runs after the container is scheduled, so it
+    bounds how long one serves rather than whether one starts. Proxy auth
+    is what keeps that from being a public, unbounded cost; the residual
+    that remains is worth naming rather than rounding away.
+    """
+    plan = make_plan()
+    assert plan.controls.require_proxy_auth is True
+    assert plan.envelope.bounded is True
+    assert any(
+        "rejects unauthenticated requests at its edge" in w for w in plan.warnings
+    )
+    assert any("is not priced above" in w for w in plan.warnings)
+
+
+def test_sglang_blocks_because_it_takes_the_key_on_its_command_line() -> None:
+    blocked = make_plan(recipe_overrides={"framework": SGLANG})
+    assert blocked.approved is False
+    assert any("command line argument" in b for b in blocked.blockers)
+
+    accepted = make_plan(
+        recipe_overrides={"framework": SGLANG},
+        accept_argv_credential_exposure=True,
+    )
+    assert accepted.approved is True
+    assert any("Accepted explicitly" in w for w in accepted.warnings)
+
+
+def test_the_default_framework_keeps_the_key_out_of_the_command_line() -> None:
+    plan = make_plan()
+    assert plan.recipe.framework == VLLM
+    assert plan.recipe.credential_transport == "environment"
+    assert plan.approved is True
+
+
+def test_startup_timeout_cannot_outlast_the_container() -> None:
+    with pytest.raises(DeploymentPlanError, match="killed while still starting"):
+        RuntimeControls(
+            timeout_seconds=600, deployment_seconds=600, startup_timeout_seconds=1200
+        )
+
+
+@pytest.mark.parametrize("bad", [0, -1, MAX_SCALEDOWN_WINDOW_SECONDS + 1])
+def test_scaledown_window_bounds(bad: int) -> None:
+    with pytest.raises(DeploymentPlanError, match="scaledown_window_seconds"):
+        RuntimeControls(
+            timeout_seconds=1800,
+            deployment_seconds=1800,
+            scaledown_window_seconds=bad,
+        )
+
+
+def test_min_containers_cannot_exceed_max_containers() -> None:
+    with pytest.raises(DeploymentPlanError, match="must not exceed max_containers"):
+        RuntimeControls(
+            timeout_seconds=1800,
+            deployment_seconds=1800,
+            max_containers=1,
+            min_containers=2,
+            allow_warm_containers=True,
+        )
+
+
+def test_concurrency_above_one_is_warned_about_as_measurement_interference() -> None:
+    plan = make_plan(controls_overrides={"max_concurrent_inputs": 8})
+    assert any("interfere" in w for w in plan.warnings)

--- a/tests/deploy/test_pricing.py
+++ b/tests/deploy/test_pricing.py
@@ -1,0 +1,125 @@
+"""Price quotes carry a date, and a stale date is a refusal."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.pricing import (
+    DEFAULT_MAX_PRICE_AGE_DAYS,
+    MAX_PLAUSIBLE_USD_PER_GIB_MONTH,
+    MAX_PLAUSIBLE_USD_PER_GPU_HOUR,
+    GpuPriceQuote,
+    StorageQuote,
+)
+
+
+def test_a_quote_records_where_and_when_it_was_read() -> None:
+    quote = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=4.54,
+        effective_date="2026-08-30",
+        source="https://modal.com/pricing",
+    )
+    payload = quote.to_dict()
+    assert payload["effective_date"] == "2026-08-30"
+    assert payload["source"] == "https://modal.com/pricing"
+
+
+def test_age_and_staleness_are_measured_against_a_supplied_date() -> None:
+    quote = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=4.54,
+        effective_date="2026-01-01",
+        source="https://modal.com/pricing",
+    )
+    assert quote.age_days(as_of=date(2026, 1, 31)) == 30
+    assert quote.is_stale(as_of=date(2026, 1, 31)) is False
+    assert quote.is_stale(as_of=date(2026, 12, 31)) is True
+    assert quote.is_stale(as_of=date(2026, 1, 31), max_age_days=10) is True
+
+
+def test_freshness_limit_boundary_is_inclusive() -> None:
+    quote = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=1.0,
+        effective_date="2026-01-01",
+        source="pricing page",
+    )
+    exactly_at_limit = date(2026, 1, 1) + timedelta(days=DEFAULT_MAX_PRICE_AGE_DAYS)
+    assert quote.is_stale(as_of=exactly_at_limit) is False
+
+
+def test_future_dated_quote_reports_a_negative_age_rather_than_zero() -> None:
+    quote = GpuPriceQuote(
+        gpu_type="H200",
+        usd_per_gpu_hour=1.0,
+        effective_date="2026-12-31",
+        source="pricing page",
+    )
+    assert quote.age_days(as_of=date(2026, 1, 1)) < 0
+
+
+@pytest.mark.parametrize(
+    "bad_date", ["30-08-2026", "2026-8-30", "2026-13-01", "2026-02-30", "today", ""]
+)
+def test_malformed_effective_dates_are_refused(bad_date: str) -> None:
+    with pytest.raises(DeploymentPlanError, match="effective_date"):
+        GpuPriceQuote(
+            gpu_type="H200",
+            usd_per_gpu_hour=1.0,
+            effective_date=bad_date,
+            source="pricing page",
+        )
+
+
+@pytest.mark.parametrize("bad_rate", [0.0, -1.0])
+def test_non_positive_rate_is_refused(bad_rate: float) -> None:
+    with pytest.raises(DeploymentPlanError, match="greater than zero"):
+        GpuPriceQuote(
+            gpu_type="H200",
+            usd_per_gpu_hour=bad_rate,
+            effective_date="2026-08-30",
+            source="pricing page",
+        )
+
+
+def test_implausible_rate_is_refused_as_a_units_mistake() -> None:
+    with pytest.raises(DeploymentPlanError, match="check the units"):
+        GpuPriceQuote(
+            gpu_type="H200",
+            usd_per_gpu_hour=MAX_PLAUSIBLE_USD_PER_GPU_HOUR + 1,
+            effective_date="2026-08-30",
+            source="pricing page",
+        )
+
+
+def test_source_is_mandatory_so_a_number_can_be_rechecked() -> None:
+    with pytest.raises(DeploymentPlanError, match="source"):
+        GpuPriceQuote(
+            gpu_type="H200",
+            usd_per_gpu_hour=1.0,
+            effective_date="2026-08-30",
+            source="   ",
+        )
+
+
+def test_storage_quote_applies_the_same_rules() -> None:
+    with pytest.raises(DeploymentPlanError, match="check the units"):
+        StorageQuote(
+            usd_per_gib_month=MAX_PLAUSIBLE_USD_PER_GIB_MONTH + 1,
+            effective_date="2026-08-30",
+            source="pricing page",
+        )
+    with pytest.raises(DeploymentPlanError, match="effective_date"):
+        StorageQuote(
+            usd_per_gib_month=0.02, effective_date="nope", source="pricing page"
+        )
+    fresh = StorageQuote(
+        usd_per_gib_month=0.02,
+        effective_date="2026-08-01",
+        source="https://modal.com/pricing",
+    )
+    assert fresh.age_days(as_of=date(2026, 8, 31)) == 30

--- a/tests/deploy/test_recipe.py
+++ b/tests/deploy/test_recipe.py
@@ -1,0 +1,231 @@
+"""Pinning rules: which model, which revision, which image, which GPUs."""
+
+from __future__ import annotations
+
+import pytest
+from _fakes import (
+    OTHER_REVISION,
+    PINNED_IMAGE,
+    TAG_ONLY_IMAGE,
+    VALID_DIGEST,
+    VALID_REVISION,
+)
+
+from llmtracefx.deploy.errors import DeploymentPlanError
+from llmtracefx.deploy.recipe import (
+    GLM_53_FLASH,
+    MIN_VRAM_HEADROOM_FRACTION,
+    SGLANG,
+    SUPPORTED_REPO_ID,
+    VLLM,
+    build_recipe,
+    check_memory_fit,
+    parse_image_reference,
+    require_model_revision,
+    require_supported_repo,
+)
+
+
+def recipe(**overrides: object):  # type: ignore[no-untyped-def]
+    kwargs: dict[str, object] = {
+        "framework": SGLANG,
+        "framework_version": "0.5.6",
+        "image_reference": PINNED_IMAGE,
+        "model_revision": VALID_REVISION,
+        "gpu_type": "H200",
+        "gpu_count": 4,
+        "context_length": 131072,
+        "weights_mount_path": "/weights",
+        "port": 30000,
+    }
+    kwargs.update(overrides)
+    return build_recipe(**kwargs)  # type: ignore[arg-type]
+
+
+def test_published_architecture_facts_are_carried_verbatim() -> None:
+    assert GLM_53_FLASH.repo_id == SUPPORTED_REPO_ID
+    assert GLM_53_FLASH.num_hidden_layers == 45
+    assert GLM_53_FLASH.max_position_embeddings == 1_048_576
+    assert GLM_53_FLASH.quantization == "fp8"
+    assert GLM_53_FLASH.quantization_format == "e4m3"
+    assert GLM_53_FLASH.multimodal is True
+    assert GLM_53_FLASH.config_source.startswith("https://huggingface.co/")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["main", "v1.0", VALID_REVISION[:12], VALID_REVISION.upper() + "X", "", "  "],
+)
+def test_only_a_full_commit_sha_counts_as_a_revision(bad: str) -> None:
+    with pytest.raises(DeploymentPlanError, match="40-character commit SHA"):
+        require_model_revision(bad)
+
+
+def test_revision_is_normalised_to_lower_case() -> None:
+    assert require_model_revision(VALID_REVISION.upper()) == VALID_REVISION
+
+
+def test_the_bf16_and_full_variants_are_refused_by_name() -> None:
+    with pytest.raises(DeploymentPlanError, match="twice the size"):
+        require_supported_repo("zai-org/GLM-5.3-Flash-BF16")
+    with pytest.raises(DeploymentPlanError, match="704 GiB"):
+        require_supported_repo("zai-org/GLM-5.3")
+    with pytest.raises(DeploymentPlanError, match="serves .* only"):
+        require_supported_repo("meta-llama/Llama-3-70B")
+
+
+def test_latest_is_refused_even_with_the_override() -> None:
+    with pytest.raises(DeploymentPlanError, match="never reproducible"):
+        parse_image_reference("lmsysorg/sglang:latest", accept_mutable=True)
+
+
+def test_tag_only_image_needs_an_explicit_acceptance() -> None:
+    with pytest.raises(DeploymentPlanError, match="accept-mutable-image"):
+        parse_image_reference(TAG_ONLY_IMAGE)
+    accepted = parse_image_reference(TAG_ONLY_IMAGE, accept_mutable=True)
+    assert accepted.is_digest_pinned is False
+    assert accepted.tag == "v0.5.6"
+
+
+def test_digest_pinned_image_is_parsed_into_its_parts() -> None:
+    reference = parse_image_reference(PINNED_IMAGE)
+    assert reference.name == "lmsysorg/sglang"
+    assert reference.tag == "v0.5.6"
+    assert reference.digest is not None
+    assert reference.is_digest_pinned is True
+    assert reference.to_dict()["digest_pinned"] is True
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "   ", "image@sha256:tooshort", "image:tag@md5:" + "a" * 32],
+)
+def test_malformed_image_references_are_refused(bad: str) -> None:
+    with pytest.raises(DeploymentPlanError):
+        parse_image_reference(bad, accept_mutable=True)
+
+
+def test_a_registry_port_is_not_mistaken_for_a_tag() -> None:
+    """``registry:5000/org/img`` has a colon and no tag.
+
+    Reading the port as a version would accept an untagged reference as
+    though it were pinned. Refusing the whole reference, which a naive
+    single pattern does, locks out every private registry.
+    """
+    reference = parse_image_reference(
+        f"registry.internal:5000/lmsysorg/sglang:v0.5.6@{VALID_DIGEST}"
+    )
+    assert reference.name == "registry.internal:5000/lmsysorg/sglang"
+    assert reference.tag == "v0.5.6"
+    assert reference.digest == VALID_DIGEST
+
+    with pytest.raises(DeploymentPlanError, match="neither a tag nor a digest"):
+        parse_image_reference("registry.internal:5000/lmsysorg/sglang")
+
+
+def test_a_digest_only_reference_is_pinned_without_a_tag() -> None:
+    reference = parse_image_reference(f"lmsysorg/sglang@{VALID_DIGEST}")
+    assert reference.tag is None
+    assert reference.is_digest_pinned is True
+
+
+def test_whitespace_inside_a_reference_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="malformed"):
+        parse_image_reference(f"lmsysorg/sglang:v1 --privileged@{VALID_DIGEST}")
+
+
+def test_four_h200_clears_the_headroom_requirement_for_the_fp8_checkpoint() -> None:
+    fit = check_memory_fit(gpu_type="H200", gpu_count=4)
+    assert fit.total_vram_gib == pytest.approx(564.0)
+    assert fit.fits is True
+    assert fit.residual_fraction > MIN_VRAM_HEADROOM_FRACTION
+    assert "does not prove" in fit.caveat
+
+
+def test_two_h200_cannot_hold_the_checkpoint() -> None:
+    fit = check_memory_fit(gpu_type="H200", gpu_count=2)
+    assert fit.total_vram_gib == pytest.approx(282.0)
+    assert fit.residual_gib < 0
+    assert fit.fits is False
+
+
+def test_enough_room_for_weights_but_not_for_kv_cache_still_fails() -> None:
+    # 320 GiB total against roughly 306 GiB of weights: the weights fit
+    # and nothing else does.
+    fit = check_memory_fit(gpu_type="H200", gpu_count=1, vram_gib_per_gpu=320.0)
+    assert fit.residual_gib > 0
+    assert fit.fits is False
+
+
+def test_unknown_gpu_requires_an_explicit_capacity() -> None:
+    with pytest.raises(DeploymentPlanError, match="unknown GPU type"):
+        check_memory_fit(gpu_type="TPUv5", gpu_count=4)
+    fit = check_memory_fit(gpu_type="TPUv5", gpu_count=4, vram_gib_per_gpu=200.0)
+    assert fit.fits is True
+
+
+def test_tensor_parallel_defaults_to_the_gpu_count() -> None:
+    assert recipe().tensor_parallel_size == 4
+
+
+def test_tensor_parallel_cannot_exceed_the_allocated_gpus() -> None:
+    with pytest.raises(DeploymentPlanError, match="exceeds gpu_count"):
+        recipe(tensor_parallel_size=8)
+
+
+def test_context_length_cannot_exceed_the_model_maximum() -> None:
+    with pytest.raises(DeploymentPlanError, match="max_position_embeddings"):
+        recipe(context_length=GLM_53_FLASH.max_position_embeddings + 1)
+
+
+def test_framework_version_must_be_stated() -> None:
+    with pytest.raises(DeploymentPlanError, match="framework_version"):
+        recipe(framework_version="  ")
+
+
+def test_unsupported_framework_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="framework must be one of"):
+        recipe(framework="tensorrt")
+
+
+def test_server_is_pointed_at_the_volume_not_at_the_repository_id() -> None:
+    built = recipe()
+    argv = built.launch_argv()
+    assert built.local_model_path() == f"/weights/{VALID_REVISION}"
+    assert built.local_model_path() in argv
+    assert SUPPORTED_REPO_ID not in argv[: argv.index("--served-model-name")]
+
+
+def test_sglang_argv_carries_parallelism_and_context_cap() -> None:
+    argv = recipe().launch_argv()
+    assert argv[:3] == ("python3", "-m", "sglang.launch_server")
+    assert "--tp" in argv and argv[argv.index("--tp") + 1] == "4"
+    assert argv[argv.index("--context-length") + 1] == "131072"
+    assert argv[argv.index("--port") + 1] == "30000"
+
+
+def test_vllm_argv_uses_its_own_flag_spellings() -> None:
+    argv = recipe(framework=VLLM).launch_argv()
+    assert argv[:2] == ("vllm", "serve")
+    assert argv[argv.index("--tensor-parallel-size") + 1] == "4"
+    assert argv[argv.index("--max-model-len") + 1] == "131072"
+
+
+def test_launch_argv_never_contains_a_credential_flag() -> None:
+    for framework in (SGLANG, VLLM):
+        argv = recipe(framework=framework).launch_argv()
+        joined = " ".join(argv).casefold()
+        assert "--api-key" not in joined
+        assert "token" not in joined
+
+
+def test_recipe_serialises_the_pin_and_the_revision() -> None:
+    payload = recipe(model_revision=OTHER_REVISION).to_dict()
+    assert payload["model_revision"] == OTHER_REVISION
+    assert payload["image"]["digest_pinned"] is True
+    assert payload["model_facts"]["quantization"] == "fp8"
+
+
+def test_relative_mount_path_is_refused() -> None:
+    with pytest.raises(DeploymentPlanError, match="absolute path"):
+        recipe(weights_mount_path="weights")

--- a/uv.lock
+++ b/uv.lock
@@ -1209,7 +1209,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi" },
-    { name = "modal" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
@@ -1239,6 +1238,9 @@ mlx = [
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
+modal = [
+    { name = "modal" },
+]
 test = [
     { name = "httpx" },
     { name = "pytest" },
@@ -1259,7 +1261,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.25.0" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.31.0" },
-    { name = "modal", specifier = ">=0.57.0" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "numpy", specifier = ">=1.25.2" },
     { name = "pandas", specifier = ">=2.1.3" },
@@ -1275,7 +1277,7 @@ requires-dist = [
     { name = "streamlit", specifier = ">=1.28.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev", "test", "mlx", "docs"]
+provides-extras = ["modal", "dev", "test", "mlx", "docs"]
 
 [[package]]
 name = "markdown"


### PR DESCRIPTION
Targets `main`. This was originally stacked on #12; that PR has since been squash-merged (`5eb171f`), and this branch has been rebased onto the resulting `main` with no conflicts. It reuses that collector's credential defences (`redact_text_for_dry_run`, `SecureArgumentParser`) rather than reimplementing them, and modifies none of its files.

Standing a 320B checkpoint up on rented accelerators is easy to do accidentally and expensive to do wrong. This adds a harness whose default behaviour is to refuse, and whose only executable output is a printed command list.

## Planning is pure, and it is also the gate

`llmtracefx-deploy plan` opens no socket, reads no credential for use, and never imports the Modal SDK, so it runs before the operator has a Modal account. It prices the worst case, checks whether the accelerators can hold the weights with headroom for KV cache, and prints every command the deployment would take.

When a gate fails the plan still renders in full, because an operator needs to see why, but every money-spending command is withheld from the executable set rather than merely annotated:

```
Deployment plan: REFUSED

Blockers (paid steps withheld until every one is cleared)
  - Worst-case cost $18.16 exceeds the authorised budget $10.00.

Steps
    setup: ...
x $ deploy: Deploy the serving app and obtain its https URL.
x $ smoke: One bounded chat completion proving the endpoint serves.
    stop: Stop the app so no container can be started by a request.
```

Teardown stays available even when refused. Those are the commands that make spending stop, so gating them on approval would withhold them exactly when they are most needed.

## Nothing has a default that spends

Budget, GPU type and count, maximum runtime, and a GPU price with the date it was read are all required with no defaults. There is deliberately no price literal in the package: prices are mutable, and a compiled-in rate decays into a false claim about the present. A quote past the freshness limit is refused.

An explicitly supplied zero is honoured rather than defaulted away. That matters most for the freshness limit, where zero means "only a quote read today", the strictest setting available, and the usual `value or DEFAULT` idiom would have handed back the laxest.

`llmtracefx-deploy budget --credit-usd 30` recommends `$10` and holds `$20` back for a failed start up, one retry, and volume storage.

## The priced window is described as what it actually is

Modal's `timeout` bounds a Function's *execution*, and this server's function returns as soon as it has launched the framework, so nothing stops the container at `max_runtime_seconds`. The window is therefore presented as authorised rather than enforced, with teardown as what closes it, and the plan says so in its own output.

For the same reason `min_containers` above zero is refused outright rather than warned about: Modal keeps those containers running while the Function is idle, so they bill continuously from deploy until the app is stopped, with no relation to any window the envelope could price. Approving that would make the envelope an estimate rather than the upper bound it claims to be.

## vLLM is the default, because of where each framework puts your key

Both frameworks are officially supported for this model and both are available here. The deciding difference is credential handling:

- vLLM reads `VLLM_API_KEY` from the environment (`vllm/envs.py`, and the auth middleware in `vllm/entrypoints/serve/middleware/register.py`), so the value never reaches a command line.
- SGLang accepts it only as `--api-key` on argv, and its engine logs its own resolved configuration with `logger.info(f"server_args={server_args.resolved_dict()}")` (`python/sglang/srt/entrypoints/engine.py`), unredacted. The key would land in container logs and in `/proc/<pid>/cmdline`.

So `--framework sglang` is refused unless `--accept-argv-credential-exposure` is passed. Both sources read 2026-08-30.

## Credentials by name, then checked again by value

Plans, manifests and generated commands carry only variable names and secret names; the curl commands reference `$GLM_SELFHOST_API_KEY` rather than interpolating it.

On top of that, the rendered document is scrubbed against the resolved credential using the same redactor `collect-api --dry-run` uses. Shape validation alone is not enough here: a real API key can be a well-formed Modal Secret name, so it would pass a pattern check and be printed. The scrub covers stdout, stderr and the `--output` artifact on the success, JSON, refusal and validation-error paths.

The credential-flag guard prints a fixed diagnostic that does not repeat the offending option, so no part of the caller's argv can reach a log through it.

Both Advanced Security clear-text-logging findings from the earlier revision are resolved; the latest CodeQL analysis on this head reports 0 results.

## Staging is separated from serving

`stage_weights` takes no `gpu` argument at all, so hundreds of GiB are never transferred while accelerators bill. It requires the revision to be restated through `--confirm`, so a stale copy-paste fails rather than fetching something else, and it writes a manifest of every file, its size, and its published sha256 where upstream provided one. Hashes are not recomputed locally: that would double the billed container time and would prove self-consistency, not provenance.

The server is pointed at the volume path rather than the repository id, so it cannot fall back to downloading on GPUs, and it verifies the manifest before launching the framework.

## Measurement stays with the collector

The server records only what it can honestly observe about its own configuration (GPU model and count, framework and version, revision, quantization, tensor parallel degree, context cap, start up duration), each marked configured or observed, and makes no performance claim. Timing evidence comes from `collect-api` against the endpoint, from outside.

The runbook documents OpenRouter (`z-ai/glm-5.3-flash`) as the cheaper primary route, with self-hosting reserved for questions about serving that a hosted endpoint cannot answer.

## Honesty about what upstream does not publish

Architecture facts are compiled in and cited to `config.json`. Everything mutable must be supplied and is validated, including a right-to-left image reference parse so a registry host with a port is not mistaken for a tag.

As of 2026-08-30 the model card states no minimum framework version, shows no multi-GPU or FP8 flags, and pins no image digest (it shows `lmsysorg/sglang:latest`, which this harness refuses). No official hardware requirement exists, so the 4x H200 check is presented as arithmetic that can disprove a configuration but not prove one.

## Packaging

Modal moves from a runtime dependency to an optional extra. Nothing in the library imported it at module scope already, and the full suite passes with the SDK uninstalled. The harness is its own `llmtracefx-deploy` console script, so no existing module is modified: the diff touches only new files plus `README.md`, `Makefile`, `pyproject.toml`, `requirements.txt` and `uv.lock`.

## Tests

292 new tests, all offline, none requiring Modal. The entrypoint is imported against a fake Modal SDK so the GPU string, timeout, container limits, concurrency and the absence of a GPU on staging are asserted directly rather than by inspection. Others make `socket.socket` raise to prove planning never connects, and plant a sentinel credential to prove it reaches neither stdout, stderr nor the written artifact.

Full suite: 1888 passed on `main`. All ten checks green, including the quality ratchet and CodeQL (latest analysis on this head: 0 results).

## What independent review changed

Three rounds, each of which found something worth fixing.

The first round caught two fail-open defaults: `_int(...) or DEFAULT` could not distinguish an unset environment variable from one set to `0`, which mattered most for the price freshness limit where `0` is the strictest setting and was being rewritten to the laxest; and the image reference pattern read every colon as a tag separator, locking out any registry with a port.

The second round caught two more. The cost envelope claimed to be an upper bound while approving `min_containers > 0`, which bills continuously and is not bounded by the priced window at all; that is now a blocker, and the plan states plainly that the window is authorised rather than platform-enforced. It also found that SGLang logs its own resolved server args unredacted, so passing the key on its argv would put it in container logs; vLLM became the default for that reason and SGLang now needs an explicit acknowledgement.

The third round found that a whitespace-padded `--api-key-env` was accepted everywhere except the lookup that resolves the value to scrub for, silently turning the redaction into a no-op, and that two ordinary typos (`--max-containers 10**308`, `--endpoint-base-url "https://[bad"`) escaped as tracebacks on the one output path the design routes through the scrub. Both are fixed and covered.

It also pointed out that one earlier sentinel test was vacuous, passing whether or not the scrub existed. It now pastes the key where the image parser will quote it back, and both it and the padded-name test were mutation-tested: reintroducing either defect makes the corresponding test fail.

The fourth round, run against this branch after it was rebased onto `main`, found the one place the harness failed open. `serve()` resolved the endpoint key and, if it came back empty, took neither the sglang nor the vLLM branch and started the server anyway. Neither framework installs authentication middleware without a non-empty key, and this endpoint has no platform auth in front of it (Modal proxy auth expects its own headers, which would stop it being OpenAI-compatible for the collector), so an empty value would not have weakened authentication, it would have removed it and published four accelerators openly. Modal's `required_keys` does not cover this: it asserts the variable is present, not that it holds anything, and `modal secret create NAME VAR="$VAR"` in a shell where the export was lost creates exactly that. The container now refuses to start, the runbook calls out the hazard, and `serve()` has direct test coverage for the first time. The same round found `recommended_session_budget_usd` overflowing to an uncaught `OverflowError` on a large finite credit, which is now a refusal.

## Fifth review round: five material issues

A review of the merged-onto-main head found five things, all fixed here.

**The entrypoint could not be imported on a worker.** `PLAN = plan_from_environ(os.environ)` runs at module import, and Modal imports the module inside every container as well as locally. Remotely none of those variables exist, so every container would have crashed on import. The deploy now derives a canonical configuration from the *validated plan* and bakes it into both container images, so a worker rebuilds the same plan from the image rather than from a shell it has never seen. Nothing baked there is a secret. The staging image was also missing the local package entirely, which is the same bug wearing a different hat, and now carries it.

**The approved spend was not actually bounded.** `serve()` returns as soon as it has launched the framework, so Modal's timeout bounded nothing and a request arriving at any future time would allocate accelerators again. There is now a deploy expiry baked into the image: the container refuses to start once it has passed, a watchdog stops the container at whichever comes first of its own timeout or the remaining window, and an unparseable expiry reads as expired. Cost is priced against the deployment window plus one container timeout, because a container starting just before the expiry still runs its full lifetime. That makes the figure an upper bound rather than an estimate. What it does not bound, and the plan now says so, is that an unauthenticated request cold-starts a container before the server checks the key; the expiry is what limits that.

**The total omitted mandatory charges.** It priced accelerators and, optionally, storage. It now prices five lines: accelerators, the CPU and memory billed alongside them, the CPU-only staging container, the CPU-only verification container, and storage for the declared retention plus the four days Modal bills after deletion. All rates are required. The container shapes live in one module imported by both the entrypoint and the pricer, so what is requested cannot drift from what is priced.

**A manifest is not an inventory.** `matches()` compared only repository and revision, so an interrupted download that left a short shard looked fine until the serving container had allocated four accelerators. A CPU-only verification step now re-checks every file's existence and size, and its published sha256 where one exists, and the serving container refuses to start without a passing record for its own revision.

**The rendered commands were shell-injectable.** Quoting applied only to tokens containing whitespace, a quote or a backslash, so `;`, `|`, `&&`, `$()` and backticks in an app name, volume name or model name executed when the operator pasted the line. Every literal token is now `shlex.quote`d, and the one intentional expansion is a structured `EnvRef` whose name is validated as an environment variable name and whose surrounding literals are escaped for the double-quoted context. Hostile values across every string flag round-trip through `shlex.split` unchanged.

CodeQL also raised three non-security notices on the new code (an empty `except` and two implicit string concatenations in a list); both classes are fixed rather than suppressed, matching how the same classes were handled on `main`.

292 offline deploy tests, 1888 in the full suite.

## Not done here

Zero paid execution. No weights downloaded, no GPU launched, no Modal account authenticated, and every price shown in examples is a placeholder rather than a measurement.