### PR TITLE
feat(workloads): execute the matrix against OpenAI-compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1975,8 +1975,17 @@ resume actually reads both sat outside every integrity check, so either
 could be edited and would still be trusted. `run.json` is removed before a
 row is rewritten and written last, so an interrupted run leaves a directory
 that is rejected rather than one that reads as trustworthy. A stale
-binding, an interrupted write, a missing marker or a file edited after the
-fact all rerun the row. `--no-resume` reruns everything regardless.
+binding, an interrupted write, a missing marker, or a file edited *without*
+regenerating the marker all rerun the row. `--no-resume` reruns everything
+regardless.
+
+This is tamper evidence, not tamper proofing, and the distinction is worth
+stating plainly: `run.json` is unsigned and derives from nothing outside
+the run directory, so anyone who can edit `final_record.json` can also
+rewrite the marker over it and resume will trust the result. What the
+marker buys is that the failures which actually happen -- a crash between
+files, a half-written directory, a hand edit nobody thought to re-seal --
+stop resume rather than sail through it.
 
 The API binding hash covers the sanitized endpoint identity (origin, path,
 query keys and hashed query values), the provider label, the model ID and

--- a/README.md
+++ b/README.md
@@ -1759,8 +1759,230 @@ uv run llmtracefx-optimizer workloads summarize --results artifacts/qwen3.8-run
 
 which reports pass rate and "correct cases per minute" (computed only from
 rows that both passed and have measured timing) overall and broken down by
-decode mode and context tier -- deliberately not blended into one combined
-score.
+decode mode, context tier, backend and provider -- deliberately not blended
+into one combined score.
+
+The `backend` and `provider` breakdowns exist so that figures which are not
+the same quantity stay apart. A row measured on a local checkpoint times a
+model on your machine; a row measured through a hosted API times a request
+to somebody else's, on hardware you cannot see. Locally executed rows have
+no provider and are left out of `by_provider` entirely rather than being
+gathered under a placeholder key, so those groups do not sum to `overall`.
+A metric that is undefined for a group is reported as `null`, never `0`: no
+evaluated rows means there is no pass rate, which is a different statement
+from a pass rate of zero.
+
+### Executing the matrix against an API: `workloads run-api`
+
+`workloads run-api` is the remote counterpart to `workloads run`. It takes
+the same matrix manifest, the same selection filters, the same
+deterministic evaluators and the same canonical `ExperimentRecord`, but
+executes each selected row through the provider-neutral streaming
+`collect-api` collector instead of a local MLX checkpoint. Transport, SSE
+decoding, failure classification and credential redaction are that
+collector's, used unmodified.
+
+> All commands in this section are **unmeasured examples**. They show the
+> shape of an invocation; no number in this repository was produced by
+> running them, and running one measures your endpoint on that day, not a
+> published result.
+
+Providers are named *profiles*, not hardcoded behaviour. A profile only
+supplies defaults for `--provider`, `--endpoint` and `--api-key-env`:
+
+```bash
+uv run llmtracefx-optimizer workloads list-api-profiles
+```
+
+```json
+{
+  "profiles": [
+    {
+      "name": "openrouter",
+      "provider_label": "openrouter",
+      "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+      "credential_env_var": "OPENROUTER_API_KEY",
+      "documented_model_ids": ["z-ai/glm-5.3", "z-ai/glm-5.3-flash"]
+    },
+    {
+      "name": "z.ai",
+      "provider_label": "z.ai",
+      "endpoint": "https://api.z.ai/api/paas/v4/chat/completions",
+      "credential_env_var": "ZAI_API_KEY",
+      "documented_model_ids": ["glm-5.3", "glm-5.3-flash"]
+    }
+  ]
+}
+```
+
+Validate a selection and see exactly what would be sent, with no network
+request and no secret in the output (**unmeasured example**):
+
+```bash
+uv run llmtracefx-optimizer workloads run-api \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --output-dir artifacts/glm-api-run \
+  --profile openrouter \
+  --model-id z-ai/glm-5.3 \
+  --mode autoregressive \
+  --context-tier 2k \
+  --dry-run
+```
+
+The plan goes to stdout as JSON (so it can be piped into `jq`) and is also
+written to `<output-dir>/api_request_plan.json`; the human-readable row
+count goes to stderr. It carries message *digests* rather than prompt text,
+endpoint query *keys* rather than values, and header *names* rather than
+header values, and the whole document is passed through the collector's
+redactor before it is printed or written.
+
+Then execute against OpenRouter (**unmeasured example**):
+
+```bash
+export OPENROUTER_API_KEY=...   # read by name, never persisted or echoed
+
+uv run llmtracefx-optimizer workloads run-api \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --output-dir artifacts/glm-api-run \
+  --profile openrouter \
+  --model-id z-ai/glm-5.3-flash \
+  --mode autoregressive \
+  --reasoning-effort high \
+  --thinking enabled
+```
+
+Or directly against Z.ai, whose model IDs carry no vendor prefix
+(**unmeasured example**):
+
+```bash
+export ZAI_API_KEY=...
+
+uv run llmtracefx-optimizer workloads run-api \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --output-dir artifacts/glm-direct-run \
+  --profile z.ai \
+  --model-id glm-5.3 \
+  --mode autoregressive
+```
+
+An unlisted provider is a first-class citizen, not a special case: drop
+`--profile` and give the three fields it would have filled in
+(**unmeasured example**):
+
+```bash
+uv run llmtracefx-optimizer workloads run-api \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --output-dir artifacts/self-hosted-run \
+  --provider self-hosted \
+  --endpoint https://vllm.internal.example/v1/chat/completions \
+  --api-key-env SELF_HOSTED_API_KEY \
+  --model-id local-glm \
+  --mode autoregressive
+```
+
+What the command guarantees:
+
+- **The matrix row decides the request.** The prompt is read from the
+  entry's `prompt_path` and its sha256 is checked against the manifest
+  before anything is sent, and the row's `max_tokens` becomes the
+  request's `max_tokens`. A mismatch fails the row instead of quietly
+  measuring a different prompt.
+- **`native-mtp` rows stay `unsupported`.** Native multi-token prediction
+  is a decoding mechanism inside a local runtime. A hosted API exposes no
+  such control, and its reasoning or "thinking" settings are a different
+  mechanism measuring something else, so those rows are rejected rather
+  than re-labelled. Passing `--reasoning-effort` does not change this.
+- **Only the final answer is graded.** The evaluator sees the assembled
+  content stream, never `reasoning_content`, so a model that reasons its
+  way to the answer and then states something else is graded on what it
+  stated.
+- **A provider failure is never overwritten by an evaluator verdict.** A
+  non-200, a timeout, a decode error, a provider error frame or a stream
+  that ends without a clean termination fails the row and the evaluator is
+  not run at all -- including when the failed response body happens to
+  contain a passing answer. A stream counts as cleanly terminated when it
+  sent either the `[DONE]` sentinel or a terminal `finish_reason`, since
+  not every OpenAI-compatible provider sends both; a documented failure
+  reason or a frame left pending at end of stream is truncation either
+  way. If collection succeeded but the evaluator itself raised, the row is
+  `inconclusive`: the timing evidence is kept and `quality_score` is left
+  unset rather than guessed.
+- **`--max-stream-events`** bounds a chatty endpoint that stays under the
+  request timeout while emitting far more events than any answer needs.
+  Tripping the cap fails the row as truncated with the cap named in the
+  reason, even if a terminal `finish_reason` had already arrived: we are
+  the ones who stopped reading, so what arrived is a prefix of the answer
+  and grading it would publish a truncation as a verdict. The timing and
+  usage evidence is still persisted; only the outcome refuses to claim
+  success.
+- **A credential is refused before it can be written down, not after.**
+  Both `--dry-run` and a real run apply the collector's pre-flight check,
+  which fails the row if the key from `--api-key-env` appears in the
+  endpoint, provider label, model ID, prompt, output path or reconstructed
+  command. This runs *before* the request plan is built, because a
+  credential sitting in an endpoint query value would otherwise be folded
+  into the config hash as its sha256 and no redactor can undo a hash.
+- **No credential is ever hashed, persisted or echoed.** There is no
+  `--api-key` flag; `--api-key-env` takes a *name*. The API binding hash
+  deliberately excludes that name, both because two runs differing only in
+  which variable held the key issue byte-identical requests and are graded
+  identically, and because a caller who pastes a key into that slot must
+  not have a derivation of it written into an artifact.
+
+Each row writes `runs/<run_id>/collection/{record.json,response.txt,
+api_evidence.json,environment.json,artifacts.json}` (the collector's own
+artifact set, with `artifacts.json` as its completion marker),
+`final_record.json` (the canonical `ExperimentRecord` carrying the
+evaluator's outcome) and `verification.json`. Aggregate it with the same
+`workloads summarize` used for local runs.
+
+Re-running with the same `--output-dir` resumes, but only on evidence that
+is provably whole. A row is skipped only if *every* one of these holds: the
+prior `verification.json` is `completed`/`skipped`, it was produced by this
+same backend, and its prompt hash, workload version and API binding hash
+all still match, **and** the collector's `artifacts.json` marker verifies
+the sha256 of every file in the collection directory. A stale binding, an
+interrupted write, a missing marker or a file edited after the fact all
+rerun the row. `--no-resume` reruns everything regardless.
+
+The API binding hash covers the sanitized endpoint identity (origin, path,
+query keys and hashed query values), the provider label, the model ID and
+revision, the request parameters including this row's `max_tokens`, the
+provider extensions and reasoning settings, the finish-reason vocabulary,
+the request timeout, the system prompt's hash, the event cap, and the
+workload version the answer is graded against. Changing any of them reruns
+the row rather than trusting evidence gathered under different conditions.
+
+#### Repeating a run
+
+The matrix deliberately has no repetition axis: `run_id` is derived from
+`(workload, context tier, decode mode)`, so one manifest row is one
+invocation. Rather than invent synthetic repetition IDs that no other part
+of the pipeline understands, repeat by giving each repetition its own
+results directory (**unmeasured example**):
+
+```bash
+for repetition in 1 2 3; do
+  uv run llmtracefx-optimizer workloads run-api \
+    --matrix artifacts/qwen3.8-matrix/manifest.json \
+    --output-dir "artifacts/glm-api-run/rep-${repetition}" \
+    --profile openrouter \
+    --model-id z-ai/glm-5.3 \
+    --mode autoregressive
+done
+```
+
+Each repetition is then summarized on its own with `workloads summarize`.
+Keeping them in separate directories is what makes repeated sampling
+honest here: resume is keyed on the run directory, so reusing one directory
+would skip the second repetition rather than measure it, and the spread
+across repetitions stays visible instead of being averaged away by a
+pipeline that never saw it as a spread.
+
+This command deliberately computes no cost, no price and no cross-provider
+ranking. The provider's own usage counters are persisted exactly as
+reported; turning them into money or into a comparison is a separate
+concern with its own correctness burden.
 
 ### Offline tuning and the `tune-report` HTML viewer
 

--- a/README.md
+++ b/README.md
@@ -1892,6 +1892,18 @@ What the command guarantees:
   such control, and its reasoning or "thinking" settings are a different
   mechanism measuring something else, so those rows are rejected rather
   than re-labelled. Passing `--reasoning-effort` does not change this.
+- **`code_completion` rows stay `unsupported` too, and this one is a
+  security boundary.** That category is graded by writing the model's
+  answer to disk and running it with this interpreter. Locally that is a
+  considered trade, because the answer came from a checkpoint on your own
+  machine. Over an API it is not: the answer comes from a remote endpoint,
+  and the evaluator has no network namespace, no filesystem confinement
+  and no seccomp policy, only a minimal environment and POSIX resource
+  limits. Executing it would hand the provider local code execution. The
+  row is refused before a request is sent and the evaluator is never
+  invoked. There is deliberately no opt-in flag; the honest time to add
+  one is when a real sandbox exists to put behind it. Run this category
+  locally with `workloads run`.
 - **Only the final answer is graded.** The evaluator sees the assembled
   content stream, never `reasoning_content`, so a model that reasons its
   way to the answer and then states something else is graded on what it
@@ -1935,17 +1947,36 @@ Each row writes `runs/<run_id>/collection/{record.json,response.txt,
 api_evidence.json,environment.json,artifacts.json}` (the collector's own
 artifact set, with `artifacts.json` as its completion marker),
 `final_record.json` (the canonical `ExperimentRecord` carrying the
-evaluator's outcome) and `verification.json`. Aggregate it with the same
-`workloads summarize` used for local runs.
+evaluator's outcome), `verification.json`, and `run.json` sealing all
+three. Aggregate it with the same `workloads summarize` used for local
+runs.
+
+`summarize` withholds `correct_cases_per_minute` for any group that mixes
+measurement contexts, reporting `timing_comparable: false` with a reason
+and listing the contexts involved. A duration only means something beside
+another measured the same way: a local row times a model on your machine,
+an API row times a request to somebody else's over a network. Quality is
+unaffected, since a pass is a pass wherever it was produced, so pass counts
+and pass rate stay populated and only the timing figure is withheld. Read
+the per-backend and per-provider groups for comparable throughput.
 
 Re-running with the same `--output-dir` resumes, but only on evidence that
 is provably whole. A row is skipped only if *every* one of these holds: the
 prior `verification.json` is `completed`/`skipped`, it was produced by this
 same backend, and its prompt hash, workload version and API binding hash
 all still match, **and** the collector's `artifacts.json` marker verifies
-the sha256 of every file in the collection directory. A stale binding, an
-interrupted write, a missing marker or a file edited after the fact all
-rerun the row. `--no-resume` reruns everything regardless.
+the sha256 of every file in the collection directory, **and** the run-level
+`run.json` marker verifies the collection marker together with
+`final_record.json` and `verification.json`.
+
+That second marker exists because the collector's own covers only the four
+files it writes. The record carrying the graded outcome and the summary
+resume actually reads both sat outside every integrity check, so either
+could be edited and would still be trusted. `run.json` is removed before a
+row is rewritten and written last, so an interrupted run leaves a directory
+that is rejected rather than one that reads as trustworthy. A stale
+binding, an interrupted write, a missing marker or a file edited after the
+fact all rerun the row. `--no-resume` reruns everything regardless.
 
 The API binding hash covers the sanitized endpoint identity (origin, path,
 query keys and hashed query values), the provider label, the model ID and

--- a/README.md
+++ b/README.md
@@ -1910,11 +1910,13 @@ What the command guarantees:
 - **`--max-stream-events`** bounds a chatty endpoint that stays under the
   request timeout while emitting far more events than any answer needs.
   Tripping the cap fails the row as truncated with the cap named in the
-  reason, even if a terminal `finish_reason` had already arrived: we are
-  the ones who stopped reading, so what arrived is a prefix of the answer
-  and grading it would publish a truncation as a verdict. The timing and
-  usage evidence is still persisted; only the outcome refuses to claim
-  success.
+  reason; the timing and usage evidence is still persisted, and only the
+  outcome refuses to claim success. The budget is denominated in
+  *dispatched SSE events*, counting the terminal sentinel. Chunks that
+  dispatch no event, such as keepalive comments or a stray blank line,
+  are not charged, and the count is taken before each chunk is handed on,
+  so two runs over identical bytes agree regardless of how the network
+  split them into reads.
 - **A credential is refused before it can be written down, not after.**
   Both `--dry-run` and a real run apply the collector's pre-flight check,
   which fails the row if the key from `--api-key-env` appears in the

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -862,12 +862,39 @@ def _cmd_workloads_list_api_profiles(args: argparse.Namespace) -> int:
     return 0
 
 
+def _effective_api_key_env(args: argparse.Namespace) -> str | None:
+    """The credential variable this invocation will actually read.
+
+    ``--api-key-env`` may be left unset and supplied by the profile, so
+    reading the flag alone misses the name in the common case. Every
+    diagnostic in this command scrubs against the resolved name, because
+    scrubbing against ``None`` silently scrubs nothing.
+    """
+    if args.api_key_env:
+        return str(args.api_key_env)
+    try:
+        profile = _resolved_api_profile(args)
+    except APIProfileError:
+        return None
+    return profile.credential_env_var if profile is not None else None
+
+
 def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
+    # Resolved once, up front, so that every failure path below scrubs
+    # against the same name the request would have used.
+    key_env = _effective_api_key_env(args)
+
     matrix_path = Path(args.matrix)
     try:
         manifest = MatrixManifest.read_json(matrix_path)
     except (OSError, MatrixSchemaError) as exc:
-        print(f"Failed to load matrix manifest: {exc}", file=sys.stderr)
+        # ``OSError`` embeds the path it failed on, and that path came from
+        # the caller, so it is scrubbed like any other caller-supplied text
+        # rather than trusted because a path is not usually a secret.
+        print(
+            f"Failed to load matrix manifest: {_scrubbed_detail(key_env, exc)}",
+            file=sys.stderr,
+        )
         return 1
 
     try:
@@ -885,7 +912,7 @@ def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
         # It has to be caught here or it escapes as an unscrubbed traceback.
         print(
             f"Failed to configure API workload execution: "
-            f"{_scrubbed_detail(args.api_key_env, exc)}",
+            f"{_scrubbed_detail(key_env, exc)}",
             file=sys.stderr,
         )
         return 1
@@ -913,7 +940,10 @@ def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
         try:
             atomic_write_text(output_dir / "api_request_plan.json", document + "\n")
         except OSError as exc:
-            print(f"Failed to write request plan: {exc}", file=sys.stderr)
+            print(
+                f"Failed to write request plan: {_scrubbed_detail(key_env, exc)}",
+                file=sys.stderr,
+            )
             return 1
 
         blocked = sum(1 for plan in plans if not plan.unsupported and not plan.ready)
@@ -1533,31 +1563,44 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
 
 _MIN_SCRUBBED_ARGUMENT_CHARS = 4
 
-_CREDENTIAL_ARGUMENT_STEMS = frozenset(
-    {
-        "apikey",
-        "apikeys",
-        "apisecret",
-        "apitoken",
-        "accesskey",
-        "accesstoken",
-        "auth",
-        "authorization",
-        "authtoken",
-        "bearer",
-        "bearertoken",
-        "clientsecret",
-        "credential",
-        "credentials",
-        "key",
-        "password",
-        "passwd",
-        "pwd",
-        "secret",
-        "secretkey",
-        "token",
-    }
-)
+#: Credential-shaped option stems, mapped to this program's own canonical
+#: spelling of each one.
+#:
+#: A mapping rather than a set because the refusal message names the flag,
+#: and naming it from the caller's own token means echoing a command-line
+#: argument that -- by the very definition of this check -- may be the
+#: credential. Splitting the token on ``=`` and printing the left half was
+#: believed to be safe, but that safety rested on reasoning about every
+#: shape an argument can take rather than on construction, and it left a
+#: tainted value flowing into a write to stderr.
+#:
+#: Resolving the stem to a value defined here instead means nothing derived
+#: from the command line reaches an output stream at all. The caller still
+#: gets an actionable flag name, just spelled the way this program spells
+#: it: someone who typed ``--API_KEY=...`` is told about ``--api-key``.
+_CREDENTIAL_ARGUMENT_STEMS: dict[str, str] = {
+    "apikey": "--api-key",
+    "apikeys": "--api-keys",
+    "apisecret": "--api-secret",
+    "apitoken": "--api-token",
+    "accesskey": "--access-key",
+    "accesstoken": "--access-token",
+    "auth": "--auth",
+    "authorization": "--authorization",
+    "authtoken": "--auth-token",
+    "bearer": "--bearer",
+    "bearertoken": "--bearer-token",
+    "clientsecret": "--client-secret",
+    "credential": "--credential",
+    "credentials": "--credentials",
+    "key": "--key",
+    "password": "--password",
+    "passwd": "--passwd",
+    "pwd": "--pwd",
+    "secret": "--secret",
+    "secretkey": "--secret-key",
+    "token": "--token",
+}
 
 _GLUED_CREDENTIAL_FLAGS = tuple(
     sorted(
@@ -2004,19 +2047,24 @@ def _reject_credential_arguments(raw_argv: Sequence[str]) -> None:
     such a run and would point the caller at a flag that does not exist on
     the subcommand they used. Those values are redacted where they are
     persisted instead.
+
+    The flag is named from ``_CREDENTIAL_ARGUMENT_STEMS`` rather than from
+    the caller's token, so no byte of the command line reaches stderr. The
+    token that matched is, by the definition of this check, the one most
+    likely to be holding a credential.
     """
     for token in raw_argv:
         if token == "--":
             return
         if not token.startswith("-"):
             continue
-        if _option_stem(token) not in _CREDENTIAL_ARGUMENT_STEMS:
+        canonical = _CREDENTIAL_ARGUMENT_STEMS.get(_option_stem(token))
+        if canonical is None:
             continue
-        name = token.split("=", 1)[0]
         print(
-            f"llmtracefx-optimizer: error: {name} is not a supported option "
-            "and a credential must never appear in a command line. Export "
-            "the credential to an environment variable and name that "
+            f"llmtracefx-optimizer: error: {canonical} is not a supported "
+            "option and a credential must never appear in a command line. "
+            "Export the credential to an environment variable and name that "
             "variable with --api-key-env.",
             file=sys.stderr,
         )

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -59,6 +59,7 @@ from .collectors.openai_api import (
     OpenAIStreamCollectorError,
     ProviderExtensions,
     UrllibStreamingTransport,
+    _contains_credential,
     assert_credential_not_embedded,
     build_request_plan,
     collect_openai_stream,
@@ -883,6 +884,32 @@ def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
     # Resolved once, up front, so that every failure path below scrubs
     # against the same name the request would have used.
     key_env = _effective_api_key_env(args)
+
+    # Before anything is read, planned, created or printed. A credential
+    # pasted into a path is the one leak no downstream redactor can undo,
+    # because creating the directory writes it into the filesystem itself,
+    # where it outlives the process and lands in backups and shell
+    # completion. The collector refuses this too, but only once a row
+    # reaches it, which is after the output directory has been created and
+    # after an unsupported or early-failing row has already written its
+    # verification.json under that name.
+    credential = os.environ.get(key_env, "").strip() if key_env else ""
+    if credential:
+        for label, value in (
+            ("--output-dir", args.output_dir),
+            ("--matrix", args.matrix),
+        ):
+            if _contains_credential(str(value), credential):
+                # The offending value is named by its flag and never
+                # echoed; it is the credential.
+                print(
+                    f"llmtracefx-optimizer: error: the value named by "
+                    f"--api-key-env appears in {label}; refusing to run "
+                    "because that value would be written into the "
+                    "filesystem as a path, where no redactor can reach it",
+                    file=sys.stderr,
+                )
+                return 1
 
     matrix_path = Path(args.matrix)
     try:

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -10,7 +10,8 @@ Subcommands:
     parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
     doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
     workloads        Generate a deterministic code/JSON/reasoning workload matrix,
-                     execute selected runnable rows (``workloads run``), and
+                     execute selected runnable rows locally (``workloads run``) or
+                     against an OpenAI-compatible API (``workloads run-api``), and
                      aggregate results (``workloads summarize``).
     tune             Offline, evidence-constrained recommendation of the best
                      verified configuration for a workload/hardware target.
@@ -94,6 +95,21 @@ from .tune.report import GroupOutcome, TuneReport, TuneReportValidationError
 from .tune.report_html import render_tune_report_html
 from .tune.tuner import tune
 from .workloads.aggregate import summarize_results, write_summary
+from .workloads.api_profiles import (
+    API_PROFILES,
+    PROFILE_NAMES,
+    APIProfile,
+    APIProfileError,
+    profile_by_name,
+)
+from .workloads.api_verify import (
+    DEFAULT_MAX_STREAM_EVENTS,
+    APIBinding,
+    APIVerifyError,
+    plan_selected_api_rows,
+    render_plan_document,
+    run_selected_api_rows,
+)
 from .workloads.catalog import WORKLOADS, workload_by_id
 from .workloads.evaluators import evaluate_workload
 from .workloads.matrix import (
@@ -327,8 +343,13 @@ def _api_detail(args: argparse.Namespace, exc: BaseException) -> str:
     that case, because it replaces every token the caller supplied
     regardless of whether it names anything.
     """
-    credential = os.environ.get(args.api_key_env, "").strip() or None
-    return _scrub_argv_values(redact_text_for_dry_run(str(exc), credential))
+    return _scrubbed_detail(args.api_key_env, exc)
+
+
+def _scrubbed_detail(env_var: str | None, exc: BaseException) -> str:
+    """The shared implementation behind every API-facing diagnostic."""
+    credential = os.environ.get(env_var, "").strip() if env_var else ""
+    return _scrub_argv_values(redact_text_for_dry_run(str(exc), credential or None))
 
 
 def _cmd_collect_api(args: argparse.Namespace) -> int:
@@ -745,6 +766,175 @@ def _cmd_workloads_run(args: argparse.Namespace) -> int:
         binding=binding,
         resume=not args.no_resume,
         runtime_factory=MLXLMRuntime,
+    )
+    if not results:
+        print("No matrix rows matched the selection filters", file=sys.stderr)
+        return 1
+
+    for result in results:
+        status = result.verification.status.value.upper()
+        suffix = f": {result.verification.reason}" if result.verification.reason else ""
+        print(f"[{status}] {result.entry.run_id}{suffix}")
+
+    failed = sum(1 for r in results if r.verification.status == RowStatus.FAILED)
+    inconclusive = sum(
+        1 for r in results if r.verification.status == RowStatus.INCONCLUSIVE
+    )
+    print(f"Artifacts written to {output_dir}")
+    if failed:
+        return 1
+    if inconclusive:
+        return 2
+    return 0
+
+
+def _resolved_api_profile(args: argparse.Namespace) -> APIProfile | None:
+    return None if args.profile is None else profile_by_name(args.profile)
+
+
+def _api_binding_from_args(args: argparse.Namespace) -> APIBinding:
+    """Build the provider binding, letting explicit flags beat the profile.
+
+    A profile supplies defaults and nothing more, so every value it
+    carries can be overridden. That keeps an unlisted provider a first
+    class citizen: omit ``--profile`` and pass the three fields it would
+    have filled in.
+    """
+    profile = _resolved_api_profile(args)
+    provider = args.provider or (profile.provider_label if profile else None)
+    endpoint = args.endpoint or (profile.endpoint if profile else None)
+    api_key_env = args.api_key_env or (profile.credential_env_var if profile else None)
+
+    missing = [
+        name
+        for name, value in (
+            ("--provider", provider),
+            ("--endpoint", endpoint),
+            ("--api-key-env", api_key_env),
+        )
+        if not value
+    ]
+    if missing:
+        raise APIVerifyError(
+            f"{', '.join(missing)} must be given explicitly when --profile is "
+            f"not used; known profiles are {', '.join(PROFILE_NAMES)}"
+        )
+
+    system_prompt = (
+        Path(args.system_prompt_file).read_text(encoding="utf-8")
+        if args.system_prompt_file
+        else None
+    )
+    # ``missing`` is empty here, so these three are strings; asserting it
+    # keeps that obvious to a reader and to the type checker.
+    assert provider is not None and endpoint is not None and api_key_env is not None
+    binding = APIBinding(
+        provider=provider,
+        endpoint=endpoint,
+        model_id=args.model_id,
+        credential_env_var=api_key_env,
+        model_revision=args.model_revision,
+        system_prompt=system_prompt,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        seed=args.seed,
+        request_timeout_seconds=args.request_timeout,
+        max_stream_events=args.max_stream_events,
+        extensions=ProviderExtensions(
+            reasoning_effort=args.reasoning_effort,
+            thinking_type=args.thinking,
+            clear_thinking=(
+                None if args.clear_thinking is None else args.clear_thinking == "true"
+            ),
+            provider_request_id=args.provider_request_id,
+        ),
+    )
+    binding.validate()
+    return binding
+
+
+def _cmd_workloads_list_api_profiles(args: argparse.Namespace) -> int:
+    print(
+        json.dumps(
+            {"profiles": [profile.to_dict() for profile in API_PROFILES]}, indent=2
+        )
+    )
+    return 0
+
+
+def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
+    matrix_path = Path(args.matrix)
+    try:
+        manifest = MatrixManifest.read_json(matrix_path)
+    except (OSError, MatrixSchemaError) as exc:
+        print(f"Failed to load matrix manifest: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        binding = _api_binding_from_args(args)
+    except (
+        OSError,
+        UnicodeError,
+        APIProfileError,
+        APIVerifyError,
+        OpenAIStreamCollectorError,
+    ) as exc:
+        # ``ProviderExtensions`` validates in its own constructor and raises
+        # the collector's error type before ``binding.validate()`` gets a
+        # chance to translate it, and its message quotes the rejected value.
+        # It has to be caught here or it escapes as an unscrubbed traceback.
+        print(
+            f"Failed to configure API workload execution: "
+            f"{_scrubbed_detail(args.api_key_env, exc)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    selection = _row_selection_from_args(args)
+    output_dir = Path(args.output_dir)
+    manifest_dir = matrix_path.parent
+
+    if args.dry_run:
+        plans = plan_selected_api_rows(
+            manifest,
+            manifest_dir=manifest_dir,
+            matrix_path=matrix_path,
+            output_dir=output_dir,
+            selection=selection,
+            binding=binding,
+            environ=os.environ,
+        )
+        if not plans:
+            print("No matrix rows matched the selection filters", file=sys.stderr)
+            return 1
+
+        document = render_plan_document(plans, binding=binding, environ=os.environ)
+        print(document)
+        try:
+            atomic_write_text(output_dir / "api_request_plan.json", document + "\n")
+        except OSError as exc:
+            print(f"Failed to write request plan: {exc}", file=sys.stderr)
+            return 1
+
+        blocked = sum(1 for plan in plans if not plan.unsupported and not plan.ready)
+        unsupported = sum(1 for plan in plans if plan.unsupported)
+        print(
+            f"{len(plans)} row(s) selected, {blocked} blocked, "
+            f"{unsupported} unsupported; no network request was performed",
+            file=sys.stderr,
+        )
+        return 0 if blocked == 0 else 2
+
+    results = run_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=output_dir,
+        selection=selection,
+        binding=binding,
+        resume=not args.no_resume,
+        transport_factory=UrllibStreamingTransport,
+        environ=os.environ,
     )
     if not results:
         print("No matrix rows matched the selection filters", file=sys.stderr)
@@ -2321,6 +2511,182 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_parser.set_defaults(func=_cmd_workloads_run)
+
+    run_api_parser = workloads_subparsers.add_parser(
+        "run-api",
+        help=(
+            "Execute selected runnable matrix rows against an "
+            "OpenAI-compatible streaming API and evaluate them deterministically"
+        ),
+        # Same reasoning as `collect-api`: prefix matching would let
+        # "--api-key <secret>" resolve to "--api-key-env" and persist the
+        # secret as though it were a variable name.
+        allow_abbrev=False,
+    )
+    run_api_parser.add_argument(
+        "--matrix",
+        required=True,
+        help="Path to a `workloads generate-matrix` manifest.json",
+    )
+    run_api_parser.add_argument("--output-dir", required=True)
+    run_api_parser.add_argument(
+        "--profile",
+        choices=PROFILE_NAMES,
+        default=None,
+        help=(
+            "Named provider profile supplying --provider/--endpoint/"
+            "--api-key-env defaults. Any of them may still be given "
+            "explicitly to override the profile, and an unlisted provider "
+            "works by giving all three without --profile. See "
+            "`workloads list-api-profiles`."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--provider",
+        default=None,
+        help="Short provider label recorded in evidence (never a secret)",
+    )
+    run_api_parser.add_argument(
+        "--endpoint",
+        default=None,
+        help=(
+            "Full chat-completions URL. Must be https for non-local hosts "
+            "and must not embed credentials."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--model-id",
+        required=True,
+        help=(
+            "Provider model ID, e.g. z-ai/glm-5.3 on OpenRouter or glm-5.3 "
+            "on Z.ai. This is the provider-side model, not the matrix's "
+            "local model_id."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--model-revision",
+        default=None,
+        help=(
+            "Provider-side model build, when the provider exposes one. "
+            "Hosted APIs usually do not, in which case leave it unset "
+            "rather than guessing."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--api-key-env",
+        default=None,
+        help=(
+            "Name of the environment variable holding the API key. Only the "
+            "name is recorded; the value is never persisted, echoed or "
+            "accepted as a command argument."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--system-prompt-file",
+        default=None,
+        help="Optional UTF-8 system prompt file; hashed into evidence, never copied",
+    )
+    run_api_parser.add_argument("--temperature", type=float, default=None)
+    run_api_parser.add_argument("--top-p", type=float, default=None)
+    run_api_parser.add_argument("--seed", type=int, default=None)
+    run_api_parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=120.0,
+        help="Per-request timeout in seconds; no retries are performed",
+    )
+    run_api_parser.add_argument(
+        "--max-stream-events",
+        type=int,
+        default=DEFAULT_MAX_STREAM_EVENTS,
+        help=(
+            "Ceiling on dispatched SSE events per row. A stream that exceeds "
+            "it is abandoned, and the row fails as truncated rather than "
+            "being graded: what arrived is a prefix of the answer."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--reasoning-effort",
+        choices=GLM_REASONING_EFFORT_LEVELS,
+        default=None,
+        help=(
+            "Provider-specific reasoning budget. Never a substitute for a "
+            "native-mtp row, which stays unsupported."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--thinking",
+        choices=THINKING_TYPES,
+        default=None,
+        help="Provider-specific thinking.type",
+    )
+    run_api_parser.add_argument(
+        "--clear-thinking",
+        choices=("true", "false"),
+        default=None,
+        help=(
+            "Provider-specific thinking.clear_thinking. Controls whether "
+            "reasoning_content from previous turns is cleared; it does not "
+            "change whether this turn thinks."
+        ),
+    )
+    run_api_parser.add_argument(
+        "--provider-request-id",
+        default=None,
+        help="Optional caller-supplied provider request ID",
+    )
+    run_api_parser.add_argument(
+        "--run-id", nargs="+", default=None, help="Select specific run_id(s)"
+    )
+    run_api_parser.add_argument(
+        "--category",
+        nargs="+",
+        default=None,
+        choices=[category.value for category in WorkloadCategory],
+        help="Filter selected rows by workload category",
+    )
+    run_api_parser.add_argument(
+        "--context-tier",
+        nargs="+",
+        default=None,
+        choices=[tier.value for tier in ContextTier],
+        help="Filter selected rows by context tier",
+    )
+    run_api_parser.add_argument(
+        "--mode",
+        nargs="+",
+        default=None,
+        choices=[DECODE_MODE_AUTOREGRESSIVE, DECODE_MODE_NATIVE_MTP],
+        help=(
+            "Filter selected rows by decode mode; native-mtp rows are always "
+            "rejected as unsupported and are never remapped onto API "
+            "reasoning settings"
+        ),
+    )
+    run_api_parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help=(
+            "Re-run all selected rows even if a complete, hash-verified "
+            "artifact set exists"
+        ),
+    )
+    run_api_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Validate selection and configuration, then print and write the "
+            "credential-free request plan without performing any network "
+            "request"
+        ),
+    )
+    run_api_parser.set_defaults(func=_cmd_workloads_run_api)
+
+    list_profiles_parser = workloads_subparsers.add_parser(
+        "list-api-profiles",
+        help="Print the documented OpenAI-compatible provider profiles as JSON",
+    )
+    list_profiles_parser.set_defaults(func=_cmd_workloads_list_api_profiles)
 
     summarize_parser = workloads_subparsers.add_parser(
         "summarize",

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -2648,9 +2648,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_MAX_STREAM_EVENTS,
         help=(
-            "Ceiling on dispatched SSE events per row. A stream that exceeds "
-            "it is abandoned, and the row fails as truncated rather than "
-            "being graded: what arrived is a prefix of the answer."
+            "Ceiling on dispatched SSE events per row, counting the "
+            "terminal sentinel. A stream that exceeds it is abandoned, and "
+            "the row fails as truncated rather than being graded. Chunks "
+            "that dispatch no event, such as keepalive comments, are not "
+            "charged, so the verdict does not depend on how the network "
+            "split the body."
         ),
     )
     run_api_parser.add_argument(

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -1000,7 +1000,11 @@ def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
     for result in results:
         status = result.verification.status.value.upper()
         suffix = f": {result.verification.reason}" if result.verification.reason else ""
-        print(f"[{status}] {result.entry.run_id}{suffix}")
+        # The verification's run_id, not the row's. A row refused for
+        # carrying the credential in its path reports "[REJECTED]"
+        # there; printing the row's own value would put the key on
+        # stdout, which is the thing the refusal exists to prevent.
+        print(f"[{status}] {result.verification.run_id}{suffix}")
 
     failed = sum(1 for r in results if r.verification.status == RowStatus.FAILED)
     inconclusive = sum(

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -914,7 +914,7 @@ def _cmd_workloads_run_api(args: argparse.Namespace) -> int:
     matrix_path = Path(args.matrix)
     try:
         manifest = MatrixManifest.read_json(matrix_path)
-    except (OSError, MatrixSchemaError) as exc:
+    except (OSError, UnicodeError, MatrixSchemaError) as exc:
         # ``OSError`` embeds the path it failed on, and that path came from
         # the caller, so it is scrubbed like any other caller-supplied text
         # rather than trusted because a path is not usually a secret.

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -760,6 +760,15 @@ class ExperimentRecord:
             raise SchemaValidationError(
                 f"Invalid JSON for ExperimentRecord: {exc}"
             ) from exc
+        # Valid JSON is not necessarily an object. Without this, a payload
+        # of ``[]`` or ``null`` reaches ``from_dict`` and raises
+        # ``AttributeError``, which no caller expects from a parser whose
+        # documented failure mode is ``SchemaValidationError``. Mirrors
+        # the check ``MatrixManifest.from_json`` already performs.
+        if not isinstance(data, dict):
+            raise SchemaValidationError(
+                f"ExperimentRecord JSON must be an object, got {type(data).__name__}"
+            )
         return cls.from_dict(data)
 
     def write_json(self, path: str | Path) -> None:

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -5,8 +5,16 @@ Reads every ``verification.json`` written by ``verify.execute_row`` under a
 distinct, well-defined metrics: how many rows landed in each
 ``RowStatus``, the pass rate among rows that were actually evaluated, and
 a throughput figure ("correct cases per minute") computed only from rows
-that both passed and have measured timing. Per-``decode_mode`` and
-per-``context_tier`` breakdowns use the same definitions.
+that both passed and have measured timing. Per-``decode_mode``,
+per-``context_tier``, per-``backend`` and per-``provider`` breakdowns use
+the same definitions.
+
+Every axis exists so that figures which are not the same quantity stay
+apart. A row measured on a local checkpoint and a row measured through a
+hosted API are separated by ``backend``; two hosted endpoints are
+separated by ``provider``. A metric that is undefined for a group is
+reported as ``null``, never as ``0``: no evaluated rows means there is no
+pass rate, which is not the same statement as a pass rate of zero.
 
 This module deliberately does **not** blend correctness and speed into a
 single combined "performance score" -- that would hide which axis (quality
@@ -26,7 +34,12 @@ from typing import Any
 from ..collectors._shared import atomic_write_text
 from .verify import RowStatus, RowVerification, VerifyError
 
-AGGREGATE_SCHEMA_VERSION = "1"
+AGGREGATE_SCHEMA_VERSION = "2"
+"""Schema version for the ``workloads summarize`` document.
+
+v2 is a strict superset of v1: it adds the ``by_backend`` and
+``by_provider`` breakdowns. Every v1 field keeps its v1 meaning.
+"""
 
 
 def _load_verifications(results_dir: Path) -> tuple[RowVerification, ...]:
@@ -147,6 +160,25 @@ class VerificationSummary:
     overall: GroupSummary
     by_decode_mode: tuple[GroupSummary, ...]
     by_context_tier: tuple[GroupSummary, ...]
+    by_backend: tuple[GroupSummary, ...] = ()
+    """One group per execution backend (``mlx``, ``openai-api``, ...).
+
+    Kept separate because a locally measured row and a row measured
+    through a hosted API do not share a hardware definition: the local
+    figure times a model on this machine, the remote figure times a
+    request to somebody else's. Their throughputs are not the same
+    quantity and blending them would produce a number describing neither.
+    """
+
+    by_provider: tuple[GroupSummary, ...] = ()
+    """One group per provider label, covering only rows that have one.
+
+    Locally executed rows have no provider and are deliberately absent
+    rather than being collected under a placeholder key, so these groups
+    do not sum to ``overall``. A synthetic "none" provider would read as
+    a real one and would silently merge every local row into a bucket
+    that invites comparison against a hosted endpoint.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -155,6 +187,8 @@ class VerificationSummary:
             "overall": self.overall.to_dict(),
             "by_decode_mode": [group.to_dict() for group in self.by_decode_mode],
             "by_context_tier": [group.to_dict() for group in self.by_context_tier],
+            "by_backend": [group.to_dict() for group in self.by_backend],
+            "by_provider": [group.to_dict() for group in self.by_provider],
         }
 
     def to_json(self, *, indent: int | None = 2) -> str:
@@ -168,9 +202,14 @@ def summarize_results(results_dir: Path) -> VerificationSummary:
 
     by_mode: dict[str, list[RowVerification]] = {}
     by_tier: dict[str, list[RowVerification]] = {}
+    by_backend: dict[str, list[RowVerification]] = {}
+    by_provider: dict[str, list[RowVerification]] = {}
     for item in verifications:
         by_mode.setdefault(item.decode_mode, []).append(item)
         by_tier.setdefault(item.context_tier, []).append(item)
+        by_backend.setdefault(item.backend, []).append(item)
+        if item.provider is not None:
+            by_provider.setdefault(item.provider, []).append(item)
 
     return VerificationSummary(
         schema_version=AGGREGATE_SCHEMA_VERSION,
@@ -181,6 +220,12 @@ def summarize_results(results_dir: Path) -> VerificationSummary:
         ),
         by_context_tier=tuple(
             _summarize_group(key, items) for key, items in sorted(by_tier.items())
+        ),
+        by_backend=tuple(
+            _summarize_group(key, items) for key, items in sorted(by_backend.items())
+        ),
+        by_provider=tuple(
+            _summarize_group(key, items) for key, items in sorted(by_provider.items())
         ),
     )
 

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -37,8 +37,20 @@ from .verify import RowStatus, RowVerification, VerifyError
 AGGREGATE_SCHEMA_VERSION = "2"
 """Schema version for the ``workloads summarize`` document.
 
-v2 is a strict superset of v1: it adds the ``by_backend`` and
-``by_provider`` breakdowns. Every v1 field keeps its v1 meaning.
+v2 adds the ``by_backend`` and ``by_provider`` breakdowns, and adds
+``timing_comparable``, ``timing_unavailable_reason`` and
+``measurement_contexts`` to every group.
+
+It is additive in shape, but one v1 field changed meaning and a reader
+that ignores that will draw the wrong conclusion.
+``correct_cases_per_minute`` was null in v1 only when no passing row
+carried timing. In v2 it is *also* null when the group spans more than
+one measurement context and the figure was deliberately withheld. Those
+are different statements -- "nothing to measure" versus "measuring this
+together would be wrong" -- and the field alone no longer distinguishes
+them, which is exactly the conflation this version exists to prevent.
+Consult ``timing_comparable`` to tell them apart, and
+``timing_unavailable_reason`` for why.
 """
 
 

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -93,6 +93,16 @@ class GroupSummary:
     evaluated_pass: int
     pass_rate: float | None
     correct_cases_per_minute: float | None
+    timing_comparable: bool = True
+    """False when the group mixes execution semantics whose durations are
+    not the same quantity."""
+
+    timing_unavailable_reason: str | None = None
+    """Why a timing-derived metric was withheld, when it was."""
+
+    measurement_contexts: tuple[str, ...] = ()
+    """The distinct ``backend/provider`` semantics present in the group,
+    in sorted order. One entry means the group is homogeneous."""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -107,6 +117,9 @@ class GroupSummary:
             "evaluated_pass": self.evaluated_pass,
             "pass_rate": self.pass_rate,
             "correct_cases_per_minute": self.correct_cases_per_minute,
+            "timing_comparable": self.timing_comparable,
+            "timing_unavailable_reason": self.timing_unavailable_reason,
+            "measurement_contexts": list(self.measurement_contexts),
         }
 
 
@@ -134,6 +147,35 @@ def _summarize_group(
         item.total_ms for item in evaluated_pass if item.total_ms is not None
     )
 
+    # A duration only means something next to another duration measured the
+    # same way. A local row times a model on this machine; an API row times
+    # a request to somebody else's, over a network, on hardware nobody here
+    # can see. Adding those together produces a "correct cases per minute"
+    # that describes no system that exists, and the more rows an aggregate
+    # covers the more authoritative that number looks.
+    #
+    # Quality is not affected: a pass is a pass wherever it was produced, so
+    # pass counts and pass rate stay populated and only the timing-derived
+    # figure is withheld, with the reason recorded rather than left to be
+    # inferred from a null.
+    contexts = sorted(
+        {
+            f"{item.backend}/{item.provider}" if item.provider else item.backend
+            for item in evaluated_pass
+        }
+    )
+    timing_comparable = len(contexts) <= 1
+    timing_reason = (
+        None
+        if timing_comparable
+        else (
+            "withheld: this group mixes measurement contexts ("
+            + ", ".join(contexts)
+            + "), whose durations are not the same quantity. Read the "
+            "per-backend and per-provider groups instead."
+        )
+    )
+
     return GroupSummary(
         key=key,
         total=len(items),
@@ -145,9 +187,14 @@ def _summarize_group(
         evaluated_total=len(evaluated),
         evaluated_pass=len(evaluated_pass),
         pass_rate=pass_rate(len(evaluated_pass), len(evaluated)),
-        correct_cases_per_minute=correct_cases_per_minute(
-            len(evaluated_pass), total_pass_ms
+        correct_cases_per_minute=(
+            correct_cases_per_minute(len(evaluated_pass), total_pass_ms)
+            if timing_comparable
+            else None
         ),
+        timing_comparable=timing_comparable,
+        timing_unavailable_reason=timing_reason,
+        measurement_contexts=tuple(contexts),
     )
 
 

--- a/llmtracefx/optimizer/workloads/api_profiles.py
+++ b/llmtracefx/optimizer/workloads/api_profiles.py
@@ -1,0 +1,114 @@
+"""Named, documented endpoint profiles for OpenAI-compatible providers.
+
+A profile is *data*, not behavior. It records the three things that are
+tedious and error-prone to retype for a given provider (the full
+chat-completions URL, the conventional credential environment variable
+name, and the model IDs that provider publishes) and nothing else. No
+module in this package branches on which profile was selected: a profile
+only supplies defaults that the caller may override, so pointing the API
+workload runner at an unlisted provider stays a pure configuration
+change with no code change and no second-class behavior.
+
+Model IDs are recorded as ``documented_model_ids`` purely so that
+``--list-profiles`` can show a caller what the provider publishes. They
+are never validated against, because a provider adds models faster than
+this file can be edited and rejecting an unlisted model would turn a
+documentation aid into a gate.
+
+The endpoints and model IDs below come from each provider's published
+documentation:
+
+* OpenRouter: https://openrouter.ai/docs/api-reference/overview
+* Z.ai: https://docs.z.ai/api-reference/llm/chat-completion
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class APIProfileError(ValueError):
+    """Raised when an unknown provider profile name is requested."""
+
+
+@dataclass(frozen=True)
+class APIProfile:
+    """Documented defaults for one OpenAI-compatible chat endpoint."""
+
+    name: str
+    """Profile selector, e.g. ``openrouter``."""
+
+    provider_label: str
+    """Short sanitized provider label recorded in evidence."""
+
+    endpoint: str
+    """Full chat-completions URL."""
+
+    credential_env_var: str
+    """Conventional environment variable holding the API key. Only the
+    name is ever used or persisted; the value is read by the collector
+    straight from the environment."""
+
+    documented_model_ids: tuple[str, ...]
+    """Model IDs the provider documents for this endpoint. Informational
+    only: an unlisted model ID is accepted without complaint."""
+
+    notes: str
+    """One-line description shown by ``--list-profiles``."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "provider_label": self.provider_label,
+            "endpoint": self.endpoint,
+            "credential_env_var": self.credential_env_var,
+            "documented_model_ids": list(self.documented_model_ids),
+            "notes": self.notes,
+        }
+
+
+OPENROUTER_PROFILE = APIProfile(
+    name="openrouter",
+    provider_label="openrouter",
+    endpoint="https://openrouter.ai/api/v1/chat/completions",
+    credential_env_var="OPENROUTER_API_KEY",
+    documented_model_ids=("z-ai/glm-5.3", "z-ai/glm-5.3-flash"),
+    notes=(
+        "OpenRouter's OpenAI-compatible gateway; GLM models are addressed "
+        "with the z-ai/ vendor prefix"
+    ),
+)
+
+ZAI_PROFILE = APIProfile(
+    name="z.ai",
+    provider_label="z.ai",
+    endpoint="https://api.z.ai/api/paas/v4/chat/completions",
+    credential_env_var="ZAI_API_KEY",
+    documented_model_ids=("glm-5.3", "glm-5.3-flash"),
+    notes="Z.ai's first-party GLM chat-completions endpoint",
+)
+
+API_PROFILES: tuple[APIProfile, ...] = (OPENROUTER_PROFILE, ZAI_PROFILE)
+
+PROFILE_NAMES: tuple[str, ...] = tuple(profile.name for profile in API_PROFILES)
+
+
+def profile_by_name(name: str) -> APIProfile:
+    """Return the profile called ``name``.
+
+    Raises ``APIProfileError`` listing the known names, which keeps the
+    diagnostic useful without echoing the caller's value; an unknown
+    profile name is a typo, not a credential, but the same restraint is
+    applied here as everywhere else in this package.
+    """
+    for profile in API_PROFILES:
+        if profile.name == name:
+            return profile
+    raise APIProfileError(
+        "unknown provider profile; known profiles are "
+        + ", ".join(PROFILE_NAMES)
+        + ". A profile only supplies defaults, so an unlisted provider can "
+        "still be measured by passing --endpoint, --provider and "
+        "--api-key-env explicitly."
+    )

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -1,0 +1,1024 @@
+"""Executing the workload matrix against an OpenAI-compatible HTTP API.
+
+This is the remote counterpart to ``workloads.verify``. It answers the
+same question that pipeline answers for a local MLX checkpoint -- *did
+this model actually solve the task, and how long did it take* -- for a
+model that is reachable only over an OpenAI-compatible streaming
+chat-completions endpoint such as OpenRouter or Z.ai.
+
+What it reuses rather than re-implements
+----------------------------------------
+Everything that touches the network, the wire protocol, or a secret
+belongs to ``collectors.openai_api`` and is used here unmodified:
+
+* ``collect_openai_stream`` performs the request, decodes the SSE
+  stream, classifies provider failures, redacts the credential out of
+  every persisted string, and publishes its own artifact set;
+* ``build_request_plan`` produces the credential-free plan that
+  ``--dry-run`` prints and that this module hashes for resume;
+* ``artifact_set_is_complete`` is the *only* thing trusted to say a
+  prior collection directory is whole;
+* ``redact_text_for_dry_run`` scrubs any diagnostic before it reaches
+  ``verification.json``.
+
+Everything about *which rows to run and what the answer was worth*
+belongs to the existing workload pipeline and is likewise reused: the
+matrix manifest and its hashed prompts, the workload catalog and its
+pinned versions, the deterministic evaluators, the ``RowStatus``
+vocabulary, and the canonical ``ExperimentRecord``.
+
+What this module adds is the binding between the two, and nothing else.
+
+Per-row data flow
+-----------------
+1. **Reject unsupported rows explicitly.** A ``native-mtp`` row is never
+   executed. Native multi-token prediction is a decoding mechanism
+   inside a local runtime; a hosted API's reasoning or "thinking"
+   settings are a different thing entirely, and quietly running such a
+   row with ``--reasoning-effort`` set would publish evidence labelled
+   ``native-mtp`` that measured something else. The row is recorded
+   ``UNSUPPORTED`` with that reason.
+2. **Verify the prompt.** The prompt text is read from the entry's
+   ``prompt_path`` and its sha256 compared with the manifest. A
+   mismatch fails the row rather than sending a different prompt than
+   the matrix planned.
+3. **Verify the workload catalog binding.** Catalog version drift fails
+   the row rather than grading against a different spec.
+4. **Resume only on complete, hash-verified evidence.** A prior row is
+   trusted only when its status is completed/skipped, it was produced
+   by *this* backend, and its prompt hash, workload version and API
+   binding hash all still match, *and* the collector's own artifact
+   marker still verifies every file in the collection directory. A
+   stale, partial or tampered artifact set reruns.
+5. **Execute through the unmodified collector**, with the matrix row's
+   ``max_tokens`` as ``max_output_tokens``. Tripping the event cap fails
+   the row as truncated even when a terminal ``finish_reason`` had already
+   arrived: this pipeline stopped reading, so what it holds is a prefix of
+   the answer.
+6. **Evaluate the final answer only.** ``response_text`` is the
+   assembled content, never the reasoning stream, so a model that
+   reasons its way to the answer and then states something else is
+   graded on what it stated. A provider failure short-circuits
+   evaluation entirely and is persisted as-is, so a passing evaluator
+   can never paper over a request that did not succeed. An evaluator
+   that raises leaves the row ``INCONCLUSIVE`` with the measurement
+   evidence preserved and ``quality_score`` unset.
+
+Both the planning and the execution path run the collector's public
+``assert_credential_not_embedded`` pre-flight *before* building a request
+plan. That ordering is load-bearing rather than tidy: an endpoint query
+value is folded into the plan's ``config_hash`` as its sha256, that hash
+reaches ``verification.json`` through the binding hash, and no redactor
+can undo a hash once it has been written down.
+
+No pricing, cost or cross-provider comparison is computed anywhere here.
+The provider's own usage counters are persisted by the collector as
+reported; turning them into money or into a ranking is a separate
+concern with its own correctness burden.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text, config_hash, sha256_text
+from ..collectors.openai_api import (
+    FAILURE_STREAM_TRUNCATED,
+    APICollectionConfig,
+    FinishReasonVocabulary,
+    HTTPRequest,
+    OpenAIStreamCollectorError,
+    ProviderExtensions,
+    RequestPlan,
+    StreamingResponse,
+    StreamingTransport,
+    UrllibStreamingTransport,
+    artifact_set_is_complete,
+    assert_credential_not_embedded,
+    build_request_plan,
+    collect_openai_stream,
+    redact_text_for_dry_run,
+)
+from ..collectors.sse import SSEDecodeError, SSEDecoder
+from ..schema import ExperimentRecord, OutcomeInfo, SchemaValidationError, utc_now_iso
+from .catalog import workload_by_id
+from .evaluators import evaluate_workload
+from .matrix import DECODE_MODE_NATIVE_MTP, MatrixEntry, MatrixManifest
+from .schema import WorkloadSchemaError
+from .verify import (
+    BACKEND_OPENAI_API,
+    VERIFICATION_SCHEMA_VERSION,
+    RowSelection,
+    RowStatus,
+    RowVerification,
+    VerifyError,
+    select_entries,
+)
+
+API_BINDING_SCHEMA_VERSION = "1"
+
+#: Default ceiling on dispatched SSE events per row. A streaming endpoint
+#: that never stops is bounded by the request timeout, but a *chatty* one
+#: can stay under that timeout while emitting far more events than any
+#: answer needs, and every event costs a timing row in memory. The cap is
+#: part of the binding because changing it changes what a run is willing
+#: to observe, which makes two runs under different caps different
+#: measurement configurations.
+DEFAULT_MAX_STREAM_EVENTS = 10_000
+
+_TRUSTABLE_RESUME_STATUSES = (RowStatus.COMPLETED, RowStatus.SKIPPED)
+
+_UNSUPPORTED_NATIVE_MTP_REASON = (
+    "native-mtp rows are not executable through an OpenAI-compatible API. "
+    "Native multi-token prediction is a decoding mechanism inside a local "
+    "runtime; a hosted API exposes no such control, and its reasoning or "
+    "thinking settings are a different mechanism measuring something else. "
+    "This row is rejected rather than silently re-labelled as API reasoning."
+)
+
+
+class APIVerifyError(VerifyError):
+    """Raised for invalid API-verify configuration (never a row outcome)."""
+
+
+# --- Event cap ---------------------------------------------------------------
+
+
+class _EventCappedResponse:
+    """A streaming response that stops after ``limit`` dispatched events.
+
+    The byte chunks are handed to the collector exactly as the transport
+    produced them. Counting is done by feeding a second copy of each
+    chunk to the shared :class:`~..collectors.sse.SSEDecoder`, so the
+    framing rules used to count are literally the framing rules used to
+    parse, and this class contains no parsing of its own.
+
+    Counting never raises. A stream this decoder cannot decode is a
+    stream the collector's own decoder is about to reject with the
+    authoritative diagnostic, so a decode error here only stops counting
+    and lets the bytes through untouched.
+    """
+
+    def __init__(self, inner: StreamingResponse, *, limit: int) -> None:
+        self._inner = inner
+        self._limit = limit
+        self._decoder = SSEDecoder()
+        self._counting = True
+        self.events_seen = 0
+        self.cap_tripped = False
+
+    @property
+    def status_code(self) -> int:
+        return self._inner.status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._inner.headers
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        for chunk in self._inner.iter_bytes():
+            yield chunk
+            if not self._counting:
+                continue
+            try:
+                self.events_seen += sum(1 for _ in self._decoder.feed(chunk))
+            except SSEDecodeError:
+                self._counting = False
+                continue
+            if self.events_seen >= self._limit:
+                self.cap_tripped = True
+                return
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _EventCappedTransport:
+    """Wrap a transport so every response it opens is event-capped."""
+
+    def __init__(self, inner: StreamingTransport, *, limit: int) -> None:
+        self._inner = inner
+        self._limit = limit
+        self.last_response: _EventCappedResponse | None = None
+
+    def open_stream(self, request: HTTPRequest) -> StreamingResponse:
+        capped = _EventCappedResponse(
+            self._inner.open_stream(request), limit=self._limit
+        )
+        self.last_response = capped
+        return capped
+
+
+# --- Binding -----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class APIBinding:
+    """Everything about *where and how* rows are sent, minus the secret.
+
+    Validation of the endpoint, provider label, credential variable name
+    and request parameters is delegated to ``APICollectionConfig``, which
+    already owns those rules; this class only adds the one field the
+    collector does not have.
+    """
+
+    provider: str
+    endpoint: str
+    model_id: str
+    credential_env_var: str
+    model_revision: str | None = None
+    system_prompt: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+    request_timeout_seconds: float = 120.0
+    max_stream_events: int = DEFAULT_MAX_STREAM_EVENTS
+    extensions: ProviderExtensions = field(default_factory=ProviderExtensions)
+    finish_reasons: FinishReasonVocabulary = field(
+        default_factory=FinishReasonVocabulary
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.max_stream_events, bool)
+            or not isinstance(self.max_stream_events, int)
+            or self.max_stream_events < 1
+        ):
+            raise APIVerifyError("max_stream_events must be a positive integer")
+
+    def collection_config(
+        self,
+        entry: MatrixEntry,
+        *,
+        prompt: str,
+        output_dir: Path,
+        command_argv: tuple[str, ...],
+    ) -> APICollectionConfig:
+        """Build the collector config for one matrix row.
+
+        Every validation rule lives in ``APICollectionConfig.__post_init__``
+        and is reached from here, so an invalid binding is reported by the
+        component that defines what valid means.
+        """
+        return APICollectionConfig(
+            run_id=entry.run_id,
+            provider=self.provider,
+            endpoint=self.endpoint,
+            model_id=self.model_id,
+            prompt=prompt,
+            output_dir=output_dir,
+            command_argv=command_argv,
+            credential_env_var=self.credential_env_var,
+            system_prompt=self.system_prompt,
+            max_output_tokens=entry.max_tokens,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            seed=self.seed,
+            request_timeout_seconds=self.request_timeout_seconds,
+            extensions=self.extensions,
+            finish_reasons=self.finish_reasons,
+            model_revision=self.model_revision,
+        )
+
+    def validate(self) -> None:
+        """Raise ``APIVerifyError`` if this binding could never be used.
+
+        Builds one throwaway ``APICollectionConfig`` against placeholder
+        row values so that a malformed endpoint, provider label, credential
+        variable name or request parameter is reported once, up front,
+        instead of once per selected row. Nothing is written and no network
+        call is made: ``APICollectionConfig`` validates purely in memory,
+        and the placeholders below are only there to satisfy the fields
+        this binding does not own.
+        """
+        placeholder = "binding-validation-probe"
+        try:
+            APICollectionConfig(
+                run_id=placeholder,
+                provider=self.provider,
+                endpoint=self.endpoint,
+                model_id=self.model_id,
+                prompt=placeholder,
+                output_dir=Path(placeholder),
+                command_argv=("llmtracefx-optimizer", "workloads", "run-api"),
+                credential_env_var=self.credential_env_var,
+                system_prompt=self.system_prompt,
+                max_output_tokens=1,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                seed=self.seed,
+                request_timeout_seconds=self.request_timeout_seconds,
+                extensions=self.extensions,
+                finish_reasons=self.finish_reasons,
+                model_revision=self.model_revision,
+            )
+        except OpenAIStreamCollectorError as exc:
+            raise APIVerifyError(str(exc)) from exc
+
+    def binding_hash(
+        self, *, request_plan: RequestPlan, workload_id: str, workload_version: str
+    ) -> str:
+        """Identity of everything that affects the request or its grading.
+
+        Built on the collector's own ``config_hash``, which already covers
+        the sanitized endpoint identity (origin, path, query keys and
+        hashed query values), provider label, model ID and revision, the
+        portable request parameters including this row's ``max_tokens``,
+        the provider extensions and reasoning settings, the finish-reason
+        vocabulary, the request timeout, and the system prompt's hash.
+        Added here are the event cap and the evaluation binding, because
+        a row graded by a different workload version is not the same
+        measurement even when the request is byte-identical.
+
+        The credential environment *variable name* is deliberately not
+        hashed, for the same reason the collector excludes it: two runs
+        differing only in which variable held the key issue byte-identical
+        requests and are graded identically, so it affects neither the
+        request nor the evaluation nor resume -- and a caller who pastes a
+        key into that slot by mistake must not have a derivation of it
+        written into an artifact. The name itself is still recorded, in
+        the masked form the request plan chooses.
+        """
+        return config_hash(
+            {
+                "binding_schema_version": API_BINDING_SCHEMA_VERSION,
+                # Namespaced by backend so an API binding hash can never
+                # collide with an MLX run-binding hash written by
+                # ``verify.RunBinding`` into the same field.
+                "backend": BACKEND_OPENAI_API,
+                "request_identity": request_plan.config_hash,
+                "max_stream_events": self.max_stream_events,
+                "workload_id": workload_id,
+                "workload_version": workload_version,
+            }
+        )
+
+
+# --- Planning ----------------------------------------------------------------
+
+
+def _run_dir(entry: MatrixEntry, *, output_dir: Path) -> Path:
+    return output_dir / "runs" / entry.run_id
+
+
+def _resolve_path(raw: str, *, base_dir: Path) -> Path:
+    """Resolve a manifest-relative path against the manifest's directory."""
+    path = Path(raw)
+    return path if path.is_absolute() else base_dir / path
+
+
+def _command_argv(
+    entry: MatrixEntry, *, binding: APIBinding, matrix_path: Path
+) -> tuple[str, ...]:
+    """The credential-free invocation recorded in the row's evidence.
+
+    Reconstructed rather than copied from ``sys.argv`` so that resolved
+    defaults are stated explicitly and nothing the caller typed can reach
+    an artifact. The collector sanitizes this further before persisting
+    it: query values are stripped from the endpoint and the credential
+    variable name is masked unless the environment actually defines it.
+    """
+    argv = [
+        "llmtracefx-optimizer",
+        "workloads",
+        "run-api",
+        "--matrix",
+        str(matrix_path),
+        "--run-id",
+        entry.run_id,
+        "--provider",
+        binding.provider,
+        "--endpoint",
+        binding.endpoint,
+        "--model-id",
+        binding.model_id,
+        "--api-key-env",
+        binding.credential_env_var,
+        "--request-timeout",
+        str(binding.request_timeout_seconds),
+        "--max-stream-events",
+        str(binding.max_stream_events),
+    ]
+    for flag, value in (
+        ("--model-revision", binding.model_revision),
+        ("--temperature", binding.temperature),
+        ("--top-p", binding.top_p),
+        ("--seed", binding.seed),
+        ("--reasoning-effort", binding.extensions.reasoning_effort),
+        ("--thinking", binding.extensions.thinking_type),
+        ("--provider-request-id", binding.extensions.provider_request_id),
+    ):
+        if value is not None:
+            argv.extend((flag, str(value)))
+    if binding.extensions.clear_thinking is not None:
+        argv.extend(
+            (
+                "--clear-thinking",
+                "true" if binding.extensions.clear_thinking else "false",
+            )
+        )
+    return tuple(argv)
+
+
+@dataclass(frozen=True)
+class APIRowPlan:
+    """A dry-run description of one selected row: what would be sent."""
+
+    entry: MatrixEntry
+    unsupported: bool
+    unsupported_reason: str | None
+    ready: bool
+    blockers: tuple[str, ...]
+    prompt_path: Path
+    collection_dir: Path
+    final_record_path: Path
+    verification_path: Path
+    request_plan: RequestPlan | None
+    binding_hash: str | None
+    credential_env_var_present: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """A secret-safe rendering of this plan.
+
+        The request plan is the collector's own credential-free document:
+        it carries message *digests* rather than prompt text, endpoint
+        query *keys* rather than values, and header *names* rather than
+        header values. Whether the credential variable is defined is
+        reported as a boolean, never as its contents.
+        """
+        return {
+            "run_id": self.entry.run_id,
+            "workload_id": self.entry.workload_id,
+            "workload_version": self.entry.workload_version,
+            "category": self.entry.category,
+            "context_tier": self.entry.context_tier,
+            "decode_mode": self.entry.decode_mode,
+            "max_tokens": self.entry.max_tokens,
+            "status": (
+                "unsupported"
+                if self.unsupported
+                else ("ready" if self.ready else "blocked")
+            ),
+            "unsupported_reason": self.unsupported_reason,
+            "blockers": list(self.blockers),
+            "prompt_path": str(self.prompt_path),
+            "collection_dir": str(self.collection_dir),
+            "final_record_path": str(self.final_record_path),
+            "verification_path": str(self.verification_path),
+            "api_binding_hash": self.binding_hash,
+            "credential_env_var_present": self.credential_env_var_present,
+            "request_plan": (
+                None if self.request_plan is None else self.request_plan.to_dict()
+            ),
+        }
+
+
+def plan_api_row(
+    entry: MatrixEntry,
+    *,
+    manifest_dir: Path,
+    matrix_path: Path,
+    output_dir: Path,
+    binding: APIBinding,
+    environ: Mapping[str, str],
+) -> APIRowPlan:
+    """Describe what running ``entry`` would send, without any network call."""
+    run_dir = _run_dir(entry, output_dir=output_dir)
+    prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
+    collection_dir = run_dir / "collection"
+    credential_present = bool(environ.get(binding.credential_env_var, "").strip())
+
+    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
+        return APIRowPlan(
+            entry=entry,
+            unsupported=True,
+            unsupported_reason=(
+                _UNSUPPORTED_NATIVE_MTP_REASON
+                if entry.decode_mode == DECODE_MODE_NATIVE_MTP
+                else (entry.unsupported_reason or _UNSUPPORTED_NATIVE_MTP_REASON)
+            ),
+            ready=False,
+            blockers=(),
+            prompt_path=prompt_path,
+            collection_dir=collection_dir,
+            final_record_path=run_dir / "final_record.json",
+            verification_path=run_dir / "verification.json",
+            request_plan=None,
+            binding_hash=None,
+            credential_env_var_present=credential_present,
+        )
+
+    blockers: list[str] = []
+    prompt_text: str | None = None
+    if not prompt_path.exists():
+        blockers.append(f"prompt file missing: {prompt_path}")
+    else:
+        try:
+            prompt_text = prompt_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            blockers.append(f"prompt file unreadable: {exc}")
+        else:
+            verified_hash = sha256_text(prompt_text)
+            if verified_hash != entry.prompt.prompt_hash:
+                prompt_text = None
+                blockers.append(
+                    "prompt hash mismatch: matrix metadata records "
+                    f"{entry.prompt.prompt_hash} but {prompt_path} hashes to "
+                    f"{verified_hash}; regenerate the matrix or restore the "
+                    "original prompt file"
+                )
+
+    workload_version: str | None = None
+    try:
+        workload = workload_by_id(entry.workload_id)
+    except KeyError:
+        blockers.append(f"unknown workload_id in catalog: {entry.workload_id!r}")
+    else:
+        workload_version = workload.version
+        if workload.version != entry.workload_version:
+            workload_version = None
+            blockers.append(
+                f"workload '{entry.workload_id}' version drift: matrix pinned "
+                f"v{entry.workload_version}, catalog has v{workload.version}"
+            )
+
+    if not credential_present:
+        # The variable name is deliberately not repeated. A name the
+        # environment does not define was never proven to be a name, and
+        # the likeliest reason it is absent is that the caller put the
+        # credential in the name slot; echoing it here would write a
+        # secret into the very plan document that promises not to hold
+        # one. This mirrors ``_persistable_env_var`` in the collector.
+        blockers.append(
+            "the environment variable named by --api-key-env is not set or "
+            "is empty; export the API key there before running without "
+            "--dry-run (it is never accepted as a command argument and never "
+            "written to any artifact)"
+        )
+
+    request_plan: RequestPlan | None = None
+    binding_hash: str | None = None
+    if prompt_text is not None:
+        try:
+            config = binding.collection_config(
+                entry,
+                prompt=prompt_text,
+                output_dir=collection_dir,
+                command_argv=_command_argv(
+                    entry, binding=binding, matrix_path=matrix_path
+                ),
+            )
+            # The same pre-flight the real run enforces, and it has to come
+            # before the plan is built rather than after. A credential
+            # sitting in an endpoint query value is folded into
+            # ``config_hash`` as ``sha256(value)``, and no redactor can
+            # remove a hash once it has been written down. Refusing here
+            # keeps a derivation of the secret out of the plan document and
+            # out of the binding hash, and stops a dry run green-lighting a
+            # configuration the real run would refuse.
+            assert_credential_not_embedded(config, environ)
+            request_plan = build_request_plan(config, environ=environ)
+        except OpenAIStreamCollectorError as exc:
+            blockers.append(f"invalid API collector configuration: {exc}")
+        else:
+            if workload_version is not None:
+                binding_hash = binding.binding_hash(
+                    request_plan=request_plan,
+                    workload_id=entry.workload_id,
+                    workload_version=workload_version,
+                )
+
+    return APIRowPlan(
+        entry=entry,
+        unsupported=False,
+        unsupported_reason=None,
+        ready=not blockers,
+        blockers=tuple(blockers),
+        prompt_path=prompt_path,
+        collection_dir=collection_dir,
+        final_record_path=run_dir / "final_record.json",
+        verification_path=run_dir / "verification.json",
+        request_plan=request_plan,
+        binding_hash=binding_hash,
+        credential_env_var_present=credential_present,
+    )
+
+
+def plan_selected_api_rows(
+    manifest: MatrixManifest,
+    *,
+    manifest_dir: Path,
+    matrix_path: Path,
+    output_dir: Path,
+    selection: RowSelection,
+    binding: APIBinding,
+    environ: Mapping[str, str],
+) -> tuple[APIRowPlan, ...]:
+    """Dry-run: describe every selected row without touching the network."""
+    return tuple(
+        plan_api_row(
+            entry,
+            manifest_dir=manifest_dir,
+            matrix_path=matrix_path,
+            output_dir=output_dir,
+            binding=binding,
+            environ=environ,
+        )
+        for entry in select_entries(manifest, selection)
+    )
+
+
+def render_plan_document(
+    plans: tuple[APIRowPlan, ...], *, binding: APIBinding, environ: Mapping[str, str]
+) -> str:
+    """Render the dry-run plan as secret-safe JSON.
+
+    Scrubbed as a whole document as well as field by field. The
+    individual fields are already credential-free by construction, but a
+    caller who pasted the key into ``--endpoint`` would otherwise have it
+    echoed back from a field that is normally harmless, so the assembled
+    text gets the collector's redactor passed over it too.
+    """
+    credential = environ.get(binding.credential_env_var, "").strip() or None
+    payload = {
+        "dry_run": True,
+        "network_request_performed": False,
+        "backend": BACKEND_OPENAI_API,
+        "credential_env_var_present": credential is not None,
+        "rows": [plan.to_dict() for plan in plans],
+    }
+    return redact_text_for_dry_run(
+        json.dumps(payload, indent=2, allow_nan=False), credential
+    )
+
+
+# --- Execution ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class APIRowResult:
+    """Outcome of planning/executing one selected matrix row over the API."""
+
+    entry: MatrixEntry
+    verification: RowVerification
+    final_record: ExperimentRecord | None
+
+
+def _load_prior_verification(path: Path) -> RowVerification | None:
+    if not path.exists():
+        return None
+    try:
+        return RowVerification.read_json(path)
+    except (OSError, json.JSONDecodeError, VerifyError):
+        # A corrupt or partial artifact from an interrupted run must never
+        # be mistaken for a trustworthy completed result.
+        return None
+
+
+def _total_ms(record: ExperimentRecord | None) -> float | None:
+    if record is None or record.timing.total is None:
+        return None
+    return record.timing.total.value
+
+
+def execute_api_row(
+    entry: MatrixEntry,
+    *,
+    manifest_dir: Path,
+    matrix_path: Path,
+    output_dir: Path,
+    binding: APIBinding,
+    resume: bool,
+    transport_factory: Callable[[], StreamingTransport],
+    environ: Mapping[str, str] | None = None,
+) -> APIRowResult:
+    """Verify, (maybe) execute, and evaluate one matrix row over the API.
+
+    ``transport_factory`` is invoked only immediately before a request is
+    actually made, so a batch of unsupported, blocked or resumed rows
+    never constructs a transport and therefore never opens a socket.
+    """
+    resolved_environ = os.environ if environ is None else environ
+    credential = resolved_environ.get(binding.credential_env_var, "").strip() or None
+    started_at = utc_now_iso()
+    run_dir = _run_dir(entry, output_dir=output_dir)
+    verification_path = run_dir / "verification.json"
+    collection_dir = run_dir / "collection"
+    final_record_path = run_dir / "final_record.json"
+
+    def _scrub(text: str) -> str:
+        return redact_text_for_dry_run(text, credential)
+
+    def _finish(
+        status: RowStatus,
+        reason: str | None,
+        *,
+        final_record: ExperimentRecord | None = None,
+        verified_hash: str | None = None,
+        binding_hash: str | None = None,
+        resumed: bool = False,
+        wrote_collection: bool = False,
+        artifacts_verified: bool | None = None,
+    ) -> APIRowResult:
+        verification = RowVerification(
+            schema_version=VERIFICATION_SCHEMA_VERSION,
+            run_id=entry.run_id,
+            workload_id=entry.workload_id,
+            workload_version=entry.workload_version,
+            category=entry.category,
+            context_tier=entry.context_tier,
+            decode_mode=entry.decode_mode,
+            status=status,
+            reason=None if reason is None else _scrub(reason),
+            recorded_prompt_hash=entry.prompt.prompt_hash,
+            verified_prompt_hash=verified_hash,
+            run_binding_hash=binding_hash,
+            resumed=resumed,
+            outcome_success=(
+                final_record.outcome.success if final_record is not None else None
+            ),
+            quality_score=(
+                final_record.outcome.quality_score if final_record is not None else None
+            ),
+            total_ms=_total_ms(final_record),
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+            final_record_path=(
+                str(final_record_path) if final_record is not None else None
+            ),
+            collection_dir=(
+                str(collection_dir)
+                if final_record is not None and wrote_collection
+                else None
+            ),
+            backend=BACKEND_OPENAI_API,
+            # Scrubbed like every other persisted string. The pre-flight
+            # above refuses a run whose provider label or model ID contains
+            # the credential, but this artifact is written on paths that
+            # never reach a request at all, so it cannot rely on that
+            # refusal having happened. Both fields are raw caller input and
+            # both are shapes a real key can take.
+            provider=_scrub(binding.provider),
+            api_model_id=_scrub(binding.model_id),
+            artifacts_verified=artifacts_verified,
+        )
+        atomic_write_text(verification_path, verification.to_json())
+        return APIRowResult(
+            entry=entry, verification=verification, final_record=final_record
+        )
+
+    # 1. Unsupported rows are rejected, never remapped onto API reasoning.
+    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
+        reason = (
+            _UNSUPPORTED_NATIVE_MTP_REASON
+            if entry.decode_mode == DECODE_MODE_NATIVE_MTP
+            else (entry.unsupported_reason or _UNSUPPORTED_NATIVE_MTP_REASON)
+        )
+        return _finish(RowStatus.UNSUPPORTED, reason)
+
+    # 2. Verify the fully materialized prompt against the matrix metadata.
+    prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
+    if not prompt_path.exists():
+        return _finish(RowStatus.FAILED, f"prompt file missing: {prompt_path}")
+
+    try:
+        prompt_text = prompt_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        return _finish(RowStatus.FAILED, f"prompt file unreadable: {exc}")
+
+    verified_hash = sha256_text(prompt_text)
+    if verified_hash != entry.prompt.prompt_hash:
+        return _finish(
+            RowStatus.FAILED,
+            "prompt hash mismatch: matrix metadata records "
+            f"{entry.prompt.prompt_hash} but {prompt_path} hashes to "
+            f"{verified_hash}; regenerate the matrix or restore the original "
+            "prompt file before running",
+            verified_hash=verified_hash,
+        )
+
+    # 3. Verify the workload catalog binding.
+    try:
+        workload = workload_by_id(entry.workload_id)
+    except KeyError:
+        return _finish(
+            RowStatus.FAILED,
+            f"unknown workload_id in catalog: {entry.workload_id!r}",
+            verified_hash=verified_hash,
+        )
+    if workload.version != entry.workload_version:
+        return _finish(
+            RowStatus.FAILED,
+            f"workload '{entry.workload_id}' version drift: matrix pinned "
+            f"v{entry.workload_version}, catalog has v{workload.version}; "
+            "regenerate the matrix",
+            verified_hash=verified_hash,
+        )
+
+    # 4. Build the collector config and derive this row's binding hash.
+    try:
+        config = binding.collection_config(
+            entry,
+            prompt=prompt_text,
+            output_dir=collection_dir,
+            command_argv=_command_argv(entry, binding=binding, matrix_path=matrix_path),
+        )
+        # Before the plan, not after. ``build_request_plan`` folds an
+        # endpoint query *value* into ``config_hash`` as its sha256, and
+        # that hash is persisted in this row's ``run_binding_hash``. A
+        # credential parked there would leave a derivation of itself in an
+        # artifact even though the request is about to be refused, and no
+        # redactor can undo a hash.
+        assert_credential_not_embedded(config, resolved_environ)
+        request_plan = build_request_plan(config, environ=resolved_environ)
+    except OpenAIStreamCollectorError as exc:
+        return _finish(
+            RowStatus.FAILED,
+            f"invalid API collector configuration: {exc}",
+            verified_hash=verified_hash,
+        )
+
+    binding_hash = binding.binding_hash(
+        request_plan=request_plan,
+        workload_id=entry.workload_id,
+        workload_version=workload.version,
+    )
+
+    # 5. Resume only on a complete, hash-verified artifact set from this
+    #    backend. Every condition below has to hold: a matching hash over
+    #    an incomplete directory, or a complete directory whose files were
+    #    edited after the marker was written, both rerun.
+    if resume:
+        prior = _load_prior_verification(verification_path)
+        if (
+            prior is not None
+            and prior.status in _TRUSTABLE_RESUME_STATUSES
+            and prior.backend == BACKEND_OPENAI_API
+            and prior.verified_prompt_hash == verified_hash
+            and prior.run_binding_hash == binding_hash
+            and prior.workload_version == workload.version
+            and artifact_set_is_complete(collection_dir)
+        ):
+            try:
+                trusted_record = ExperimentRecord.read_json(final_record_path)
+            except (OSError, SchemaValidationError):
+                trusted_record = None
+            if trusted_record is not None:
+                return _finish(
+                    RowStatus.SKIPPED,
+                    "trusted prior completed artifact set (hash-verified and "
+                    "complete); not re-executed",
+                    final_record=trusted_record,
+                    verified_hash=verified_hash,
+                    binding_hash=binding_hash,
+                    resumed=True,
+                    wrote_collection=True,
+                    artifacts_verified=True,
+                )
+
+    # 6. Execute through the unmodified collector.
+    capped = _EventCappedTransport(transport_factory(), limit=binding.max_stream_events)
+    try:
+        collection_result = collect_openai_stream(
+            config, transport=capped, environ=resolved_environ
+        )
+    except (OSError, OpenAIStreamCollectorError) as exc:
+        # A missing credential, an unusable environment or a failed
+        # artifact write never describes a request whose result could be
+        # graded, so it fails the row rather than producing evidence.
+        return _finish(
+            RowStatus.FAILED,
+            f"API collection could not be attempted: {exc}",
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+        )
+
+    artifacts_verified = artifact_set_is_complete(collection_dir)
+    collected_record = collection_result.record
+    cap_tripped = capped.last_response is not None and capped.last_response.cap_tripped
+    cap_note = (
+        f"the stream was abandoned after the configured "
+        f"{binding.max_stream_events}-event cap, so the answer cannot be "
+        "known to be whole"
+    )
+
+    if not collected_record.outcome.success:
+        # A provider failure is evidence in its own right and is never
+        # overwritten by an evaluator verdict; the evaluator is not run.
+        failure = collection_result.evidence.failure
+        detail = (
+            "collector reported failure without an error detail"
+            if failure is None
+            else f"{failure.category}: {failure.message}"
+        )
+        if cap_tripped:
+            detail += f" ({cap_note})"
+        collected_record.write_json(final_record_path)
+        return _finish(
+            RowStatus.FAILED,
+            detail,
+            final_record=collected_record,
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+            wrote_collection=True,
+            artifacts_verified=artifacts_verified,
+        )
+
+    if cap_tripped:
+        # Cutting the stream short can land after a terminal finish_reason,
+        # which is enough for the collector to call the stream cleanly
+        # ended. It is not enough for us: we are the ones who stopped
+        # reading, so what arrived is a prefix of the answer and grading it
+        # would publish a truncation as a verdict. The collected outcome is
+        # replaced rather than the record being dropped, so the timing and
+        # usage evidence survives while the outcome stops claiming success.
+        capped_record = dataclasses.replace(
+            collected_record,
+            outcome=OutcomeInfo(
+                success=False,
+                quality_score=None,
+                quality_metric=None,
+                notes=cap_note,
+            ),
+        )
+        capped_record.write_json(final_record_path)
+        return _finish(
+            RowStatus.FAILED,
+            f"{FAILURE_STREAM_TRUNCATED}: {cap_note}",
+            final_record=capped_record,
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+            wrote_collection=True,
+            artifacts_verified=artifacts_verified,
+        )
+
+    # 7. Grade the final answer only. ``response_text`` is the assembled
+    #    content stream; reasoning deltas are not part of it.
+    try:
+        evaluated_outcome = evaluate_workload(workload, collection_result.response_text)
+    except (WorkloadSchemaError, OSError, RuntimeError) as exc:
+        inconclusive_record = dataclasses.replace(
+            collected_record,
+            outcome=OutcomeInfo(
+                success=collected_record.outcome.success,
+                quality_score=None,
+                quality_metric=None,
+                notes=_scrub(f"evaluation inconclusive: {exc}"),
+            ),
+        )
+        inconclusive_record.write_json(final_record_path)
+        return _finish(
+            RowStatus.INCONCLUSIVE,
+            f"evaluator raised an unexpected error: {exc}",
+            final_record=inconclusive_record,
+            verified_hash=verified_hash,
+            binding_hash=binding_hash,
+            wrote_collection=True,
+            artifacts_verified=artifacts_verified,
+        )
+
+    final_record = dataclasses.replace(collected_record, outcome=evaluated_outcome)
+    final_record.write_json(final_record_path)
+    return _finish(
+        RowStatus.COMPLETED,
+        None,
+        final_record=final_record,
+        verified_hash=verified_hash,
+        binding_hash=binding_hash,
+        wrote_collection=True,
+        artifacts_verified=artifacts_verified,
+    )
+
+
+def run_selected_api_rows(
+    manifest: MatrixManifest,
+    *,
+    manifest_dir: Path,
+    matrix_path: Path,
+    output_dir: Path,
+    selection: RowSelection,
+    binding: APIBinding,
+    resume: bool,
+    transport_factory: Callable[[], StreamingTransport] = UrllibStreamingTransport,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[APIRowResult, ...]:
+    """Execute and evaluate every selected matrix row in manifest order."""
+    return tuple(
+        execute_api_row(
+            entry,
+            manifest_dir=manifest_dir,
+            matrix_path=matrix_path,
+            output_dir=output_dir,
+            binding=binding,
+            resume=resume,
+            transport_factory=transport_factory,
+            environ=environ,
+        )
+        for entry in select_entries(manifest, selection)
+    )

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -149,6 +149,9 @@ _DONE_SENTINEL = "[DONE]"
 RUN_MANIFEST_NAME = "run.json"
 RUN_MANIFEST_SCHEMA_VERSION = "1"
 
+#: Stand-in for a value this module refuses to repeat.
+_REJECTED = "[REJECTED]"
+
 #: Exactly what the run-level marker seals, as relative names under the run
 #: directory. Fixed here rather than taken from the marker, because the
 #: marker is a file and its contents are not authority over which paths
@@ -633,7 +636,10 @@ def _unsafe_run_id_reason(run_id: str) -> str | None:
         return "run_id contains a path separator"
     if "\x00" in run_id:
         return "run_id contains a null byte"
-    if not _SAFE_RUN_ID.match(run_id):
+    # ``fullmatch`` rather than ``match``: ``$`` also matches just
+    # before a trailing newline, so ``match`` would accept "row\\n" and
+    # create a directory whose name the refusal text says is impossible.
+    if not _SAFE_RUN_ID.fullmatch(run_id):
         return (
             "run_id is not a single safe path component matching "
             "[A-Za-z0-9][A-Za-z0-9._-]{0,127}"
@@ -720,6 +726,10 @@ class APIRowPlan:
     request_plan: RequestPlan | None
     binding_hash: str | None
     credential_env_var_present: bool
+    path_rejected: bool = False
+    """True when this row was refused for an unsafe or credential-bearing
+    artifact path, in which case its ``run_id`` is withheld from the
+    rendered plan along with the paths derived from it."""
 
     def to_dict(self) -> dict[str, Any]:
         """A secret-safe rendering of this plan.
@@ -731,7 +741,9 @@ class APIRowPlan:
         reported as a boolean, never as its contents.
         """
         return {
-            "run_id": self.entry.run_id,
+            # Withheld on the refusal path for the same reason the paths
+            # are: the value that was refused may be the credential.
+            "run_id": _REJECTED if self.path_rejected else self.entry.run_id,
             "workload_id": self.entry.workload_id,
             "workload_version": self.entry.workload_version,
             "category": self.entry.category,
@@ -789,7 +801,7 @@ def plan_api_row(
             "value into the filesystem"
         )
     if refusal is not None:
-        placeholder = Path("[REJECTED]")
+        placeholder = Path(_REJECTED)
         return APIRowPlan(
             entry=entry,
             unsupported=False,
@@ -803,6 +815,7 @@ def plan_api_row(
             request_plan=None,
             binding_hash=None,
             credential_env_var_present=credential_present,
+            path_rejected=True,
         )
 
     unsupported_reason = _unsupported_reason(entry)
@@ -1053,7 +1066,7 @@ def execute_api_row(
             entry=entry,
             verification=RowVerification(
                 schema_version=VERIFICATION_SCHEMA_VERSION,
-                run_id="[REJECTED]",
+                run_id=_REJECTED,
                 workload_id=entry.workload_id,
                 workload_version=entry.workload_version,
                 category=entry.category,

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -164,21 +164,33 @@ class _EventCappedResponse:
     authoritative diagnostic, so a decode error here only stops counting
     and lets the bytes through untouched.
 
-    The cap trips only when the stream genuinely had more events than the
-    limit allows, never merely on reaching it. Those are different facts
-    and conflating them condemns clean measurements: a provider may close
+    The cap trips only when the stream actually dispatched more events
+    than the limit allows. Reaching the limit is not exceeding it, and
+    conflating the two condemns clean measurements: a provider may close
     with a terminal ``finish_reason`` and no ``[DONE]`` sentinel, which
     this project supports, and the collector keeps pulling after the final
-    chunk. Tripping the moment the count reached the limit therefore
-    failed streams that had already delivered every byte they were ever
-    going to send, discarding a valid answer as a truncation.
+    chunk.
 
-    Telling the two apart needs one chunk of lookahead, because "the count
-    reached the limit" and "there was more to read" are only distinguished
-    by trying to read. The lookahead chunk is deliberately not yielded:
-    once the limit is known to be exceeded the row fails, so forwarding it
-    would only grow the answer this class has already decided not to
-    trust.
+    The decision is made from the event count alone, never from whether
+    another chunk happens to exist. Those are different quantities: a
+    chunk may carry several events, or none at all. A keepalive comment, a
+    stray blank line and a sentinel arriving in its own socket read are all
+    chunks that dispatch nothing, so treating "another chunk arrived" as
+    "the cap was exceeded" fails streams that never exceeded it, and makes
+    the verdict depend on how the network happened to segment the body.
+    Two runs over identical bytes must not disagree because one of them
+    was read in smaller pieces.
+
+    Counting only what the shared decoder dispatches keeps the outcome a
+    property of the stream rather than of the network. The count is taken
+    before the chunk is handed on, so the decision cannot depend on
+    whether the collector happened to stop reading first: a body that
+    arrives in one large read is capped exactly as the same body split
+    across many small ones.
+
+    The terminal ``[DONE]`` sentinel is itself a dispatched event and is
+    charged to the budget like any other. That is the only reading under
+    which the count is a property of the bytes alone.
     """
 
     def __init__(self, inner: StreamingResponse, *, limit: int) -> None:
@@ -198,29 +210,20 @@ class _EventCappedResponse:
         return self._inner.headers
 
     def iter_bytes(self) -> Iterator[bytes]:
-        iterator = iter(self._inner.iter_bytes())
-        while True:
-            try:
-                chunk = next(iterator)
-            except StopIteration:
-                return
-            yield chunk
-            if not self._counting:
-                continue
-            try:
-                self.events_seen += sum(1 for _ in self._decoder.feed(chunk))
-            except SSEDecodeError:
-                self._counting = False
-                continue
-            if self.events_seen >= self._limit:
+        for chunk in self._inner.iter_bytes():
+            if self._counting:
                 try:
-                    next(iterator)
-                except StopIteration:
-                    # The stream ended exactly at the limit. Nothing was
-                    # abandoned, so nothing was truncated.
-                    return
-                self.cap_tripped = True
-                return
+                    self.events_seen += sum(1 for _ in self._decoder.feed(chunk))
+                except SSEDecodeError:
+                    # The collector's own decoder is about to reject this
+                    # with the authoritative diagnostic, so counting stops
+                    # and the bytes go through untouched.
+                    self._counting = False
+                else:
+                    if self.events_seen > self._limit:
+                        self.cap_tripped = True
+                        return
+            yield chunk
 
     def close(self) -> None:
         self._inner.close()

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -87,8 +87,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from ..collectors._shared import atomic_write_text, config_hash, sha256_text
+from ..collectors._shared import (
+    atomic_write_text,
+    config_hash,
+    sha256_bytes,
+    sha256_text,
+)
 from ..collectors.openai_api import (
+    ARTIFACT_MANIFEST_NAME,
     FAILURE_STREAM_TRUNCATED,
     APICollectionConfig,
     FinishReasonVocabulary,
@@ -110,7 +116,7 @@ from ..schema import ExperimentRecord, OutcomeInfo, SchemaValidationError, utc_n
 from .catalog import workload_by_id
 from .evaluators import evaluate_workload
 from .matrix import DECODE_MODE_NATIVE_MTP, MatrixEntry, MatrixManifest
-from .schema import WorkloadSchemaError
+from .schema import WorkloadCategory, WorkloadSchemaError
 from .verify import (
     BACKEND_OPENAI_API,
     VERIFICATION_SCHEMA_VERSION,
@@ -132,6 +138,83 @@ API_BINDING_SCHEMA_VERSION = "1"
 #: measurement configurations.
 DEFAULT_MAX_STREAM_EVENTS = 10_000
 
+#: The terminal sentinel an OpenAI-compatible stream closes with. Matched
+#: here only to stop charging events past it; the collector remains the
+#: authority on what the sentinel means.
+_DONE_SENTINEL = "[DONE]"
+
+#: Name of the run-level completion marker, written last.
+RUN_MANIFEST_NAME = "run.json"
+RUN_MANIFEST_SCHEMA_VERSION = "1"
+
+
+def _run_marker_payload(
+    *,
+    run_id: str,
+    collection_dir: Path,
+    final_record_path: Path,
+    verification_path: Path,
+) -> dict[str, Any]:
+    """Seal the whole run directory, not just the collector's own set.
+
+    ``artifact_set_is_complete`` covers the four files the collector
+    writes and nothing else, so ``final_record.json`` and
+    ``verification.json`` sat outside every integrity check: the record
+    carrying the graded outcome, and the summary resume actually reads,
+    could both be edited and would still be trusted. This marker closes
+    that by hashing all three together, including the collector's own
+    marker, so tampering with any file in the run is detected.
+    """
+    return {
+        "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
+        "run_id": run_id,
+        "artifacts": [
+            {"name": name, "sha256": sha256_bytes(path.read_bytes())}
+            for name, path in (
+                (
+                    "collection/" + ARTIFACT_MANIFEST_NAME,
+                    collection_dir / ARTIFACT_MANIFEST_NAME,
+                ),
+                ("final_record.json", final_record_path),
+                ("verification.json", verification_path),
+            )
+        ],
+    }
+
+
+def run_artifacts_are_complete(run_dir: Path) -> bool:
+    """True when the run directory is whole and unmodified since it landed.
+
+    The marker is removed before the run's files are written and written
+    last, so any interruption leaves a directory this rejects rather than
+    one that reads as trustworthy.
+    """
+    try:
+        marker = json.loads((run_dir / RUN_MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(marker, dict):
+        return False
+    if marker.get("schema_version") != RUN_MANIFEST_SCHEMA_VERSION:
+        return False
+    artifacts = marker.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        return False
+    for entry in artifacts:
+        if not isinstance(entry, dict):
+            return False
+        name, digest = entry.get("name"), entry.get("sha256")
+        if not isinstance(name, str) or not isinstance(digest, str):
+            return False
+        try:
+            raw = (run_dir / name).read_bytes()
+        except OSError:
+            return False
+        if sha256_bytes(raw) != digest:
+            return False
+    return True
+
+
 _TRUSTABLE_RESUME_STATUSES = (RowStatus.COMPLETED, RowStatus.SKIPPED)
 
 _UNSUPPORTED_NATIVE_MTP_REASON = (
@@ -141,6 +224,52 @@ _UNSUPPORTED_NATIVE_MTP_REASON = (
     "thinking settings are a different mechanism measuring something else. "
     "This row is rejected rather than silently re-labelled as API reasoning."
 )
+
+#: Workload categories whose evaluator executes the model's answer.
+#:
+#: ``evaluate_code_completion`` writes the candidate to disk and runs it
+#: with this interpreter. Locally that is a considered trade: the answer
+#: came from a checkpoint on this machine, and the evaluator bounds it
+#: with a minimal environment, a new session and POSIX resource limits.
+#:
+#: None of that is a sandbox. There is no network namespace, no filesystem
+#: confinement and no seccomp policy, so the code may open sockets and
+#: read anything the invoking user can read. Over an API the answer is
+#: produced by a remote party, which turns "grade this workload" into
+#: "execute whatever that endpoint returned", and a compromised or hostile
+#: endpoint gets arbitrary local code execution out of a benchmark run.
+#:
+#: So the API backend fails closed. There is deliberately no opt-in flag:
+#: a flag would make this a default rather than a boundary, and the honest
+#: time to add one is when a real sandbox exists to put behind it.
+_EXECUTING_EVALUATOR_CATEGORIES = frozenset({WorkloadCategory.CODE_COMPLETION.value})
+
+_UNSUPPORTED_EXECUTING_EVALUATOR_REASON = (
+    "this workload is graded by executing the model's answer as a local "
+    "program, which is not something to do with output from a remote "
+    "endpoint. The evaluator bounds the process with a minimal environment "
+    "and resource limits, but it has no network or filesystem sandbox, so "
+    "running an API provider's answer would hand that provider local code "
+    "execution. The row is rejected rather than executed; no request is "
+    "sent and the evaluator is never invoked. Run this category locally "
+    "with `workloads run`, where the answer comes from a checkpoint on "
+    "this machine."
+)
+
+
+def _unsupported_reason(entry: MatrixEntry) -> str | None:
+    """Why this row cannot be run through an API, or ``None`` if it can.
+
+    Checked before anything is planned, sent or graded, so an unsupported
+    row never reaches a transport or an evaluator.
+    """
+    if entry.decode_mode == DECODE_MODE_NATIVE_MTP:
+        return _UNSUPPORTED_NATIVE_MTP_REASON
+    if entry.category in _EXECUTING_EVALUATOR_CATEGORIES:
+        return _UNSUPPORTED_EXECUTING_EVALUATOR_REASON
+    if not entry.runnable:
+        return entry.unsupported_reason or _UNSUPPORTED_NATIVE_MTP_REASON
+    return None
 
 
 class APIVerifyError(VerifyError):
@@ -188,9 +317,16 @@ class _EventCappedResponse:
     arrives in one large read is capped exactly as the same body split
     across many small ones.
 
-    The terminal ``[DONE]`` sentinel is itself a dispatched event and is
-    charged to the budget like any other. That is the only reading under
-    which the count is a property of the bytes alone.
+    Counting stops at the ``[DONE]`` sentinel, because the collector stops
+    there too. Anything a gateway appends after it -- a duplicated
+    sentinel, a stray trailing frame -- is never read by the collector and
+    so must never be charged. Charging it would reintroduce exactly the
+    dependence this class exists to remove, since those frames are only
+    ever seen when they happen to share a socket read with the sentinel.
+
+    The sentinel itself is a dispatched event and is charged like any
+    other, so ``limit`` admits ``limit - 1`` content events. That is the
+    only reading under which the count is a property of the bytes alone.
     """
 
     def __init__(self, inner: StreamingResponse, *, limit: int) -> None:
@@ -209,20 +345,38 @@ class _EventCappedResponse:
     def headers(self) -> Mapping[str, str]:
         return self._inner.headers
 
+    def _charge(self, chunk: bytes) -> bool:
+        """Charge ``chunk``'s events. True when the budget is now exceeded.
+
+        Stops charging at the sentinel and reports no excess for anything
+        past it, so a frame the collector will never read cannot decide
+        this row's verdict.
+        """
+        try:
+            events = list(self._decoder.feed(chunk))
+        except SSEDecodeError:
+            # The collector's own decoder is about to reject this with the
+            # authoritative diagnostic, so counting stops and the bytes go
+            # through untouched.
+            self._counting = False
+            return False
+
+        for event in events:
+            self.events_seen += 1
+            if self.events_seen > self._limit:
+                return True
+            if event.data.strip() == _DONE_SENTINEL:
+                # The collector returns here, so nothing after this frame
+                # is ever read and nothing after it is ever chargeable.
+                self._counting = False
+                return False
+        return False
+
     def iter_bytes(self) -> Iterator[bytes]:
         for chunk in self._inner.iter_bytes():
-            if self._counting:
-                try:
-                    self.events_seen += sum(1 for _ in self._decoder.feed(chunk))
-                except SSEDecodeError:
-                    # The collector's own decoder is about to reject this
-                    # with the authoritative diagnostic, so counting stops
-                    # and the bytes go through untouched.
-                    self._counting = False
-                else:
-                    if self.events_seen > self._limit:
-                        self.cap_tripped = True
-                        return
+            if self._counting and self._charge(chunk):
+                self.cap_tripped = True
+                return
             yield chunk
 
     def close(self) -> None:
@@ -524,15 +678,12 @@ def plan_api_row(
     collection_dir = run_dir / "collection"
     credential_present = bool(environ.get(binding.credential_env_var, "").strip())
 
-    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
+    unsupported_reason = _unsupported_reason(entry)
+    if unsupported_reason is not None:
         return APIRowPlan(
             entry=entry,
             unsupported=True,
-            unsupported_reason=(
-                _UNSUPPORTED_NATIVE_MTP_REASON
-                if entry.decode_mode == DECODE_MODE_NATIVE_MTP
-                else (entry.unsupported_reason or _UNSUPPORTED_NATIVE_MTP_REASON)
-            ),
+            unsupported_reason=unsupported_reason,
             ready=False,
             blockers=(),
             prompt_path=prompt_path,
@@ -799,18 +950,45 @@ def execute_api_row(
             artifacts_verified=artifacts_verified,
         )
         atomic_write_text(verification_path, verification.to_json())
+
+        # The run-level marker is written last and removed first, so a
+        # crash anywhere above leaves a directory `run_artifacts_are_
+        # complete` rejects rather than one that reads as trustworthy. It
+        # is only meaningful for a row that produced a full artifact set;
+        # a rejected or failed-before-execution row has nothing to seal.
+        if final_record is not None and wrote_collection and artifacts_verified:
+            try:
+                atomic_write_text(
+                    run_dir / RUN_MANIFEST_NAME,
+                    json.dumps(
+                        _run_marker_payload(
+                            run_id=entry.run_id,
+                            collection_dir=collection_dir,
+                            final_record_path=final_record_path,
+                            verification_path=verification_path,
+                        ),
+                        indent=2,
+                        allow_nan=False,
+                    )
+                    + "\n",
+                )
+            except OSError:
+                # A marker that cannot be written simply is not written.
+                # The row's evidence still stands on its own; only resume
+                # declines to trust it, which is the safe direction.
+                pass
+
         return APIRowResult(
             entry=entry, verification=verification, final_record=final_record
         )
 
-    # 1. Unsupported rows are rejected, never remapped onto API reasoning.
-    if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
-        reason = (
-            _UNSUPPORTED_NATIVE_MTP_REASON
-            if entry.decode_mode == DECODE_MODE_NATIVE_MTP
-            else (entry.unsupported_reason or _UNSUPPORTED_NATIVE_MTP_REASON)
-        )
-        return _finish(RowStatus.UNSUPPORTED, reason)
+    # 1. Unsupported rows are rejected first, before a transport is built
+    #    or an evaluator is chosen. Native-MTP is never remapped onto API
+    #    reasoning, and a workload graded by executing the answer is never
+    #    handed output from a remote endpoint.
+    unsupported_reason = _unsupported_reason(entry)
+    if unsupported_reason is not None:
+        return _finish(RowStatus.UNSUPPORTED, unsupported_reason)
 
     # 2. Verify the fully materialized prompt against the matrix metadata.
     prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
@@ -894,6 +1072,9 @@ def execute_api_row(
             and prior.run_binding_hash == binding_hash
             and prior.workload_version == workload.version
             and artifact_set_is_complete(collection_dir)
+            # Seals final_record.json and verification.json too, which the
+            # collector's own marker does not cover.
+            and run_artifacts_are_complete(run_dir)
         ):
             try:
                 trusted_record = ExperimentRecord.read_json(final_record_path)
@@ -912,7 +1093,12 @@ def execute_api_row(
                     artifacts_verified=True,
                 )
 
-    # 6. Execute through the unmodified collector.
+    # 6. Execute through the unmodified collector. Resume has declined to
+    #    trust whatever was here, so the marker vouching for it is dropped
+    #    before the first byte is overwritten and rewritten only once the
+    #    replacement set is complete.
+    (run_dir / RUN_MANIFEST_NAME).unlink(missing_ok=True)
+
     capped = _EventCappedTransport(transport_factory(), limit=binding.max_stream_events)
     try:
         collection_result = collect_openai_stream(

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -151,7 +151,7 @@ class APIVerifyError(VerifyError):
 
 
 class _EventCappedResponse:
-    """A streaming response that stops after ``limit`` dispatched events.
+    """A streaming response that stops once ``limit`` events are exceeded.
 
     The byte chunks are handed to the collector exactly as the transport
     produced them. Counting is done by feeding a second copy of each
@@ -163,6 +163,22 @@ class _EventCappedResponse:
     stream the collector's own decoder is about to reject with the
     authoritative diagnostic, so a decode error here only stops counting
     and lets the bytes through untouched.
+
+    The cap trips only when the stream genuinely had more events than the
+    limit allows, never merely on reaching it. Those are different facts
+    and conflating them condemns clean measurements: a provider may close
+    with a terminal ``finish_reason`` and no ``[DONE]`` sentinel, which
+    this project supports, and the collector keeps pulling after the final
+    chunk. Tripping the moment the count reached the limit therefore
+    failed streams that had already delivered every byte they were ever
+    going to send, discarding a valid answer as a truncation.
+
+    Telling the two apart needs one chunk of lookahead, because "the count
+    reached the limit" and "there was more to read" are only distinguished
+    by trying to read. The lookahead chunk is deliberately not yielded:
+    once the limit is known to be exceeded the row fails, so forwarding it
+    would only grow the answer this class has already decided not to
+    trust.
     """
 
     def __init__(self, inner: StreamingResponse, *, limit: int) -> None:
@@ -182,7 +198,12 @@ class _EventCappedResponse:
         return self._inner.headers
 
     def iter_bytes(self) -> Iterator[bytes]:
-        for chunk in self._inner.iter_bytes():
+        iterator = iter(self._inner.iter_bytes())
+        while True:
+            try:
+                chunk = next(iterator)
+            except StopIteration:
+                return
             yield chunk
             if not self._counting:
                 continue
@@ -192,6 +213,12 @@ class _EventCappedResponse:
                 self._counting = False
                 continue
             if self.events_seen >= self._limit:
+                try:
+                    next(iterator)
+                except StopIteration:
+                    # The stream ended exactly at the limit. Nothing was
+                    # abandoned, so nothing was truncated.
+                    return
                 self.cap_tripped = True
                 return
 

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -116,7 +116,7 @@ from ..schema import ExperimentRecord, OutcomeInfo, SchemaValidationError, utc_n
 from .catalog import workload_by_id
 from .evaluators import evaluate_workload
 from .matrix import DECODE_MODE_NATIVE_MTP, MatrixEntry, MatrixManifest
-from .schema import WorkloadCategory, WorkloadSchemaError
+from .schema import Workload, WorkloadCategory, WorkloadSchemaError
 from .verify import (
     BACKEND_OPENAI_API,
     VERIFICATION_SCHEMA_VERSION,
@@ -147,6 +147,15 @@ _DONE_SENTINEL = "[DONE]"
 RUN_MANIFEST_NAME = "run.json"
 RUN_MANIFEST_SCHEMA_VERSION = "1"
 
+#: Exactly what the run-level marker seals, as relative names under the run
+#: directory. Fixed here rather than taken from the marker, because the
+#: marker is a file and its contents are not authority over which paths
+#: this process will open.
+_SEALED_COLLECTION_MARKER = f"collection/{ARTIFACT_MANIFEST_NAME}"
+_SEALED_ARTIFACT_NAMES = frozenset(
+    {_SEALED_COLLECTION_MARKER, "final_record.json", "verification.json"}
+)
+
 
 def _run_marker_payload(
     *,
@@ -163,7 +172,10 @@ def _run_marker_payload(
     carrying the graded outcome, and the summary resume actually reads,
     could both be edited and would still be trusted. This marker closes
     that by hashing all three together, including the collector's own
-    marker, so tampering with any file in the run is detected.
+    marker. It is tamper evidence rather than tamper proofing: an
+    unsigned marker can itself be rewritten, but a partial write or an
+    edit made without regenerating it both stop resume from trusting the
+    directory.
     """
     return {
         "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
@@ -171,10 +183,7 @@ def _run_marker_payload(
         "artifacts": [
             {"name": name, "sha256": sha256_bytes(path.read_bytes())}
             for name, path in (
-                (
-                    "collection/" + ARTIFACT_MANIFEST_NAME,
-                    collection_dir / ARTIFACT_MANIFEST_NAME,
-                ),
+                (_SEALED_COLLECTION_MARKER, collection_dir / ARTIFACT_MANIFEST_NAME),
                 ("final_record.json", final_record_path),
                 ("verification.json", verification_path),
             )
@@ -188,6 +197,11 @@ def run_artifacts_are_complete(run_dir: Path) -> bool:
     The marker is removed before the run's files are written and written
     last, so any interruption leaves a directory this rejects rather than
     one that reads as trustworthy.
+
+    Tamper evidence, not tamper proofing: nothing here is signed, so
+    anyone able to edit the artifacts can rewrite the marker too. What it
+    catches is the partial write, the crash between files, and the edit
+    made without regenerating the marker.
     """
     try:
         marker = json.loads((run_dir / RUN_MANIFEST_NAME).read_text(encoding="utf-8"))
@@ -200,12 +214,30 @@ def run_artifacts_are_complete(run_dir: Path) -> bool:
     artifacts = marker.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
         return False
+
+    sealed: dict[str, str] = {}
     for entry in artifacts:
         if not isinstance(entry, dict):
             return False
         name, digest = entry.get("name"), entry.get("sha256")
         if not isinstance(name, str) or not isinstance(digest, str):
             return False
+        # The name comes back out of a file, so it is never joined onto the
+        # run directory as given. An absolute path, or one containing "..",
+        # would otherwise send this check off to hash some unrelated file,
+        # and a marker that verifies against a file nobody touched is worse
+        # than no marker at all.
+        if name not in _SEALED_ARTIFACT_NAMES:
+            return False
+        sealed[name] = digest
+
+    # Every expected artifact must be named exactly once. A marker that
+    # simply omitted an entry would otherwise vouch for a file it never
+    # covered.
+    if set(sealed) != _SEALED_ARTIFACT_NAMES:
+        return False
+
+    for name, digest in sealed.items():
         try:
             raw = (run_dir / name).read_bytes()
         except OSError:
@@ -257,11 +289,28 @@ _UNSUPPORTED_EXECUTING_EVALUATOR_REASON = (
 )
 
 
+def _executes_the_answer(workload: Workload) -> bool:
+    """True when grading this workload runs the model's answer as a program.
+
+    Asked of the catalog workload rather than of the matrix row, because
+    the catalog is what ``evaluate_workload`` dispatches on. A manifest is
+    a file on disk, and one that labels a code-completion row as
+    ``structured_json`` would otherwise satisfy a check that trusted the
+    row and then be graded by executing the answer anyway. The row's own
+    category is still checked first, but only as a cheap short circuit;
+    the authority is here.
+    """
+    return workload.category.value in _EXECUTING_EVALUATOR_CATEGORIES
+
+
 def _unsupported_reason(entry: MatrixEntry) -> str | None:
     """Why this row cannot be run through an API, or ``None`` if it can.
 
     Checked before anything is planned, sent or graded, so an unsupported
-    row never reaches a transport or an evaluator.
+    row never reaches a transport or an evaluator. This looks only at the
+    row, so it cannot be the last word on a workload's evaluator: see
+    ``_executes_the_answer``, which is re-checked against the catalog once
+    the workload has been resolved.
     """
     if entry.decode_mode == DECODE_MODE_NATIVE_MTP:
         return _UNSUPPORTED_NATIVE_MTP_REASON
@@ -721,6 +770,24 @@ def plan_api_row(
     except KeyError:
         blockers.append(f"unknown workload_id in catalog: {entry.workload_id!r}")
     else:
+        # Same authority as the execution path: the catalog decides which
+        # evaluator runs, so a manifest that mislabels a code workload
+        # cannot present it here as runnable either.
+        if _executes_the_answer(workload):
+            return APIRowPlan(
+                entry=entry,
+                unsupported=True,
+                unsupported_reason=_UNSUPPORTED_EXECUTING_EVALUATOR_REASON,
+                ready=False,
+                blockers=(),
+                prompt_path=prompt_path,
+                collection_dir=collection_dir,
+                final_record_path=run_dir / "final_record.json",
+                verification_path=run_dir / "verification.json",
+                request_plan=None,
+                binding_hash=None,
+                credential_env_var_present=credential_present,
+            )
         workload_version = workload.version
         if workload.version != entry.workload_version:
             workload_version = None
@@ -1026,6 +1093,16 @@ def execute_api_row(
             f"workload '{entry.workload_id}' version drift: matrix pinned "
             f"v{entry.workload_version}, catalog has v{workload.version}; "
             "regenerate the matrix",
+            verified_hash=verified_hash,
+        )
+
+    # The catalog decides which evaluator runs, so the catalog decides
+    # whether this row is safe to run at all. Checking only the manifest's
+    # category left a mislabelled row executing a remote answer.
+    if _executes_the_answer(workload):
+        return _finish(
+            RowStatus.UNSUPPORTED,
+            _UNSUPPORTED_EXECUTING_EVALUATOR_REASON,
             verified_hash=verified_hash,
         )
 

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -82,6 +82,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
+import re
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -105,6 +106,7 @@ from ..collectors.openai_api import (
     StreamingResponse,
     StreamingTransport,
     UrllibStreamingTransport,
+    _contains_credential,
     artifact_set_is_complete,
     assert_credential_not_embedded,
     build_request_plan,
@@ -191,7 +193,7 @@ def _run_marker_payload(
     }
 
 
-def run_artifacts_are_complete(run_dir: Path) -> bool:
+def run_artifacts_are_complete(run_dir: Path, *, expected_run_id: str) -> bool:
     """True when the run directory is whole and unmodified since it landed.
 
     The marker is removed before the run's files are written and written
@@ -205,11 +207,17 @@ def run_artifacts_are_complete(run_dir: Path) -> bool:
     """
     try:
         marker = json.loads((run_dir / RUN_MANIFEST_NAME).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return False
     if not isinstance(marker, dict):
         return False
     if marker.get("schema_version") != RUN_MANIFEST_SCHEMA_VERSION:
+        return False
+    # A run directory copied from another row carries that row's evidence
+    # under this row's name. Every hash still checks out, because nothing
+    # in it was edited, so identity has to be asserted rather than
+    # inferred from integrity.
+    if marker.get("run_id") != expected_run_id:
         return False
     artifacts = marker.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
@@ -596,6 +604,43 @@ class APIBinding:
 # --- Planning ----------------------------------------------------------------
 
 
+#: A run_id becomes a directory name, so it has to be one path component
+#: and nothing more. The generated ids are ``<workload>-<tier>-<mode>``
+#: with an optional ``-depth<n>``, so this is the shape they already have.
+_SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _unsafe_run_id_reason(run_id: str) -> str | None:
+    """Why ``run_id`` cannot be used as a directory name, or ``None``.
+
+    A run_id is read straight out of the matrix manifest, which is a file
+    on disk, and is then joined onto the output directory. An absolute
+    value replaces the output directory outright; ``..`` climbs out of it;
+    a separator plants artifacts somewhere nobody asked for. None of that
+    needs an attacker, either: a hand-edited manifest is enough to have a
+    run quietly write outside the directory the caller named.
+
+    The value is not echoed. It failed this check, which is exactly the
+    circumstance in which repeating it is a bad idea.
+    """
+    if not isinstance(run_id, str) or not run_id:
+        return "run_id is empty"
+    if run_id in (".", ".."):
+        return "run_id is a relative directory reference"
+    if os.path.isabs(run_id) or os.path.splitdrive(run_id)[0]:
+        return "run_id is an absolute path"
+    if "/" in run_id or "\\" in run_id or os.sep in run_id:
+        return "run_id contains a path separator"
+    if "\x00" in run_id:
+        return "run_id contains a null byte"
+    if not _SAFE_RUN_ID.match(run_id):
+        return (
+            "run_id is not a single safe path component matching "
+            "[A-Za-z0-9][A-Za-z0-9._-]{0,127}"
+        )
+    return None
+
+
 def _run_dir(entry: MatrixEntry, *, output_dir: Path) -> Path:
     return output_dir / "runs" / entry.run_id
 
@@ -725,7 +770,40 @@ def plan_api_row(
     run_dir = _run_dir(entry, output_dir=output_dir)
     prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
     collection_dir = run_dir / "collection"
-    credential_present = bool(environ.get(binding.credential_env_var, "").strip())
+    credential = environ.get(binding.credential_env_var, "").strip()
+    credential_present = bool(credential)
+
+    # The same refusal the execution path applies, so a dry run reports
+    # what a real run would do rather than printing a plan for a row that
+    # would then be rejected. The path is not echoed either way: it is
+    # rejected precisely because of what it may contain.
+    refusal = _unsafe_run_id_reason(entry.run_id)
+    if (
+        refusal is None
+        and credential
+        and _contains_credential(str(run_dir), credential)
+    ):
+        refusal = (
+            "the value named by --api-key-env appears in this row's "
+            "artifact path; refusing because creating it would write that "
+            "value into the filesystem"
+        )
+    if refusal is not None:
+        placeholder = Path("[REJECTED]")
+        return APIRowPlan(
+            entry=entry,
+            unsupported=False,
+            unsupported_reason=None,
+            ready=False,
+            blockers=(f"unsafe artifact path: {refusal}",),
+            prompt_path=placeholder,
+            collection_dir=placeholder,
+            final_record_path=placeholder,
+            verification_path=placeholder,
+            request_plan=None,
+            binding_hash=None,
+            credential_env_var_present=credential_present,
+        )
 
     unsupported_reason = _unsupported_reason(entry)
     if unsupported_reason is not None:
@@ -923,7 +1001,7 @@ def _load_prior_verification(path: Path) -> RowVerification | None:
         return None
     try:
         return RowVerification.read_json(path)
-    except (OSError, json.JSONDecodeError, VerifyError):
+    except (OSError, UnicodeError, json.JSONDecodeError, VerifyError):
         # A corrupt or partial artifact from an interrupted run must never
         # be mistaken for a trustworthy completed result.
         return None
@@ -955,6 +1033,53 @@ def execute_api_row(
     resolved_environ = os.environ if environ is None else environ
     credential = resolved_environ.get(binding.credential_env_var, "").strip() or None
     started_at = utc_now_iso()
+
+    # Before a path is derived, let alone created. Everything below joins
+    # run_id onto the output directory and then writes there, including
+    # the rejection paths, so an unsafe id would have its refusal written
+    # to the very place it should not reach. Nothing is written here for
+    # the same reason: there is no directory this row may safely touch.
+    refusal = _unsafe_run_id_reason(entry.run_id)
+    if refusal is None and credential is not None:
+        candidate = _run_dir(entry, output_dir=output_dir)
+        if _contains_credential(str(candidate), credential):
+            refusal = (
+                "the value named by --api-key-env appears in this row's "
+                "artifact path; refusing because creating it would write "
+                "that value into the filesystem"
+            )
+    if refusal is not None:
+        return APIRowResult(
+            entry=entry,
+            verification=RowVerification(
+                schema_version=VERIFICATION_SCHEMA_VERSION,
+                run_id="[REJECTED]",
+                workload_id=entry.workload_id,
+                workload_version=entry.workload_version,
+                category=entry.category,
+                context_tier=entry.context_tier,
+                decode_mode=entry.decode_mode,
+                status=RowStatus.FAILED,
+                reason=f"unsafe artifact path: {refusal}",
+                recorded_prompt_hash=entry.prompt.prompt_hash,
+                verified_prompt_hash=None,
+                run_binding_hash=None,
+                resumed=False,
+                outcome_success=None,
+                quality_score=None,
+                total_ms=None,
+                started_at=started_at,
+                ended_at=utc_now_iso(),
+                final_record_path=None,
+                collection_dir=None,
+                backend=BACKEND_OPENAI_API,
+                provider=None,
+                api_model_id=None,
+                artifacts_verified=None,
+            ),
+            final_record=None,
+        )
+
     run_dir = _run_dir(entry, output_dir=output_dir)
     verification_path = run_dir / "verification.json"
     collection_dir = run_dir / "collection"
@@ -1148,14 +1273,23 @@ def execute_api_row(
             and prior.verified_prompt_hash == verified_hash
             and prior.run_binding_hash == binding_hash
             and prior.workload_version == workload.version
+            # The summary must be this row's, not one copied in from
+            # another. Integrity says the bytes are unedited; it says
+            # nothing about which row they describe.
+            and prior.run_id == entry.run_id
             and artifact_set_is_complete(collection_dir)
             # Seals final_record.json and verification.json too, which the
-            # collector's own marker does not cover.
-            and run_artifacts_are_complete(run_dir)
+            # collector's own marker does not cover, and asserts the same
+            # identity over the directory as a whole.
+            and run_artifacts_are_complete(run_dir, expected_run_id=entry.run_id)
         ):
             try:
                 trusted_record = ExperimentRecord.read_json(final_record_path)
-            except (OSError, SchemaValidationError):
+            except (OSError, UnicodeError, SchemaValidationError):
+                trusted_record = None
+            # The record carries its own run_id, and a copied directory
+            # is exactly the case where it disagrees with this row.
+            if trusted_record is not None and trusted_record.run_id != entry.run_id:
                 trusted_record = None
             if trusted_record is not None:
                 return _finish(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -311,6 +311,16 @@ class RowVerification:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RowVerification:
+        # ``json.loads`` happily returns a list, a scalar or ``None`` for
+        # perfectly valid JSON, and every field access below then raises
+        # ``AttributeError`` or ``TypeError``. Neither is a
+        # ``VerifyError``, so a ``verification.json`` containing ``[]``
+        # escaped every handler and crashed the run instead of being
+        # treated as the unreadable evidence it is.
+        if not isinstance(data, dict):
+            raise VerifyError(
+                f"verification.json must be a JSON object, got {type(data).__name__}"
+            )
         try:
             return cls(
                 schema_version=str(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -84,7 +84,24 @@ from .evaluators import evaluate_workload
 from .matrix import DECODE_MODE_NATIVE_MTP, MatrixEntry, MatrixManifest
 from .schema import WorkloadSchemaError
 
-VERIFICATION_SCHEMA_VERSION = "1"
+VERIFICATION_SCHEMA_VERSION = "2"
+"""Schema version for ``verification.json``.
+
+v2 is a strict superset of v1: it adds ``backend``, ``provider``,
+``api_model_id`` and ``artifacts_verified``, all optional on read with
+defaults that describe exactly what a v1 artifact meant (a locally
+measured MLX row with no provider and no separately verified artifact
+set). A v1 artifact therefore still parses, still aggregates and still
+resumes; nothing that was written before this version needs rewriting.
+"""
+
+#: Which execution backend produced a row. Recorded so that aggregation can
+#: keep locally measured rows and rows measured through a hosted API apart:
+#: they do not share a hardware definition and their timings are not
+#: comparable. Absent from schema v1 artifacts, which predate any backend
+#: other than local MLX, so reading one back defaults to ``mlx``.
+BACKEND_MLX = "mlx"
+BACKEND_OPENAI_API = "openai-api"
 
 
 class VerifyError(ValueError):
@@ -244,6 +261,22 @@ class RowVerification:
     ended_at: str
     final_record_path: str | None
     collection_dir: str | None
+    backend: str = BACKEND_MLX
+    """Which execution backend produced the row. Defaults to ``mlx`` so a
+    schema v1 artifact, written before any other backend existed, reads
+    back as exactly what it was."""
+
+    provider: str | None = None
+    """Sanitized provider label for API-backed rows; ``None`` for local
+    rows, which have no provider."""
+
+    api_model_id: str | None = None
+    """Provider-side model ID for API-backed rows. Kept separate from the
+    matrix's local ``model_id`` because the two name different things."""
+
+    artifacts_verified: bool | None = None
+    """Whether the backend's own artifact set was hash-verified complete.
+    ``None`` when the backend publishes no such marker."""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -254,12 +287,16 @@ class RowVerification:
             "category": self.category,
             "context_tier": self.context_tier,
             "decode_mode": self.decode_mode,
+            "backend": self.backend,
+            "provider": self.provider,
+            "api_model_id": self.api_model_id,
             "status": self.status.value,
             "reason": self.reason,
             "recorded_prompt_hash": self.recorded_prompt_hash,
             "verified_prompt_hash": self.verified_prompt_hash,
             "run_binding_hash": self.run_binding_hash,
             "resumed": self.resumed,
+            "artifacts_verified": self.artifacts_verified,
             "outcome_success": self.outcome_success,
             "quality_score": self.quality_score,
             "total_ms": self.total_ms,
@@ -298,6 +335,12 @@ class RowVerification:
                 ended_at=data["ended_at"],
                 final_record_path=data.get("final_record_path"),
                 collection_dir=data.get("collection_dir"),
+                # Additive v2 fields. A v1 artifact predates any backend
+                # other than local MLX, so its absence is not ambiguous.
+                backend=str(data.get("backend", BACKEND_MLX)),
+                provider=data.get("provider"),
+                api_model_id=data.get("api_model_id"),
+                artifacts_verified=data.get("artifacts_verified"),
             )
         except (KeyError, ValueError) as exc:
             raise VerifyError(f"invalid verification.json: {exc}") from exc

--- a/tests/optimizer/test_openai_api_cli.py
+++ b/tests/optimizer/test_openai_api_cli.py
@@ -699,28 +699,36 @@ def run_main(argv: list[str]) -> tuple[int, str, str]:
 
 
 @pytest.mark.parametrize(
-    "flag",
+    ("flag", "canonical"),
     [
-        "--api-key",
-        "--api_key",
-        "--apikey",
-        "--API-KEY",
-        "--token",
-        "--access-token",
-        "--bearer-token",
-        "--secret",
-        "--password",
-        "--credential",
+        ("--api-key", "--api-key"),
+        ("--api_key", "--api-key"),
+        ("--apikey", "--api-key"),
+        ("--API-KEY", "--api-key"),
+        ("--token", "--token"),
+        ("--access-token", "--access-token"),
+        ("--bearer-token", "--bearer-token"),
+        ("--secret", "--secret"),
+        ("--password", "--password"),
+        ("--credential", "--credential"),
     ],
 )
 @pytest.mark.parametrize("attached", [False, True])
 def test_a_credential_flag_is_rejected_without_repeating_its_value(
-    tmp_path: Path, flag: str, attached: bool
+    tmp_path: Path, flag: str, canonical: str, attached: bool
 ) -> None:
     """argparse quotes an unrecognized argument back, value and all.
 
     The credential is read from the environment and no flag accepts one,
     so the flag is refused before argparse can format it into a message.
+
+    The message names the flag using this program's own spelling rather
+    than the caller's token. Echoing the token was believed safe because
+    it was split on ``=`` first, but that relied on reasoning about every
+    argument shape instead of on construction, and it kept a value that
+    may be the credential flowing into a write to stderr. So
+    ``--API_KEY`` is answered with ``--api-key``: still actionable, and
+    built only from bytes this program defined.
     """
     extra = [f"{flag}={_SENTINEL}"] if attached else [flag, _SENTINEL]
 
@@ -729,9 +737,27 @@ def test_a_credential_flag_is_rejected_without_repeating_its_value(
     assert code == 2
     assert _SENTINEL not in err
     assert _SENTINEL not in out
-    assert flag.split("=")[0] in err
+    assert canonical in err
     assert "--api-key-env" in err
     assert not (tmp_path / "artifacts").exists()
+
+
+@pytest.mark.parametrize("flag", ["--API_KEY", "--Api-Key", "--apikey"])
+def test_the_refusal_never_echoes_the_callers_own_spelling(
+    tmp_path: Path, flag: str
+) -> None:
+    """No byte of the command line reaches an output stream.
+
+    A spelling this program did not define is caller-supplied text, and
+    the token that reached this check is the one most likely to be
+    holding a credential, so it is answered rather than repeated.
+    """
+    code, out, err = run_main(base_argv(tmp_path) + [f"{flag}={_SENTINEL}"])
+
+    assert code == 2
+    assert flag not in err + out
+    assert _SENTINEL not in err + out
+    assert "--api-key" in err
 
 
 def test_the_env_var_flag_is_not_mistaken_for_a_credential_flag(

--- a/tests/optimizer/test_workloads_aggregate.py
+++ b/tests/optimizer/test_workloads_aggregate.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from llmtracefx.optimizer.workloads.aggregate import summarize_results, write_summary
-from llmtracefx.optimizer.workloads.verify import RowStatus, RowVerification
+from llmtracefx.optimizer.workloads.aggregate import (
+    AGGREGATE_SCHEMA_VERSION,
+    summarize_results,
+    write_summary,
+)
+from llmtracefx.optimizer.workloads.verify import (
+    BACKEND_MLX,
+    BACKEND_OPENAI_API,
+    RowStatus,
+    RowVerification,
+)
 
 SCHEMA_VERSION = "1"
 
@@ -21,6 +30,8 @@ def _write_verification(
     outcome_success: bool | None = None,
     quality_score: float | None = None,
     total_ms: float | None = None,
+    backend: str = BACKEND_MLX,
+    provider: str | None = None,
 ) -> None:
     verification = RowVerification(
         schema_version=SCHEMA_VERSION,
@@ -43,6 +54,8 @@ def _write_verification(
         ended_at="2024-01-01T00:00:01.000000Z",
         final_record_path=str(results_dir / "runs" / run_id / "final_record.json"),
         collection_dir=str(results_dir / "runs" / run_id / "collection"),
+        backend=backend,
+        provider=provider,
     )
     run_dir = results_dir / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -265,4 +278,98 @@ def test_write_summary_persists_json(tmp_path):
 
     payload = json.loads(output_path.read_text())
     assert payload["overall"]["total"] == 1
-    assert payload["schema_version"] == "1"
+    assert payload["schema_version"] == AGGREGATE_SCHEMA_VERSION
+    # v2 is a strict superset of v1: both new axes are always present.
+    assert "by_backend" in payload
+    assert "by_provider" in payload
+
+
+def test_backend_axis_keeps_local_and_api_rows_apart(tmp_path):
+    """A local row and a hosted-API row are never blended into one figure."""
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "local",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+        backend=BACKEND_MLX,
+    )
+    _write_verification(
+        results_dir,
+        "remote",
+        status=RowStatus.COMPLETED,
+        outcome_success=False,
+        quality_score=0.0,
+        total_ms=4000,
+        backend=BACKEND_OPENAI_API,
+        provider="openrouter",
+    )
+    summary = summarize_results(results_dir)
+
+    by_backend = {group.key: group for group in summary.by_backend}
+    assert set(by_backend) == {BACKEND_MLX, BACKEND_OPENAI_API}
+    assert by_backend[BACKEND_MLX].pass_rate == 1.0
+    assert by_backend[BACKEND_OPENAI_API].pass_rate == 0.0
+    # The blended overall figure still exists, but each backend keeps its own.
+    assert summary.overall.pass_rate == 0.5
+
+
+def test_provider_axis_only_covers_rows_that_have_a_provider(tmp_path):
+    """Local rows are absent rather than gathered under a fake provider."""
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "local",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+    )
+    _write_verification(
+        results_dir,
+        "router",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=2000,
+        backend=BACKEND_OPENAI_API,
+        provider="openrouter",
+    )
+    _write_verification(
+        results_dir,
+        "direct",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=3000,
+        backend=BACKEND_OPENAI_API,
+        provider="z.ai",
+    )
+    summary = summarize_results(results_dir)
+
+    by_provider = {group.key: group for group in summary.by_provider}
+    assert set(by_provider) == {"openrouter", "z.ai"}
+    assert by_provider["openrouter"].total == 1
+    assert by_provider["z.ai"].total == 1
+
+
+def test_group_with_no_evaluated_rows_reports_null_not_zero(tmp_path):
+    """An unavailable metric is never rendered as a measured zero."""
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "failed-remote",
+        status=RowStatus.FAILED,
+        backend=BACKEND_OPENAI_API,
+        provider="openrouter",
+    )
+    summary = summarize_results(results_dir)
+
+    group = next(g for g in summary.by_provider if g.key == "openrouter")
+    assert group.evaluated_total == 0
+    assert group.pass_rate is None
+    assert group.correct_cases_per_minute is None
+    payload = json.loads(summary.to_json())
+    assert payload["by_provider"][0]["pass_rate"] is None

--- a/tests/optimizer/test_workloads_aggregate.py
+++ b/tests/optimizer/test_workloads_aggregate.py
@@ -373,3 +373,120 @@ def test_group_with_no_evaluated_rows_reports_null_not_zero(tmp_path):
     assert group.correct_cases_per_minute is None
     payload = json.loads(summary.to_json())
     assert payload["by_provider"][0]["pass_rate"] is None
+
+
+def test_a_mixed_backend_group_withholds_its_timing_metric(tmp_path):
+    """A local duration and an API duration are not the same quantity.
+
+    Blending them yields a throughput figure describing no system that
+    exists, and the wider the aggregate the more authoritative it looks.
+    """
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "local",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1000,
+        backend=BACKEND_MLX,
+    )
+    _write_verification(
+        results_dir,
+        "remote",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=9000,
+        backend=BACKEND_OPENAI_API,
+        provider="openrouter",
+    )
+    summary = summarize_results(results_dir)
+
+    # Quality survives: a pass is a pass wherever it was produced.
+    assert summary.overall.pass_rate == 1.0
+    assert summary.overall.evaluated_pass == 2
+    # The timing-derived figure does not, and says why.
+    assert summary.overall.correct_cases_per_minute is None
+    assert summary.overall.timing_comparable is False
+    assert "not the same quantity" in (summary.overall.timing_unavailable_reason or "")
+    assert summary.overall.measurement_contexts == ("mlx", "openai-api/openrouter")
+
+    # The homogeneous per-backend groups keep theirs.
+    by_backend = {group.key: group for group in summary.by_backend}
+    assert by_backend[BACKEND_MLX].correct_cases_per_minute is not None
+    assert by_backend[BACKEND_MLX].timing_comparable is True
+    assert by_backend[BACKEND_OPENAI_API].correct_cases_per_minute is not None
+
+
+def test_two_providers_in_one_group_also_withhold_timing(tmp_path):
+    """Two hosted endpoints are not one measurement context either."""
+    results_dir = tmp_path / "results"
+    for run_id, provider in (("a", "openrouter"), ("b", "z.ai")):
+        _write_verification(
+            results_dir,
+            run_id,
+            status=RowStatus.COMPLETED,
+            outcome_success=True,
+            quality_score=1.0,
+            total_ms=2000,
+            backend=BACKEND_OPENAI_API,
+            provider=provider,
+        )
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.correct_cases_per_minute is None
+    assert summary.overall.timing_comparable is False
+    by_backend = {group.key: group for group in summary.by_backend}
+    # Same backend, still two providers, so still not comparable.
+    assert by_backend[BACKEND_OPENAI_API].correct_cases_per_minute is None
+    by_provider = {group.key: group for group in summary.by_provider}
+    assert by_provider["openrouter"].correct_cases_per_minute is not None
+    assert by_provider["z.ai"].correct_cases_per_minute is not None
+
+
+def test_a_homogeneous_group_is_unaffected(tmp_path):
+    """The suppression is narrow: one context keeps every metric."""
+    results_dir = tmp_path / "results"
+    for run_id in ("a", "b"):
+        _write_verification(
+            results_dir,
+            run_id,
+            status=RowStatus.COMPLETED,
+            outcome_success=True,
+            quality_score=1.0,
+            total_ms=1000,
+            backend=BACKEND_OPENAI_API,
+            provider="openrouter",
+        )
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.timing_comparable is True
+    assert summary.overall.timing_unavailable_reason is None
+    assert summary.overall.correct_cases_per_minute is not None
+
+
+def test_a_failing_row_from_another_backend_does_not_suppress_timing(tmp_path):
+    """Only rows that contribute a duration define the context.
+
+    A failed row has no timing to blend, so its backend must not withhold
+    a figure the passing rows can legitimately support.
+    """
+    results_dir = tmp_path / "results"
+    _write_verification(
+        results_dir,
+        "remote-pass",
+        status=RowStatus.COMPLETED,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=2000,
+        backend=BACKEND_OPENAI_API,
+        provider="openrouter",
+    )
+    _write_verification(
+        results_dir, "local-fail", status=RowStatus.FAILED, backend=BACKEND_MLX
+    )
+    summary = summarize_results(results_dir)
+
+    assert summary.overall.timing_comparable is True
+    assert summary.overall.correct_cases_per_minute is not None

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -10,12 +10,14 @@ only as configuration.
 from __future__ import annotations
 
 import json
+import shutil
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from llmtracefx.optimizer.collectors._shared import sha256_bytes
 from llmtracefx.optimizer.collectors.openai_api import (
     ARTIFACT_MANIFEST_NAME,
     FAILURE_HTTP_STATUS,
@@ -1406,7 +1408,7 @@ def test_a_completed_row_writes_a_run_level_marker(tmp_path):
     run_dir = Path(result.verification.collection_dir or "").parent
 
     assert (run_dir / RUN_MANIFEST_NAME).exists()
-    assert run_artifacts_are_complete(run_dir)
+    assert run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
     sealed = {
         entry["name"]
         for entry in json.loads(
@@ -1438,7 +1440,7 @@ def test_editing_a_file_outside_the_collection_marker_forces_a_rerun(tmp_path, v
         payload["outcome"]["quality_score"] = 1.0
     target.write_text(json.dumps(payload), encoding="utf-8")
 
-    assert not run_artifacts_are_complete(run_dir)
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
 
     transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
     second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
@@ -1559,7 +1561,7 @@ def test_a_marker_naming_another_file_is_rejected(tmp_path, rewritten_name):
     marker["artifacts"][1]["name"] = rewritten_name
     marker_path.write_text(json.dumps(marker), encoding="utf-8")
 
-    assert not run_artifacts_are_complete(run_dir)
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
 
 
 def test_a_marker_that_omits_an_artifact_is_rejected(tmp_path):
@@ -1576,4 +1578,250 @@ def test_a_marker_that_omits_an_artifact_is_rejected(tmp_path):
     ]
     marker_path.write_text(json.dumps(marker), encoding="utf-8")
 
-    assert not run_artifacts_are_complete(run_dir)
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+
+
+# --- Unsafe artifact paths ----------------------------------------------------
+
+
+def _entry_with_run_id(manifest, run_id: str) -> MatrixEntry:
+    doctored = dict(autoregressive_entry(manifest).to_dict())
+    doctored["run_id"] = run_id
+    return MatrixEntry.from_dict(doctored)
+
+
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "../escaped",
+        "../../escaped",
+        "nested/child",
+        "..",
+        ".",
+        "",
+        "with space",
+        "semi;colon",
+    ],
+)
+def test_an_unsafe_run_id_is_refused_and_writes_nothing(tmp_path, run_id):
+    """A run_id is read from a manifest and becomes a directory name.
+
+    An absolute value replaces the output directory outright and ``..``
+    climbs out of it, so an edited manifest could plant artifacts
+    anywhere the user can write. The refusal itself must not be written
+    either, since the only path available is the unsafe one.
+    """
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    output_dir = tmp_path / "results"
+
+    result = execute_api_row(
+        _entry_with_run_id(manifest, run_id),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=output_dir,
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert "unsafe artifact path" in (result.verification.reason or "")
+    assert result.final_record is None
+    # Nothing was created anywhere, including the traversal target.
+    assert not output_dir.exists()
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_an_absolute_run_id_cannot_escape_the_output_directory(tmp_path):
+    """The starkest case: an absolute id discards the output directory."""
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    target = tmp_path / "planted"
+
+    result = execute_api_row(
+        _entry_with_run_id(manifest, str(target)),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert not target.exists()
+    assert not (tmp_path / "results").exists()
+
+
+def test_an_unsafe_run_id_is_refused_in_the_plan_without_echoing_it(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    plan = plan_api_row(
+        _entry_with_run_id(manifest, "../escaped"),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        environ=ENVIRON,
+    )
+
+    assert plan.ready is False
+    assert plan.request_plan is None
+    assert any("unsafe artifact path" in blocker for blocker in plan.blockers)
+    assert not (tmp_path / "results").exists()
+
+
+def test_a_credential_in_the_effective_row_path_is_refused(tmp_path):
+    """--output-dir may be clean while the run_id carries the key."""
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    output_dir = tmp_path / "results"
+
+    result = execute_api_row(
+        _entry_with_run_id(manifest, f"row-{API_KEY}"),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=output_dir,
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert API_KEY not in (result.verification.reason or "")
+    assert API_KEY not in (result.verification.run_id or "")
+    assert not output_dir.exists()
+
+
+# --- Resume binds the row's identity ------------------------------------------
+
+
+def test_a_run_directory_copied_from_another_row_is_never_trusted(tmp_path):
+    """Every hash checks out; the evidence still describes another row.
+
+    Integrity says the bytes were not edited. It says nothing about which
+    row they belong to, so identity has to be asserted separately.
+    """
+    bundle = build_manifest(
+        tmp_path,
+        workloads=(STRUCTURED_JSON_PROFILE_EXTRACTION,),
+        context_tiers=(ContextTier.TIER_2K, ContextTier.TIER_8K),
+    )
+    manifest, manifest_dir, matrix_path = bundle
+    rows = [e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE]
+    source, destination = rows[0], rows[1]
+    output_dir = tmp_path / "results"
+
+    first = execute_api_row(
+        source,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=output_dir,
+        binding=make_binding(),
+        resume=True,
+        transport_factory=lambda: FakeTransport(
+            FakeResponse(answer_stream(GOOD_JSON_ANSWER))
+        ),
+        environ=ENVIRON,
+    )
+    assert first.verification.status is RowStatus.COMPLETED
+
+    source_dir = Path(first.verification.collection_dir or "").parent
+    destination_dir = output_dir / "runs" / destination.run_id
+    shutil.copytree(source_dir, destination_dir)
+
+    # The copy is byte-identical, so every hash in it still verifies.
+    assert artifact_set_is_complete(destination_dir / "collection")
+    # But it is not this row's evidence.
+    assert not run_artifacts_are_complete(
+        destination_dir, expected_run_id=destination.run_id
+    )
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = execute_api_row(
+        destination,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=output_dir,
+        binding=make_binding(),
+        resume=True,
+        transport_factory=lambda: transport,
+        environ=ENVIRON,
+    )
+    assert transport.requests, "a copied run directory must rerun"
+    assert second.verification.status is RowStatus.COMPLETED
+
+
+def test_a_marker_renamed_to_another_run_is_rejected(tmp_path):
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+
+    assert run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+    assert not run_artifacts_are_complete(run_dir, expected_run_id="some-other-row")
+
+
+# --- Corrupt, non-UTF-8 artifacts -------------------------------------------
+
+
+@pytest.mark.parametrize("victim", [RUN_MANIFEST_NAME, "verification.json"])
+def test_a_non_utf8_artifact_reruns_instead_of_crashing(tmp_path, victim):
+    """A corrupted file is untrusted evidence, not an unhandled exception.
+
+    ``UnicodeDecodeError`` is neither an ``OSError`` nor a
+    ``JSONDecodeError``, so a file that is not valid UTF-8 escaped every
+    handler and took the whole run down with it.
+    """
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    (run_dir / victim).write_bytes(b"\xff\xfe\x00 not valid utf-8 at all")
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+
+    assert transport.requests, "a corrupt artifact must rerun"
+    assert second.verification.status is RowStatus.COMPLETED
+
+
+def _reseal(run_dir: Path) -> None:
+    """Rewrite the marker so it matches whatever is on disk now."""
+    marker_path = run_dir / RUN_MANIFEST_NAME
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    for entry in marker["artifacts"]:
+        entry["sha256"] = sha256_bytes((run_dir / entry["name"]).read_bytes())
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+
+def test_a_non_utf8_final_record_behind_a_valid_marker_reruns(tmp_path):
+    """Reaching the record read at all requires the marker to agree.
+
+    Corrupting the record alone breaks the marker, so resume stops
+    earlier and the decode never happens. Reselaing puts the run back
+    into the one state where the record is actually parsed, which is the
+    state an attacker who rewrites the marker would leave behind.
+    """
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    (run_dir / "final_record.json").write_bytes(b"\xff\xfe\x00 not valid utf-8")
+    _reseal(run_dir)
+
+    # The marker now agrees with the corrupt file, so resume gets as far
+    # as parsing it.
+    assert run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+
+    assert transport.requests, "an unparsable record must rerun"
+    assert second.verification.status is RowStatus.COMPLETED

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -26,7 +26,7 @@ from llmtracefx.optimizer.collectors.openai_api import (
     TransportConnectionError,
     artifact_set_is_complete,
 )
-from llmtracefx.optimizer.workloads import api_verify
+from llmtracefx.optimizer.workloads import api_verify, evaluators
 from llmtracefx.optimizer.workloads.api_profiles import (
     API_PROFILES,
     OPENROUTER_PROFILE,
@@ -39,6 +39,7 @@ from llmtracefx.optimizer.workloads.api_verify import (
     APIBinding,
     APIVerifyError,
     execute_api_row,
+    plan_api_row,
     plan_selected_api_rows,
     render_plan_document,
     run_artifacts_are_complete,
@@ -52,6 +53,7 @@ from llmtracefx.optimizer.workloads.catalog import (
 from llmtracefx.optimizer.workloads.matrix import (
     DECODE_MODE_AUTOREGRESSIVE,
     DECODE_MODE_NATIVE_MTP,
+    MatrixEntry,
     MatrixManifest,
     generate_matrix,
     write_matrix,
@@ -1475,3 +1477,103 @@ def test_a_corrupt_run_marker_forces_a_rerun(tmp_path):
     second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
     assert transport.requests
     assert second.verification.status is RowStatus.COMPLETED
+
+
+def test_a_manifest_that_mislabels_a_code_workload_cannot_bypass_the_refusal(
+    tmp_path, monkeypatch
+):
+    """The catalog is the authority, because the evaluator dispatches on it.
+
+    A matrix manifest is a file on disk. One that declares a
+    code-completion row as ``structured_json`` passes a check that trusts
+    the manifest, then resolves the real workload from the catalog and is
+    graded by executing the answer. The manifest must not be able to talk
+    the pipeline into running a remote endpoint's code.
+    """
+
+    def forbidden(spec, response_text):
+        raise AssertionError("the code evaluator must never run for an API row")
+
+    monkeypatch.setattr(evaluators, "evaluate_code_completion", forbidden)
+
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path, workloads=(CODE_COMPLETION_PALINDROME,)
+    )
+    doctored = dict(autoregressive_entry(manifest).to_dict())
+    doctored["category"] = "structured_json"
+
+    result = execute_api_row(
+        MatrixEntry.from_dict(doctored),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=lambda: FakeTransport(
+            FakeResponse(answer_stream("def is_palindrome(s): return True"))
+        ),
+        environ=ENVIRON,
+    )
+
+    assert result.verification.status is RowStatus.UNSUPPORTED
+    assert "executing the model's answer" in (result.verification.reason or "")
+
+
+def test_a_mislabelled_code_workload_is_also_blocked_in_the_plan(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path, workloads=(CODE_COMPLETION_PALINDROME,)
+    )
+    doctored = dict(autoregressive_entry(manifest).to_dict())
+    doctored["category"] = "structured_json"
+
+    plan = plan_api_row(
+        MatrixEntry.from_dict(doctored),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        environ=ENVIRON,
+    )
+
+    assert plan.unsupported is True
+    assert plan.request_plan is None
+
+
+@pytest.mark.parametrize(
+    "rewritten_name",
+    ["../escaped.json", "/etc/hostname", "collection/record.json"],
+)
+def test_a_marker_naming_another_file_is_rejected(tmp_path, rewritten_name):
+    """The marker's names are not authority over what this process opens.
+
+    Redirecting an entry at a file nobody edited would otherwise let a
+    tampered run verify clean, which is worse than having no marker.
+    """
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+    marker_path = run_dir / RUN_MANIFEST_NAME
+
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    marker["artifacts"][1]["name"] = rewritten_name
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    assert not run_artifacts_are_complete(run_dir)
+
+
+def test_a_marker_that_omits_an_artifact_is_rejected(tmp_path):
+    """Dropping an entry must not silently narrow what is sealed."""
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+    marker_path = run_dir / RUN_MANIFEST_NAME
+
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    marker["artifacts"] = [
+        entry for entry in marker["artifacts"] if entry["name"] != "final_record.json"
+    ]
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+    assert not run_artifacts_are_complete(run_dir)

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1,0 +1,1180 @@
+"""Tests for executing the workload matrix through an OpenAI-compatible API.
+
+Nothing here touches the network. Every test injects a fake transport, and
+the two tests that must prove no request was attempted inject a transport
+that fails the test if it is ever opened. No real API key is used and no
+real endpoint is contacted: the OpenRouter and Z.ai profiles are exercised
+only as configuration.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llmtracefx.optimizer.collectors.openai_api import (
+    ARTIFACT_MANIFEST_NAME,
+    FAILURE_HTTP_STATUS,
+    FAILURE_STREAM_DECODE,
+    FAILURE_STREAM_TRUNCATED,
+    HTTPRequest,
+    ProviderExtensions,
+    TransportConnectionError,
+    artifact_set_is_complete,
+)
+from llmtracefx.optimizer.workloads import api_verify
+from llmtracefx.optimizer.workloads.api_profiles import (
+    API_PROFILES,
+    OPENROUTER_PROFILE,
+    ZAI_PROFILE,
+    APIProfileError,
+    profile_by_name,
+)
+from llmtracefx.optimizer.workloads.api_verify import (
+    APIBinding,
+    APIVerifyError,
+    execute_api_row,
+    plan_selected_api_rows,
+    render_plan_document,
+    run_selected_api_rows,
+)
+from llmtracefx.optimizer.workloads.catalog import (
+    PROSE_REASONING_TRAIN_PROBLEM,
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    DECODE_MODE_NATIVE_MTP,
+    MatrixManifest,
+    generate_matrix,
+    write_matrix,
+)
+from llmtracefx.optimizer.workloads.schema import ContextTier
+from llmtracefx.optimizer.workloads.verify import (
+    BACKEND_MLX,
+    BACKEND_OPENAI_API,
+    RowSelection,
+    RowStatus,
+    RowVerification,
+)
+
+API_KEY = "api-verify-test-key-not-a-real-credential"
+ENV_VAR = "LLMTRACEFX_TEST_API_KEY"
+ENVIRON: Mapping[str, str] = {ENV_VAR: API_KEY}
+
+GOOD_JSON_ANSWER = '{"name": "Priya", "age": 34, "is_active": true}'
+BAD_JSON_ANSWER = "there is no json here at all"
+
+
+# --- Fakes -------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        status_code: int = 200,
+        headers: Mapping[str, str] | None = None,
+        raise_after: Exception | None = None,
+    ) -> None:
+        self._chunks = chunks
+        self._status_code = status_code
+        self._headers = dict(headers or {})
+        self._raise_after = raise_after
+        self.closed = False
+
+    @property
+    def status_code(self) -> int:
+        return self._status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._headers
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        yield from self._chunks
+        if self._raise_after is not None:
+            raise self._raise_after
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeTransport:
+    """Replays one recorded response, recording what was requested."""
+
+    def __init__(self, response: FakeResponse | Exception) -> None:
+        self._response = response
+        self.requests: list[HTTPRequest] = []
+
+    def open_stream(self, request: HTTPRequest) -> FakeResponse:
+        self.requests.append(request)
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class ExplodingTransport:
+    """Fails the test if a request is ever attempted."""
+
+    def open_stream(self, request: HTTPRequest) -> FakeResponse:
+        raise AssertionError("no network request should have been attempted")
+
+
+def sse(payload: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+def answer_stream(
+    answer: str, *, reasoning: str = "weighing the options"
+) -> list[bytes]:
+    """A GLM-shaped stream whose *content* is ``answer``.
+
+    The reasoning delta deliberately says something other than the answer,
+    so a test asserting the evaluator's verdict is asserting that only the
+    content stream was graded.
+    """
+    return [
+        sse(
+            {
+                "id": "chatcmpl-test",
+                "model": "glm-5.3",
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant", "content": ""}}
+                ],
+            }
+        ),
+        sse({"choices": [{"index": 0, "delta": {"reasoning_content": reasoning}}]}),
+        sse({"choices": [{"index": 0, "delta": {"content": answer}}]}),
+        sse(
+            {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 7,
+                    "total_tokens": 18,
+                },
+            }
+        ),
+        b"data: [DONE]\n\n",
+    ]
+
+
+# --- Fixtures ----------------------------------------------------------------
+
+
+def build_manifest(
+    tmp_path: Path,
+    *,
+    workloads: tuple[Any, ...] = (STRUCTURED_JSON_PROFILE_EXTRACTION,),
+    context_tiers: tuple[ContextTier, ...] = (ContextTier.TIER_2K,),
+) -> tuple[MatrixManifest, Path, Path]:
+    """Generate and write a small matrix; return manifest, dir and path."""
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        workloads=workloads,
+        context_tiers=context_tiers,
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+    matrix_path = output_dir / "manifest.json"
+    return MatrixManifest.read_json(matrix_path), output_dir, matrix_path
+
+
+def make_binding(**overrides: Any) -> APIBinding:
+    kwargs: dict[str, Any] = {
+        "provider": OPENROUTER_PROFILE.provider_label,
+        "endpoint": OPENROUTER_PROFILE.endpoint,
+        "model_id": "z-ai/glm-5.3",
+        "credential_env_var": ENV_VAR,
+    }
+    kwargs.update(overrides)
+    return APIBinding(**kwargs)
+
+
+def autoregressive_entry(manifest: MatrixManifest) -> Any:
+    return next(
+        entry
+        for entry in manifest.entries
+        if entry.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+
+
+def native_mtp_entry(manifest: MatrixManifest) -> Any:
+    return next(
+        entry
+        for entry in manifest.entries
+        if entry.decode_mode == DECODE_MODE_NATIVE_MTP
+    )
+
+
+def run_one(
+    tmp_path: Path,
+    *,
+    transport: Any,
+    binding: APIBinding | None = None,
+    resume: bool = True,
+    entry: Any = None,
+    environ: Mapping[str, str] = ENVIRON,
+    manifest_bundle: tuple[MatrixManifest, Path, Path] | None = None,
+) -> Any:
+    manifest, manifest_dir, matrix_path = manifest_bundle or build_manifest(tmp_path)
+    return execute_api_row(
+        entry or autoregressive_entry(manifest),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=binding or make_binding(),
+        resume=resume,
+        transport_factory=lambda: transport,
+        environ=environ,
+    )
+
+
+# --- Profiles ----------------------------------------------------------------
+
+
+def test_openrouter_profile_matches_documented_values():
+    assert OPENROUTER_PROFILE.endpoint == (
+        "https://openrouter.ai/api/v1/chat/completions"
+    )
+    assert OPENROUTER_PROFILE.credential_env_var == "OPENROUTER_API_KEY"
+    assert OPENROUTER_PROFILE.documented_model_ids == (
+        "z-ai/glm-5.3",
+        "z-ai/glm-5.3-flash",
+    )
+
+
+def test_zai_profile_is_retained_alongside_openrouter():
+    assert ZAI_PROFILE.endpoint == "https://api.z.ai/api/paas/v4/chat/completions"
+    assert ZAI_PROFILE.credential_env_var == "ZAI_API_KEY"
+    assert {profile.name for profile in API_PROFILES} == {"openrouter", "z.ai"}
+
+
+def test_profile_lookup_rejects_unknown_name_without_echoing_it():
+    with pytest.raises(APIProfileError) as excinfo:
+        profile_by_name("not-a-profile-and-possibly-a-secret")
+    message = str(excinfo.value)
+    assert "not-a-profile-and-possibly-a-secret" not in message
+    assert "openrouter" in message
+
+
+def test_profiles_are_defaults_not_hardcoded_behaviour(tmp_path):
+    """An unlisted provider is a first-class citizen, not a special case."""
+    binding = make_binding(
+        provider="self-hosted",
+        endpoint="https://vllm.internal.example/v1/chat/completions",
+        model_id="local-glm",
+    )
+    result = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        binding=binding,
+    )
+    assert result.verification.status is RowStatus.COMPLETED
+    assert result.verification.provider == "self-hosted"
+
+
+# --- Binding -----------------------------------------------------------------
+
+
+def test_binding_rejects_non_positive_event_cap():
+    with pytest.raises(APIVerifyError):
+        make_binding(max_stream_events=0)
+
+
+def test_binding_validate_rejects_plain_http_remote_endpoint():
+    binding = make_binding(endpoint="http://openrouter.ai/api/v1/chat/completions")
+    with pytest.raises(APIVerifyError):
+        binding.validate()
+
+
+def test_binding_validate_accepts_documented_profiles():
+    for profile in API_PROFILES:
+        make_binding(
+            provider=profile.provider_label,
+            endpoint=profile.endpoint,
+            model_id=profile.documented_model_ids[0],
+            credential_env_var=profile.credential_env_var,
+        ).validate()
+
+
+def _binding_hash_for(tmp_path: Path, binding: APIBinding) -> str:
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=binding,
+        environ=ENVIRON,
+    )
+    assert plans[0].binding_hash is not None
+    return plans[0].binding_hash
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"model_id": "z-ai/glm-5.3-flash"},
+        {"model_revision": "2026-01-01"},
+        {"endpoint": "https://api.z.ai/api/paas/v4/chat/completions"},
+        {"provider": "z.ai"},
+        {"temperature": 0.25},
+        {"top_p": 0.9},
+        {"seed": 7},
+        {"request_timeout_seconds": 30.0},
+        {"max_stream_events": 42},
+        {"system_prompt": "Answer tersely."},
+        {"extensions": ProviderExtensions(reasoning_effort="low")},
+        {"extensions": ProviderExtensions(thinking_type="enabled")},
+    ],
+)
+def test_binding_hash_changes_with_every_request_affecting_value(tmp_path, overrides):
+    baseline = _binding_hash_for(tmp_path / "a", make_binding())
+    changed = _binding_hash_for(tmp_path / "b", make_binding(**overrides))
+    assert baseline != changed
+
+
+def test_binding_hash_ignores_credential_variable_name(tmp_path):
+    """Two runs differing only in which variable held the key are identical.
+
+    They issue byte-identical requests and are graded identically, so the
+    name affects neither request, evaluation nor resume -- and hashing it
+    would persist a derivation of a value that may be the credential.
+    """
+    baseline = _binding_hash_for(tmp_path / "a", make_binding())
+    renamed = _binding_hash_for(
+        tmp_path / "b", make_binding(credential_env_var="OTHER_KEY_VAR")
+    )
+    assert baseline == renamed
+
+
+def test_binding_hash_never_contains_the_credential(tmp_path):
+    binding = make_binding()
+    assert API_KEY not in _binding_hash_for(tmp_path, binding)
+
+
+# --- Successful execution ----------------------------------------------------
+
+
+def test_successful_row_is_completed_and_evaluated(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(tmp_path, transport=transport)
+
+    verification = result.verification
+    assert verification.status is RowStatus.COMPLETED
+    assert verification.backend == BACKEND_OPENAI_API
+    assert verification.provider == "openrouter"
+    assert verification.api_model_id == "z-ai/glm-5.3"
+    assert verification.artifacts_verified is True
+    assert verification.outcome_success is True
+    assert verification.quality_score == 1.0
+    assert result.final_record is not None
+    assert result.final_record.outcome.quality_metric is not None
+
+
+def test_row_uses_matrix_max_tokens_for_the_request(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    manifest, _, _ = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    run_one(tmp_path, transport=transport)
+
+    body = json.loads(transport.requests[0].body.decode("utf-8"))
+    assert body["max_tokens"] == entry.max_tokens
+    assert body["stream"] is True
+
+
+def test_reasoning_settings_are_sent_when_configured(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    binding = make_binding(
+        extensions=ProviderExtensions(
+            reasoning_effort="high", thinking_type="enabled", clear_thinking=False
+        )
+    )
+    run_one(tmp_path, transport=transport, binding=binding)
+
+    body = json.loads(transport.requests[0].body.decode("utf-8"))
+    assert body["reasoning_effort"] == "high"
+    assert body["thinking"] == {"type": "enabled", "clear_thinking": False}
+
+
+def test_evaluation_grades_the_content_not_the_reasoning(tmp_path):
+    """A model that reasons correctly but answers wrongly must fail."""
+    transport = FakeTransport(
+        FakeResponse(answer_stream(BAD_JSON_ANSWER, reasoning=GOOD_JSON_ANSWER))
+    )
+    result = run_one(tmp_path, transport=transport)
+
+    assert result.verification.status is RowStatus.COMPLETED
+    assert result.verification.outcome_success is False
+    assert result.verification.quality_score == 0.0
+
+
+def test_quality_failure_is_completed_not_failed(tmp_path):
+    """A wrong answer is a measured result, not a broken run."""
+    transport = FakeTransport(FakeResponse(answer_stream(BAD_JSON_ANSWER)))
+    result = run_one(tmp_path, transport=transport)
+    assert result.verification.status is RowStatus.COMPLETED
+    assert result.verification.outcome_success is False
+
+
+def test_artifacts_are_written_and_marked_complete(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(tmp_path, transport=transport)
+
+    collection_dir = Path(result.verification.collection_dir or "")
+    assert artifact_set_is_complete(collection_dir)
+    for name in (
+        "record.json",
+        "response.txt",
+        "api_evidence.json",
+        "environment.json",
+    ):
+        assert (collection_dir / name).exists()
+    assert Path(result.verification.final_record_path or "").exists()
+
+
+# --- Provider failures -------------------------------------------------------
+
+
+def test_http_status_failure_is_failed_and_never_evaluated(tmp_path):
+    transport = FakeTransport(
+        FakeResponse([b'{"error": {"message": "no"}}'], status_code=429)
+    )
+    result = run_one(tmp_path, transport=transport)
+
+    assert result.verification.status is RowStatus.FAILED
+    assert FAILURE_HTTP_STATUS in (result.verification.reason or "")
+    # The evaluator never ran, so no quality verdict was invented.
+    assert result.verification.quality_score is None
+    assert result.verification.outcome_success is False
+
+
+def test_provider_failure_is_not_overwritten_by_a_passing_answer(tmp_path):
+    """A 500 whose body happens to contain a passing answer still fails.
+
+    This is the case the short circuit exists for: the content is exactly
+    what the evaluator wants, so a pipeline that graded before checking the
+    outcome would publish it as a pass.
+    """
+    transport = FakeTransport(
+        FakeResponse([GOOD_JSON_ANSWER.encode("utf-8")], status_code=500)
+    )
+    result = run_one(tmp_path, transport=transport)
+
+    assert result.verification.status is RowStatus.FAILED
+    assert result.verification.outcome_success is False
+    assert result.verification.quality_score is None
+
+
+def test_connection_failure_is_failed(tmp_path):
+    transport = FakeTransport(TransportConnectionError("connection refused"))
+    result = run_one(tmp_path, transport=transport)
+    assert result.verification.status is RowStatus.FAILED
+
+
+def test_truncated_stream_is_failed(tmp_path):
+    """A stream that stops before [DONE] is never published as an answer."""
+    chunks = answer_stream(GOOD_JSON_ANSWER)[:-2]
+    transport = FakeTransport(FakeResponse(chunks))
+    result = run_one(tmp_path, transport=transport)
+
+    assert result.verification.status is RowStatus.FAILED
+    assert FAILURE_STREAM_TRUNCATED in (result.verification.reason or "")
+
+
+def test_malformed_sse_is_propagated_as_a_decode_failure(tmp_path):
+    """The collector's decode error reaches the row verdict unchanged.
+
+    The event cap feeds a second copy of every chunk to its own decoder,
+    so this also proves that counting never swallows or pre-empts the
+    collector's authoritative diagnostic.
+    """
+    transport = FakeTransport(FakeResponse([b"data: {\xff\xfe not utf-8 \n\n"]))
+    result = run_one(tmp_path, transport=transport)
+
+    assert result.verification.status is RowStatus.FAILED
+    assert FAILURE_STREAM_DECODE in (result.verification.reason or "")
+
+
+def test_missing_credential_fails_the_row_without_evidence(tmp_path):
+    result = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        environ={},
+    )
+    assert result.verification.status is RowStatus.FAILED
+    assert "could not be attempted" in (result.verification.reason or "")
+    assert result.final_record is None
+
+
+# --- Event cap ---------------------------------------------------------------
+
+
+def test_event_cap_abandons_a_chatty_stream_and_says_so(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(
+        tmp_path, transport=transport, binding=make_binding(max_stream_events=2)
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    reason = result.verification.reason or ""
+    assert "2-event cap" in reason
+
+
+@pytest.mark.parametrize("cap", [1, 2, 3, 4])
+def test_no_cap_below_the_stream_length_ever_yields_a_graded_pass(tmp_path, cap):
+    """Cutting the stream short must never be published as a verdict.
+
+    The cap can land after a terminal ``finish_reason`` but before
+    ``[DONE]``, which the collector alone would call a clean ending. This
+    pipeline stopped reading, so the answer it holds is a prefix and the
+    row has to fail however tidy the fragment looks.
+    """
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(
+        tmp_path / f"cap{cap}",
+        transport=transport,
+        binding=make_binding(max_stream_events=cap),
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert result.verification.outcome_success is False
+    assert result.verification.quality_score is None
+    assert f"{cap}-event cap" in (result.verification.reason or "")
+    # The measurement survives even though the outcome refuses to claim it.
+    assert result.final_record is not None
+    assert result.final_record.outcome.success is False
+    assert result.verification.total_ms is not None
+
+
+def test_event_cap_high_enough_does_not_interfere(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(
+        tmp_path, transport=transport, binding=make_binding(max_stream_events=1000)
+    )
+    assert result.verification.status is RowStatus.COMPLETED
+
+
+# --- Credential pre-flight ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field", ["provider", "model_id", "endpoint", "credential_env_var"]
+)
+def test_a_credential_in_a_binding_field_never_reaches_an_artifact(tmp_path, field):
+    """A key pasted into any persisted slot is refused, not written down.
+
+    ``verification.json`` is written on paths that never issue a request,
+    so it cannot rely on the collector having refused first.
+    """
+    # Shaped to satisfy every validator it has to pass on the way in: the
+    # provider label pattern, the model ID check and the uppercase
+    # environment-variable rule all accept this string.
+    pasted = "AKIAIOSFODNN7EXAMPLE"
+    overrides: dict[str, Any] = {
+        "provider": pasted,
+        "model_id": pasted,
+        "endpoint": f"https://openrouter.ai/api/v1/chat/completions?deployment={pasted}",
+        "credential_env_var": pasted,
+    }
+    binding = make_binding(**{field: overrides[field]})
+    result = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        binding=binding,
+        environ={binding.credential_env_var: pasted},
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    for path in sorted((tmp_path / "results").rglob("*")):
+        if path.is_file():
+            assert pasted not in path.read_text(encoding="utf-8", errors="replace")
+
+
+def test_a_credential_in_an_endpoint_query_is_never_hashed_into_the_plan(tmp_path):
+    """A hash of the secret is still a derivation of the secret.
+
+    ``config_hash`` folds in sha256 of every endpoint query value, so the
+    pre-flight has to run before the plan is built. If it did not, two
+    runs differing only in the pasted key would produce different plan
+    documents, which is exactly what a stored derivation looks like.
+    """
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    documents = []
+    for pasted in ("AKIAIOSFODNN7EXAMPLE", "AKIAI44QH8DHBEXAMPLE"):
+        binding = make_binding(
+            endpoint=(
+                f"https://openrouter.ai/api/v1/chat/completions?deployment={pasted}"
+            )
+        )
+        plans = plan_selected_api_rows(
+            manifest,
+            manifest_dir=manifest_dir,
+            matrix_path=matrix_path,
+            output_dir=tmp_path / "results",
+            selection=RowSelection(
+                decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})
+            ),
+            binding=binding,
+            environ={ENV_VAR: pasted},
+        )
+        assert plans[0].ready is False
+        assert plans[0].binding_hash is None
+        assert any("refusing to run" in blocker for blocker in plans[0].blockers)
+        document = render_plan_document(
+            plans, binding=binding, environ={ENV_VAR: pasted}
+        )
+        assert pasted not in document
+        documents.append(document)
+
+    # Identical apart from the pasted key, so nothing derived from it was
+    # written into either document.
+    assert documents[0] == documents[1]
+
+
+def test_dry_run_and_a_real_run_agree_about_an_embedded_credential(tmp_path):
+    """A pre-flight that green-lights what the real run refuses is useless."""
+    pasted = "AKIAIOSFODNN7EXAMPLE"
+    bundle = build_manifest(tmp_path)
+    manifest, manifest_dir, matrix_path = bundle
+    binding = make_binding(provider=pasted)
+    environ = {ENV_VAR: pasted}
+
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=binding,
+        environ=environ,
+    )
+    assert plans[0].ready is False
+
+    result = run_one(
+        tmp_path,
+        transport=ExplodingTransport(),
+        binding=binding,
+        environ=environ,
+        manifest_bundle=bundle,
+    )
+    assert result.verification.status is RowStatus.FAILED
+
+
+# --- Inconclusive ------------------------------------------------------------
+
+
+def test_evaluator_error_is_inconclusive_with_evidence_preserved(tmp_path, monkeypatch):
+    def exploding_evaluator(workload, response_text):
+        raise RuntimeError("sandbox unavailable")
+
+    monkeypatch.setattr(api_verify, "evaluate_workload", exploding_evaluator)
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(tmp_path, transport=transport)
+
+    verification = result.verification
+    assert verification.status is RowStatus.INCONCLUSIVE
+    # Quality is never guessed, but the measurement survives.
+    assert verification.quality_score is None
+    assert verification.total_ms is not None
+    assert verification.artifacts_verified is True
+    assert artifact_set_is_complete(Path(verification.collection_dir or ""))
+
+
+# --- Unsupported rows --------------------------------------------------------
+
+
+def test_native_mtp_row_is_unsupported_and_never_sent(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    result = execute_api_row(
+        native_mtp_entry(manifest),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.UNSUPPORTED
+    assert "native multi-token prediction" in (result.verification.reason or "").lower()
+
+
+def test_native_mtp_row_stays_unsupported_even_with_reasoning_configured(tmp_path):
+    """Reasoning settings are never a stand-in for native MTP."""
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    result = execute_api_row(
+        native_mtp_entry(manifest),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(
+            extensions=ProviderExtensions(
+                reasoning_effort="max", thinking_type="enabled"
+            )
+        ),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.UNSUPPORTED
+
+
+# --- Prompt and catalog integrity -------------------------------------------
+
+
+def test_prompt_hash_mismatch_fails_without_sending(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    Path(entry.prompt_path).write_text("a different prompt entirely", encoding="utf-8")
+
+    result = execute_api_row(
+        entry,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.FAILED
+    assert "prompt hash mismatch" in (result.verification.reason or "")
+
+
+def test_missing_prompt_file_fails_without_sending(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    Path(entry.prompt_path).unlink()
+
+    result = execute_api_row(
+        entry,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.FAILED
+    assert "prompt file missing" in (result.verification.reason or "")
+
+
+def test_workload_version_drift_fails_without_sending(tmp_path, monkeypatch):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    drifted = dict(entry.to_dict())
+    drifted["workload_version"] = "999"
+
+    from llmtracefx.optimizer.workloads.matrix import MatrixEntry
+
+    result = execute_api_row(
+        MatrixEntry.from_dict(drifted),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.FAILED
+    assert "version drift" in (result.verification.reason or "")
+
+
+# --- Resume ------------------------------------------------------------------
+
+
+def test_resume_trusts_a_complete_hash_matching_artifact_set(tmp_path):
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    assert first.verification.status is RowStatus.COMPLETED
+
+    second = run_one(tmp_path, transport=ExplodingTransport(), manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.SKIPPED
+    assert second.verification.resumed is True
+    assert second.verification.artifacts_verified is True
+
+
+def test_no_resume_reruns_even_a_valid_artifact_set(tmp_path):
+    bundle = build_manifest(tmp_path)
+    run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(
+        tmp_path, transport=transport, resume=False, manifest_bundle=bundle
+    )
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests, "a re-run must actually issue a request"
+
+
+def test_resume_reruns_when_the_binding_changed(tmp_path):
+    bundle = build_manifest(tmp_path)
+    run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(
+        tmp_path,
+        transport=transport,
+        binding=make_binding(model_id="z-ai/glm-5.3-flash"),
+        manifest_bundle=bundle,
+    )
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests
+
+
+def test_resume_reruns_when_the_prompt_changed(tmp_path):
+    bundle = build_manifest(tmp_path)
+    manifest, _, _ = bundle
+    entry = autoregressive_entry(manifest)
+    run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+
+    Path(entry.prompt_path).write_text("tampered prompt", encoding="utf-8")
+    second = run_one(tmp_path, transport=ExplodingTransport(), manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.FAILED
+    assert "prompt hash mismatch" in (second.verification.reason or "")
+
+
+def test_resume_reruns_when_the_artifact_marker_is_missing(tmp_path):
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    collection_dir = Path(first.verification.collection_dir or "")
+    (collection_dir / ARTIFACT_MANIFEST_NAME).unlink()
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests, "an incomplete artifact set must rerun"
+
+
+def test_resume_reruns_when_an_artifact_was_tampered_with(tmp_path):
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    collection_dir = Path(first.verification.collection_dir or "")
+    (collection_dir / "response.txt").write_text("edited by hand", encoding="utf-8")
+    assert not artifact_set_is_complete(collection_dir)
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests, "a tampered artifact set must rerun"
+
+
+def test_resume_never_trusts_a_row_from_another_backend(tmp_path):
+    """An MLX verification.json must not satisfy an API resume check."""
+    bundle = build_manifest(tmp_path)
+    manifest, _, _ = bundle
+    entry = autoregressive_entry(manifest)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    verification_path = (
+        tmp_path / "results" / "runs" / entry.run_id / "verification.json"
+    )
+    payload = json.loads(verification_path.read_text(encoding="utf-8"))
+    payload["backend"] = BACKEND_MLX
+    verification_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert first.verification.status is RowStatus.COMPLETED
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests
+
+
+def test_resume_ignores_a_corrupt_verification_file(tmp_path):
+    bundle = build_manifest(tmp_path)
+    manifest, _, _ = bundle
+    entry = autoregressive_entry(manifest)
+    run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    verification_path = (
+        tmp_path / "results" / "runs" / entry.run_id / "verification.json"
+    )
+    verification_path.write_text("{ not json", encoding="utf-8")
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert second.verification.status is RowStatus.COMPLETED
+    assert transport.requests
+
+
+# --- Selection and batch execution -------------------------------------------
+
+
+def test_run_selected_rows_respects_filters_and_orders_by_manifest(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path,
+        workloads=(STRUCTURED_JSON_PROFILE_EXTRACTION, PROSE_REASONING_TRAIN_PROBLEM),
+    )
+    results = run_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(categories=frozenset({"structured_json"})),
+        binding=make_binding(),
+        resume=True,
+        transport_factory=lambda: FakeTransport(
+            FakeResponse(answer_stream(GOOD_JSON_ANSWER))
+        ),
+        environ=ENVIRON,
+    )
+    assert results
+    assert {r.entry.category for r in results} == {"structured_json"}
+
+
+def test_selecting_only_unsupported_rows_never_builds_a_transport(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+
+    def exploding_factory():
+        raise AssertionError("no transport should be constructed")
+
+    results = run_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_NATIVE_MTP})),
+        binding=make_binding(),
+        resume=True,
+        transport_factory=exploding_factory,
+        environ=ENVIRON,
+    )
+    assert results
+    assert all(r.verification.status is RowStatus.UNSUPPORTED for r in results)
+
+
+def test_empty_selection_returns_no_results(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    results = run_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(run_ids=frozenset({"no-such-row"})),
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert results == ()
+
+
+# --- Dry run -----------------------------------------------------------------
+
+
+def test_dry_run_plans_every_selected_row_without_network(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(),
+        binding=make_binding(),
+        environ=ENVIRON,
+    )
+    assert len(plans) == len(manifest.entries)
+    ready = [plan for plan in plans if plan.ready]
+    assert ready and all(plan.request_plan is not None for plan in ready)
+    assert all(plan.binding_hash is not None for plan in ready)
+    unsupported = [plan for plan in plans if plan.unsupported]
+    assert unsupported and all(plan.request_plan is None for plan in unsupported)
+
+
+def test_dry_run_blocks_when_the_credential_variable_is_unset(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=make_binding(),
+        environ={},
+    )
+    assert plans[0].ready is False
+    assert plans[0].credential_env_var_present is False
+    assert any("--api-key-env" in blocker for blocker in plans[0].blockers)
+
+
+def test_dry_run_blocker_never_echoes_the_credential_variable_slot(tmp_path):
+    """A key pasted into the name slot must not reach the plan document.
+
+    The uppercase shape rule stops most keys, so this uses one shaped
+    like a variable name to prove the message does not repeat it.
+    """
+    pasted = "AKIAIOSFODNN7EXAMPLE"
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    binding = make_binding(credential_env_var=pasted)
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=binding,
+        environ={},
+    )
+    document = render_plan_document(plans, binding=binding, environ={})
+    assert pasted not in document
+
+
+def test_plan_document_holds_no_prompt_text_and_no_credential(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    prompt_text = Path(entry.prompt_path).read_text(encoding="utf-8")
+    binding = make_binding()
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=binding,
+        environ=ENVIRON,
+    )
+    document = render_plan_document(plans, binding=binding, environ=ENVIRON)
+
+    assert API_KEY not in document
+    assert prompt_text[:200] not in document
+    payload = json.loads(document)
+    assert payload["network_request_performed"] is False
+    assert payload["backend"] == BACKEND_OPENAI_API
+    assert payload["rows"][0]["request_plan"]["messages"][0]["characters"] == len(
+        prompt_text
+    )
+
+
+def test_dry_run_reports_prompt_and_catalog_blockers(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
+    entry = autoregressive_entry(manifest)
+    Path(entry.prompt_path).write_text("edited", encoding="utf-8")
+
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(run_ids=frozenset({entry.run_id})),
+        binding=make_binding(),
+        environ=ENVIRON,
+    )
+    assert plans[0].ready is False
+    assert any("prompt hash mismatch" in blocker for blocker in plans[0].blockers)
+    assert plans[0].binding_hash is None
+
+
+# --- Secret containment ------------------------------------------------------
+
+
+def test_no_persisted_artifact_contains_the_credential(tmp_path):
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(tmp_path, transport=transport)
+    assert result.verification.status is RowStatus.COMPLETED
+
+    for path in sorted((tmp_path / "results").rglob("*")):
+        if path.is_file():
+            assert API_KEY not in path.read_text(encoding="utf-8", errors="replace")
+
+
+def test_a_provider_that_echoes_the_key_cannot_leak_it(tmp_path):
+    """Evidence is redacted even when the provider replays the credential."""
+    transport = FakeTransport(FakeResponse(answer_stream(f"key is {API_KEY}")))
+    result = run_one(tmp_path, transport=transport)
+
+    for path in sorted((tmp_path / "results").rglob("*")):
+        if path.is_file():
+            assert API_KEY not in path.read_text(encoding="utf-8", errors="replace")
+    assert result.verification.status is RowStatus.COMPLETED
+
+
+def test_the_recorded_command_masks_an_undefined_credential_variable(tmp_path):
+    pasted = "AKIAIOSFODNN7EXAMPLE"
+    binding = make_binding(credential_env_var=pasted)
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = run_one(
+        tmp_path, transport=transport, binding=binding, environ={pasted: API_KEY}
+    )
+    # Defined in the environment, so it is a real variable name and is kept.
+    assert result.verification.status is RowStatus.COMPLETED
+    evidence = json.loads(
+        (
+            Path(result.verification.collection_dir or "") / "api_evidence.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert evidence["plan"]["credential_env_var"] == pasted
+
+
+# --- Verification schema -----------------------------------------------------
+
+
+def test_schema_v1_verification_still_parses_as_a_local_row():
+    """v2 fields are additive: a v1 document keeps its v1 meaning."""
+    legacy = {
+        "schema_version": "1",
+        "run_id": "legacy-row",
+        "workload_id": "structured-json-profile-extraction",
+        "workload_version": "1",
+        "category": "structured_json",
+        "context_tier": "2k",
+        "decode_mode": "autoregressive",
+        "status": "completed",
+        "reason": None,
+        "recorded_prompt_hash": "sha256:abc",
+        "verified_prompt_hash": "sha256:abc",
+        "run_binding_hash": "sha256:def",
+        "resumed": False,
+        "outcome_success": True,
+        "quality_score": 1.0,
+        "total_ms": 12.0,
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T00:00:01Z",
+        "final_record_path": "/tmp/final.json",
+        "collection_dir": "/tmp/collection",
+    }
+    verification = RowVerification.from_dict(legacy)
+    assert verification.backend == BACKEND_MLX
+    assert verification.provider is None
+    assert verification.api_model_id is None
+    assert verification.artifacts_verified is None

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1601,6 +1601,10 @@ def _entry_with_run_id(manifest, run_id: str) -> MatrixEntry:
         "",
         "with space",
         "semi;colon",
+        # `$` matches before a trailing newline, so `re.match` accepted
+        # this and created a directory the refusal text calls impossible.
+        "trailing-newline\n",
+        "embedded\nnewline",
     ],
 )
 def test_an_unsafe_run_id_is_refused_and_writes_nothing(tmp_path, run_id):
@@ -1655,6 +1659,14 @@ def test_an_absolute_run_id_cannot_escape_the_output_directory(tmp_path):
 
 
 def test_an_unsafe_run_id_is_refused_in_the_plan_without_echoing_it(tmp_path):
+    """The rendered plan withholds the value, not just the paths.
+
+    ``to_dict`` used to emit ``entry.run_id`` on the refusal path while
+    blanking only the four path fields, so the rejected value still
+    reached stdout and ``api_request_plan.json``. The credential case was
+    saved by the whole-document redactor, which is incidental cover
+    rather than the property this asserts.
+    """
     manifest, manifest_dir, matrix_path = build_manifest(tmp_path)
     plan = plan_api_row(
         _entry_with_run_id(manifest, "../escaped"),
@@ -1669,6 +1681,11 @@ def test_an_unsafe_run_id_is_refused_in_the_plan_without_echoing_it(tmp_path):
     assert plan.request_plan is None
     assert any("unsafe artifact path" in blocker for blocker in plan.blockers)
     assert not (tmp_path / "results").exists()
+
+    # The whole rendered row, which is what a caller actually sees.
+    rendered = json.dumps(plan.to_dict())
+    assert "../escaped" not in rendered
+    assert plan.to_dict()["run_id"] == "[REJECTED]"
 
 
 def test_a_credential_in_the_effective_row_path_is_refused(tmp_path):

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -35,14 +35,17 @@ from llmtracefx.optimizer.workloads.api_profiles import (
     profile_by_name,
 )
 from llmtracefx.optimizer.workloads.api_verify import (
+    RUN_MANIFEST_NAME,
     APIBinding,
     APIVerifyError,
     execute_api_row,
     plan_selected_api_rows,
     render_plan_document,
+    run_artifacts_are_complete,
     run_selected_api_rows,
 )
 from llmtracefx.optimizer.workloads.catalog import (
+    CODE_COMPLETION_PALINDROME,
     PROSE_REASONING_TRAIN_PROBLEM,
     STRUCTURED_JSON_PROFILE_EXTRACTION,
 )
@@ -536,7 +539,7 @@ def test_event_cap_abandons_a_chatty_stream_and_says_so(tmp_path):
     assert "2-event cap" in (result.verification.reason or "")
 
 
-@pytest.mark.parametrize("cap", [1, 2, 3])
+@pytest.mark.parametrize("cap", [1, 2, 3, 4])
 def test_a_cap_the_stream_exceeds_never_yields_a_graded_pass(tmp_path, cap):
     """Exceeding the cap discards the verdict but keeps the measurement."""
     transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
@@ -595,44 +598,73 @@ def test_a_trailing_non_event_chunk_never_trips_the_cap(tmp_path, label, trailer
     assert result.verification.quality_score == 1.0
 
 
-@pytest.mark.parametrize(
-    ("label", "segment"),
-    [
-        ("one read per event", lambda parts: list(parts)),
-        ("sentinel in its own read", lambda parts: list(parts)),
-        (
-            "sentinel glued to the last event",
-            lambda parts: [*parts[:-2], parts[-2] + parts[-1]],
-        ),
-        ("whole body in one read", lambda parts: [b"".join(parts)]),
-        (
-            "sixteen byte reads",
-            lambda parts: [
-                b"".join(parts)[i : i + 16] for i in range(0, len(b"".join(parts)), 16)
-            ],
-        ),
-    ],
-)
-def test_the_verdict_does_not_depend_on_network_segmentation(tmp_path, label, segment):
-    """Identical wire bytes must produce an identical verdict.
+def segmentations(parts: list[bytes]) -> dict[str, list[bytes]]:
+    """The same wire bytes, split the ways a network might deliver them."""
+    body = b"".join(parts)
+    return {
+        "one read per event": list(parts),
+        "sentinel glued to the last event": [*parts[:-2], parts[-2] + parts[-1]],
+        "whole body in one read": [body],
+        "sixteen byte reads": [body[i : i + 16] for i in range(0, len(body), 16)],
+        "sixty four byte reads": [body[i : i + 64] for i in range(0, len(body), 64)],
+    }
 
-    How a body is split across socket reads is a property of the network,
-    not of the answer. A cap that consulted chunk arrival, or that counted
-    only what the collector had not yet abandoned, let TCP decide whether
-    a run passed.
+
+@pytest.mark.parametrize("cap", [2, 3, 4, 5, 6])
+def test_the_verdict_never_depends_on_network_segmentation(tmp_path, cap):
+    """Identical wire bytes must produce one verdict, at every cap.
+
+    Asserting a fixed outcome at a cap the stream cannot exceed proves
+    nothing: every implementation of this class agrees there. The property
+    is that all segmentations agree *with each other*, so it is swept
+    across the boundary rather than pinned to one side of it, and the
+    caps either side of the boundary are included.
     """
     parts = answer_stream(GOOD_JSON_ANSWER)
-    transport = FakeTransport(FakeResponse(segment(parts)))
-    result = run_one(
-        tmp_path,
-        transport=transport,
-        # Five events including the sentinel, so this is the smallest cap
-        # the stream does not exceed.
-        binding=make_binding(max_stream_events=len(parts)),
-    )
+    verdicts = {}
+    for label, chunks in segmentations(parts).items():
+        result = run_one(
+            tmp_path / f"cap{cap}" / label.replace(" ", "-"),
+            transport=FakeTransport(FakeResponse(chunks)),
+            binding=make_binding(max_stream_events=cap),
+        )
+        verdicts[label] = result.verification.status
 
-    assert result.verification.status is RowStatus.COMPLETED, label
-    assert result.verification.quality_score == 1.0
+    assert len(set(verdicts.values())) == 1, verdicts
+
+
+@pytest.mark.parametrize("trailer_label", ["duplicate sentinel", "trailing content"])
+def test_frames_after_the_sentinel_are_never_charged(tmp_path, trailer_label):
+    """A gateway may append frames the collector will never read.
+
+    The collector returns at ``[DONE]``, so anything after it is only
+    ever observed when it shares a socket read with the sentinel. Charging
+    it would let the network decide the verdict, and would fail a
+    complete, correct answer as a truncation.
+    """
+    parts = answer_stream(GOOD_JSON_ANSWER)
+    trailer = (
+        b"data: [DONE]\n\n"
+        if trailer_label == "duplicate sentinel"
+        else sse({"choices": [{"index": 0, "delta": {"content": " extra"}}]})
+    )
+    parts = [*parts, trailer]
+
+    verdicts = {}
+    for label, chunks in segmentations(parts).items():
+        result = run_one(
+            tmp_path / label.replace(" ", "-"),
+            transport=FakeTransport(FakeResponse(chunks)),
+            binding=make_binding(
+                max_stream_events=len(answer_stream(GOOD_JSON_ANSWER))
+            ),
+        )
+        verdicts[label] = (
+            result.verification.status,
+            result.verification.quality_score,
+        )
+
+    assert set(verdicts.values()) == {(RowStatus.COMPLETED, 1.0)}, verdicts
 
 
 def test_a_stream_past_the_cap_still_fails_whatever_the_segmentation(tmp_path):
@@ -1267,3 +1299,179 @@ def test_schema_v1_verification_still_parses_as_a_local_row():
     assert verification.provider is None
     assert verification.api_model_id is None
     assert verification.artifacts_verified is None
+
+
+# --- Executable evaluators are refused over an API ----------------------------
+
+
+def test_a_code_workload_is_unsupported_and_never_sent(tmp_path):
+    """Grading this category runs the answer as a local program.
+
+    Over an API that answer is produced by a remote party, so executing it
+    hands that party local code execution. The row is refused before a
+    transport exists and before the evaluator is chosen.
+    """
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path, workloads=(CODE_COMPLETION_PALINDROME,)
+    )
+    entry = autoregressive_entry(manifest)
+    assert entry.category == "code_completion"
+
+    result = execute_api_row(
+        entry,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+
+    assert result.verification.status is RowStatus.UNSUPPORTED
+    reason = (result.verification.reason or "").lower()
+    assert "executing the model's answer" in reason
+    assert "sandbox" in reason
+    assert result.final_record is None
+
+
+def test_a_code_workload_never_reaches_the_evaluator(tmp_path, monkeypatch):
+    """Belt and braces: the evaluator must not be invoked at all."""
+
+    def forbidden(workload, response_text):
+        raise AssertionError("the evaluator must never run for an API code row")
+
+    monkeypatch.setattr(api_verify, "evaluate_workload", forbidden)
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path, workloads=(CODE_COMPLETION_PALINDROME,)
+    )
+    result = execute_api_row(
+        autoregressive_entry(manifest),
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=make_binding(),
+        resume=True,
+        transport_factory=ExplodingTransport,
+        environ=ENVIRON,
+    )
+    assert result.verification.status is RowStatus.UNSUPPORTED
+
+
+def test_a_code_workload_is_blocked_in_the_dry_run_plan(tmp_path):
+    manifest, manifest_dir, matrix_path = build_manifest(
+        tmp_path, workloads=(CODE_COMPLETION_PALINDROME,)
+    )
+    plans = plan_selected_api_rows(
+        manifest,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        selection=RowSelection(decode_modes=frozenset({DECODE_MODE_AUTOREGRESSIVE})),
+        binding=make_binding(),
+        environ=ENVIRON,
+    )
+
+    assert plans[0].unsupported is True
+    assert plans[0].request_plan is None
+    assert "local code execution" in (plans[0].unsupported_reason or "")
+
+
+def test_non_executing_categories_are_still_runnable(tmp_path):
+    """The refusal is narrow: only the category that executes is refused."""
+    for workload in (STRUCTURED_JSON_PROFILE_EXTRACTION, PROSE_REASONING_TRAIN_PROBLEM):
+        bundle = build_manifest(tmp_path / workload.workload_id, workloads=(workload,))
+        answer = (
+            GOOD_JSON_ANSWER
+            if workload is STRUCTURED_JSON_PROFILE_EXTRACTION
+            else "The gap closes after 2 hours."
+        )
+        result = run_one(
+            tmp_path / workload.workload_id,
+            transport=FakeTransport(FakeResponse(answer_stream(answer))),
+            manifest_bundle=bundle,
+        )
+        assert result.verification.status is RowStatus.COMPLETED, workload.workload_id
+
+
+# --- Run-level completion marker ---------------------------------------------
+
+
+def test_a_completed_row_writes_a_run_level_marker(tmp_path):
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+
+    assert (run_dir / RUN_MANIFEST_NAME).exists()
+    assert run_artifacts_are_complete(run_dir)
+    sealed = {
+        entry["name"]
+        for entry in json.loads(
+            (run_dir / RUN_MANIFEST_NAME).read_text(encoding="utf-8")
+        )["artifacts"]
+    }
+    # The two files the collector's own marker does not cover.
+    assert "final_record.json" in sealed
+    assert "verification.json" in sealed
+
+
+@pytest.mark.parametrize("victim", ["final_record.json", "verification.json"])
+def test_editing_a_file_outside_the_collection_marker_forces_a_rerun(tmp_path, victim):
+    """These two sit outside the collector's marker and were trusted blind."""
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+
+    target = run_dir / victim
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    if victim == "verification.json":
+        payload["quality_score"] = 1.0
+        payload["outcome_success"] = True
+    else:
+        payload["outcome"]["quality_score"] = 1.0
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not run_artifacts_are_complete(run_dir)
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert transport.requests, "a tampered run directory must rerun"
+    assert second.verification.status is RowStatus.COMPLETED
+
+
+def test_a_missing_run_marker_forces_a_rerun(tmp_path):
+    """An interrupted write leaves no marker, and no marker means no trust."""
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    (run_dir / RUN_MANIFEST_NAME).unlink()
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert transport.requests, "a run with no marker must rerun"
+    assert second.verification.status is RowStatus.COMPLETED
+
+
+def test_a_corrupt_run_marker_forces_a_rerun(tmp_path):
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    (run_dir / RUN_MANIFEST_NAME).write_text("{ not json", encoding="utf-8")
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+    assert transport.requests
+    assert second.verification.status is RowStatus.COMPLETED

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1782,30 +1782,6 @@ def test_a_marker_renamed_to_another_run_is_rejected(tmp_path):
 # --- Corrupt, non-UTF-8 artifacts -------------------------------------------
 
 
-@pytest.mark.parametrize("victim", [RUN_MANIFEST_NAME, "verification.json"])
-def test_a_non_utf8_artifact_reruns_instead_of_crashing(tmp_path, victim):
-    """A corrupted file is untrusted evidence, not an unhandled exception.
-
-    ``UnicodeDecodeError`` is neither an ``OSError`` nor a
-    ``JSONDecodeError``, so a file that is not valid UTF-8 escaped every
-    handler and took the whole run down with it.
-    """
-    bundle = build_manifest(tmp_path)
-    first = run_one(
-        tmp_path,
-        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
-        manifest_bundle=bundle,
-    )
-    run_dir = Path(first.verification.collection_dir or "").parent
-    (run_dir / victim).write_bytes(b"\xff\xfe\x00 not valid utf-8 at all")
-
-    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
-    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
-
-    assert transport.requests, "a corrupt artifact must rerun"
-    assert second.verification.status is RowStatus.COMPLETED
-
-
 def _reseal(run_dir: Path) -> None:
     """Rewrite the marker so it matches whatever is on disk now."""
     marker_path = run_dir / RUN_MANIFEST_NAME
@@ -1815,13 +1791,38 @@ def _reseal(run_dir: Path) -> None:
     marker_path.write_text(json.dumps(marker), encoding="utf-8")
 
 
-def test_a_non_utf8_final_record_behind_a_valid_marker_reruns(tmp_path):
-    """Reaching the record read at all requires the marker to agree.
+# --- Malformed but syntactically valid artifacts -------------------------------
 
-    Corrupting the record alone breaks the marker, so resume stops
-    earlier and the decode never happens. Reselaing puts the run back
-    into the one state where the record is actually parsed, which is the
-    state an attacker who rewrites the marker would leave behind.
+#: Payloads that are valid JSON, or valid nothing, but are not the object
+#: every one of these readers assumes. ``json.loads`` returns a list, a
+#: scalar or ``None`` without complaint, and the field access that follows
+#: raises ``AttributeError`` or ``TypeError`` -- neither of which is a
+#: parse error any caller was catching.
+_MALFORMED_ROOTS = {
+    "empty list": b"[]",
+    "populated list": b'["run_id"]',
+    "null": b"null",
+    "integer": b"5",
+    "string": b'"not an object"',
+    "bare true": b"true",
+    "invalid utf-8": b"\xff\xfe\x00 not utf-8",
+    "truncated json": b'{"run_id": ',
+}
+
+
+@pytest.mark.parametrize("payload_label", sorted(_MALFORMED_ROOTS))
+@pytest.mark.parametrize(
+    "victim", [RUN_MANIFEST_NAME, "verification.json", "final_record.json"]
+)
+def test_a_malformed_artifact_reruns_instead_of_crashing(
+    tmp_path, victim, payload_label
+):
+    """Unreadable evidence is untrusted evidence, never an exception.
+
+    Corrupt is not only "not JSON": ``[]`` parses fine and then fails on
+    the first field access, which is a different exception type from the
+    one the handlers were written for. Every reader on the resume path
+    has to survive all of it and simply decline to trust the row.
     """
     bundle = build_manifest(tmp_path)
     first = run_one(
@@ -1830,15 +1831,50 @@ def test_a_non_utf8_final_record_behind_a_valid_marker_reruns(tmp_path):
         manifest_bundle=bundle,
     )
     run_dir = Path(first.verification.collection_dir or "").parent
-    (run_dir / "final_record.json").write_bytes(b"\xff\xfe\x00 not valid utf-8")
+    (run_dir / victim).write_bytes(_MALFORMED_ROOTS[payload_label])
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+
+    assert transport.requests, f"{victim} / {payload_label} must rerun"
+    assert second.verification.status is RowStatus.COMPLETED
+
+
+@pytest.mark.parametrize("payload_label", sorted(_MALFORMED_ROOTS))
+def test_a_malformed_final_record_behind_a_valid_marker_reruns(tmp_path, payload_label):
+    """Reaching the record parse at all requires the marker to agree.
+
+    Corrupting the record alone breaks the marker, so resume stops
+    earlier. Resealing puts the run into the one state where the record
+    is actually parsed, which is what an attacker rewriting the marker
+    would leave behind, and is the only way to exercise that reader.
+    """
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    (run_dir / "final_record.json").write_bytes(_MALFORMED_ROOTS[payload_label])
     _reseal(run_dir)
 
-    # The marker now agrees with the corrupt file, so resume gets as far
-    # as parsing it.
     assert run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
 
     transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
     second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
 
-    assert transport.requests, "an unparsable record must rerun"
+    assert transport.requests, f"an unparsable record ({payload_label}) must rerun"
     assert second.verification.status is RowStatus.COMPLETED
+
+
+@pytest.mark.parametrize("payload_label", sorted(_MALFORMED_ROOTS))
+def test_a_malformed_run_marker_is_rejected_not_raised(tmp_path, payload_label):
+    """The marker reader is the one gate that must never raise."""
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+    (run_dir / RUN_MANIFEST_NAME).write_bytes(_MALFORMED_ROOTS[payload_label])
+
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -521,6 +521,11 @@ def test_missing_credential_fails_the_row_without_evidence(tmp_path):
 # --- Event cap ---------------------------------------------------------------
 
 
+def sse_comment() -> bytes:
+    """A keepalive comment: a chunk that dispatches no event at all."""
+    return b": keepalive\n\n"
+
+
 def test_event_cap_abandons_a_chatty_stream_and_says_so(tmp_path):
     transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
     result = run_one(
@@ -528,19 +533,12 @@ def test_event_cap_abandons_a_chatty_stream_and_says_so(tmp_path):
     )
 
     assert result.verification.status is RowStatus.FAILED
-    reason = result.verification.reason or ""
-    assert "2-event cap" in reason
+    assert "2-event cap" in (result.verification.reason or "")
 
 
-@pytest.mark.parametrize("cap", [1, 2, 3, 4])
-def test_no_cap_below_the_stream_length_ever_yields_a_graded_pass(tmp_path, cap):
-    """Cutting the stream short must never be published as a verdict.
-
-    The cap can land after a terminal ``finish_reason`` but before
-    ``[DONE]``, which the collector alone would call a clean ending. This
-    pipeline stopped reading, so the answer it holds is a prefix and the
-    row has to fail however tidy the fragment looks.
-    """
+@pytest.mark.parametrize("cap", [1, 2, 3])
+def test_a_cap_the_stream_exceeds_never_yields_a_graded_pass(tmp_path, cap):
+    """Exceeding the cap discards the verdict but keeps the measurement."""
     transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
     result = run_one(
         tmp_path / f"cap{cap}",
@@ -552,9 +550,7 @@ def test_no_cap_below_the_stream_length_ever_yields_a_graded_pass(tmp_path, cap)
     assert result.verification.outcome_success is False
     assert result.verification.quality_score is None
     assert f"{cap}-event cap" in (result.verification.reason or "")
-    # The measurement survives even though the outcome refuses to claim it.
     assert result.final_record is not None
-    assert result.final_record.outcome.success is False
     assert result.verification.total_ms is not None
 
 
@@ -566,40 +562,97 @@ def test_event_cap_high_enough_does_not_interfere(tmp_path):
     assert result.verification.status is RowStatus.COMPLETED
 
 
-def test_a_fully_delivered_stream_is_not_failed_at_the_exact_cap(tmp_path):
-    """Reaching the cap is not the same as being cut short by it.
+@pytest.mark.parametrize(
+    ("label", "trailer"),
+    [
+        ("nothing", []),
+        ("a keepalive comment", [sse_comment()]),
+        ("a stray blank line", [b"\n"]),
+        ("a keepalive split across reads", [b": keep", b"alive\n\n"]),
+        ("several non-event chunks", [sse_comment(), b"\n", sse_comment()]),
+    ],
+)
+def test_a_trailing_non_event_chunk_never_trips_the_cap(tmp_path, label, trailer):
+    """A chunk is not an event, and only events are charged to the cap.
 
-    A provider may end with a terminal ``finish_reason`` and no ``[DONE]``
-    sentinel, which this project documents as supported. The collector
-    keeps pulling after the final chunk, so a cap equal to the number of
-    events the stream actually sent used to trip on a stream where every
-    byte had already been delivered, and a clean measurement was
-    published as a truncation.
+    A provider may close with a terminal ``finish_reason`` and no
+    ``[DONE]`` sentinel, then leave a keepalive or a blank line in the
+    pipe. Deciding truncation on "another chunk exists" rather than on the
+    event count failed these streams even though every byte of the answer
+    had already been delivered.
     """
-    chunks = answer_stream(GOOD_JSON_ANSWER)[:-1]
+    chunks = answer_stream(GOOD_JSON_ANSWER)[:-1] + list(trailer)
     transport = FakeTransport(FakeResponse(chunks))
     result = run_one(
         tmp_path,
         transport=transport,
-        binding=make_binding(max_stream_events=len(chunks)),
+        # Four events were dispatched; the trailer adds none.
+        binding=make_binding(max_stream_events=4),
     )
 
-    assert result.verification.status is RowStatus.COMPLETED
+    assert result.verification.status is RowStatus.COMPLETED, label
     assert result.verification.outcome_success is True
+    assert result.verification.quality_score == 1.0
 
 
-def test_a_stream_one_event_past_the_cap_still_fails(tmp_path):
-    """The boundary moved by one; it did not disappear."""
-    chunks = answer_stream(GOOD_JSON_ANSWER)[:-1]
-    transport = FakeTransport(FakeResponse(chunks))
+@pytest.mark.parametrize(
+    ("label", "segment"),
+    [
+        ("one read per event", lambda parts: list(parts)),
+        ("sentinel in its own read", lambda parts: list(parts)),
+        (
+            "sentinel glued to the last event",
+            lambda parts: [*parts[:-2], parts[-2] + parts[-1]],
+        ),
+        ("whole body in one read", lambda parts: [b"".join(parts)]),
+        (
+            "sixteen byte reads",
+            lambda parts: [
+                b"".join(parts)[i : i + 16] for i in range(0, len(b"".join(parts)), 16)
+            ],
+        ),
+    ],
+)
+def test_the_verdict_does_not_depend_on_network_segmentation(tmp_path, label, segment):
+    """Identical wire bytes must produce an identical verdict.
+
+    How a body is split across socket reads is a property of the network,
+    not of the answer. A cap that consulted chunk arrival, or that counted
+    only what the collector had not yet abandoned, let TCP decide whether
+    a run passed.
+    """
+    parts = answer_stream(GOOD_JSON_ANSWER)
+    transport = FakeTransport(FakeResponse(segment(parts)))
     result = run_one(
         tmp_path,
         transport=transport,
-        binding=make_binding(max_stream_events=len(chunks) - 1),
+        # Five events including the sentinel, so this is the smallest cap
+        # the stream does not exceed.
+        binding=make_binding(max_stream_events=len(parts)),
     )
 
-    assert result.verification.status is RowStatus.FAILED
-    assert f"{len(chunks) - 1}-event cap" in (result.verification.reason or "")
+    assert result.verification.status is RowStatus.COMPLETED, label
+    assert result.verification.quality_score == 1.0
+
+
+def test_a_stream_past_the_cap_still_fails_whatever_the_segmentation(tmp_path):
+    """The boundary still exists; it is just denominated in events."""
+    parts = answer_stream(GOOD_JSON_ANSWER)
+    for label, chunks in (
+        ("one read per event", list(parts)),
+        ("whole body in one read", [b"".join(parts)]),
+        (
+            "sixteen byte reads",
+            [b"".join(parts)[i : i + 16] for i in range(0, len(b"".join(parts)), 16)],
+        ),
+    ):
+        transport = FakeTransport(FakeResponse(chunks))
+        result = run_one(
+            tmp_path / label.replace(" ", "-"),
+            transport=transport,
+            binding=make_binding(max_stream_events=2),
+        )
+        assert result.verification.status is RowStatus.FAILED, label
 
 
 # --- Credential pre-flight ---------------------------------------------------

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -566,6 +566,42 @@ def test_event_cap_high_enough_does_not_interfere(tmp_path):
     assert result.verification.status is RowStatus.COMPLETED
 
 
+def test_a_fully_delivered_stream_is_not_failed_at_the_exact_cap(tmp_path):
+    """Reaching the cap is not the same as being cut short by it.
+
+    A provider may end with a terminal ``finish_reason`` and no ``[DONE]``
+    sentinel, which this project documents as supported. The collector
+    keeps pulling after the final chunk, so a cap equal to the number of
+    events the stream actually sent used to trip on a stream where every
+    byte had already been delivered, and a clean measurement was
+    published as a truncation.
+    """
+    chunks = answer_stream(GOOD_JSON_ANSWER)[:-1]
+    transport = FakeTransport(FakeResponse(chunks))
+    result = run_one(
+        tmp_path,
+        transport=transport,
+        binding=make_binding(max_stream_events=len(chunks)),
+    )
+
+    assert result.verification.status is RowStatus.COMPLETED
+    assert result.verification.outcome_success is True
+
+
+def test_a_stream_one_event_past_the_cap_still_fails(tmp_path):
+    """The boundary moved by one; it did not disappear."""
+    chunks = answer_stream(GOOD_JSON_ANSWER)[:-1]
+    transport = FakeTransport(FakeResponse(chunks))
+    result = run_one(
+        tmp_path,
+        transport=transport,
+        binding=make_binding(max_stream_events=len(chunks) - 1),
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert f"{len(chunks) - 1}-event cap" in (result.verification.reason or "")
+
+
 # --- Credential pre-flight ---------------------------------------------------
 
 

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -946,10 +946,84 @@ def test_a_provider_echoing_the_key_leaks_it_to_neither_stream(
             assert _SENTINEL not in path.read_text(encoding="utf-8", errors="replace")
 
 
-def test_a_sentinel_in_the_matrix_path_is_not_echoed_by_the_load_error(
+@pytest.mark.parametrize("slot", ["--output-dir", "--matrix"])
+def test_a_credential_in_a_path_is_refused_before_anything_is_created(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, slot: str
+) -> None:
+    """A path is the one place a redactor can never reach.
+
+    Creating the directory writes the value into the filesystem itself,
+    where it outlives the process and reaches backups and shell
+    completion. So the refusal has to come before any planning, any
+    mkdir and any diagnostic, not from the collector's own preflight,
+    which a row only reaches after the output directory exists.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    root = tmp_path / "root"
+    root.mkdir()
+    poisoned = str(root / f"{_SENTINEL}-path")
+
+    argv = [
+        "workloads",
+        "run-api",
+        "--matrix",
+        str(build_matrix(tmp_path)),
+        "--output-dir",
+        str(tmp_path / "results"),
+        "--profile",
+        "openrouter",
+        "--model-id",
+        "z-ai/glm-5.3",
+        "--dry-run",
+    ]
+    argv[argv.index(slot) + 1] = poisoned
+
+    code, out, err = run_main(argv)
+
+    assert code == 1
+    assert "refusing to run" in err
+    assert _SENTINEL not in out + err
+    # Nothing named after the credential was created anywhere.
+    assert list(root.iterdir()) == []
+    assert not any(_SENTINEL in str(path) for path in tmp_path.rglob("*"))
+
+
+def test_a_credential_in_a_path_is_refused_before_the_network_too(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``OSError`` embeds the path it failed on, and that path is caller text."""
+    """The same refusal on the execution path, not only under --dry-run."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    root = tmp_path / "root"
+    root.mkdir()
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(build_matrix(tmp_path)),
+            "--output-dir",
+            str(root / f"{_SENTINEL}-results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+        ]
+    )
+
+    assert code == 1
+    assert _SENTINEL not in out + err
+    assert list(root.iterdir()) == []
+    # The autouse fixture leaves an exploding transport installed, so
+    # reaching the network would have failed the test outright.
+
+
+def test_a_path_without_the_credential_still_reports_its_error_scrubbed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard is narrow: an ordinary bad path still gets a diagnostic."""
     monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
 
     code, out, err = run_main(
@@ -957,7 +1031,7 @@ def test_a_sentinel_in_the_matrix_path_is_not_echoed_by_the_load_error(
             "workloads",
             "run-api",
             "--matrix",
-            str(tmp_path / f"{_SENTINEL}.json"),
+            str(tmp_path / "no-such-manifest.json"),
             "--output-dir",
             str(tmp_path / "results"),
             "--profile",
@@ -969,39 +1043,6 @@ def test_a_sentinel_in_the_matrix_path_is_not_echoed_by_the_load_error(
 
     assert code == 1
     assert "Failed to load matrix manifest" in err
-    assert _SENTINEL not in out + err
-
-
-def test_a_sentinel_in_the_output_dir_is_not_echoed_by_the_write_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The plan-write failure path scrubs the caller's --output-dir too."""
-    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
-    blocked = tmp_path / f"{_SENTINEL}-dir"
-    # A regular file where the results directory must be, so the atomic
-    # write fails with an OSError naming the path.
-    blocked.write_text("not a directory", encoding="utf-8")
-
-    code, out, err = run_main(
-        [
-            "workloads",
-            "run-api",
-            "--matrix",
-            str(build_matrix(tmp_path)),
-            "--output-dir",
-            str(blocked),
-            "--profile",
-            "openrouter",
-            "--model-id",
-            "z-ai/glm-5.3",
-            "--mode",
-            DECODE_MODE_AUTOREGRESSIVE,
-            "--dry-run",
-        ]
-    )
-
-    assert code == 1
-    assert "Failed to write request plan" in err
     assert _SENTINEL not in out + err
 
 

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -8,6 +8,8 @@ OpenRouter nor Z.ai is ever contacted; both appear only as configuration.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -148,6 +150,27 @@ def invoke(argv: list[str]) -> int:
     parser = cli.build_parser()
     args = parser.parse_args(argv)
     return int(args.func(args))
+
+
+def run_main(argv: list[str]) -> tuple[int, str, str]:
+    """Drive ``cli.main`` the way a shell does, capturing both streams.
+
+    ``invoke`` reaches past ``main`` straight to the handler, which skips
+    the credential-flag refusal and the argv scrub that only ``main``
+    installs. Anything asserting that a value never surfaces has to go
+    through here, or it is testing a path no user takes.
+    """
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = 0
+    try:
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            cli.main(argv)
+    except SystemExit as exit_error:
+        code = int(exit_error.code or 0)
+    return code, stdout.getvalue(), stderr.getvalue()
 
 
 # --- Profiles ----------------------------------------------------------------
@@ -723,3 +746,278 @@ def test_manifest_is_never_mutated_by_a_run(
     )
     assert matrix_path.read_text(encoding="utf-8") == before
     assert MatrixManifest.read_json(matrix_path).entries
+
+
+# --- Sentinel containment across both streams --------------------------------
+#
+# Every test below drives `cli.main`, not the parsed-args shortcut, so the
+# credential-flag refusal and the argv scrub that only `main` installs are
+# both in force. Each asserts on stdout *and* stderr, because a value that
+# is kept out of one and printed to the other has still been disclosed:
+# both end up in a terminal, a CI log and a screenshot alike.
+
+_SENTINEL = "sentinel-not-a-real-credential-4471"
+
+
+def _matrix_argv(tmp_path: Path, *extra: str) -> list[str]:
+    return [
+        "workloads",
+        "run-api",
+        "--matrix",
+        str(build_matrix(tmp_path)),
+        "--output-dir",
+        str(tmp_path / "results"),
+        *extra,
+    ]
+
+
+@pytest.mark.parametrize(
+    "slot",
+    ["--provider", "--model-id", "--endpoint", "--api-key-env", "--model-revision"],
+)
+def test_a_sentinel_in_any_caller_slot_reaches_neither_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, slot: str
+) -> None:
+    """Any slot the caller fills may be holding the credential.
+
+    A key is pasted into whichever slot the caller reached for, not the
+    one the threat model expected, so each is checked rather than only
+    the obvious two.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    argv = _matrix_argv(
+        tmp_path,
+        "--profile",
+        "openrouter",
+        "--model-id",
+        "z-ai/glm-5.3",
+        "--mode",
+        DECODE_MODE_AUTOREGRESSIVE,
+        "--dry-run",
+    )
+    argv += [slot, _SENTINEL]
+
+    _, out, err = run_main(argv)
+
+    assert _SENTINEL not in out
+    assert _SENTINEL not in err
+
+
+def test_the_credential_value_itself_reaches_neither_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The configured key is never echoed, even on the happy path."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    _, out, err = run_main(
+        _matrix_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+
+    assert _SENTINEL not in out
+    assert _SENTINEL not in err
+    # The plan still reports that the variable resolved, without its value.
+    assert json.loads(out)["credential_env_var_present"] is True
+
+
+@pytest.mark.parametrize(
+    ("flag", "canonical"),
+    [
+        ("--api-key", "--api-key"),
+        ("--token", "--token"),
+        ("--password", "--password"),
+        ("--secret", "--secret"),
+        ("--API_KEY", "--api-key"),
+        ("--Api_Key", "--api-key"),
+        ("--accesstoken", "--access-token"),
+    ],
+)
+def test_a_credential_flag_on_run_api_is_refused_without_echoing_anything(
+    tmp_path: Path, flag: str, canonical: str
+) -> None:
+    """`run-api` inherits the refusal, and answers with its own spelling.
+
+    A flag that happens to match how this program spells it is named
+    because that spelling is a program literal, not because the caller
+    typed it. A spelling the program did not define is caller text and
+    never appears.
+    """
+    code, out, err = run_main(
+        _matrix_argv(
+            tmp_path, "--profile", "openrouter", "--model-id", "m", flag, _SENTINEL
+        )
+    )
+
+    assert code == 2
+    assert _SENTINEL not in out + err
+    assert canonical in err
+    if flag != canonical:
+        assert flag not in out + err
+    assert "--api-key-env" in err
+
+
+def test_an_unparsable_value_is_not_quoted_back_by_argparse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """argparse echoes a rejected value verbatim unless it is scrubbed.
+
+    ``--request-timeout`` takes a float, so a credential landing there is
+    a type error, and the type error is formatted from the value.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unused-but-present")
+    code, out, err = run_main(
+        _matrix_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--request-timeout",
+            _SENTINEL,
+        )
+    )
+
+    assert code == 2
+    assert _SENTINEL not in out + err
+
+
+def test_an_unknown_subcommand_argument_is_not_quoted_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "unused-but-present")
+    code, out, err = run_main(
+        _matrix_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            f"--not-a-real-flag={_SENTINEL}",
+        )
+    )
+
+    assert code == 2
+    assert _SENTINEL not in out + err
+
+
+def test_a_provider_echoing_the_key_leaks_it_to_neither_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hostile or careless provider cannot launder the key back out."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    FakeTransport.chunks = answer_stream(f"your key is {_SENTINEL}")
+
+    _, out, err = run_main(
+        _matrix_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+        )
+    )
+
+    assert _SENTINEL not in out
+    assert _SENTINEL not in err
+    for path in sorted((tmp_path / "results").rglob("*")):
+        if path.is_file():
+            assert _SENTINEL not in path.read_text(encoding="utf-8", errors="replace")
+
+
+def test_a_sentinel_in_the_matrix_path_is_not_echoed_by_the_load_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OSError`` embeds the path it failed on, and that path is caller text."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(tmp_path / f"{_SENTINEL}.json"),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+        ]
+    )
+
+    assert code == 1
+    assert "Failed to load matrix manifest" in err
+    assert _SENTINEL not in out + err
+
+
+def test_a_sentinel_in_the_output_dir_is_not_echoed_by_the_write_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The plan-write failure path scrubs the caller's --output-dir too."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    blocked = tmp_path / f"{_SENTINEL}-dir"
+    # A regular file where the results directory must be, so the atomic
+    # write fails with an OSError naming the path.
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(build_matrix(tmp_path)),
+            "--output-dir",
+            str(blocked),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        ]
+    )
+
+    assert code == 1
+    assert "Failed to write request plan" in err
+    assert _SENTINEL not in out + err
+
+
+def test_the_credential_is_scrubbed_even_when_the_env_name_came_from_a_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scrubbing against the raw flag misses the profile-supplied default.
+
+    ``--api-key-env`` is left unset here, so reading the flag alone yields
+    ``None`` and scrubs nothing. The resolved name is what matters.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(tmp_path / f"{_SENTINEL}.json"),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+        ]
+    )
+
+    assert code == 1
+    assert _SENTINEL not in out + err

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -1119,3 +1119,37 @@ def test_effective_api_key_env_resolves_every_combination(
     )
 
     assert cli._effective_api_key_env(args) == expected
+
+
+def test_a_non_utf8_manifest_is_reported_not_crashed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A manifest is a file, and a file can be corrupt.
+
+    ``UnicodeDecodeError`` is neither an ``OSError`` nor a
+    ``MatrixSchemaError``, so a manifest that is not valid UTF-8 escaped
+    the handler and reached the caller as a traceback.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+    manifest = tmp_path / "manifest.json"
+    manifest.write_bytes(b"\xff\xfe\x00 not valid utf-8")
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(manifest),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--dry-run",
+        ]
+    )
+
+    assert code == 1
+    assert "Failed to load matrix manifest" in err
+    assert _SENTINEL not in out + err

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -646,9 +646,16 @@ def test_an_innocuous_query_key_holding_the_key_is_also_refused(
     assert any("refusing to run" in blocker for blocker in row["blockers"])
 
 
-def test_an_innocuous_endpoint_query_still_records_only_its_keys(
+def test_an_innocuous_endpoint_query_records_neither_key_nor_value(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """The plan keeps the shape of the query and none of its content.
+
+    The collector redacts the key alongside the value, so only the number
+    of parameters survives. A key is provider- or user-chosen and can name
+    a tenant, a deployment or an account, which is worth as little in an
+    artifact as the value beside it.
+    """
     monkeypatch.setenv(ENV_VAR, API_KEY)
     code = invoke(
         base_argv(
@@ -666,8 +673,12 @@ def test_an_innocuous_endpoint_query_still_records_only_its_keys(
     )
     assert code == 0
     plan = json.loads(capsys.readouterr().out)["rows"][0]["request_plan"]
-    assert plan["endpoint_query_keys"] == ["deployment"]
-    assert "prod-eu" not in json.dumps(plan)
+
+    # One parameter was present, and that is the whole of what is recorded.
+    assert len(plan["endpoint_query_keys"]) == 1
+    rendered = json.dumps(plan)
+    assert "deployment" not in rendered
+    assert "prod-eu" not in rendered
 
 
 def test_an_invalid_provider_extension_is_reported_not_raised(
@@ -994,22 +1005,34 @@ def test_a_sentinel_in_the_output_dir_is_not_echoed_by_the_write_error(
     assert _SENTINEL not in out + err
 
 
-def test_the_credential_is_scrubbed_even_when_the_env_name_came_from_a_profile(
+def test_the_credential_value_is_scrubbed_using_the_profile_resolved_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Scrubbing against the raw flag misses the profile-supplied default.
+    """The env var name is resolved from the profile, not read off the flag.
 
     ``--api-key-env`` is left unset here, so reading the flag alone yields
-    ``None`` and scrubs nothing. The resolved name is what matters.
+    ``None`` and the credential redactor is handed nothing to look for.
+    Only the profile-resolved name makes it fire.
+
+    The sentinel has to reach the diagnostic from somewhere other than
+    argv, or the argv scrub would remove it regardless and the test would
+    pass without the resolution ever mattering. So the manifest read is
+    made to raise an error carrying the environment value, which is the
+    shape of a library that echoes what it was handed.
     """
     monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    def exploding_read(path: Any) -> Any:
+        raise OSError(f"upstream library echoed the value {_SENTINEL} back")
+
+    monkeypatch.setattr(cli.MatrixManifest, "read_json", staticmethod(exploding_read))
 
     code, out, err = run_main(
         [
             "workloads",
             "run-api",
             "--matrix",
-            str(tmp_path / f"{_SENTINEL}.json"),
+            str(tmp_path / "manifest.json"),
             "--output-dir",
             str(tmp_path / "results"),
             "--profile",
@@ -1020,4 +1043,38 @@ def test_the_credential_is_scrubbed_even_when_the_env_name_came_from_a_profile(
     )
 
     assert code == 1
+    assert "Failed to load matrix manifest" in err
     assert _SENTINEL not in out + err
+
+
+@pytest.mark.parametrize(
+    ("argv_extra", "expected"),
+    [
+        (["--api-key-env", "EXPLICIT_VAR"], "EXPLICIT_VAR"),
+        (["--profile", "openrouter"], "OPENROUTER_API_KEY"),
+        (["--profile", "z.ai"], "ZAI_API_KEY"),
+        # An explicit flag beats the profile default.
+        (["--profile", "openrouter", "--api-key-env", "EXPLICIT_VAR"], "EXPLICIT_VAR"),
+        # Neither given: there is no name to resolve, and that is not an error.
+        ([], None),
+    ],
+)
+def test_effective_api_key_env_resolves_every_combination(
+    tmp_path: Path, argv_extra: list[str], expected: str | None
+) -> None:
+    """Unit coverage for the resolution itself, including the empty case."""
+    args = cli.build_parser().parse_args(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(tmp_path / "manifest.json"),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--model-id",
+            "z-ai/glm-5.3",
+            *argv_extra,
+        ]
+    )
+
+    assert cli._effective_api_key_env(args) == expected

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -1,0 +1,725 @@
+"""Tests for the ``workloads run-api`` CLI surface.
+
+No test here performs a network request. The dry-run tests install a
+transport that fails if it is ever opened, and the execution tests inject
+one that replays recorded byte chunks. No real API key is used and neither
+OpenRouter nor Z.ai is ever contacted; both appear only as configuration.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llmtracefx.optimizer import cli
+from llmtracefx.optimizer.collectors.openai_api import HTTPRequest
+from llmtracefx.optimizer.workloads.catalog import (
+    STRUCTURED_JSON_PROFILE_EXTRACTION,
+)
+from llmtracefx.optimizer.workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    DECODE_MODE_NATIVE_MTP,
+    MatrixManifest,
+    generate_matrix,
+    write_matrix,
+)
+from llmtracefx.optimizer.workloads.schema import ContextTier
+
+API_KEY = "run-api-cli-test-key-not-a-real-credential"
+ENV_VAR = "LLMTRACEFX_TEST_API_KEY"
+GOOD_JSON_ANSWER = '{"name": "Priya", "age": 34, "is_active": true}'
+
+
+class ExplodingTransport:
+    def open_stream(self, request: HTTPRequest) -> Any:
+        raise AssertionError("no network request should have been attempted")
+
+
+class FakeResponse:
+    def __init__(self, chunks: list[bytes], status_code: int = 200) -> None:
+        self._chunks = chunks
+        self._status_code = status_code
+
+    @property
+    def status_code(self) -> int:
+        return self._status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return {}
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        yield from self._chunks
+
+    def close(self) -> None:
+        return None
+
+
+class FakeTransport:
+    """Class-level request log, so the CLI can construct it itself."""
+
+    requests: list[HTTPRequest] = []
+    chunks: list[bytes] = []
+    status_code: int = 200
+
+    def open_stream(self, request: HTTPRequest) -> FakeResponse:
+        FakeTransport.requests.append(request)
+        return FakeResponse(FakeTransport.chunks, FakeTransport.status_code)
+
+
+def sse(payload: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+def answer_stream(answer: str) -> list[bytes]:
+    return [
+        sse(
+            {
+                "id": "chatcmpl-1",
+                "model": "glm-5.3",
+                "choices": [{"index": 0, "delta": {"content": answer}}],
+            }
+        ),
+        sse(
+            {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "total_tokens": 6,
+                },
+            }
+        ),
+        b"data: [DONE]\n\n",
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_transport() -> Iterator[None]:
+    FakeTransport.requests = []
+    FakeTransport.chunks = answer_stream(GOOD_JSON_ANSWER)
+    FakeTransport.status_code = 200
+    yield
+    FakeTransport.requests = []
+
+
+@pytest.fixture(autouse=True)
+def _no_real_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test starts unable to reach the network.
+
+    Tests that need a response opt in by swapping in ``FakeTransport``.
+    """
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", ExplodingTransport)
+
+
+def build_matrix(tmp_path: Path) -> Path:
+    output_dir = tmp_path / "matrix"
+    manifest = generate_matrix(
+        model_id="local/test-model",
+        model_family="qwen3_next",
+        output_dir=str(output_dir),
+        workloads=(STRUCTURED_JSON_PROFILE_EXTRACTION,),
+        context_tiers=(ContextTier.TIER_2K,),
+        mtp_depths=(2,),
+    )
+    write_matrix(manifest)
+    return output_dir / "manifest.json"
+
+
+def base_argv(tmp_path: Path, *extra: str) -> list[str]:
+    return [
+        "workloads",
+        "run-api",
+        "--matrix",
+        str(build_matrix(tmp_path)),
+        "--output-dir",
+        str(tmp_path / "results"),
+        "--model-id",
+        "z-ai/glm-5.3",
+        *extra,
+    ]
+
+
+def invoke(argv: list[str]) -> int:
+    parser = cli.build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+# --- Profiles ----------------------------------------------------------------
+
+
+def test_list_api_profiles_prints_both_documented_profiles(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert invoke(["workloads", "list-api-profiles"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    by_name = {profile["name"]: profile for profile in payload["profiles"]}
+    assert by_name["openrouter"]["endpoint"] == (
+        "https://openrouter.ai/api/v1/chat/completions"
+    )
+    assert by_name["openrouter"]["credential_env_var"] == "OPENROUTER_API_KEY"
+    assert "z-ai/glm-5.3" in by_name["openrouter"]["documented_model_ids"]
+    assert by_name["z.ai"]["endpoint"] == (
+        "https://api.z.ai/api/paas/v4/chat/completions"
+    )
+
+
+@pytest.mark.parametrize(
+    ("profile", "endpoint", "env_var"),
+    [
+        ("openrouter", "https://openrouter.ai", "OPENROUTER_API_KEY"),
+        ("z.ai", "https://api.z.ai", "ZAI_API_KEY"),
+    ],
+)
+def test_profile_supplies_endpoint_and_credential_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    profile: str,
+    endpoint: str,
+    env_var: str,
+) -> None:
+    monkeypatch.setenv(env_var, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            profile,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    plan = payload["rows"][0]["request_plan"]
+    assert plan["endpoint_origin"] == endpoint
+    assert plan["credential_env_var"] == env_var
+
+
+def test_explicit_flags_override_the_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--provider",
+            "self-hosted",
+            "--endpoint",
+            "https://vllm.internal.example/v1/chat/completions",
+            "--api-key-env",
+            ENV_VAR,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 0
+    plan = json.loads(capsys.readouterr().out)["rows"][0]["request_plan"]
+    assert plan["provider"] == "self-hosted"
+    assert plan["endpoint_origin"] == "https://vllm.internal.example"
+
+
+def test_unlisted_provider_works_without_a_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--provider",
+            "self-hosted",
+            "--endpoint",
+            "https://vllm.internal.example/v1/chat/completions",
+            "--api-key-env",
+            ENV_VAR,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["rows"][0]["status"] == "ready"
+
+
+def test_missing_binding_fields_without_a_profile_is_an_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert invoke(base_argv(tmp_path, "--dry-run")) == 1
+    error = capsys.readouterr().err
+    assert "--provider" in error
+    assert "--endpoint" in error
+    assert "--api-key-env" in error
+
+
+# --- Dry run -----------------------------------------------------------------
+
+
+def test_dry_run_writes_a_plan_and_performs_no_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["dry_run"] is True
+    assert payload["network_request_performed"] is False
+    assert payload["credential_env_var_present"] is True
+    assert FakeTransport.requests == []
+
+    written = (tmp_path / "results" / "api_request_plan.json").read_text(
+        encoding="utf-8"
+    )
+    assert json.loads(written) == payload
+
+
+def test_dry_run_reports_unsupported_and_ready_rows_together(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    assert invoke(base_argv(tmp_path, "--profile", "openrouter", "--dry-run")) == 0
+    rows = json.loads(capsys.readouterr().out)["rows"]
+    statuses = {row["decode_mode"]: row["status"] for row in rows}
+    assert statuses[DECODE_MODE_AUTOREGRESSIVE] == "ready"
+    assert statuses[DECODE_MODE_NATIVE_MTP] == "unsupported"
+
+
+def test_dry_run_returns_two_when_a_row_is_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 2
+    assert json.loads(capsys.readouterr().out)["rows"][0]["status"] == "blocked"
+
+
+def test_dry_run_with_no_matching_rows_is_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--run-id",
+            "no-such-row",
+            "--dry-run",
+        )
+    )
+    assert code == 1
+    assert "No matrix rows matched" in capsys.readouterr().err
+
+
+def test_dry_run_rejects_a_plain_http_remote_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--provider",
+            "insecure",
+            "--endpoint",
+            "http://openrouter.ai/api/v1/chat/completions",
+            "--api-key-env",
+            ENV_VAR,
+            "--dry-run",
+        )
+    )
+    assert code == 1
+    assert "must use https" in capsys.readouterr().err
+
+
+# --- Execution ---------------------------------------------------------------
+
+
+def test_successful_run_writes_artifacts_and_returns_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+
+    code = invoke(
+        base_argv(
+            tmp_path, "--profile", "openrouter", "--mode", DECODE_MODE_AUTOREGRESSIVE
+        )
+    )
+    assert code == 0
+    assert len(FakeTransport.requests) == 1
+    out = capsys.readouterr().out
+    assert "[COMPLETED]" in out
+
+    verification = json.loads(
+        next((tmp_path / "results" / "runs").glob("*/verification.json")).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert verification["backend"] == "openai-api"
+    assert verification["provider"] == "openrouter"
+    assert verification["api_model_id"] == "z-ai/glm-5.3"
+    assert verification["artifacts_verified"] is True
+
+
+def test_provider_failure_returns_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    FakeTransport.status_code = 503
+    FakeTransport.chunks = [b'{"error": {"message": "upstream is down"}}']
+
+    code = invoke(
+        base_argv(
+            tmp_path, "--profile", "openrouter", "--mode", DECODE_MODE_AUTOREGRESSIVE
+        )
+    )
+    assert code == 1
+    assert "[FAILED]" in capsys.readouterr().out
+
+
+def test_native_mtp_only_selection_never_opens_a_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    # The transport stays ExplodingTransport from the autouse fixture, so
+    # this asserts by construction that nothing was sent.
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--mode",
+            DECODE_MODE_NATIVE_MTP,
+            "--reasoning-effort",
+            "max",
+        )
+    )
+    assert code == 0
+    assert "[UNSUPPORTED]" in capsys.readouterr().out
+
+
+def test_rerun_resumes_without_a_second_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    matrix = str(build_matrix(tmp_path))
+    argv = [
+        "workloads",
+        "run-api",
+        "--matrix",
+        matrix,
+        "--output-dir",
+        str(tmp_path / "results"),
+        "--model-id",
+        "z-ai/glm-5.3",
+        "--profile",
+        "openrouter",
+        "--mode",
+        DECODE_MODE_AUTOREGRESSIVE,
+    ]
+    assert invoke(argv) == 0
+    assert len(FakeTransport.requests) == 1
+
+    capsys.readouterr()
+    assert invoke(argv) == 0
+    assert len(FakeTransport.requests) == 1, "resume must not re-issue a request"
+    assert "[SKIPPED]" in capsys.readouterr().out
+
+
+def test_no_resume_forces_a_second_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    matrix = str(build_matrix(tmp_path))
+    argv = [
+        "workloads",
+        "run-api",
+        "--matrix",
+        matrix,
+        "--output-dir",
+        str(tmp_path / "results"),
+        "--model-id",
+        "z-ai/glm-5.3",
+        "--profile",
+        "openrouter",
+        "--mode",
+        DECODE_MODE_AUTOREGRESSIVE,
+    ]
+    assert invoke(argv) == 0
+    assert invoke([*argv, "--no-resume"]) == 0
+    assert len(FakeTransport.requests) == 2
+
+
+def test_reasoning_settings_reach_the_request_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+
+    assert (
+        invoke(
+            base_argv(
+                tmp_path,
+                "--profile",
+                "openrouter",
+                "--mode",
+                DECODE_MODE_AUTOREGRESSIVE,
+                "--reasoning-effort",
+                "high",
+                "--thinking",
+                "enabled",
+                "--clear-thinking",
+                "false",
+            )
+        )
+        == 0
+    )
+    body = json.loads(FakeTransport.requests[0].body.decode("utf-8"))
+    assert body["reasoning_effort"] == "high"
+    assert body["thinking"] == {"type": "enabled", "clear_thinking": False}
+
+
+def test_missing_matrix_manifest_is_an_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = invoke(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(tmp_path / "nope.json"),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--profile",
+            "openrouter",
+        ]
+    )
+    assert code == 1
+    assert "Failed to load matrix manifest" in capsys.readouterr().err
+
+
+# --- Secret containment ------------------------------------------------------
+
+
+def test_there_is_no_api_key_flag(tmp_path: Path) -> None:
+    """A credential must never be accepted as a command argument."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "workloads",
+                "run-api",
+                "--matrix",
+                str(tmp_path / "manifest.json"),
+                "--output-dir",
+                str(tmp_path / "results"),
+                "--model-id",
+                "z-ai/glm-5.3",
+                "--api-key",
+                API_KEY,
+            ]
+        )
+    assert excinfo.value.code == 2
+
+
+def test_an_endpoint_query_holding_the_key_is_refused_before_it_is_hashed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A secret-shaped query key is refused, and nothing derived is written.
+
+    Only query *keys* are recorded, but every query *value* is folded into
+    the plan's config hash as its sha256. A redactor cannot undo a hash, so
+    the pre-flight has to refuse before the plan is built rather than
+    relying on the value being withheld.
+    """
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--provider",
+            "leaky",
+            "--endpoint",
+            f"https://openrouter.ai/api/v1/chat/completions?token={API_KEY}",
+            "--api-key-env",
+            ENV_VAR,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 1
+    captured = capsys.readouterr()
+    assert "looks like a credential" in captured.err
+    assert API_KEY not in captured.out
+    assert API_KEY not in captured.err
+
+
+def test_an_innocuous_query_key_holding_the_key_is_also_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The key check does not depend on the query key looking suspicious.
+
+    A dry run that green-lights what the real run refuses is worse than no
+    pre-flight at all, so this must be blocked rather than ready.
+    """
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--provider",
+            "azure-like",
+            "--endpoint",
+            f"https://openrouter.ai/api/v1/chat/completions?deployment={API_KEY}",
+            "--api-key-env",
+            ENV_VAR,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 2
+    captured = capsys.readouterr()
+    assert API_KEY not in captured.out
+    assert API_KEY not in captured.err
+
+    written = (tmp_path / "results" / "api_request_plan.json").read_text(
+        encoding="utf-8"
+    )
+    assert API_KEY not in written
+    row = json.loads(written)["rows"][0]
+    assert row["status"] == "blocked"
+    assert row["api_binding_hash"] is None
+    assert any("refusing to run" in blocker for blocker in row["blockers"])
+
+
+def test_an_innocuous_endpoint_query_still_records_only_its_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv(ENV_VAR, API_KEY)
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--provider",
+            "azure-like",
+            "--endpoint",
+            "https://openrouter.ai/api/v1/chat/completions?deployment=prod-eu",
+            "--api-key-env",
+            ENV_VAR,
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        )
+    )
+    assert code == 0
+    plan = json.loads(capsys.readouterr().out)["rows"][0]["request_plan"]
+    assert plan["endpoint_query_keys"] == ["deployment"]
+    assert "prod-eu" not in json.dumps(plan)
+
+
+def test_an_invalid_provider_extension_is_reported_not_raised(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``ProviderExtensions`` raises the collector's error type directly.
+
+    It validates in its own constructor, before ``binding.validate()`` can
+    translate the failure, and its message quotes the rejected value. An
+    uncaught traceback here would print that value unscrubbed.
+    """
+    code = invoke(
+        base_argv(
+            tmp_path,
+            "--profile",
+            "openrouter",
+            "--provider-request-id",
+            "   ",
+            "--dry-run",
+        )
+    )
+    assert code == 1
+    assert "Failed to configure API workload execution" in capsys.readouterr().err
+
+
+def test_no_run_artifact_contains_the_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    FakeTransport.chunks = answer_stream(f"the key is {API_KEY}")
+
+    assert (
+        invoke(
+            base_argv(
+                tmp_path,
+                "--profile",
+                "openrouter",
+                "--mode",
+                DECODE_MODE_AUTOREGRESSIVE,
+            )
+        )
+        == 0
+    )
+    for path in sorted((tmp_path / "results").rglob("*")):
+        if path.is_file():
+            assert API_KEY not in path.read_text(encoding="utf-8", errors="replace")
+
+
+def test_manifest_is_never_mutated_by_a_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", API_KEY)
+    monkeypatch.setattr(cli, "UrllibStreamingTransport", FakeTransport)
+    matrix_path = build_matrix(tmp_path)
+    before = matrix_path.read_text(encoding="utf-8")
+
+    assert (
+        invoke(
+            [
+                "workloads",
+                "run-api",
+                "--matrix",
+                str(matrix_path),
+                "--output-dir",
+                str(tmp_path / "results"),
+                "--model-id",
+                "z-ai/glm-5.3",
+                "--profile",
+                "openrouter",
+                "--mode",
+                DECODE_MODE_AUTOREGRESSIVE,
+            ]
+        )
+        == 0
+    )
+    assert matrix_path.read_text(encoding="utf-8") == before
+    assert MatrixManifest.read_json(matrix_path).entries

--- a/tests/optimizer/test_workloads_run_api_cli.py
+++ b/tests/optimizer/test_workloads_run_api_cli.py
@@ -1153,3 +1153,120 @@ def test_a_non_utf8_manifest_is_reported_not_crashed(
     assert code == 1
     assert "Failed to load matrix manifest" in err
     assert _SENTINEL not in out + err
+
+
+def _manifest_with_run_id(tmp_path: Path, run_id: str) -> Path:
+    """Write a matrix manifest whose first row carries ``run_id``."""
+    matrix_path = build_matrix(tmp_path)
+    payload = json.loads(matrix_path.read_text(encoding="utf-8"))
+    for entry in payload["entries"]:
+        if entry["decode_mode"] == DECODE_MODE_AUTOREGRESSIVE:
+            entry["run_id"] = run_id
+            break
+    matrix_path.write_text(json.dumps(payload), encoding="utf-8")
+    return matrix_path
+
+
+def test_a_credential_in_a_manifest_run_id_never_reaches_a_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal must not print the value it refused.
+
+    A key shaped like an ordinary identifier passes the path-component
+    rules, so the credential branch is the only one that fires. Rendering
+    the row's own run_id then put the key on stdout, which is precisely
+    what declining to create the directory was protecting against. The
+    CLI guard cannot help here: it inspects the flags, and this value came
+    from the manifest.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(_manifest_with_run_id(tmp_path, _SENTINEL)),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+        ]
+    )
+
+    assert code == 1
+    assert "[FAILED]" in out
+    assert _SENTINEL not in out
+    assert _SENTINEL not in err
+    assert not (tmp_path / "results").exists()
+
+
+def test_a_credential_in_a_manifest_run_id_is_withheld_from_the_dry_run_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", _SENTINEL)
+
+    code, out, err = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(_manifest_with_run_id(tmp_path, _SENTINEL)),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        ]
+    )
+
+    assert code == 2
+    assert _SENTINEL not in out + err
+    row = json.loads(out)["rows"][0]
+    # Withheld structurally by the refusal, rather than only by the
+    # whole-document redactor that would otherwise have caught it.
+    assert row["run_id"] == "[REJECTED]"
+
+
+def test_an_unsafe_manifest_run_id_is_withheld_from_the_dry_run_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A traversal string is the caller's own, but it is still withheld.
+
+    The plan withholds the rejected value whatever it turned out to be,
+    rather than deciding case by case which rejected values are safe to
+    repeat.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "present-but-unused")
+
+    code, out, _ = run_main(
+        [
+            "workloads",
+            "run-api",
+            "--matrix",
+            str(_manifest_with_run_id(tmp_path, "../escaped")),
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--profile",
+            "openrouter",
+            "--model-id",
+            "z-ai/glm-5.3",
+            "--mode",
+            DECODE_MODE_AUTOREGRESSIVE,
+            "--dry-run",
+        ]
+    )
+
+    assert code == 2
+    assert "../escaped" not in out
+    row = json.loads(out)["rows"][0]
+    assert row["run_id"] == "[REJECTED]"
+    assert row["status"] == "blocked"


### PR DESCRIPTION
**Now based on `main`.** #12 was squash-merged as `5eb171f`, and this stack's three commits have been rebased onto it. `llmtracefx/optimizer/collectors/openai_api.py` is untouched by this PR (`git diff origin/main HEAD -- llmtracefx/optimizer/collectors/` is empty).

## What this adds

`workloads run-api`: the remote counterpart to `workloads run`. It takes the same matrix manifest, the same selection filters, the same deterministic evaluators and the same canonical `ExperimentRecord`, and executes each selected runnable autoregressive row through PR #12's streaming API collector.

```bash
export OPENROUTER_API_KEY=...

uv run llmtracefx-optimizer workloads run-api \
  --matrix artifacts/qwen3.8-matrix/manifest.json \
  --output-dir artifacts/glm-api-run \
  --profile openrouter \
  --model-id z-ai/glm-5.3-flash \
  --mode autoregressive \
  --reasoning-effort high
```

Every command in the README section added here is labelled an **unmeasured example**. No number in this repository was produced by running one.

## Reuse, not reimplementation

Everything that touches the network, the wire protocol, or a secret belongs to `collectors/openai_api.py` and is used unmodified. That file is untouched by this PR:

- `collect_openai_stream` performs the request, decodes the SSE stream, classifies provider failures, redacts the credential out of every persisted string, and publishes its own artifact set
- `build_request_plan` produces the credential-free plan that `--dry-run` prints and that this module hashes for resume
- `artifact_set_is_complete` is the only thing trusted to call a prior collection directory whole
- `assert_credential_not_embedded` is the pre-flight both the plan and the execute path run
- `redact_text_for_dry_run` scrubs every diagnostic before it is persisted

What is new is the binding between that collector and the existing workload pipeline, and nothing else.

## Behaviour worth checking closely

**Provider binding.** `APIBinding` carries the sanitized endpoint identity, provider label, model id and revision, credential variable name, request parameters, provider extensions and reasoning settings, timeout, and an event cap. Its hash builds on the collector's own `config_hash` and adds the cap and the evaluation binding.

The credential environment **variable name** is deliberately excluded from the hash, for the same reason the collector excludes it: two runs differing only in which variable held the key issue byte-identical requests and are graded identically, so the name affects neither the request nor the evaluation nor resume, and a caller who pastes a key into that slot must not have a derivation of it written into an artifact. The name itself is still recorded, in the masked form the request plan chooses.

**Native-MTP stays unsupported.** Native multi-token prediction is a decoding mechanism inside a local runtime. A hosted API exposes no such control, and its reasoning or thinking settings are a different mechanism measuring something else, so those rows are rejected rather than re-labelled. Passing `--reasoning-effort` does not change this, and no transport is constructed for such a row.

**Only the final answer is graded.** `response_text` is the assembled content stream, never `reasoning_content`, so a model that reasons its way to the answer and then states something else is graded on what it stated.

**Failure precedence.** A provider failure short-circuits evaluation entirely and is persisted as-is, including when the failed response body happens to contain a passing answer. Collection success plus an evaluator that raises leaves the row `inconclusive` with the timing evidence preserved and `quality_score` unset. A wrong-but-well-formed answer is `completed` with `outcome_success` false, because that is a measurement rather than a break.

**Resume.** A row is skipped only when all of these hold: the prior verification is completed/skipped, it came from this same backend, and its prompt hash, workload version and binding hash all still match, **and** the collector's `artifacts.json` marker verifies the sha256 of every file in the collection directory. A stale binding, an interrupted write, a missing marker or a file edited after the fact all rerun the row.

**Dry run.** Validates selection and configuration, writes and prints a secret-safe plan, and performs no network access.

**Profiles, not hardcoded behaviour.** OpenRouter (`https://openrouter.ai/api/v1/chat/completions`, `z-ai/glm-5.3`, `z-ai/glm-5.3-flash`, `OPENROUTER_API_KEY`) and Z.ai are data-only profiles supplying defaults. No module branches on which one was selected, and an unlisted provider works by passing the three fields a profile would have filled in.

## Additive schema changes

`verification.json` and the `workloads summarize` document both move to schema v2, each a strict superset of v1. A v1 artifact still parses, still aggregates and still resumes; nothing written before this needs rewriting.

Aggregation gains `by_backend` and `by_provider` axes so a locally measured row and a hosted-API row are never blended: they do not share a hardware definition and their timings are not the same quantity. Local rows have no provider and are left out of `by_provider` rather than gathered under a placeholder key, so those groups do not sum to `overall`. An undefined metric stays `null` rather than becoming a measured zero.

## Repetitions

The matrix has no repetition axis, since `run_id` is derived from `(workload, context tier, decode mode)`. Rather than invent synthetic repetition IDs that no other part of the pipeline understands, the README documents repeating by giving each repetition its own results directory, and explains why that is what keeps repeated sampling honest here.

## Out of scope

No pricing, no cost and no cross-provider ranking. The provider's own usage counters are persisted exactly as reported.

## Review findings addressed

An independent review of the first draft found four issues, all fixed here, each with a regression test that was confirmed to fail against the unfixed code:

1. **Critical.** A credential pasted into `--provider` or `--model-id` was written verbatim into every `verification.json`, and propagated into `verification_summary.json` through the new `by_provider` axis. Both fields now pass through the redactor, and the pre-flight refuses the run before any artifact is written.
2. **Medium.** `run-api --dry-run` skipped the collector's `assert_credential_not_embedded` pre-flight, so it green-lit configurations the real run refuses, and a credential in an endpoint query value was folded into `config_hash` as its sha256 and persisted. The pre-flight now runs on both paths, **before** the request plan is built, because no redactor can undo a hash.
3. **Medium.** A cap-truncated stream could be published as a `completed`, graded answer when the cap landed after a terminal `finish_reason` but before `[DONE]`. Tripping the cap now fails the row as truncated whatever the collector concluded, since this pipeline is the one that stopped reading. Three inaccurate documentation claims were corrected at the same time.
4. **Low.** `ProviderExtensions` raises the collector's error type from its own constructor, before `binding.validate()` could translate it, so an invalid `--provider-request-id` escaped as an unscrubbed traceback quoting the rejected value. It is now caught and scrubbed.

## Second commit: the CodeQL clear-text logging fix

Advanced Security flagged `Clear-text logging of sensitive information` (high) in `_reject_credential_arguments`. That function refuses a credential-shaped flag before argparse can echo its value, and it named the flag by printing the caller's own argv token, split on `=` and truncated to the left half.

In practice that was safe: every shape reaching that branch carries its value either in a separate argv token or after an `=`. But the safety rested on reasoning about argument shapes rather than on construction, and the token reaching that check is, by the definition of the check, the one most likely to be holding a credential. The finding is fair.

**Fixed without any suppression.** `_CREDENTIAL_ARGUMENT_STEMS` becomes a stem-to-spelling mapping, and the message prints the mapped literal defined in this module rather than anything derived from the command line. `--API_KEY=...` is now answered with `--api-key`: still actionable, built only from bytes this program defined. Both existing readers test membership with `in`, which is unchanged for a dict, so `_is_credential_flag` keeps its behaviour exactly.

The existing test asserted the caller's own spelling appeared in the message, which is precisely the property being removed, so it now asserts the canonical spelling and a new case asserts that a spelling this program did not define never appears at all.

### Adjacent diagnostic paths audited

Two more paths in `_cmd_workloads_run_api` echoed `OSError` verbatim, and an `OSError` embeds the path it failed on. The matrix-load and plan-write failures now scrub through `_scrubbed_detail`.

That surfaced a related gap: `--api-key-env` is usually left unset and defaulted from `--profile`, so scrubbing against the raw flag scrubbed against `None` and did nothing. `_effective_api_key_env` resolves the name the invocation will actually read, and every failure path in the command now scrubs against it.

### Sentinel regressions

Added across **stdout and stderr together**, because a value kept out of one stream and printed to the other has still been disclosed. These drive `cli.main` rather than the parsed-args shortcut, so the credential-flag refusal and the argv scrub are both in force. Covered: every caller-filled slot (`--provider`, `--model-id`, `--endpoint`, `--api-key-env`, `--model-revision`), the credential value itself, credential-shaped flags, a value argparse would quote back as a type error, an unknown flag, a provider that echoes the key, and the two newly scrubbed diagnostics.

Each new assertion was verified to **fail** against the unfixed code before being kept.

## Third commit: second independent review round

Two findings on the CodeQL fix head, both fixed.

**The event cap tripped on reaching its limit rather than exceeding it.** A provider may close with a terminal `finish_reason` and no `[DONE]` sentinel, which this stack's own README documents as supported, and the collector keeps pulling after the final chunk. So a cap equal to the number of events the stream actually sent condemned a stream that had already delivered every byte it would ever send: the row failed as `stream_truncated`, its quality score was discarded, and the persisted note claimed "what arrived is a prefix of the answer" when it was the whole answer. Streams that do send `[DONE]` were accidentally safe, since the collector stops consuming at the sentinel, so only the sentinel-less shape was affected.

"The count reached the limit" and "there was more to read" can only be told apart by trying to read, so the cap now looks ahead exactly one chunk. Ending there means nothing was abandoned and the row proceeds to grading; a chunk still waiting means the stream really was cut short. Both boundaries are now pinned by tests.

**`_effective_api_key_env` had no coverage at all.** The test named for it was a duplicate: its sentinel arrived through argv, which the argv scrub removes on its own, so the credential redactor never fired and the resolution never mattered. Neutralising the function left the entire suite green. It is now exercised directly across all five flag/profile combinations, plus an integration test whose sentinel reaches the diagnostic from the environment rather than argv, which is the only shape that depends on resolving the name. Neutralising it now fails 3 tests.

The reviewer separately confirmed the taint flow is genuinely broken, the `frozenset` to `dict` change is behaviour-preserving with a byte-identical key set, and no remaining credential-bearing output path exists on either the dry-run or the execution path.

## Rebase onto squashed `main`

#12 merged as `5eb171f`. Only this stack's three commits were replayed; no parent commit was re-applied. Two things needed resolving, both in `main`'s favour for collector-owned content:

**`cli.py` conflict around `_CREDENTIAL_ARGUMENT_STEMS`.** After this branch was frozen, `main` removed `_MIN_GLUED_CREDENTIAL_CHARS` and introduced `_GLUED_CREDENTIAL_FLAGS`. The resolution keeps `main`'s structure entirely and layers on only this stack's change, the frozenset-to-mapping conversion. The 21 stem keys are verified identical to `main`'s frozenset, so `main`'s `{f"--{stem}" for stem in _CREDENTIAL_ARGUMENT_STEMS}` and its `in` membership test both behave exactly as before.

Worth noting: `main` still carries the clear-text-logging pattern this stack fixes, so the CodeQL fix in `08f558a` remains necessary rather than redundant.

**One test updated for a `main` behaviour change.** `main`'s collector now redacts endpoint query *keys* as well as values, preserving only the parameter count. A test that asserted the literal key name was rewritten to assert the count plus the absence of both key and value, which is the stronger property.

Verified after rebase: exactly three commits, exactly the ten intended files, and zero changes under `llmtracefx/optimizer/collectors/`.

## Fourth commit: exact-head review on `main`

The post-rebase review found one material issue in the event cap, and it was worse than the round before.

The cap is denominated in dispatched SSE events, but the previous commit decided whether it had been exceeded by asking whether another *chunk* existed. A chunk may carry several events, or none. So a stream that dispatched exactly the budget and then left a keepalive comment, a stray blank line, or its terminal sentinel in a separate socket read was failed as truncated with its quality score discarded, even though every byte had been delivered. The SSE decoder already documents keepalive comments as frames that never contribute an event.

Worse, it made the verdict a property of the network: the same wire bytes passed or failed depending only on how they were split into reads. A measurement tool whose result depends on TCP segmentation is not measuring what it claims to.

The count now comes from the shared decoder alone and is taken *before* each chunk is handed on. Counting after the yield left a body arriving in one read uncapped entirely, because the collector reached the sentinel and abandoned the generator before anything was counted. The terminal sentinel is charged to the budget like any other event, which is the only reading under which the count is a property of the bytes alone; the flag help and README say so.

New coverage: the trailing non-event shapes, a stream ending exactly at its budget, and the segmentation invariant in both directions (one event per read, sixteen byte pieces, all at once). All five were verified to fail against the previous implementation.

The reviewer independently re-derived and confirmed the rebase itself: an AST-level comparison of `cli.py` shows nothing from `main` dropped, `_GLUED_CREDENTIAL_FLAGS` byte-identical, the 21 stem keys identical to `main`'s frozenset, the CodeQL taint break structural rather than suppressed, and the query-key test update the correct reading of `main`'s behaviour.

## Review rounds five and six

**A HIGH security fix that did not actually work.** The refusal for executable evaluators asked the wrong object: it read `entry.category` off the matrix row, but `evaluate_workload` dispatches on `workload.category` from the catalog, and a matrix manifest is a file on disk. A manifest declaring a code-completion row as `structured_json` passed the check, resolved the real workload, and was graded by executing the answer. Reproduced before fixing: the code evaluator really did run on content supplied by the provider, and the reviewer's independent probe wrote a canary file from a "model answer". The catalog is now the authority, re-checked after resolution in both the plan and execute paths; the row's own category survives only as a cheap short circuit. Post-fix probe: plan `unsupported`, **0 network requests**, no canary.

**Run-marker hardening.** The marker's `name` field was read out of a file and joined straight onto the run directory, so an absolute path or one containing `..` sent the check off to hash an unrelated file and a tampered run verified clean. Sealed names are now fixed in code and each must appear exactly once, so redirecting or dropping an entry both fail.

**Two documentation overclaims corrected.** The README described the marker as though it made the directory unforgeable; it is tamper evidence, not tamper proofing, since an unsigned marker can be regenerated over edited files. And the summarize schema note claimed every v1 field kept its meaning, when `correct_cases_per_minute` gained a second null-cause that readers must disambiguate via `timing_comparable`.

The reviewer separately verified the event cap across 10 segmentations x 9 caps x 5 stream shapes with **zero divergences**, confirmed the credential-in-path guard has no ordering holes and that `--system-prompt-file` is not one, confirmed the aggregation predicate is correct (deriving contexts from `evaluated_pass` is exactly the row set feeding the metric), and confirmed the local MLX path is untouched.

## Review round seven

**A HIGH leak that defeated one of the fixes.** The credential-in-path refusal declined to create the directory, returned `run_id="[REJECTED]"`, and wrote nothing to disk. The CLI then rendered the status line from `result.entry.run_id` and printed the key to stdout anyway. Nothing else covered it: the CLI guard inspects the flags and the argv scrub reaches only argv, but this value comes from the manifest file. Nor is it a corner, since a key is alphanumeric with dashes and well under the length limit, so it passes the path-component rules cleanly and the credential branch is the only one that fires. The status line now renders the verification's `run_id`, which equals the row's everywhere else.

The rendered dry-run plan had the same hole: it blanked the four path fields and kept `run_id`. The credential case happened to be caught by the whole-document redactor, which is incidental cover rather than the claimed property, and a traversal string was echoed outright. The plan now withholds the value structurally on the refusal path.

**The test named for that property asserted none of it** — only that the plan was not ready and that nothing was created. It now asserts the rendered document does not contain the value, which is what would have generalised to the stdout leak in the first place.

**`_SAFE_RUN_ID` accepted a trailing newline.** `$` matches before a trailing newline, so `re.match` allowed `"row\n"` and created a directory whose name the refusal text calls impossible. Anchored with `fullmatch`.

The reviewer separately confirmed the `run_id` guard placement precedes every path derivation on both paths, that identity binding is complete for the stated attack, that `UnicodeError` handling is complete within scope, and that all six previous fixes remain intact. Their exhaustive vector sweep found no escape: `../`, `nested/child`, `.`, `..`, `.hidden`, drive letters, UNC paths, NUL, tab, space, percent-encoding, fullwidth and division-slash lookalikes, RTL override, BOM, combining marks, overlong names and leading punctuation were all refused.

Three pre-existing `UnicodeDecodeError` crashes on the local pipeline are tracked separately rather than folded in here, to keep this diff scoped to the code it owns.

## Validation

- `uv run pytest`: 1783 passed
- All 10 CI checks green, including CodeQL
- `scripts/lint-changed.sh origin/main`: ruff, black, isort and mypy all clean on changed files
- Every new test is offline. Each injects a fake transport, and the ones that must prove nothing was sent inject a transport that fails the test if it is ever opened. No real key and no real endpoint is used anywhere.






