### PR TITLE
Add an offline cross-system comparison layer (local vs frontier vs flash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2267,6 +2267,14 @@ would skip the second repetition rather than measure it, and the spread
 across repetitions stays visible instead of being averaged away by a
 pipeline that never saw it as a spread.
 
+`compare` consumes those directories directly: pass every repetition to
+`--results` and each one counts as a separate measurement of the same row,
+which is how a policy's `min_measured_repetitions` above 1 is satisfied.
+Repetitions are distinguished by the artifact they were read from, not by
+run id, because a matrix `run_id` names the task and every repetition of a
+matrix therefore carries the same one. Naming the same directory twice is
+still counted once.
+
 This command deliberately computes no cost, no price and no cross-provider
 ranking. The provider's own usage counters are persisted exactly as
 reported; turning them into money or into a comparison is a separate
@@ -2328,6 +2336,216 @@ and marks execution, verification, tuning, and rendering as `not_run`; it does
 not load MLX or write tune reports. Existing unrelated runs under `--results`
 are excluded from tuning, while repeatable `--extra-results` paths explicitly
 opt additional evidence into the comparison.
+
+### Cross-system comparison: local vs frontier vs flash
+
+`tune` answers "which configuration of this model on this machine is
+fastest". `compare` answers a different question: **how does a local model
+actually stack up against a hosted frontier API and a cheap fast API on work
+they have all already done.**
+
+It is offline in the strictest sense. It loads no model, calls no API,
+deploys nothing, and runs no benchmark. It reads results directories that
+already exist and produces a versioned JSON report and a self-contained
+branded HTML rendering of it.
+
+**What it can ingest, precisely.** The only accepted input is a results
+directory shaped like `workloads run --output-dir`: a `runs/<run_id>/` tree
+holding a `verification.json` and the `final_record.json` it points at. When
+a run was collected against a hosted API, the collector's
+`api_evidence.json` is read from the collection directory that verification
+names, and the whole artifact set is checked against the collector's own
+`artifacts.json` marker before a single number is taken from it.
+
+Raw `collect-api` output is **not** directly ingestible, and `compare` says
+so rather than silently reporting nothing. That command writes a flat
+artifact set into whatever `--output-dir` it is given and produces no
+`verification.json`, which means nothing has evaluated the response: there
+is no pass rate and no quality score, so there is nothing to compare
+honestly.
+
+The hosted side of a comparison comes from `workloads run-api`, which
+executes the matrix against an OpenAI-compatible endpoint and writes the
+same `runs/<run_id>/` tree the local pipeline does:
+
+```bash
+uv run llmtracefx-optimizer workloads run-api \
+  --matrix artifacts/qwen3.8-matrix/manifest.json \
+  --output-dir artifacts/glm-5.3-run \
+  --profile z.ai --model-id glm-5.3
+```
+
+`compare` deliberately does not invent an adapter of its own, because a
+second, subtly different ingestion path is exactly how two numbers stop
+meaning the same thing.
+
+```bash
+uv run llmtracefx-optimizer compare \
+  --results artifacts/qwen3.8-local-run artifacts/glm-5.3-run artifacts/glm-5.3-flash-run \
+  --policy examples/optimizer/compare-policy-local-vs-api-latency.json \
+  --pricing examples/optimizer/pricing-manifest-illustrative.json \
+  --output artifacts/cross-system-compare.json
+
+uv run llmtracefx-optimizer compare-report \
+  --input artifacts/cross-system-compare.json \
+  --output artifacts/cross-system-compare.html
+```
+
+**This is evidence, not marketing.** Everything below exists because the
+easiest way to produce a cross-system chart is also the fastest way to
+produce a dishonest one.
+
+**Systems are only compared when they answered the identical question.** The
+comparable unit is the workload id and version, the exact prompt hash, the
+context tier, the evaluator/quality metric, the maximum output tokens, the
+sampling settings, and the shape of the request itself. If any of those
+differ, the runs land in *separate strata* and are reported side by side as
+different questions rather than averaged into one. An unrecorded setting is
+not a wildcard: a run whose output cap was never recorded is only ever
+compared against other runs whose cap is equally unrecorded, because
+"unknown" is not the same as "512".
+
+Request shape matters because a prompt hash alone does not identify a
+request. The same user prompt sent under a system prompt, or as the tail of
+a conversation, is a different question. The message structure is normalized
+so the ordinary case still works: a single user message whose content hash
+is the workload prompt is exactly what a local run does, so it and a bare
+API request share a unit. Anything else gets a structural digest that no
+local run can match, which separates the stratum instead of quietly
+comparing a system-prompted request against a bare one.
+
+**Systems keep their labels.** Each system is identified by model and model
+revision, provider, runtime and backend, accelerator, quantization, reasoning
+effort, thinking type, deployment endpoint, decode mode, and the collector's
+own execution configuration hash. That last one is the catch-all: it covers
+endpoint, sampling, provider extensions, finish-reason vocabulary, timeout
+and system prompt, so a configuration difference this layer does not model
+by name still separates two systems rather than pooling them. Two candidates
+that differ on any one of those are
+different systems, and their measurements are never pooled.
+
+**Metrics are reported where the evidence supports them**: pass rate, mean
+quality score with its metric named, mean/p50/p95 total latency,
+time-to-first-token, correct cases per minute, provider-reported
+input/output/cached/reasoning token usage, estimated cost per case, and
+correct cases per unit of currency.
+
+Three of those need a caveat the report always carries:
+
+- **Time-to-first-token is two different measurements.** A local collector
+  records prefill, which is prompt processing observed on the host. A hosted
+  API can only offer the client-observed offset to the first content token,
+  which also contains DNS, connection setup, TLS, request transfer and
+  server-side queueing. The report labels which one each figure is, never
+  averages them together, and never ranks on them.
+- **Peak memory stays local-only.** A hosted API cannot produce one, so the
+  field is absent for those systems rather than zero, and the schema refuses
+  to load a report that claims otherwise.
+- **A missing value stays unavailable.** Nothing is ever backfilled with a
+  zero, because a zero wins latency and cost rankings for free.
+
+**Pricing is an input, not a constant.** No rate is baked into this code and
+nothing is fetched at runtime. Rates arrive through a versioned pricing
+manifest that must declare a currency, an `effective_at` date, and a `source`
+for every entry:
+
+```json
+{
+  "schema_version": "1",
+  "currency": "USD",
+  "entries": [
+    {
+      "entry_id": "example-flash-api",
+      "provider": "example-provider",
+      "model_id": "example-flash-model",
+      "currency": "USD",
+      "effective_at": "2026-01-01",
+      "source": "illustrative example, not a published price list",
+      "rates_are_illustrative": true,
+      "input_per_million": 0.10,
+      "output_per_million": 0.30,
+      "cached_input_per_million": 0.02
+    }
+  ]
+}
+```
+
+The manifest is refused outright on an ambiguous provider/model match, a
+non-finite or negative rate, mixed currencies, or a duplicate entry id. The
+exact entry used for every figure is recorded by id *and* by content hash, so
+editing the manifest afterwards cannot quietly change what a published report
+claimed to have used.
+
+Cost derivation keeps provider accounting and client timing strictly apart,
+and every monetary value is labeled estimated:
+
+- `prompt_tokens` already includes cached tokens, so a declared
+  `cached_input_per_million` bills them separately instead of double-charging
+  them. If the provider reports cached tokens and the manifest has no cached
+  rate, the cost is refused rather than guessed at full price or at zero. The
+  reverse is refused too: if the manifest prices a cache tier but the
+  provider reported no cached count, there is no way to know how much of the
+  prompt was served from cache, and assuming none of it was would overstate
+  the bill.
+- `completion_tokens` already includes reasoning tokens. With no separate
+  reasoning rate they are billed at the output rate, which is the ordinary
+  OpenAI-compatible behaviour. **If the provider omits reasoning usage, no
+  hidden reasoning cost is inferred** -- the omission is recorded instead.
+
+`pricing-manifest-illustrative.json` in `examples/optimizer/` is exactly what
+its name says. Every rate in it is invented to demonstrate the arithmetic,
+`rates_are_illustrative` is `true`, and the HTML report prints that back on
+the page. Replace it with rates you sourced yourself, cite the page in
+`source`, pin the date in `effective_at`, and set the flag to `false`.
+
+**Ranking is constraints-first and single-objective.** A system is only
+ranked once it has cleared every constraint, and a run ranks on exactly one
+objective: `min_mean_total_latency_ms`, `max_correct_cases_per_minute`,
+`min_cost_per_correct_case`, or `max_correct_cases_per_currency_unit`. There
+is no blended score, because a single number mixing speed, quality and price
+hides the axis a reader actually needs. The pass-rate and
+correct-cases-per-minute formulas are imported from
+`workloads.aggregate` -- the same functions `tune` uses -- rather than
+restated.
+
+When the top two systems are exactly tied, or differ by less than their
+combined measurement noise, the result is **inconclusive** with the reason
+recorded. Each objective measures that noise on the axis it actually ranks
+on: latency uses the spread of the timings, and the two money objectives use
+the spread of the per-run costs. A system can be metronomically steady in
+latency while its token usage swings run to run, so borrowing the timing
+figure to judge a price difference would call a real gap noise, or noise a
+real gap. So is a unit where only one system produced evidence: nothing was
+compared against anything.
+
+**There is no universal winner.** Alongside the ranking, each unit publishes
+a Pareto-style evidence frontier over the axes every ranked system carries
+evidence for, naming which systems dominate which. Axes that not every system
+has evidence for are dropped and listed under missing evidence rather than
+filled in. Every recommendation is stated with the workload, context tier,
+evaluator, decode settings, objective and constraints it applies to, and
+nothing else.
+
+**Privacy.** Local artifact paths are redacted by default
+(`--include-paths` opts out). A per-run artifact keeps its stable
+`runs/<run_id>/<file>` label; a path with no run id to anchor on, such as a
+results directory or the pricing manifest, is reduced to its final component
+alone, so no ancestor directory name travels with the report. Deployment
+endpoints are redacted to their route, keeping what distinguishes two
+deployments without naming the host they run on. No
+prompt text, no response text, no reasoning content and no credential can
+reach the report, because the schema has no field that could carry one. The
+HTML is inline CSS and inline SVG with no JavaScript, no CDN and no external
+reference of any kind, every string from the report is escaped, and rendering
+the same report twice is byte-identical.
+
+See `examples/optimizer/compare-report-example.json` for a synthetic,
+clearly-marked non-benchmark report that exercises every section: two strata,
+a genuine speed-versus-reliability trade-off on the frontier, a dominated
+local system, a rejected system, illustrative cost figures, and an excluded
+run. Its companion policies are
+`compare-policy-local-vs-api-latency.json` and
+`compare-policy-cost-per-correct-case.json`.
 
 **Not yet included** (tracked as a follow-up PR): a genuinely capable
 native-MTP runtime adapter (none exists upstream today), native Metal/CUDA

--- a/examples/optimizer/compare-policy-cost-per-correct-case.json
+++ b/examples/optimizer/compare-policy-cost-per-correct-case.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1",
+  "name": "cheapest correct answer at an acceptable quality floor",
+  "description": "Requires a pricing manifest. Cost is derived from provider-reported token usage, so a system whose provider reported no usage is simply not ranked here rather than being treated as free.",
+  "objective": "min_cost_per_correct_case",
+  "constraints": {
+    "required_statuses": [
+      "completed",
+      "skipped"
+    ],
+    "min_pass_rate": 0.75,
+    "required_quality_metric": "structured_json_exact_field_match",
+    "min_quality_score": 0.75,
+    "min_measured_repetitions": 2
+  }
+}

--- a/examples/optimizer/compare-policy-local-vs-api-latency.json
+++ b/examples/optimizer/compare-policy-local-vs-api-latency.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1",
+  "name": "local vs frontier vs flash, lowest mean latency",
+  "description": "One objective, constraints first. A system is only ranked once it has cleared every constraint below; nothing is blended into an overall score. Swap the objective for `max_correct_cases_per_minute`, `min_cost_per_correct_case` or `max_correct_cases_per_currency_unit` to ask a different question of the same evidence.",
+  "objective": "min_mean_total_latency_ms",
+  "constraints": {
+    "required_statuses": [
+      "completed",
+      "skipped"
+    ],
+    "min_pass_rate": 0.75,
+    "required_quality_metric": "structured_json_exact_field_match",
+    "min_quality_score": 0.75,
+    "min_measured_repetitions": 2,
+    "max_coefficient_of_variation": 0.35
+  }
+}

--- a/examples/optimizer/compare-report-example.json
+++ b/examples/optimizer/compare-report-example.json
@@ -1,0 +1,746 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-01-01T00:00:00.000000Z",
+  "results_dirs": [
+    "artifacts/example-results"
+  ],
+  "tune_report_paths": [],
+  "policy": {
+    "schema_version": "1",
+    "name": "local vs frontier vs flash, lowest mean latency",
+    "description": "SYNTHETIC EXAMPLE DATA ONLY. Not a real benchmark, and not evidence about any actual model's performance, latency or price. It exists solely to exercise every section of the `compare` report and its HTML renderer: a recommended system, a full ranking, a Pareto-style evidence frontier, a rejected system, provider-reported token usage, an illustrative cost estimate, a separate stratum for a different comparable unit, and an excluded run.",
+    "objective": "min_mean_total_latency_ms",
+    "constraints": {
+      "required_statuses": [
+        "completed",
+        "skipped"
+      ],
+      "min_pass_rate": 0.75,
+      "min_quality_score": 0.75,
+      "required_quality_metric": "structured_json_exact_field_match",
+      "max_mean_total_latency_ms": null,
+      "max_cost_per_correct_case": null,
+      "allowed_provenances": null,
+      "min_measured_repetitions": 2,
+      "max_coefficient_of_variation": 0.35
+    }
+  },
+  "pricing": {
+    "manifest_path": "artifacts/example-pricing/illustrative-rates.json",
+    "manifest_sha256": "11b7bf1654cd766ad576fa875f917113a73ed94378e3121edcd6459329cbeac7",
+    "currency": "USD",
+    "rates_are_illustrative": true,
+    "entry_ids_used": [
+      "example-flash-api",
+      "example-frontier-api"
+    ]
+  },
+  "strata": [
+    {
+      "comparable_unit_key": {
+        "workload_id": "structured-json-profile-extraction",
+        "workload_version": "1",
+        "workload_prompt_hash": "sha256:synthetic-prompt-abc",
+        "context_tier": "2k",
+        "quality_metric": "structured_json_exact_field_match",
+        "max_output_tokens": 512,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "request_shape": null
+      },
+      "comparable_unit_label": "structured-json-profile-extraction@v1 [2k] evaluator=structured_json_exact_field_match max_output=512 temperature=0 top_p=1",
+      "outcome": "recommended",
+      "objective_name": "min_mean_total_latency_ms",
+      "recommended": {
+        "system_key": {
+          "model_id": "example-flash-model",
+          "model_revision": null,
+          "provider": "example-provider",
+          "runtime_name": "openai-compatible-stream",
+          "runtime_backend": null,
+          "accelerator": null,
+          "quantization": null,
+          "reasoning_effort": "low",
+          "decode_mode": "autoregressive",
+          "endpoint": "https://example.invalid/v1/chat/completions",
+          "thinking_type": null,
+          "execution_config_hash": "flash-cfg",
+          "is_local": false
+        },
+        "system_label": "example-flash-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=low decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+        "rank": 1,
+        "run_ids": [
+          "flash-2k-1",
+          "flash-2k-2",
+          "flash-2k-3",
+          "flash-2k-4"
+        ],
+        "verification_paths": [
+          "artifacts/example-results/runs/flash-2k-1/verification.json",
+          "artifacts/example-results/runs/flash-2k-2/verification.json",
+          "artifacts/example-results/runs/flash-2k-3/verification.json",
+          "artifacts/example-results/runs/flash-2k-4/verification.json"
+        ],
+        "record_paths": [
+          "artifacts/example-results/runs/flash-2k-1/final_record.json",
+          "artifacts/example-results/runs/flash-2k-2/final_record.json",
+          "artifacts/example-results/runs/flash-2k-3/final_record.json",
+          "artifacts/example-results/runs/flash-2k-4/final_record.json"
+        ],
+        "evidence_count": 4,
+        "objective_name": "min_mean_total_latency_ms",
+        "objective_value": 1195.0,
+        "pass_rate": 0.75,
+        "mean_quality_score": 0.75,
+        "quality_metric": "structured_json_exact_field_match",
+        "mean_total_latency_ms": 1195.0,
+        "p50_total_latency_ms": 1200.0,
+        "p95_total_latency_ms": 1230.0,
+        "stdev_total_latency_ms": 29.58039891549808,
+        "coefficient_of_variation": 0.024753471895814293,
+        "correct_cases_per_minute": 50.420168067226896,
+        "mean_ttft_ms": 107.5,
+        "ttft_basis": "client_observed_stream",
+        "usage": {
+          "provenance": "provider_reported",
+          "runs_reporting_usage": 4,
+          "runs_total": 4,
+          "complete": true,
+          "input_tokens": 8400,
+          "output_tokens": 1840,
+          "cached_input_tokens": 2400,
+          "reasoning_tokens": null
+        },
+        "cost": {
+          "currency": "USD",
+          "estimated": true,
+          "monetary_basis": "estimated_from_provider_reported_usage_and_manifest_rates",
+          "pricing_entry_id": "example-flash-api",
+          "pricing_entry_sha256": "1258f24dfa65f4367707374daf099b4d969db3b04af5de654463a6a8c3bfdad8",
+          "rates_are_illustrative": true,
+          "total_amount": 0.0012,
+          "cost_per_case": 0.0003,
+          "cost_per_correct_case": 0.00039999999999999996,
+          "correct_cases_per_currency_unit": 2500.0,
+          "reasons": [
+            "run flash-2k-1: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+            "run flash-2k-2: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+            "run flash-2k-3: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+            "run flash-2k-4: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred"
+          ]
+        },
+        "mean_peak_memory_bytes": null,
+        "max_peak_memory_bytes": null,
+        "missing_evidence": [
+          "peak memory is a local-only measurement and is not available for a system executed by a hosted provider"
+        ]
+      },
+      "inconclusive_reason": null,
+      "ranked": [
+        {
+          "system_key": {
+            "model_id": "example-flash-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "low",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "flash-cfg",
+            "is_local": false
+          },
+          "system_label": "example-flash-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=low decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "rank": 1,
+          "run_ids": [
+            "flash-2k-1",
+            "flash-2k-2",
+            "flash-2k-3",
+            "flash-2k-4"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/flash-2k-1/verification.json",
+            "artifacts/example-results/runs/flash-2k-2/verification.json",
+            "artifacts/example-results/runs/flash-2k-3/verification.json",
+            "artifacts/example-results/runs/flash-2k-4/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/flash-2k-1/final_record.json",
+            "artifacts/example-results/runs/flash-2k-2/final_record.json",
+            "artifacts/example-results/runs/flash-2k-3/final_record.json",
+            "artifacts/example-results/runs/flash-2k-4/final_record.json"
+          ],
+          "evidence_count": 4,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 1195.0,
+          "pass_rate": 0.75,
+          "mean_quality_score": 0.75,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_total_latency_ms": 1195.0,
+          "p50_total_latency_ms": 1200.0,
+          "p95_total_latency_ms": 1230.0,
+          "stdev_total_latency_ms": 29.58039891549808,
+          "coefficient_of_variation": 0.024753471895814293,
+          "correct_cases_per_minute": 50.420168067226896,
+          "mean_ttft_ms": 107.5,
+          "ttft_basis": "client_observed_stream",
+          "usage": {
+            "provenance": "provider_reported",
+            "runs_reporting_usage": 4,
+            "runs_total": 4,
+            "complete": true,
+            "input_tokens": 8400,
+            "output_tokens": 1840,
+            "cached_input_tokens": 2400,
+            "reasoning_tokens": null
+          },
+          "cost": {
+            "currency": "USD",
+            "estimated": true,
+            "monetary_basis": "estimated_from_provider_reported_usage_and_manifest_rates",
+            "pricing_entry_id": "example-flash-api",
+            "pricing_entry_sha256": "1258f24dfa65f4367707374daf099b4d969db3b04af5de654463a6a8c3bfdad8",
+            "rates_are_illustrative": true,
+            "total_amount": 0.0012,
+            "cost_per_case": 0.0003,
+            "cost_per_correct_case": 0.00039999999999999996,
+            "correct_cases_per_currency_unit": 2500.0,
+            "reasons": [
+              "run flash-2k-1: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+              "run flash-2k-2: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+              "run flash-2k-3: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+              "run flash-2k-4: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred"
+            ]
+          },
+          "mean_peak_memory_bytes": null,
+          "max_peak_memory_bytes": null,
+          "missing_evidence": [
+            "peak memory is a local-only measurement and is not available for a system executed by a hosted provider"
+          ]
+        },
+        {
+          "system_key": {
+            "model_id": "example-frontier-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "high",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "frontier-cfg",
+            "is_local": false
+          },
+          "system_label": "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "rank": 2,
+          "run_ids": [
+            "frontier-2k-1",
+            "frontier-2k-2"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/frontier-2k-1/verification.json",
+            "artifacts/example-results/runs/frontier-2k-2/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/frontier-2k-1/final_record.json",
+            "artifacts/example-results/runs/frontier-2k-2/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 3000.0,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_total_latency_ms": 3000.0,
+          "p50_total_latency_ms": 3000.0,
+          "p95_total_latency_ms": 3100.0,
+          "stdev_total_latency_ms": 100.0,
+          "coefficient_of_variation": 0.03333333333333333,
+          "correct_cases_per_minute": 20.0,
+          "mean_ttft_ms": 217.5,
+          "ttft_basis": "client_observed_stream",
+          "usage": {
+            "provenance": "provider_reported",
+            "runs_reporting_usage": 2,
+            "runs_total": 2,
+            "complete": true,
+            "input_tokens": 4200,
+            "output_tokens": 960,
+            "cached_input_tokens": 1200,
+            "reasoning_tokens": null
+          },
+          "cost": {
+            "currency": "USD",
+            "estimated": true,
+            "monetary_basis": "estimated_from_provider_reported_usage_and_manifest_rates",
+            "pricing_entry_id": "example-frontier-api",
+            "pricing_entry_sha256": "337697c524f506936ea43c9f97aa5dd8e464575e72e4148857d9739180e5af69",
+            "rates_are_illustrative": true,
+            "total_amount": 0.004044,
+            "cost_per_case": 0.002022,
+            "cost_per_correct_case": 0.002022,
+            "correct_cases_per_currency_unit": 494.5598417408507,
+            "reasons": [
+              "run frontier-2k-1: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+              "run frontier-2k-2: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred"
+            ]
+          },
+          "mean_peak_memory_bytes": null,
+          "max_peak_memory_bytes": null,
+          "missing_evidence": [
+            "peak memory is a local-only measurement and is not available for a system executed by a hosted provider"
+          ]
+        },
+        {
+          "system_key": {
+            "model_id": "example-local/qwen3-8b",
+            "model_revision": null,
+            "provider": null,
+            "runtime_name": "mlx-lm",
+            "runtime_backend": "Metal",
+            "accelerator": "Apple M5 Pro",
+            "quantization": "Q4",
+            "reasoning_effort": null,
+            "decode_mode": "autoregressive",
+            "endpoint": null,
+            "thinking_type": null,
+            "execution_config_hash": "cfg-hash",
+            "is_local": true
+          },
+          "system_label": "example-local/qwen3-8b via Apple M5 Pro [mlx-lm/Metal] quant=Q4 reasoning=unrecorded decode=autoregressive",
+          "rank": 3,
+          "run_ids": [
+            "local-qwen3-8b-2k-1",
+            "local-qwen3-8b-2k-2"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/local-qwen3-8b-2k-1/verification.json",
+            "artifacts/example-results/runs/local-qwen3-8b-2k-2/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/local-qwen3-8b-2k-1/final_record.json",
+            "artifacts/example-results/runs/local-qwen3-8b-2k-2/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 8100.0,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_total_latency_ms": 8100.0,
+          "p50_total_latency_ms": 8100.0,
+          "p95_total_latency_ms": 8300.0,
+          "stdev_total_latency_ms": 200.0,
+          "coefficient_of_variation": 0.024691358024691357,
+          "correct_cases_per_minute": 7.407407407407408,
+          "mean_ttft_ms": 315.0,
+          "ttft_basis": "local_prefill",
+          "usage": null,
+          "cost": null,
+          "mean_peak_memory_bytes": 9663676416.0,
+          "max_peak_memory_bytes": 9663676416.0,
+          "missing_evidence": [
+            "the pricing manifest has no entry for provider None model 'example-local/qwen3-8b'; no cost is estimated for this system"
+          ]
+        }
+      ],
+      "rejected": [
+        {
+          "system_key": {
+            "model_id": "example-flash-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "none",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "flash-nothink-cfg",
+            "is_local": false
+          },
+          "system_label": "example-flash-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=none decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "run_ids": [
+            "flash-nothink-2k-1",
+            "flash-nothink-2k-2"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/flash-nothink-2k-1/verification.json",
+            "artifacts/example-results/runs/flash-nothink-2k-2/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/flash-nothink-2k-1/final_record.json",
+            "artifacts/example-results/runs/flash-nothink-2k-2/final_record.json"
+          ],
+          "reasons": [
+            "pass rate 0.0 is below the required minimum 0.75",
+            "mean quality_score 0.2500 is below the required minimum 0.75"
+          ]
+        }
+      ],
+      "frontier_axes": [
+        "max_pass_rate",
+        "max_correct_cases_per_minute",
+        "min_mean_total_latency_ms"
+      ],
+      "frontier": [
+        {
+          "system_key": {
+            "model_id": "example-flash-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "low",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "flash-cfg",
+            "is_local": false
+          },
+          "system_label": "example-flash-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=low decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "dominated": false,
+          "dominated_by": []
+        },
+        {
+          "system_key": {
+            "model_id": "example-frontier-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "high",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "frontier-cfg",
+            "is_local": false
+          },
+          "system_label": "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "dominated": false,
+          "dominated_by": []
+        },
+        {
+          "system_key": {
+            "model_id": "example-local/qwen3-8b",
+            "model_revision": null,
+            "provider": null,
+            "runtime_name": "mlx-lm",
+            "runtime_backend": "Metal",
+            "accelerator": "Apple M5 Pro",
+            "quantization": "Q4",
+            "reasoning_effort": null,
+            "decode_mode": "autoregressive",
+            "endpoint": null,
+            "thinking_type": null,
+            "execution_config_hash": "cfg-hash",
+            "is_local": true
+          },
+          "system_label": "example-local/qwen3-8b via Apple M5 Pro [mlx-lm/Metal] quant=Q4 reasoning=unrecorded decode=autoregressive",
+          "dominated": true,
+          "dominated_by": [
+            "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions"
+          ]
+        }
+      ],
+      "missing_evidence": [
+        "frontier axes min_cost_per_correct_case were dropped because at least one ranked system has no evidence for them"
+      ]
+    },
+    {
+      "comparable_unit_key": {
+        "workload_id": "structured-json-profile-extraction",
+        "workload_version": "1",
+        "workload_prompt_hash": "sha256:synthetic-prompt-32k",
+        "context_tier": "32k",
+        "quality_metric": "structured_json_exact_field_match",
+        "max_output_tokens": 512,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "request_shape": null
+      },
+      "comparable_unit_label": "structured-json-profile-extraction@v1 [32k] evaluator=structured_json_exact_field_match max_output=512 temperature=0 top_p=1",
+      "outcome": "recommended",
+      "objective_name": "min_mean_total_latency_ms",
+      "recommended": {
+        "system_key": {
+          "model_id": "example-frontier-model",
+          "model_revision": null,
+          "provider": "example-provider",
+          "runtime_name": "openai-compatible-stream",
+          "runtime_backend": null,
+          "accelerator": null,
+          "quantization": null,
+          "reasoning_effort": "high",
+          "decode_mode": "autoregressive",
+          "endpoint": "https://example.invalid/v1/chat/completions",
+          "thinking_type": null,
+          "execution_config_hash": "frontier-cfg",
+          "is_local": false
+        },
+        "system_label": "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+        "rank": 1,
+        "run_ids": [
+          "frontier-32k-1",
+          "frontier-32k-2"
+        ],
+        "verification_paths": [
+          "artifacts/example-results/runs/frontier-32k-1/verification.json",
+          "artifacts/example-results/runs/frontier-32k-2/verification.json"
+        ],
+        "record_paths": [
+          "artifacts/example-results/runs/frontier-32k-1/final_record.json",
+          "artifacts/example-results/runs/frontier-32k-2/final_record.json"
+        ],
+        "evidence_count": 2,
+        "objective_name": "min_mean_total_latency_ms",
+        "objective_value": 6250.0,
+        "pass_rate": 1.0,
+        "mean_quality_score": 1.0,
+        "quality_metric": "structured_json_exact_field_match",
+        "mean_total_latency_ms": 6250.0,
+        "p50_total_latency_ms": 6250.0,
+        "p95_total_latency_ms": 6400.0,
+        "stdev_total_latency_ms": 150.0,
+        "coefficient_of_variation": 0.024,
+        "correct_cases_per_minute": 9.6,
+        "mean_ttft_ms": 640.0,
+        "ttft_basis": "client_observed_stream",
+        "usage": {
+          "provenance": "provider_reported",
+          "runs_reporting_usage": 2,
+          "runs_total": 2,
+          "complete": true,
+          "input_tokens": 62000,
+          "output_tokens": 1040,
+          "cached_input_tokens": 16000,
+          "reasoning_tokens": null
+        },
+        "cost": {
+          "currency": "USD",
+          "estimated": true,
+          "monetary_basis": "estimated_from_provider_reported_usage_and_manifest_rates",
+          "pricing_entry_id": "example-frontier-api",
+          "pricing_entry_sha256": "337697c524f506936ea43c9f97aa5dd8e464575e72e4148857d9739180e5af69",
+          "rates_are_illustrative": true,
+          "total_amount": 0.031648,
+          "cost_per_case": 0.015824,
+          "cost_per_correct_case": 0.015824,
+          "correct_cases_per_currency_unit": 63.19514661274014,
+          "reasons": [
+            "run frontier-32k-1: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+            "run frontier-32k-2: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred"
+          ]
+        },
+        "mean_peak_memory_bytes": null,
+        "max_peak_memory_bytes": null,
+        "missing_evidence": [
+          "peak memory is a local-only measurement and is not available for a system executed by a hosted provider"
+        ]
+      },
+      "inconclusive_reason": null,
+      "ranked": [
+        {
+          "system_key": {
+            "model_id": "example-frontier-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "high",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "frontier-cfg",
+            "is_local": false
+          },
+          "system_label": "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "rank": 1,
+          "run_ids": [
+            "frontier-32k-1",
+            "frontier-32k-2"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/frontier-32k-1/verification.json",
+            "artifacts/example-results/runs/frontier-32k-2/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/frontier-32k-1/final_record.json",
+            "artifacts/example-results/runs/frontier-32k-2/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 6250.0,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_total_latency_ms": 6250.0,
+          "p50_total_latency_ms": 6250.0,
+          "p95_total_latency_ms": 6400.0,
+          "stdev_total_latency_ms": 150.0,
+          "coefficient_of_variation": 0.024,
+          "correct_cases_per_minute": 9.6,
+          "mean_ttft_ms": 640.0,
+          "ttft_basis": "client_observed_stream",
+          "usage": {
+            "provenance": "provider_reported",
+            "runs_reporting_usage": 2,
+            "runs_total": 2,
+            "complete": true,
+            "input_tokens": 62000,
+            "output_tokens": 1040,
+            "cached_input_tokens": 16000,
+            "reasoning_tokens": null
+          },
+          "cost": {
+            "currency": "USD",
+            "estimated": true,
+            "monetary_basis": "estimated_from_provider_reported_usage_and_manifest_rates",
+            "pricing_entry_id": "example-frontier-api",
+            "pricing_entry_sha256": "337697c524f506936ea43c9f97aa5dd8e464575e72e4148857d9739180e5af69",
+            "rates_are_illustrative": true,
+            "total_amount": 0.031648,
+            "cost_per_case": 0.015824,
+            "cost_per_correct_case": 0.015824,
+            "correct_cases_per_currency_unit": 63.19514661274014,
+            "reasons": [
+              "run frontier-32k-1: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred",
+              "run frontier-32k-2: provider did not report reasoning token usage; completion tokens are billed at the output rate and no hidden reasoning cost is inferred"
+            ]
+          },
+          "mean_peak_memory_bytes": null,
+          "max_peak_memory_bytes": null,
+          "missing_evidence": [
+            "peak memory is a local-only measurement and is not available for a system executed by a hosted provider"
+          ]
+        },
+        {
+          "system_key": {
+            "model_id": "example-local/qwen3-8b",
+            "model_revision": null,
+            "provider": null,
+            "runtime_name": "mlx-lm",
+            "runtime_backend": "Metal",
+            "accelerator": "Apple M5 Pro",
+            "quantization": "Q4",
+            "reasoning_effort": null,
+            "decode_mode": "autoregressive",
+            "endpoint": null,
+            "thinking_type": null,
+            "execution_config_hash": "cfg-hash",
+            "is_local": true
+          },
+          "system_label": "example-local/qwen3-8b via Apple M5 Pro [mlx-lm/Metal] quant=Q4 reasoning=unrecorded decode=autoregressive",
+          "rank": 2,
+          "run_ids": [
+            "local-qwen3-8b-32k-1",
+            "local-qwen3-8b-32k-2"
+          ],
+          "verification_paths": [
+            "artifacts/example-results/runs/local-qwen3-8b-32k-1/verification.json",
+            "artifacts/example-results/runs/local-qwen3-8b-32k-2/verification.json"
+          ],
+          "record_paths": [
+            "artifacts/example-results/runs/local-qwen3-8b-32k-1/final_record.json",
+            "artifacts/example-results/runs/local-qwen3-8b-32k-2/final_record.json"
+          ],
+          "evidence_count": 2,
+          "objective_name": "min_mean_total_latency_ms",
+          "objective_value": 21700.0,
+          "pass_rate": 1.0,
+          "mean_quality_score": 1.0,
+          "quality_metric": "structured_json_exact_field_match",
+          "mean_total_latency_ms": 21700.0,
+          "p50_total_latency_ms": 21700.0,
+          "p95_total_latency_ms": 22400.0,
+          "stdev_total_latency_ms": 700.0,
+          "coefficient_of_variation": 0.03225806451612903,
+          "correct_cases_per_minute": 2.7649769585253456,
+          "mean_ttft_ms": 2100.0,
+          "ttft_basis": "local_prefill",
+          "usage": null,
+          "cost": null,
+          "mean_peak_memory_bytes": 13958643712.0,
+          "max_peak_memory_bytes": 13958643712.0,
+          "missing_evidence": [
+            "the pricing manifest has no entry for provider None model 'example-local/qwen3-8b'; no cost is estimated for this system"
+          ]
+        }
+      ],
+      "rejected": [],
+      "frontier_axes": [
+        "max_pass_rate",
+        "max_correct_cases_per_minute",
+        "min_mean_total_latency_ms"
+      ],
+      "frontier": [
+        {
+          "system_key": {
+            "model_id": "example-frontier-model",
+            "model_revision": null,
+            "provider": "example-provider",
+            "runtime_name": "openai-compatible-stream",
+            "runtime_backend": null,
+            "accelerator": null,
+            "quantization": null,
+            "reasoning_effort": "high",
+            "decode_mode": "autoregressive",
+            "endpoint": "https://example.invalid/v1/chat/completions",
+            "thinking_type": null,
+            "execution_config_hash": "frontier-cfg",
+            "is_local": false
+          },
+          "system_label": "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions",
+          "dominated": false,
+          "dominated_by": []
+        },
+        {
+          "system_key": {
+            "model_id": "example-local/qwen3-8b",
+            "model_revision": null,
+            "provider": null,
+            "runtime_name": "mlx-lm",
+            "runtime_backend": "Metal",
+            "accelerator": "Apple M5 Pro",
+            "quantization": "Q4",
+            "reasoning_effort": null,
+            "decode_mode": "autoregressive",
+            "endpoint": null,
+            "thinking_type": null,
+            "execution_config_hash": "cfg-hash",
+            "is_local": true
+          },
+          "system_label": "example-local/qwen3-8b via Apple M5 Pro [mlx-lm/Metal] quant=Q4 reasoning=unrecorded decode=autoregressive",
+          "dominated": true,
+          "dominated_by": [
+            "example-frontier-model via example-provider [openai-compatible-stream/unknown] quant=unrecorded reasoning=high decode=autoregressive endpoint=https://example.invalid/v1/chat/completions"
+          ]
+        }
+      ],
+      "missing_evidence": [
+        "frontier axes min_cost_per_correct_case were dropped because at least one ranked system has no evidence for them"
+      ]
+    }
+  ],
+  "excluded_runs": [
+    {
+      "run_id": "interrupted-run",
+      "source_results_dir": "artifacts/example-results",
+      "reason": "final_record.json failed schema validation: Invalid JSON for ExperimentRecord (the artifact set was interrupted mid-write)"
+    }
+  ]
+}

--- a/examples/optimizer/pricing-manifest-illustrative.json
+++ b/examples/optimizer/pricing-manifest-illustrative.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "1",
+  "name": "illustrative-example-rates",
+  "description": "ILLUSTRATIVE EXAMPLE RATES. Every number below is invented to demonstrate the cost arithmetic on real provider-reported usage. None of it is a published price, none of it was fetched from a provider, and none of it should be used to budget anything. Replace this file with rates you have sourced yourself, set `rates_are_illustrative` to false, and put the page you took them from in `source` with the date in `effective_at`.",
+  "currency": "USD",
+  "entries": [
+    {
+      "entry_id": "example-frontier-api",
+      "provider": "example-provider",
+      "model_id": "example-frontier-model",
+      "model_revision": null,
+      "currency": "USD",
+      "effective_at": "2026-01-01",
+      "source": "illustrative example, not a published price list",
+      "rates_are_illustrative": true,
+      "input_per_million": 0.6,
+      "output_per_million": 2.2,
+      "cached_input_per_million": 0.11,
+      "reasoning_per_million": null,
+      "notes": "No separate reasoning rate is declared, so reasoning tokens are billed at the output rate, which is the usual OpenAI-compatible behaviour."
+    },
+    {
+      "entry_id": "example-flash-api",
+      "provider": "example-provider",
+      "model_id": "example-flash-model",
+      "model_revision": null,
+      "currency": "USD",
+      "effective_at": "2026-01-01",
+      "source": "illustrative example, not a published price list",
+      "rates_are_illustrative": true,
+      "input_per_million": 0.1,
+      "output_per_million": 0.3,
+      "cached_input_per_million": 0.02,
+      "reasoning_per_million": null,
+      "notes": null
+    }
+  ]
+}

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -19,6 +19,11 @@ Subcommands:
                      verified configuration for a workload/hardware target.
     tune-report      Render a `tune` JSON report as a self-contained, portable
                      HTML file for offline inspection (no Streamlit needed).
+    compare          Offline cross-system comparison of already-collected
+                     evidence (local MLX vs hosted APIs), stratified by
+                     comparable unit and priced from an explicit manifest.
+    compare-report   Render a `compare` JSON report as a self-contained,
+                     portable HTML file.
     optimize         End-to-end: execute selected matrix rows, tune the
                      resulting evidence, and render the JSON/HTML report,
                      composing the above primitives without duplicating any
@@ -67,6 +72,16 @@ from .collectors.openai_api import (
     collect_openai_stream,
     redact_text_for_dry_run,
 )
+from .compare.compare import compare
+from .compare.evidence import CompareEvidenceError
+from .compare.explain import format_compare_report_text
+from .compare.policy import ComparePolicy, ComparePolicyError
+from .compare.pricing import PricingError, PricingManifest
+from .compare.report import (
+    CompareReport,
+    CompareReportValidationError,
+)
+from .compare.report_html import render_compare_report_html
 from .doctor.speculative import diagnose_speculative_regression
 from .instruments import (
     METAL_SYSTEM_TRACE_TEMPLATE,
@@ -1260,6 +1275,126 @@ def _cmd_tune_report(args: argparse.Namespace) -> int:
         print(
             "Local artifact paths were redacted to basenames/stable labels; "
             "rerun with --include-paths to include full paths."
+        )
+    return 0
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    try:
+        policy = ComparePolicy.from_file(args.policy)
+    except (OSError, UnicodeError, ComparePolicyError) as exc:
+        print(f"Invalid compare policy: {exc}", file=sys.stderr)
+        return 1
+
+    pricing: PricingManifest | None = None
+    pricing_path: str | None = None
+    if args.pricing:
+        try:
+            pricing = PricingManifest.from_file(args.pricing)
+        except (OSError, UnicodeError, PricingError) as exc:
+            print(f"Invalid pricing manifest: {exc}", file=sys.stderr)
+            return 1
+        pricing_path = str(args.pricing)
+
+    # A tune report is published under "Corroborating tune reports" in the
+    # provenance section, so an unreadable or malformed one would assert
+    # corroboration that does not exist. It is validated for the same reason
+    # the pricing manifest is hashed: provenance has to be true. Nothing from
+    # it is merged into the comparison.
+    for raw_tune_report in args.tune_report or ():
+        tune_report_path = Path(raw_tune_report)
+        try:
+            TuneReport.read_json(tune_report_path)
+        except (OSError, UnicodeError) as exc:
+            print(
+                f"Could not read tune report {tune_report_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        except TuneReportValidationError as exc:
+            print(
+                f"Invalid tune report in {tune_report_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        report = compare(
+            results_dirs=tuple(Path(path) for path in args.results),
+            policy=policy,
+            pricing=pricing,
+            pricing_manifest_path=pricing_path,
+            tune_report_paths=tuple(args.tune_report or ()),
+        )
+    except CompareEvidenceError as exc:
+        print(f"Invalid comparison input: {exc}", file=sys.stderr)
+        return 1
+
+    print(format_compare_report_text(report, verbose=args.explain))
+
+    if args.output:
+        output_path = Path(args.output)
+        try:
+            atomic_write_text(output_path, report.to_json() + "\n")
+        except OSError as exc:
+            # The comparison already succeeded; losing all of it behind a
+            # stack trace because the destination is unwritable is the one
+            # failure here that costs the user real work.
+            print(
+                f"Could not write compare report JSON to {output_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"\nCompare report written to {args.output}")
+
+    if not report.strata:
+        print(
+            "\nNo comparable units were found across the given results " "directories.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0 if report.has_recommendation else 2
+
+
+def _cmd_compare_report(args: argparse.Namespace) -> int:
+    input_path = Path(args.input)
+    try:
+        report = CompareReport.read_json(input_path)
+    except (OSError, UnicodeError) as exc:
+        print(
+            f"Could not read compare report input {input_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except CompareReportValidationError as exc:
+        print(f"Invalid compare report in {input_path}: {exc}", file=sys.stderr)
+        return 1
+
+    html_document = render_compare_report_html(
+        report, redact_paths=not args.include_paths
+    )
+    output_path = Path(args.output)
+    try:
+        atomic_write_text(output_path, html_document)
+    except OSError as exc:
+        print(
+            f"Could not write compare report HTML to {output_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Compare report HTML written to {output_path}")
+    if args.include_paths:
+        print("Full local artifact paths are included (--include-paths was set).")
+    else:
+        print(
+            "Local artifact paths were redacted to basenames/stable labels; "
+            "rerun with --include-paths to include full paths."
+        )
+    if report.pricing is not None and report.pricing.rates_are_illustrative:
+        print(
+            "The pricing manifest declares illustrative rates, so every "
+            "monetary figure in the report is an example, not a price."
         )
     return 0
 
@@ -3137,6 +3272,94 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     tune_report_parser.set_defaults(func=_cmd_tune_report)
+
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help=(
+            "Offline cross-system comparison of already-collected evidence "
+            "(for example a local MLX model against hosted API models). Reads "
+            "`workloads run --output-dir` results directories; never loads a "
+            "model, calls an API, or executes a benchmark. Systems are only "
+            "compared within a comparable unit: identical workload, version, "
+            "prompt hash, context tier, evaluator, output cap and sampling."
+        ),
+    )
+    compare_parser.add_argument(
+        "--results",
+        nargs="+",
+        required=True,
+        help="One or more `workloads run --output-dir` results directories",
+    )
+    compare_parser.add_argument(
+        "--policy",
+        required=True,
+        help=(
+            "Path to a compare policy JSON/YAML file (one objective plus the "
+            "constraints a system must clear before it is ranked)"
+        ),
+    )
+    compare_parser.add_argument(
+        "--pricing",
+        default=None,
+        help=(
+            "Path to a versioned pricing manifest JSON/YAML file. Required for "
+            "any cost objective. Without it the report contains no monetary "
+            "values at all rather than guessed ones."
+        ),
+    )
+    compare_parser.add_argument(
+        "--tune-report",
+        nargs="+",
+        default=None,
+        help=(
+            "Optional paths to `tune --output` reports to record as "
+            "corroborating evidence in the report's provenance. They are "
+            "recorded, never merged into the comparison."
+        ),
+    )
+    compare_parser.add_argument(
+        "--output",
+        default=None,
+        help="Atomically write the full compare report JSON to this path",
+    )
+    compare_parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Print every ranked system, every dominated frontier entry and "
+            "every rejection reason (default: a concise summary)"
+        ),
+    )
+    compare_parser.set_defaults(func=_cmd_compare)
+
+    compare_report_parser = subparsers.add_parser(
+        "compare-report",
+        help=(
+            "Render a `compare` JSON report as a single, self-contained, "
+            "portable HTML file (inline CSS, no JavaScript, no CDN, works "
+            "offline). Never re-scores or re-computes anything."
+        ),
+    )
+    compare_report_parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to a `compare --output` JSON report",
+    )
+    compare_report_parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to atomically write the rendered HTML report to",
+    )
+    compare_report_parser.add_argument(
+        "--include-paths",
+        action="store_true",
+        help=(
+            "Include full local artifact paths as plain text. Default: redact "
+            "every path to a basename/stable `runs/<run_id>/<file>` label so "
+            "the report is safe to share."
+        ),
+    )
+    compare_report_parser.set_defaults(func=_cmd_compare_report)
 
     optimize_parser = subparsers.add_parser(
         "optimize",

--- a/llmtracefx/optimizer/compare/__init__.py
+++ b/llmtracefx/optimizer/compare/__init__.py
@@ -1,0 +1,121 @@
+"""Offline, scientifically honest comparison of systems that ran the same task.
+
+The tuner answers "which configuration of this model on this machine is
+fastest". This package answers the different question "how do a local model,
+a frontier API and a cheap fast API actually compare on work they have both
+already done", using only evidence that was already collected.
+
+Nothing in here loads a model, calls an API, deploys anything, or executes a
+benchmark. It reads ``workloads run`` results directories and produces a
+versioned JSON report plus a self-contained branded HTML rendering of it.
+
+The invariants are the point:
+
+* Two runs are only ever compared when they share a ``ComparableUnitKey``:
+  identical workload, version, prompt hash, context tier, evaluator, output
+  cap and sampling. Different identities become different strata.
+* Systems keep their labels (model/revision, provider, runtime/backend,
+  accelerator, quantization, reasoning effort, decode mode) and unlike
+  systems are never averaged together.
+* A measurement that was not recorded stays unavailable. It never becomes
+  zero, and it never quietly disqualifies the axis it belongs to.
+* Money is derived from provider-reported usage and an explicit versioned
+  pricing manifest, is labeled estimated everywhere, and is refused outright
+  when the manifest is ambiguous or the usage needed for it is missing.
+* Ranking is constraints-first and single-objective. Ties and noise produce
+  an explicit inconclusive verdict rather than a coin flip, and the frontier
+  is published so no single universal winner is ever implied.
+"""
+
+from __future__ import annotations
+
+from .compare import FRONTIER_AXES, compare
+from .cost import (
+    MONETARY_BASIS,
+    CostBreakdown,
+    TokenUsage,
+    correct_cases_per_currency_unit,
+    cost_per_case,
+    estimate_run_cost,
+)
+from .evidence import (
+    ApiEvidence,
+    ApiEvidenceError,
+    CompareEvidenceError,
+    DecodeSettings,
+    SystemRun,
+    load_comparison_evidence,
+)
+from .identity import ComparableUnitKey, CompareIdentityError, SystemKey
+from .policy import (
+    COMPARE_POLICY_SCHEMA_VERSION,
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+    ComparePolicyError,
+)
+from .pricing import (
+    PRICING_MANIFEST_SCHEMA_VERSION,
+    PricingEntry,
+    PricingError,
+    PricingManifest,
+)
+from .report import (
+    COMPARE_REPORT_SCHEMA_VERSION,
+    CompareReport,
+    CompareReportValidationError,
+    CostSummary,
+    FrontierEntry,
+    ParetoAxis,
+    PricingProvenance,
+    RejectedSystemReport,
+    StratumOutcome,
+    StratumReport,
+    SystemReport,
+    TtftBasis,
+    UsageTotals,
+)
+from .report_html import render_compare_report_html
+
+__all__ = [
+    "COMPARE_POLICY_SCHEMA_VERSION",
+    "COMPARE_REPORT_SCHEMA_VERSION",
+    "FRONTIER_AXES",
+    "MONETARY_BASIS",
+    "PRICING_MANIFEST_SCHEMA_VERSION",
+    "ApiEvidence",
+    "ApiEvidenceError",
+    "ComparableUnitKey",
+    "CompareConstraints",
+    "CompareEvidenceError",
+    "CompareIdentityError",
+    "CompareObjective",
+    "ComparePolicy",
+    "ComparePolicyError",
+    "CompareReport",
+    "CompareReportValidationError",
+    "CostBreakdown",
+    "CostSummary",
+    "DecodeSettings",
+    "FrontierEntry",
+    "ParetoAxis",
+    "PricingEntry",
+    "PricingError",
+    "PricingManifest",
+    "PricingProvenance",
+    "RejectedSystemReport",
+    "StratumOutcome",
+    "StratumReport",
+    "SystemKey",
+    "SystemReport",
+    "SystemRun",
+    "TokenUsage",
+    "TtftBasis",
+    "UsageTotals",
+    "compare",
+    "correct_cases_per_currency_unit",
+    "cost_per_case",
+    "estimate_run_cost",
+    "load_comparison_evidence",
+    "render_compare_report_html",
+]

--- a/llmtracefx/optimizer/compare/compare.py
+++ b/llmtracefx/optimizer/compare/compare.py
@@ -1,0 +1,1064 @@
+"""Constraint evaluation, single-objective ranking and frontier for ``compare``.
+
+Given already loaded, identity-checked cross-system evidence
+(``evidence.load_comparison_evidence``), this module:
+
+1. Splits runs into comparable units (``identity.ComparableUnitKey``) and,
+   within each unit, into systems (``identity.SystemKey``). Two runs that do
+   not share a unit are never placed side by side, and two runs that do not
+   share a system are never averaged together.
+2. Evaluates every system against the policy's constraints, collecting
+   *every* violation rather than stopping at the first.
+3. Ranks the systems that cleared every constraint by exactly one configured
+   objective, with deterministic tie-breaking, and declares the unit
+   inconclusive when nothing survives or the leaders cannot be told apart
+   from measurement noise.
+4. Places every ranked system on a Pareto-style evidence frontier, so the
+   report can show the trade-off instead of claiming a universal winner.
+
+Formulas are reused, not restated. ``pass_rate`` and
+``correct_cases_per_minute`` are imported from ``workloads.aggregate`` (the
+same functions the tuner uses), mean/population-stdev/coefficient-of-
+variation follow ``tune.tuner`` exactly, the median/p95 pair uses the same
+definitions the API collector already uses for its latency distribution
+(``statistics.median`` and nearest rank), and the tie-versus-noise test
+mirrors ``tune.tuner``'s: a gap smaller than the two leaders' combined noise
+band is not a difference.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..schema import Measurement, MetricProvenance, utc_now_iso
+from ..workloads.aggregate import correct_cases_per_minute, pass_rate
+from ..workloads.verify import RowStatus
+from .cost import (
+    CostBreakdown,
+    TokenUsage,
+    correct_cases_per_currency_unit,
+    cost_per_case,
+    estimate_run_cost,
+)
+from .evidence import (
+    CompareEvidenceError,
+    SystemRun,
+    load_comparison_evidence,
+)
+from .identity import ComparableUnitKey, SystemKey
+from .policy import CompareConstraints, CompareObjective, ComparePolicy
+from .pricing import PricingEntry, PricingError, PricingManifest
+from .report import (
+    COMPARE_REPORT_SCHEMA_VERSION,
+    CompareReport,
+    CostSummary,
+    FrontierEntry,
+    ParetoAxis,
+    PricingProvenance,
+    RejectedSystemReport,
+    StratumOutcome,
+    StratumReport,
+    SystemReport,
+    TtftBasis,
+    UsageTotals,
+)
+
+#: The frontier axes, in reading order. Only the axes every ranked system in
+#: a unit has evidence for are used; the rest are dropped from that unit's
+#: frontier and named in ``missing_evidence`` rather than filled in.
+FRONTIER_AXES: tuple[ParetoAxis, ...] = (
+    ParetoAxis.MAX_PASS_RATE,
+    ParetoAxis.MAX_CORRECT_CASES_PER_MINUTE,
+    ParetoAxis.MIN_MEAN_TOTAL_LATENCY_MS,
+    ParetoAxis.MIN_COST_PER_CORRECT_CASE,
+)
+
+
+def _percentiles(values: Sequence[float]) -> tuple[float | None, float | None]:
+    """Median and nearest-rank p95, matching the API collector's definitions."""
+    if not values:
+        return None, None
+    ordered = sorted(values)
+    rank = max(1, -(-95 * len(ordered) // 100))
+    # The median of an even-length list is ``(a + b) / 2`` in float, which
+    # overflows to ``inf`` for two large-but-finite timings. Filtering the
+    # inputs for finiteness therefore does not make the median finite, and an
+    # infinite p50 is not a measurement: it prints as "p50 inf ms" and makes
+    # ``to_json`` raise, since the report is written with ``allow_nan=False``.
+    # Every other statistic here is already routed through this filter.
+    return (
+        _finite_or_none(float(statistics.median(ordered))),
+        _finite_or_none(ordered[rank - 1]),
+    )
+
+
+def _finite_or_none(value: float | None) -> float | None:
+    if value is None or not math.isfinite(value):
+        return None
+    return value
+
+
+def _provenance_allowed(
+    measurement: Measurement, allowed: frozenset[MetricProvenance] | None
+) -> bool:
+    return allowed is None or measurement.provenance in allowed
+
+
+@dataclass(frozen=True)
+class _SystemEvaluation:
+    """Internal, pre-ranking evaluation of one system within a unit."""
+
+    system_key: SystemKey
+    runs: tuple[SystemRun, ...]
+    eligible_runs: tuple[SystemRun, ...]
+    timed_runs: tuple[SystemRun, ...]
+    accepted: bool
+    reasons: tuple[str, ...]
+    missing_evidence: tuple[str, ...]
+    objective_value: float | None
+    pass_rate: float | None
+    mean_quality_score: float | None
+    quality_metric: str | None
+    mean_total_latency_ms: float | None
+    p50_total_latency_ms: float | None
+    p95_total_latency_ms: float | None
+    stdev_total_latency_ms: float | None
+    coefficient_of_variation: float | None
+    throughput_coefficient_of_variation: float | None
+    correct_cases_per_minute: float | None
+    mean_ttft_ms: float | None
+    ttft_basis: TtftBasis | None
+    usage: UsageTotals | None
+    cost: CostSummary | None
+    cost_per_correct_case: float | None
+    cost_dispersion: float | None
+    mean_run_cost: float | None
+    correct_cases: int
+    mean_peak_memory_bytes: float | None
+    max_peak_memory_bytes: float | None
+
+
+def _collect_ttft(
+    runs: Sequence[SystemRun],
+) -> tuple[float | None, TtftBasis | None, list[str]]:
+    """Mean time-to-first-token, with the measurement it actually is.
+
+    A local prefill and a hosted API's client-observed first-token offset are
+    different quantities. If one system somehow produced both, neither is
+    reported: averaging them would publish a number that is not a
+    measurement of anything.
+    """
+    missing: list[str] = []
+    samples: dict[TtftBasis, list[float]] = defaultdict(list)
+    for run in runs:
+        if run.api_evidence is not None:
+            value = run.api_evidence.client_ttft_ms
+            if value is not None:
+                samples[TtftBasis.CLIENT_OBSERVED_STREAM].append(value)
+                continue
+        else:
+            value = run.local_prefill_ms
+            if value is not None:
+                samples[TtftBasis.LOCAL_PREFILL].append(value)
+                continue
+        missing.append(f"run {run.run_id}: no time-to-first-token was recorded")
+
+    if not samples:
+        return None, None, missing
+    if len(samples) > 1:
+        missing.append(
+            "runs mix a local prefill measurement with a client-observed "
+            "stream offset; these are different quantities and are not "
+            "averaged, so no time-to-first-token is reported"
+        )
+        return None, None, missing
+    basis, values = next(iter(samples.items()))
+    return _finite_or_none(statistics.mean(values)), basis, missing
+
+
+def _collect_usage(runs: Sequence[SystemRun]) -> UsageTotals | None:
+    """Sum provider-reported usage across runs, or ``None`` if none reported.
+
+    A total is only produced when *every* run in the set reports that
+    component. Summing across the subset that happened to report would emit a
+    number smaller than the real total while still labelling it
+    ``input_tokens``, and any cost or ratio derived from it would understate
+    the truth by however many runs were silently skipped. Partial knowledge
+    is reported as no total, with the shortfall visible in
+    ``runs_reporting_usage`` versus ``runs_total``.
+    """
+    reporting = [
+        run
+        for run in runs
+        if run.api_evidence is not None and run.api_evidence.usage_reported
+    ]
+    if not reporting:
+        return None
+
+    def total(field: str) -> int | None:
+        values = [
+            (
+                None
+                if run.api_evidence is None or not run.api_evidence.usage_reported
+                else getattr(run.api_evidence.usage, field)
+            )
+            for run in runs
+        ]
+        # A single unreported component makes the total unknowable, not
+        # smaller: it stays null rather than summing the rest.
+        if any(value is None for value in values):
+            return None
+        return sum(int(value) for value in values if value is not None)
+
+    return UsageTotals(
+        runs_reporting_usage=len(reporting),
+        runs_total=len(runs),
+        input_tokens=total("prompt_tokens"),
+        output_tokens=total("completion_tokens"),
+        cached_input_tokens=total("cached_prompt_tokens"),
+        reasoning_tokens=total("reasoning_tokens"),
+    )
+
+
+def _collect_cost(
+    runs: Sequence[SystemRun],
+    *,
+    entry: PricingEntry,
+    correct_cases: int,
+) -> tuple[CostSummary, float | None, tuple[float, ...]]:
+    """Total, per-case and per-correct-case cost for one system's runs.
+
+    Also returns the per-run amounts. Those are the only dispersion this
+    module has in monetary units, and a cost objective must not borrow the
+    latency coefficient of variation to decide whether two systems are
+    distinguishable on price.
+    """
+    reasons: list[str] = []
+    breakdowns: list[CostBreakdown] = []
+    for run in runs:
+        if run.api_evidence is None or not run.api_evidence.usage_reported:
+            reasons.append(
+                f"run {run.run_id}: no provider-reported usage, so its cost "
+                "cannot be estimated"
+            )
+            continue
+        breakdown = estimate_run_cost(run.api_evidence.usage, entry)
+        breakdowns.append(breakdown)
+        reasons.extend(f"run {run.run_id}: {reason}" for reason in breakdown.reasons)
+
+    complete = len(breakdowns) == len(runs) and all(
+        breakdown.available for breakdown in breakdowns
+    )
+    total: float | None = None
+    if complete and breakdowns:
+        total = sum(breakdown.amount or 0.0 for breakdown in breakdowns)
+        total = _finite_or_none(total)
+        if total is None:  # pragma: no cover - defensive
+            reasons.append("summed cost is not a finite number")
+    elif breakdowns:
+        reasons.append(
+            "at least one run could not be priced, so no total is reported; a "
+            "partial total would understate the real spend"
+        )
+
+    per_case = cost_per_case(total, len(runs))
+    per_correct = cost_per_case(total, correct_cases)
+    if total is not None and correct_cases == 0:
+        reasons.append(
+            "no run passed, so cost per correct case is undefined rather than "
+            "zero or infinite"
+        )
+    summary = CostSummary(
+        currency=entry.currency,
+        pricing_entry_id=entry.entry_id,
+        pricing_entry_sha256=entry.content_sha256,
+        rates_are_illustrative=entry.rates_are_illustrative,
+        total_amount=total,
+        cost_per_case=per_case,
+        cost_per_correct_case=per_correct,
+        correct_cases_per_currency_unit=correct_cases_per_currency_unit(
+            correct_cases, total
+        ),
+        reasons=tuple(dict.fromkeys(reasons)),
+    )
+    per_run_amounts = tuple(
+        breakdown.amount for breakdown in breakdowns if breakdown.amount is not None
+    )
+    return summary, per_correct, per_run_amounts
+
+
+def _evaluate_system(
+    system_key: SystemKey,
+    runs: Sequence[SystemRun],
+    *,
+    constraints: CompareConstraints,
+    objective: CompareObjective,
+    pricing: PricingManifest | None,
+) -> _SystemEvaluation:
+    reasons: list[str] = []
+    missing: list[str] = []
+
+    eligible = [
+        run for run in runs if run.verification.status in constraints.required_statuses
+    ]
+    for run in runs:
+        if run.verification.status not in constraints.required_statuses:
+            reasons.append(
+                f"run {run.run_id}: status '{run.verification.status.value}' is "
+                "not one of the required statuses "
+                f"{sorted(s.value for s in constraints.required_statuses)}"
+            )
+
+    if not eligible:
+        return _SystemEvaluation(
+            system_key=system_key,
+            runs=tuple(runs),
+            eligible_runs=(),
+            timed_runs=(),
+            accepted=False,
+            reasons=tuple(reasons),
+            missing_evidence=tuple(missing),
+            objective_value=None,
+            pass_rate=None,
+            mean_quality_score=None,
+            quality_metric=None,
+            mean_total_latency_ms=None,
+            p50_total_latency_ms=None,
+            p95_total_latency_ms=None,
+            stdev_total_latency_ms=None,
+            coefficient_of_variation=None,
+            throughput_coefficient_of_variation=None,
+            correct_cases_per_minute=None,
+            mean_ttft_ms=None,
+            ttft_basis=None,
+            usage=None,
+            cost=None,
+            cost_per_correct_case=None,
+            cost_dispersion=None,
+            mean_run_cost=None,
+            correct_cases=0,
+            mean_peak_memory_bytes=None,
+            max_peak_memory_bytes=None,
+        )
+
+    # --- Correctness -----------------------------------------------------
+    successes = [run for run in eligible if run.record.outcome.success]
+    pass_rate_value = pass_rate(len(successes), len(eligible))
+    if constraints.min_pass_rate is not None and (
+        pass_rate_value is None or pass_rate_value < constraints.min_pass_rate
+    ):
+        reasons.append(
+            f"pass rate {pass_rate_value} is below the required minimum "
+            f"{constraints.min_pass_rate}"
+        )
+
+    # --- Quality ---------------------------------------------------------
+    # The evaluator/quality metric is part of the comparable unit key, so
+    # every run here already agrees on it; this only reads the scores.
+    quality_metric = eligible[0].record.outcome.quality_metric
+    if (
+        constraints.required_quality_metric is not None
+        and quality_metric != constraints.required_quality_metric
+    ):
+        reasons.append(
+            f"quality_metric {quality_metric!r} does not match the required "
+            f"quality_metric {constraints.required_quality_metric!r}"
+        )
+    quality_scores: list[float] = []
+    for run in eligible:
+        score = run.record.outcome.quality_score
+        if score is None:
+            if constraints.min_quality_score is not None:
+                reasons.append(
+                    f"run {run.run_id}: missing outcome.quality_score, required "
+                    f"by min_quality_score={constraints.min_quality_score}"
+                )
+            else:
+                missing.append(f"run {run.run_id}: no quality score was recorded")
+            continue
+        if not math.isfinite(score):
+            reasons.append(
+                f"run {run.run_id}: outcome.quality_score is non-finite and unusable"
+            )
+            continue
+        quality_scores.append(score)
+    mean_quality = (
+        _finite_or_none(statistics.mean(quality_scores)) if quality_scores else None
+    )
+    if (
+        constraints.min_quality_score is not None
+        and mean_quality is not None
+        and mean_quality < constraints.min_quality_score
+    ):
+        reasons.append(
+            f"mean quality_score {mean_quality:.4f} is below the required "
+            f"minimum {constraints.min_quality_score}"
+        )
+
+    # --- Latency ---------------------------------------------------------
+    timed: list[tuple[SystemRun, float]] = []
+    for run in eligible:
+        total = run.record.timing.total
+        if total is None:
+            reasons.append(f"run {run.run_id}: missing timing.total measurement")
+            continue
+        value = run.total_ms
+        if value is None:
+            reasons.append(f"run {run.run_id}: timing.total is non-finite and unusable")
+            continue
+        if not _provenance_allowed(total, constraints.allowed_provenances):
+            allowed = constraints.allowed_provenances or frozenset()
+            reasons.append(
+                f"run {run.run_id}: timing.total provenance "
+                f"'{total.provenance.value}' is not in the allowed provenance "
+                f"set {sorted(p.value for p in allowed)}"
+            )
+            continue
+        timed.append((run, value))
+
+    mean_total: float | None = None
+    stdev_total: float | None = None
+    cv: float | None = None
+    p50: float | None = None
+    p95: float | None = None
+    if not timed:
+        reasons.append(
+            "no eligible run has a usable timing.total measurement; latency and "
+            "throughput cannot be computed for this system"
+        )
+    else:
+        totals = [value for _run, value in timed]
+        mean_total = _finite_or_none(statistics.mean(totals))
+        stdev_total = (
+            _finite_or_none(statistics.pstdev(totals)) if len(totals) > 1 else 0.0
+        )
+        p50, p95 = _percentiles(totals)
+        cv = (
+            _finite_or_none(stdev_total / mean_total)
+            if mean_total is not None and stdev_total is not None and mean_total > 0
+            else None
+        )
+        if (
+            len(totals) > 1
+            and constraints.max_coefficient_of_variation is not None
+            and cv is not None
+            and cv > constraints.max_coefficient_of_variation
+        ):
+            reasons.append(
+                f"coefficient of variation {cv:.4f} exceeds the maximum "
+                f"{constraints.max_coefficient_of_variation}"
+            )
+        if (
+            constraints.max_mean_total_latency_ms is not None
+            and mean_total is not None
+            and mean_total > constraints.max_mean_total_latency_ms
+        ):
+            reasons.append(
+                f"mean total latency {mean_total:.2f} ms exceeds the maximum "
+                f"{constraints.max_mean_total_latency_ms} ms"
+            )
+
+    if len(timed) < constraints.min_measured_repetitions:
+        reasons.append(
+            f"only {len(timed)} run(s) with usable timing evidence; policy "
+            f"requires at least {constraints.min_measured_repetitions}"
+        )
+
+    passing_timed = [value for run, value in timed if run.record.outcome.success]
+    ccpm = _finite_or_none(
+        correct_cases_per_minute(len(passing_timed), sum(passing_timed))
+    )
+    # Throughput counts only the runs that both passed and were timed, so its
+    # noise band has to come from those same samples. Reusing the latency
+    # coefficient of variation above would mix in the failed runs' timings,
+    # which contribute nothing to correct cases per minute: a system whose
+    # failures are erratic but whose passes are steady would be called noisy
+    # on a figure none of that erratic evidence feeds, and a system whose
+    # failures happen to be uniform would look steadier than its throughput
+    # really is.
+    throughput_cv: float | None = None
+    if len(passing_timed) > 1:
+        passing_mean = _finite_or_none(statistics.mean(passing_timed))
+        passing_stdev = _finite_or_none(statistics.pstdev(passing_timed))
+        if passing_mean is not None and passing_stdev is not None and passing_mean > 0:
+            throughput_cv = _finite_or_none(passing_stdev / passing_mean)
+
+    # --- Time to first token ---------------------------------------------
+    mean_ttft, ttft_basis, ttft_missing = _collect_ttft(eligible)
+    missing.extend(ttft_missing)
+
+    # --- Local-only memory ------------------------------------------------
+    mean_peak: float | None = None
+    max_peak: float | None = None
+    if system_key.is_local:
+        peaks = [
+            value
+            for value in (run.peak_memory_bytes for run in eligible)
+            if value is not None
+        ]
+        if peaks:
+            mean_peak = _finite_or_none(statistics.mean(peaks))
+            max_peak = max(peaks)
+        else:
+            missing.append("no run recorded a local peak memory measurement")
+    else:
+        missing.append(
+            "peak memory is a local-only measurement and is not available for a "
+            "system executed by a hosted provider"
+        )
+
+    # --- Provider usage and money -----------------------------------------
+    usage = _collect_usage(eligible)
+    if usage is not None and not usage.complete:
+        missing.append(
+            f"only {usage.runs_reporting_usage} of {usage.runs_total} run(s) "
+            "carry provider-reported token usage"
+        )
+
+    cost: CostSummary | None = None
+    per_correct_cost: float | None = None
+    per_run_costs: tuple[float, ...] = ()
+    if pricing is not None:
+        try:
+            entry = pricing.resolve(
+                provider=system_key.provider,
+                model_id=system_key.model_id,
+                model_revision=system_key.model_revision,
+            )
+        except PricingError as exc:
+            reasons.append(f"pricing lookup failed: {exc}")
+            entry = None
+        if entry is None:
+            missing.append(
+                "the pricing manifest has no entry for provider "
+                f"{system_key.provider!r} model {system_key.model_id!r}"
+                + (
+                    f" revision {system_key.model_revision!r}"
+                    if system_key.model_revision
+                    else ""
+                )
+                + "; no cost is estimated for this system"
+            )
+        else:
+            cost, per_correct_cost, per_run_costs = _collect_cost(
+                eligible, entry=entry, correct_cases=len(successes)
+            )
+
+    # The cost ceiling is evaluated here, outside every pricing branch, on
+    # purpose. Nested inside "an entry resolved" it would exempt every system
+    # the manifest did not price -- which includes every local system, since a
+    # provider-keyed manifest can never match one -- and would publish
+    # ``accepted`` meaning "cleared every constraint" for a system whose
+    # ceiling was never checked. An unevaluable ceiling is a rejection, not a
+    # pass.
+    if constraints.max_cost_per_correct_case is not None:
+        if per_correct_cost is None:
+            reasons.append(
+                "constraints.max_cost_per_correct_case is configured but no "
+                "cost per correct case could be estimated for this system"
+            )
+        elif per_correct_cost > constraints.max_cost_per_correct_case:
+            currency = f" {cost.currency}" if cost is not None else ""
+            reasons.append(
+                f"estimated cost per correct case {per_correct_cost:.6g}"
+                f"{currency} exceeds the maximum "
+                f"{constraints.max_cost_per_correct_case}"
+            )
+
+    # --- Objective ---------------------------------------------------------
+    objective_value: float | None
+    if objective == CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS:
+        objective_value = mean_total
+        if objective_value is None:
+            reasons.append(
+                "objective 'min_mean_total_latency_ms' cannot be computed: no "
+                "usable timing.total evidence"
+            )
+    elif objective == CompareObjective.MAX_CORRECT_CASES_PER_MINUTE:
+        objective_value = ccpm
+        if objective_value is None:
+            reasons.append(
+                "objective 'max_correct_cases_per_minute' cannot be computed: "
+                "no passing run has usable timing.total evidence"
+            )
+    elif objective == CompareObjective.MIN_COST_PER_CORRECT_CASE:
+        objective_value = per_correct_cost
+        if objective_value is None:
+            reasons.append(
+                "objective 'min_cost_per_correct_case' cannot be computed: no "
+                "estimated cost per correct case is available for this system"
+            )
+    elif objective == CompareObjective.MAX_CORRECT_CASES_PER_CURRENCY_UNIT:
+        objective_value = None if cost is None else cost.correct_cases_per_currency_unit
+        if objective_value is None:
+            reasons.append(
+                "objective 'max_correct_cases_per_currency_unit' cannot be "
+                "computed: no estimated spend is available for this system"
+            )
+    else:  # pragma: no cover - CompareObjective is exhaustively handled above
+        raise AssertionError(f"unhandled compare objective: {objective!r}")
+
+    return _SystemEvaluation(
+        system_key=system_key,
+        runs=tuple(runs),
+        eligible_runs=tuple(eligible),
+        timed_runs=tuple(run for run, _value in timed),
+        accepted=not reasons,
+        reasons=tuple(reasons),
+        missing_evidence=tuple(dict.fromkeys(missing)),
+        objective_value=objective_value,
+        pass_rate=pass_rate_value,
+        mean_quality_score=mean_quality,
+        quality_metric=quality_metric,
+        mean_total_latency_ms=mean_total,
+        p50_total_latency_ms=p50,
+        p95_total_latency_ms=p95,
+        stdev_total_latency_ms=stdev_total,
+        coefficient_of_variation=cv,
+        throughput_coefficient_of_variation=throughput_cv,
+        correct_cases_per_minute=ccpm,
+        mean_ttft_ms=mean_ttft,
+        ttft_basis=ttft_basis,
+        usage=usage,
+        cost=cost,
+        cost_per_correct_case=per_correct_cost,
+        cost_dispersion=(
+            _finite_or_none(statistics.pstdev(per_run_costs))
+            if len(per_run_costs) > 1
+            else None
+        ),
+        mean_run_cost=(
+            _finite_or_none(statistics.mean(per_run_costs)) if per_run_costs else None
+        ),
+        correct_cases=len(successes),
+        mean_peak_memory_bytes=mean_peak,
+        max_peak_memory_bytes=max_peak,
+    )
+
+
+def _objective_noise(
+    evaluation: _SystemEvaluation, objective: CompareObjective
+) -> float:
+    """A rough absolute noise band in the objective's own units.
+
+    Each objective uses the dispersion of the quantity it actually ranks on.
+    Latency uses the measured population standard deviation of the timings,
+    following ``tune.tuner._objective_noise``. The two money objectives use
+    the dispersion of the per-run costs, because the timing coefficient of
+    variation says nothing about whether two systems differ on price: a
+    system can be metronomically steady in latency while its token usage, and
+    therefore its cost, swings run to run, and borrowing the timing figure
+    would then declare a real price difference to be noise, or vice versa.
+
+    Returning ``0.0`` means "no dispersion evidence", which leaves only an
+    exact tie detectable. That is the honest default: with one priced run
+    there is nothing to estimate a band from, and inventing one from an
+    unrelated axis would be worse than admitting the gap.
+    """
+    if objective == CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS:
+        return evaluation.stdev_total_latency_ms or 0.0
+
+    if objective == CompareObjective.MIN_COST_PER_CORRECT_CASE:
+        # The per-run amounts are per *attempt*. The objective divides the
+        # total by the number of *correct* cases, so with mixed pass/fail the
+        # two are on different scales and the raw attempt dispersion
+        # understates the band by exactly the pass rate. Scaling by
+        # attempts/correct puts it back in the objective's units: with four
+        # attempts and two passes, a swing of x per attempt moves cost per
+        # correct case by 2x.
+        if evaluation.cost_dispersion is None or not evaluation.correct_cases:
+            return 0.0
+        attempts = len(evaluation.eligible_runs)
+        if attempts <= 0:  # pragma: no cover - eligible_runs is non-empty here
+            return 0.0
+        return abs(evaluation.cost_dispersion * attempts / evaluation.correct_cases)
+
+    if objective == CompareObjective.MAX_CORRECT_CASES_PER_CURRENCY_UNIT:
+        # This objective is the reciprocal of a cost, so the band is scaled
+        # by the *relative* cost dispersion rather than its absolute value.
+        # A relative spread is already dimensionless, so the attempts-versus-
+        # correct-cases scaling above does not apply: it cancels in the
+        # ratio.
+        if (
+            evaluation.cost_dispersion
+            and evaluation.mean_run_cost
+            and evaluation.objective_value
+        ):
+            relative = evaluation.cost_dispersion / evaluation.mean_run_cost
+            return abs(evaluation.objective_value * relative)
+        return 0.0
+
+    # Throughput. Its dispersion comes from the passing timed runs only,
+    # which are exactly the samples correct cases per minute is computed
+    # from.
+    if evaluation.throughput_coefficient_of_variation and evaluation.objective_value:
+        return abs(
+            evaluation.objective_value * evaluation.throughput_coefficient_of_variation
+        )
+    return 0.0
+
+
+def _tie_reason(
+    best: _SystemEvaluation,
+    second: _SystemEvaluation | None,
+    objective: CompareObjective,
+) -> str | None:
+    """Whether the top two systems are indistinguishable on this evidence."""
+    if second is None:
+        return None
+    best_value = best.objective_value
+    second_value = second.objective_value
+    if best_value is None or second_value is None:  # pragma: no cover - defensive
+        raise AssertionError("accepted systems must have an objective_value")
+    if best_value == second_value:
+        return (
+            f"top two systems are exactly tied on {objective.value} "
+            f"({best_value:.6g})"
+        )
+    noise = _objective_noise(best, objective) + _objective_noise(second, objective)
+    delta = abs(best_value - second_value)
+    if noise > 0 and delta < noise:
+        return (
+            f"top two systems differ by {delta:.6g} on {objective.value}, "
+            f"smaller than their combined measurement noise ({noise:.6g}); "
+            "collect more repetitions to distinguish them"
+        )
+    return None
+
+
+def _axis_value(evaluation: _SystemEvaluation, axis: ParetoAxis) -> float | None:
+    if axis == ParetoAxis.MAX_PASS_RATE:
+        return evaluation.pass_rate
+    if axis == ParetoAxis.MAX_CORRECT_CASES_PER_MINUTE:
+        return evaluation.correct_cases_per_minute
+    if axis == ParetoAxis.MIN_MEAN_TOTAL_LATENCY_MS:
+        return evaluation.mean_total_latency_ms
+    return evaluation.cost_per_correct_case
+
+
+def _build_frontier(
+    evaluations: Sequence[_SystemEvaluation],
+) -> tuple[tuple[ParetoAxis, ...], tuple[FrontierEntry, ...], list[str]]:
+    """Non-dominated systems over every axis all of them have evidence for.
+
+    Dominance is computed on point estimates, so a system that wins only
+    inside the noise band still shows as dominating. That is why the frontier
+    is presented as evidence rather than as a verdict, and why the ranking
+    (which does apply the noise test) is reported separately.
+    """
+    notes: list[str] = []
+    if not evaluations:
+        return (), (), notes
+
+    usable_axes = tuple(
+        axis
+        for axis in FRONTIER_AXES
+        if all(_axis_value(item, axis) is not None for item in evaluations)
+    )
+    dropped = [axis.value for axis in FRONTIER_AXES if axis not in usable_axes]
+    if dropped:
+        notes.append(
+            "frontier axes "
+            + ", ".join(sorted(dropped))
+            + " were dropped because at least one ranked system has no evidence "
+            "for them"
+        )
+    if not usable_axes:
+        notes.append(
+            "no frontier could be computed: the ranked systems share no axis "
+            "on which all of them carry evidence"
+        )
+        return (), (), notes
+
+    def dominates(left: _SystemEvaluation, right: _SystemEvaluation) -> bool:
+        strictly_better = False
+        for axis in usable_axes:
+            left_value = _axis_value(left, axis)
+            right_value = _axis_value(right, axis)
+            assert left_value is not None and right_value is not None
+            if axis.prefers_lower:
+                if left_value > right_value:
+                    return False
+                if left_value < right_value:
+                    strictly_better = True
+            else:
+                if left_value < right_value:
+                    return False
+                if left_value > right_value:
+                    strictly_better = True
+        return strictly_better
+
+    entries: list[FrontierEntry] = []
+    for candidate in evaluations:
+        dominators = tuple(
+            other.system_key.label()
+            for other in evaluations
+            if other is not candidate and dominates(other, candidate)
+        )
+        entries.append(
+            FrontierEntry(
+                system_key=candidate.system_key,
+                dominated=bool(dominators),
+                dominated_by=dominators,
+            )
+        )
+    return usable_axes, tuple(entries), notes
+
+
+def _to_system_report(
+    evaluation: _SystemEvaluation, *, rank: int, objective: CompareObjective
+) -> SystemReport:
+    objective_value = evaluation.objective_value
+    if objective_value is None:  # pragma: no cover - accepted implies set
+        raise AssertionError("accepted system must have an objective_value")
+    return SystemReport(
+        system_key=evaluation.system_key,
+        rank=rank,
+        run_ids=tuple(run.run_id for run in evaluation.eligible_runs),
+        verification_paths=tuple(
+            str(run.verification_path) for run in evaluation.eligible_runs
+        ),
+        record_paths=tuple(str(run.record_path) for run in evaluation.eligible_runs),
+        evidence_count=len(evaluation.timed_runs),
+        objective_name=objective.value,
+        objective_value=objective_value,
+        pass_rate=evaluation.pass_rate,
+        mean_quality_score=evaluation.mean_quality_score,
+        quality_metric=evaluation.quality_metric,
+        mean_total_latency_ms=evaluation.mean_total_latency_ms,
+        p50_total_latency_ms=evaluation.p50_total_latency_ms,
+        p95_total_latency_ms=evaluation.p95_total_latency_ms,
+        stdev_total_latency_ms=evaluation.stdev_total_latency_ms,
+        coefficient_of_variation=evaluation.coefficient_of_variation,
+        correct_cases_per_minute=evaluation.correct_cases_per_minute,
+        mean_ttft_ms=evaluation.mean_ttft_ms,
+        ttft_basis=evaluation.ttft_basis,
+        usage=evaluation.usage,
+        cost=evaluation.cost,
+        mean_peak_memory_bytes=evaluation.mean_peak_memory_bytes,
+        max_peak_memory_bytes=evaluation.max_peak_memory_bytes,
+        missing_evidence=evaluation.missing_evidence,
+    )
+
+
+def _to_rejected_report(evaluation: _SystemEvaluation) -> RejectedSystemReport:
+    return RejectedSystemReport(
+        system_key=evaluation.system_key,
+        run_ids=tuple(run.run_id for run in evaluation.runs),
+        verification_paths=tuple(str(run.verification_path) for run in evaluation.runs),
+        record_paths=tuple(str(run.record_path) for run in evaluation.runs),
+        reasons=evaluation.reasons,
+    )
+
+
+def _build_stratum(
+    unit_key: ComparableUnitKey,
+    runs: Sequence[SystemRun],
+    *,
+    policy: ComparePolicy,
+    pricing: PricingManifest | None,
+) -> StratumReport:
+    by_system: dict[SystemKey, list[SystemRun]] = defaultdict(list)
+    for run in runs:
+        by_system[run.system_key].append(run)
+
+    evaluations = [
+        _evaluate_system(
+            system_key,
+            sorted(system_runs, key=lambda run: run.run_id),
+            constraints=policy.constraints,
+            objective=policy.objective,
+            pricing=pricing,
+        )
+        for system_key, system_runs in sorted(
+            by_system.items(), key=lambda item: item[0].sort_key()
+        )
+    ]
+
+    accepted = [item for item in evaluations if item.accepted]
+    rejected = tuple(
+        _to_rejected_report(item) for item in evaluations if not item.accepted
+    )
+
+    # Deterministic ordering: objective first, then the system's own sort key,
+    # so two systems with an identical objective value never swap places
+    # between runs. The objective value is read explicitly rather than through
+    # an ``or`` fallback, which would silently substitute a value for a
+    # genuine 0.0 objective and would hide a missing one behind a plausible
+    # number instead of failing.
+    def rank_sort_key(evaluation: _SystemEvaluation) -> tuple[Any, ...]:
+        value = evaluation.objective_value
+        if value is None:  # pragma: no cover - defensive; accepted implies set
+            raise AssertionError("accepted system must have an objective_value")
+        return (
+            value if policy.objective.prefers_lower else -value,
+            evaluation.system_key.sort_key(),
+        )
+
+    accepted.sort(key=rank_sort_key)
+
+    missing: list[str] = []
+    if len(by_system) < 2:
+        missing.append(
+            f"only {len(by_system)} system produced evidence for this comparable "
+            "unit; a comparison needs at least two"
+        )
+
+    frontier_axes, frontier, frontier_notes = _build_frontier(accepted)
+    missing.extend(frontier_notes)
+
+    ranked = tuple(
+        _to_system_report(item, rank=index, objective=policy.objective)
+        for index, item in enumerate(accepted, start=1)
+    )
+
+    if not accepted:
+        return StratumReport(
+            unit_key=unit_key,
+            outcome=StratumOutcome.INCONCLUSIVE,
+            objective_name=policy.objective.value,
+            ranked=(),
+            rejected=rejected,
+            recommended=None,
+            inconclusive_reason=(
+                "no system cleared every constraint on the available evidence"
+            ),
+            frontier_axes=frontier_axes,
+            frontier=frontier,
+            missing_evidence=tuple(dict.fromkeys(missing)),
+        )
+
+    tie = _tie_reason(
+        accepted[0], accepted[1] if len(accepted) > 1 else None, policy.objective
+    )
+    if tie is not None:
+        return StratumReport(
+            unit_key=unit_key,
+            outcome=StratumOutcome.INCONCLUSIVE,
+            objective_name=policy.objective.value,
+            ranked=ranked,
+            rejected=rejected,
+            recommended=None,
+            inconclusive_reason=tie,
+            frontier_axes=frontier_axes,
+            frontier=frontier,
+            missing_evidence=tuple(dict.fromkeys(missing)),
+        )
+
+    if len(by_system) < 2:
+        return StratumReport(
+            unit_key=unit_key,
+            outcome=StratumOutcome.INCONCLUSIVE,
+            objective_name=policy.objective.value,
+            ranked=ranked,
+            rejected=rejected,
+            recommended=None,
+            inconclusive_reason=(
+                "only one system produced evidence for this comparable unit, so "
+                "nothing was compared against anything"
+            ),
+            frontier_axes=frontier_axes,
+            frontier=frontier,
+            missing_evidence=tuple(dict.fromkeys(missing)),
+        )
+
+    return StratumReport(
+        unit_key=unit_key,
+        outcome=StratumOutcome.RECOMMENDED,
+        objective_name=policy.objective.value,
+        ranked=ranked,
+        rejected=rejected,
+        recommended=ranked[0],
+        inconclusive_reason=None,
+        frontier_axes=frontier_axes,
+        frontier=frontier,
+        missing_evidence=tuple(dict.fromkeys(missing)),
+    )
+
+
+def compare(
+    *,
+    results_dirs: tuple[Path, ...],
+    policy: ComparePolicy,
+    pricing: PricingManifest | None = None,
+    pricing_manifest_path: str | None = None,
+    tune_report_paths: tuple[str, ...] = (),
+) -> CompareReport:
+    """Compare already-collected evidence across systems, offline.
+
+    Reads nothing but artifacts on disk: no model is loaded, no API is
+    called, and no benchmark is executed.
+    """
+    if policy.objective.requires_cost and pricing is None:
+        raise CompareEvidenceError(
+            f"objective {policy.objective.value!r} ranks on money, so a pricing "
+            "manifest is required; refusing to rank on a cost that was never "
+            "supplied"
+        )
+    if policy.constraints.max_cost_per_correct_case is not None and pricing is None:
+        raise CompareEvidenceError(
+            "constraints.max_cost_per_correct_case is configured but no pricing "
+            "manifest was supplied; refusing to run a comparison whose cost "
+            "ceiling could never be evaluated for any system"
+        )
+    if pricing is not None and pricing_manifest_path is None:
+        raise CompareEvidenceError(
+            "a pricing manifest was supplied without its path; every monetary "
+            "value must be attributable to the file it came from"
+        )
+
+    loaded = load_comparison_evidence(results_dirs)
+
+    by_unit: dict[ComparableUnitKey, list[SystemRun]] = defaultdict(list)
+    for run in loaded.runs:
+        by_unit[run.unit_key].append(run)
+
+    strata = tuple(
+        _build_stratum(unit_key, unit_runs, policy=policy, pricing=pricing)
+        for unit_key, unit_runs in sorted(
+            by_unit.items(), key=lambda item: item[0].sort_key()
+        )
+    )
+
+    provenance: PricingProvenance | None = None
+    if pricing is not None and pricing_manifest_path is not None:
+        used = sorted(
+            {
+                system.cost.pricing_entry_id
+                for stratum in strata
+                for system in stratum.ranked
+                if system.cost is not None
+            }
+        )
+        provenance = PricingProvenance(
+            manifest_path=pricing_manifest_path,
+            manifest_sha256=pricing.content_sha256,
+            currency=pricing.currency,
+            rates_are_illustrative=pricing.rates_are_illustrative,
+            entry_ids_used=tuple(used),
+        )
+
+    return CompareReport(
+        schema_version=COMPARE_REPORT_SCHEMA_VERSION,
+        generated_at=utc_now_iso(),
+        results_dirs=tuple(str(path) for path in results_dirs),
+        tune_report_paths=tune_report_paths,
+        policy=policy,
+        strata=strata,
+        pricing=provenance,
+        excluded_runs=loaded.excluded,
+    )
+
+
+__all__ = [
+    "FRONTIER_AXES",
+    "RowStatus",
+    "TokenUsage",
+    "compare",
+]

--- a/llmtracefx/optimizer/compare/cost.py
+++ b/llmtracefx/optimizer/compare/cost.py
@@ -1,0 +1,344 @@
+"""Deriving monetary cost from provider-reported usage and a pricing manifest.
+
+Two rules shape everything in this module.
+
+**Cost is derived, never measured.** Token counts come from the provider's
+own accounting (``MetricProvenance.PROVIDER_REPORTED``); rates come from a
+user-supplied manifest. Neither is something this client observed, so every
+monetary value produced here is labeled ``estimated`` and is kept strictly
+apart from the wall-clock timings the client did measure.
+
+**A missing input makes the answer unavailable, never zero.** If usage was
+not reported, or the manifest has no rate for the tokens that were used, the
+cost is ``None`` with a recorded reason. A free-looking number is worse than
+no number, because it silently wins every cost ranking.
+
+The two composition subtleties an OpenAI-compatible ``usage`` block hides are
+both handled explicitly rather than assumed away:
+
+* ``prompt_tokens`` already *includes* ``prompt_tokens_details.cached_tokens``.
+  Billing both at full rate would double-count the cache.
+* ``completion_tokens`` already *includes*
+  ``completion_tokens_details.reasoning_tokens``. Reasoning is normally billed
+  at the output rate, which is what happens when the manifest declares no
+  separate reasoning rate. Crucially, when the provider does not report
+  reasoning tokens at all this module does **not** invent them: it bills the
+  completion total at the output rate and records that reasoning usage was
+  unavailable, so nobody reads the result as "reasoning was free".
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+from .pricing import PricingEntry, PricingError
+
+#: Provider usage is billed per million tokens.
+TOKENS_PER_RATE_UNIT = 1_000_000
+
+#: The largest token count this module will multiply by a rate. Above it a
+#: Python int either raises ``OverflowError`` on conversion to a float or
+#: converts with silent precision loss, so the product is not arithmetic.
+#: ``compare.evidence`` already refuses a count this large when it loads a
+#: sidecar; the bound is repeated here because this function is public and a
+#: caller can hand it any ``TokenUsage`` at all.
+MAX_BILLABLE_TOKEN_COUNT = 2**53
+
+#: Recorded on every monetary value this module produces, so a reader never
+#: has to guess whether a currency figure was observed or computed.
+MONETARY_BASIS = "estimated_from_provider_reported_usage_and_manifest_rates"
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Provider-reported token accounting for one run, as reported.
+
+    Every field is exactly what the provider said, with no derivation. A
+    field the provider omitted stays ``None``.
+    """
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    cached_prompt_tokens: int | None = None
+    reasoning_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        """Mirror the loader's rule, because this constructor is public.
+
+        The sidecar parser already refuses a negative count, but a caller
+        constructing this directly bypasses that parser entirely, and a
+        negative count subtracts from a bill.
+
+        Representability is deliberately *not* enforced here. A count past
+        ``MAX_BILLABLE_TOKEN_COUNT`` is refused where it is parsed, and
+        ``estimate_run_cost`` treats one that reached it by another route as
+        an unpriceable run rather than raising. Refusing it in the
+        constructor as well would remove the only way to exercise that
+        defence, and the guarantee worth keeping is that the cost helper
+        never raises, not that the value cannot be built.
+        """
+        for name in (
+            "prompt_tokens",
+            "completion_tokens",
+            "cached_prompt_tokens",
+            "reasoning_tokens",
+        ):
+            value = getattr(self, name)
+            if value is None:
+                continue
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise PricingError(
+                    f"usage.{name} must be an integer or null, got {value!r}"
+                )
+            if value < 0:
+                raise PricingError(f"usage.{name} must be >= 0, got {value!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "cached_prompt_tokens": self.cached_prompt_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
+        }
+
+
+@dataclass(frozen=True)
+class CostBreakdown:
+    """One run's estimated cost, or the reason it could not be estimated."""
+
+    amount: float | None
+    currency: str
+    entry_id: str
+    entry_sha256: str
+    rates_are_illustrative: bool
+    billed_input_tokens: int | None = None
+    billed_cached_tokens: int | None = None
+    billed_output_tokens: int | None = None
+    billed_reasoning_tokens: int | None = None
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+    """Why ``amount`` is ``None``, or caveats that apply to a computed one."""
+
+    @property
+    def available(self) -> bool:
+        return self.amount is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "amount": self.amount,
+            "currency": self.currency,
+            "monetary_basis": MONETARY_BASIS,
+            "estimated": True,
+            "pricing_entry_id": self.entry_id,
+            "pricing_entry_sha256": self.entry_sha256,
+            "rates_are_illustrative": self.rates_are_illustrative,
+            "billed_input_tokens": self.billed_input_tokens,
+            "billed_cached_tokens": self.billed_cached_tokens,
+            "billed_output_tokens": self.billed_output_tokens,
+            "billed_reasoning_tokens": self.billed_reasoning_tokens,
+            "reasons": list(self.reasons),
+        }
+
+
+def _unavailable(
+    entry: PricingEntry, reasons: list[str], **billed: int | None
+) -> CostBreakdown:
+    return CostBreakdown(
+        amount=None,
+        currency=entry.currency,
+        entry_id=entry.entry_id,
+        entry_sha256=entry.content_sha256,
+        rates_are_illustrative=entry.rates_are_illustrative,
+        reasons=tuple(reasons),
+        **billed,
+    )
+
+
+def estimate_run_cost(usage: TokenUsage, entry: PricingEntry) -> CostBreakdown:
+    """Estimate one run's cost, refusing to guess at anything missing.
+
+    Returns a breakdown whose ``amount`` is ``None`` (with reasons) whenever
+    the usage or the manifest cannot support an honest total.
+    """
+    reasons: list[str] = []
+
+    oversized = [
+        name
+        for name, count in (
+            ("prompt_tokens", usage.prompt_tokens),
+            ("completion_tokens", usage.completion_tokens),
+            ("cached_prompt_tokens", usage.cached_prompt_tokens),
+            ("reasoning_tokens", usage.reasoning_tokens),
+        )
+        if count is not None and count > MAX_BILLABLE_TOKEN_COUNT
+    ]
+    if oversized:
+        # Multiplying one of these by a rate raises ``OverflowError``, which
+        # is an ``ArithmeticError`` and so is caught by nothing downstream.
+        # Refusing here keeps the failure inside this function's own
+        # unavailable-with-a-reason contract instead of crashing the run.
+        reasons.append(
+            f"provider-reported {', '.join(oversized)} exceeds "
+            f"{MAX_BILLABLE_TOKEN_COUNT}, above the largest count that can be "
+            "billed exactly; refusing to derive a cost from it"
+        )
+        return _unavailable(entry, reasons)
+
+    if usage.prompt_tokens is None:
+        reasons.append(
+            "provider did not report prompt_tokens, so input cost cannot be "
+            "estimated"
+        )
+    if usage.completion_tokens is None:
+        reasons.append(
+            "provider did not report completion_tokens, so output cost cannot "
+            "be estimated"
+        )
+    if reasons:
+        return _unavailable(entry, reasons)
+
+    prompt_tokens = usage.prompt_tokens
+    completion_tokens = usage.completion_tokens
+    assert prompt_tokens is not None and completion_tokens is not None
+
+    cached = usage.cached_prompt_tokens
+    if cached is None and entry.cached_input_per_million is not None:
+        # The manifest prices a cache tier, so this provider has one. With no
+        # reported cached count there is no way to know how much of the
+        # prompt was served from it. Treating the absence as "nothing was
+        # cached" bills every token at the full input rate, which overstates
+        # the cost; treating it as fully cached understates it. Neither is a
+        # measurement, so the total is unavailable.
+        reasons.append(
+            f"pricing entry {entry.entry_id!r} declares a "
+            "cached_input_per_million rate but the provider reported no "
+            "cached prompt token count; refusing to assume none of the "
+            "prompt was cached"
+        )
+        return _unavailable(entry, reasons)
+    if cached is not None and cached > prompt_tokens:
+        reasons.append(
+            f"provider reported {cached} cached prompt tokens but only "
+            f"{prompt_tokens} prompt tokens in total; the usage block is "
+            "internally inconsistent and cannot be billed"
+        )
+        return _unavailable(entry, reasons)
+
+    if cached and entry.cached_input_per_million is None:
+        # The provider says part of the prompt was served from cache, which
+        # means a cache price exists; billing it at the full input rate would
+        # overstate the cost, and billing it at zero would understate it.
+        reasons.append(
+            f"provider reported {cached} cached prompt token(s) but pricing "
+            f"entry {entry.entry_id!r} declares no cached_input_per_million "
+            "rate; refusing to bill cached tokens at the full input rate or "
+            "at zero"
+        )
+        return _unavailable(entry, reasons)
+
+    billed_cached = cached if entry.cached_input_per_million is not None else None
+    billed_input = prompt_tokens - (billed_cached or 0)
+
+    reasoning = usage.reasoning_tokens
+    if entry.reasoning_per_million is not None and reasoning is None:
+        reasons.append(
+            f"pricing entry {entry.entry_id!r} declares a separate "
+            "reasoning_per_million rate but the provider did not report "
+            "reasoning tokens; refusing to infer hidden reasoning usage"
+        )
+        return _unavailable(entry, reasons)
+
+    if reasoning is not None and reasoning > completion_tokens:
+        reasons.append(
+            f"provider reported {reasoning} reasoning tokens but only "
+            f"{completion_tokens} completion tokens in total; the usage block "
+            "is internally inconsistent and cannot be billed"
+        )
+        return _unavailable(entry, reasons)
+
+    if entry.reasoning_per_million is not None:
+        billed_reasoning = reasoning
+        billed_output = completion_tokens - (reasoning or 0)
+    else:
+        # Standard OpenAI-compatible behaviour: reasoning tokens are part of
+        # completion_tokens and are billed at the output rate.
+        billed_reasoning = None
+        billed_output = completion_tokens
+        if reasoning is None:
+            reasons.append(
+                "provider did not report reasoning token usage; completion "
+                "tokens are billed at the output rate and no hidden reasoning "
+                "cost is inferred"
+            )
+
+    components: list[tuple[str, int, float | None]] = [
+        ("input_per_million", billed_input, entry.input_per_million),
+        ("output_per_million", billed_output, entry.output_per_million),
+    ]
+    if billed_cached is not None:
+        components.append(
+            ("cached_input_per_million", billed_cached, entry.cached_input_per_million)
+        )
+    if billed_reasoning is not None:
+        components.append(
+            ("reasoning_per_million", billed_reasoning, entry.reasoning_per_million)
+        )
+
+    missing = [name for name, tokens, rate in components if tokens > 0 and rate is None]
+    if missing:
+        reasons.append(
+            f"pricing entry {entry.entry_id!r} is missing rate(s) "
+            f"{', '.join(sorted(missing))} needed for the reported usage"
+        )
+        return _unavailable(
+            entry,
+            reasons,
+            billed_input_tokens=billed_input,
+            billed_cached_tokens=billed_cached,
+            billed_output_tokens=billed_output,
+            billed_reasoning_tokens=billed_reasoning,
+        )
+
+    amount = sum(
+        tokens * (rate or 0.0) / TOKENS_PER_RATE_UNIT
+        for _name, tokens, rate in components
+    )
+    if not math.isfinite(amount):  # pragma: no cover - defensive
+        reasons.append("computed cost is not a finite number")
+        return _unavailable(entry, reasons)
+
+    return CostBreakdown(
+        amount=amount,
+        currency=entry.currency,
+        entry_id=entry.entry_id,
+        entry_sha256=entry.content_sha256,
+        rates_are_illustrative=entry.rates_are_illustrative,
+        billed_input_tokens=billed_input,
+        billed_cached_tokens=billed_cached,
+        billed_output_tokens=billed_output,
+        billed_reasoning_tokens=billed_reasoning,
+        reasons=tuple(reasons),
+    )
+
+
+def cost_per_case(total_cost: float | None, case_count: int) -> float | None:
+    """Mean estimated cost of one evaluated case, or ``None`` if undefined."""
+    if total_cost is None or case_count <= 0:
+        return None
+    value = total_cost / case_count
+    return value if math.isfinite(value) else None
+
+
+def correct_cases_per_currency_unit(
+    correct_cases: int, total_cost: float | None
+) -> float | None:
+    """Correct cases bought per unit of currency, or ``None`` if undefined.
+
+    A zero total cost is *not* treated as infinite throughput-per-money: it
+    makes the ratio undefined, and undefined is reported as unavailable.
+    """
+    if total_cost is None or total_cost <= 0 or correct_cases <= 0:
+        return None
+    value = correct_cases / total_cost
+    return value if math.isfinite(value) else None

--- a/llmtracefx/optimizer/compare/evidence.py
+++ b/llmtracefx/optimizer/compare/evidence.py
@@ -1,0 +1,1185 @@
+"""Loading cross-system evidence from already-collected result directories.
+
+Nothing here executes anything. It reads artifacts that a previous
+``workloads run`` or ``workloads run-api`` invocation already wrote,
+re-validates them, and turns each trustworthy run into a ``SystemRun``.
+
+**What this can and cannot ingest.** The only accepted input is a results
+directory shaped like ``workloads run --output-dir``: a ``runs/<run_id>/``
+tree holding a ``verification.json`` and the ``final_record.json`` it points
+at. Raw ``collect-api`` output is *not* directly ingestible. That command
+writes a flat artifact set (``record.json``, ``api_evidence.json``,
+``response.txt``, ``environment.json``, ``artifacts.json``) into whatever
+``--output-dir`` it was given; it produces no ``verification.json``, so
+nothing has evaluated the response, and an unevaluated run has no pass rate,
+no quality score and therefore nothing this module can honestly compare.
+Getting API rows into a comparable shape is the job of
+``workloads run-api``, which executes the matrix against an
+OpenAI-compatible endpoint and writes the same ``runs/<run_id>/`` tree the
+local pipeline does. ``_raw_collector_directory_error`` detects the mistake
+and says so, rather than reporting "no comparable units" and leaving the
+operator to guess why.
+
+Run/record identity checking is *not* re-implemented: per directory, this
+module delegates to ``optimizer.tune.loader.load_evidence``, which re-reads
+every ``final_record.json`` behind a ``verification.json`` and re-checks run
+id and prompt-hash agreement. What this module does *not* inherit is that
+loader's global keying on ``run_id`` alone. A matrix ``run_id`` is
+``<workload>-<tier>-<decode_mode>``: it names the task and nothing about the
+system, so executing one matrix against a local model and against a hosted
+API produces two results directories whose run ids collide completely. That
+is the ordinary case here and must not be an error, so directories are
+loaded independently and merged under a source-scoped key. What separates
+distinct evidence from a repeated reference is the *artifact*, not the
+identity: two results trees holding the same matrix row are two repetitions,
+which is how a policy's ``min_measured_repetitions`` is satisfied, while the
+same directory named twice is one run.
+
+On top of that, this module adds the two things cross-system comparison
+needs and tuning does not:
+
+* **Provider evidence.** For a run collected against a hosted API, the
+  collector wrote an ``api_evidence.json`` beside the record. It carries the
+  provider's own token accounting, the requested reasoning effort, the
+  decode settings that were actually sent, the request identity, and the
+  client-observed time-to-first-token. Before any of it is read, the
+  surrounding artifact set is checked for completeness against the
+  collector's own ``artifacts.json`` marker, and the sidecar's schema
+  version, run id and model/workload identity are checked against the
+  record. A sidecar that fails any of that excludes the run rather than
+  degrading it.
+
+* **Decode settings.** Output cap and sampling are part of the comparable
+  unit, so they are read from evidence: from the API request plan when there
+  is one, otherwise from the long options this project itself put into
+  ``command.argv``. A setting that neither source records stays ``None``,
+  which makes the run comparable only against other runs whose setting is
+  equally unrecorded.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..collectors.openai_api import (
+    _MAX_ARTIFACT_MANIFEST_BYTES,
+    API_EVIDENCE_SCHEMA_VERSION,
+    ARTIFACT_MANIFEST_NAME,
+    _read_bounded_regular_file,
+    artifact_set_is_complete,
+)
+from ..schema import ExperimentRecord
+from ..tune.loader import ExcludedRun, LoadedEvidence, RunEvidence, load_evidence
+from ..workloads.api_verify import RUN_MANIFEST_NAME, run_artifacts_are_complete
+from ..workloads.verify import RowVerification
+from .cost import TokenUsage
+from .identity import ComparableUnitKey, SystemKey, request_shape_for
+
+#: Written beside ``record.json`` by the OpenAI-compatible API collector.
+API_EVIDENCE_FILENAME = "api_evidence.json"
+
+#: The largest token count that survives a round trip through a float, and
+#: therefore the largest one any rate or cost derived from it can be honest
+#: about. Above it ``float(value)`` either raises ``OverflowError`` or loses
+#: integer precision silently.
+#:
+#: The collector applies the same bound when it writes a count (see
+#: ``openai_api._MAX_EXACT_TOKEN_COUNT``). It is re-established here rather
+#: than assumed, for two reasons: this layer exists to read artifacts that an
+#: *earlier* build wrote, and the collector's cap landed only recently; and
+#: the counts are provider-controlled input in the first place, which is
+#: exactly why the writer bounds them. Without it a single oversized count
+#: turns cost estimation into an unhandled ``OverflowError`` (an
+#: ``ArithmeticError``, so nothing downstream catches it) or, worse, into a
+#: number that is quietly wrong.
+MAX_EXACT_TOKEN_COUNT = 2**53
+
+#: Long options this project's own collectors put into ``command.argv``.
+#: Only these exact spellings are read; nothing is inferred from positional
+#: arguments or from an option this table does not name.
+_ARGV_INT_OPTIONS: dict[str, str] = {"--max-tokens": "max_output_tokens"}
+_ARGV_FLOAT_OPTIONS: dict[str, str] = {
+    "--temperature": "temperature",
+    "--top-p": "top_p",
+}
+
+
+class CompareEvidenceError(ValueError):
+    """Raised when the *set* of comparison inputs cannot be trusted."""
+
+
+class ApiEvidenceError(ValueError):
+    """Raised when an ``api_evidence.json`` sidecar is malformed."""
+
+
+def _optional_non_negative_int(
+    data: Any, key: str, *, context: str, maximum: int | None = None
+) -> int | None:
+    if not isinstance(data, dict):
+        raise ApiEvidenceError(f"{context} must be a JSON object, got {data!r}")
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ApiEvidenceError(
+            f"{context}.{key} must be an integer or null, got {value!r}"
+        )
+    if value < 0:
+        raise ApiEvidenceError(f"{context}.{key} must be >= 0, got {value}")
+    if maximum is not None and value > maximum:
+        raise ApiEvidenceError(
+            f"{context}.{key} is {value}, above the largest count that can be "
+            f"used in an exact calculation ({maximum}); refusing to derive a "
+            "rate or a cost from a number that cannot round trip through a "
+            "float"
+        )
+    return int(value)
+
+
+def _optional_finite_float(
+    data: Any, key: str, *, context: str, minimum: float | None = None
+) -> float | None:
+    if not isinstance(data, dict):
+        raise ApiEvidenceError(f"{context} must be a JSON object, got {data!r}")
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ApiEvidenceError(
+            f"{context}.{key} must be a number or null, got {value!r}"
+        )
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal larger than a float can represent reaches
+        # here as a Python int. ``float()`` raises ``OverflowError``, which
+        # is an ``ArithmeticError`` rather than a ``ValueError``, so nothing
+        # downstream would catch it. Convert it into the same strict
+        # validation failure every other malformed field produces.
+        raise ApiEvidenceError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric):
+        raise ApiEvidenceError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    if minimum is not None and numeric < minimum:
+        raise ApiEvidenceError(f"{context}.{key} must be >= {minimum}, got {numeric!r}")
+    return numeric
+
+
+def _optional_str(data: Any, key: str, *, context: str) -> str | None:
+    if not isinstance(data, dict):
+        raise ApiEvidenceError(f"{context} must be a JSON object, got {data!r}")
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ApiEvidenceError(
+            f"{context}.{key} must be a non-empty string or null, got {value!r}"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class DecodeSettings:
+    """Output cap and sampling for one run, plus where each value came from."""
+
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    source: str | None = None
+    """``"api_request_plan"``, ``"command_argv"``, or ``None`` if unrecorded."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "max_output_tokens": self.max_output_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True)
+class ApiEvidence:
+    """The parts of an ``api_evidence.json`` cross-system comparison needs."""
+
+    provider: str | None
+    model_id: str | None
+    model_revision: str | None
+    reasoning_effort: str | None
+    usage_reported: bool
+    usage: TokenUsage
+    usage_malformed_fields: tuple[str, ...]
+    decode_settings: DecodeSettings
+    client_ttft_ms: float | None
+    """Client-observed offset to the first content token.
+
+    This includes DNS, connection setup, TLS, request transfer and any
+    server-side queueing, so it is *not* the same measurement as a local
+    collector's ``timing.prefill``. The two are never pooled; see
+    ``TtftBasis`` in ``compare.py``.
+    """
+    schema_version: str | None = None
+    run_id: str | None = None
+    workload_hash: str | None = None
+    config_hash: str | None = None
+    endpoint: str | None = None
+    thinking_type: str | None = None
+    messages: tuple[tuple[str, str], ...] = ()
+    """``(role, content_sha256)`` per message. Digests only, never text."""
+
+    def fingerprint(self) -> dict[str, Any]:
+        """Everything this comparison reads out of the sidecar.
+
+        Used to tell a genuine duplicate from two runs that differ only in
+        evidence the verification and the record do not carry.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "provider": self.provider,
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "workload_hash": self.workload_hash,
+            "config_hash": self.config_hash,
+            "endpoint": self.endpoint,
+            "reasoning_effort": self.reasoning_effort,
+            "thinking_type": self.thinking_type,
+            "messages": [list(message) for message in self.messages],
+            "usage_reported": self.usage_reported,
+            "usage": self.usage.to_dict(),
+            "usage_malformed_fields": list(self.usage_malformed_fields),
+            "decode_settings": self.decode_settings.to_dict(),
+            "client_ttft_ms": self.client_ttft_ms,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> ApiEvidence:
+        if not isinstance(data, dict):
+            raise ApiEvidenceError("api_evidence.json must be a JSON object")
+        plan = data.get("plan")
+        if not isinstance(plan, dict):
+            raise ApiEvidenceError("api_evidence.json is missing its 'plan' object")
+
+        parameters = plan.get("request_parameters", {})
+        if not isinstance(parameters, dict):
+            raise ApiEvidenceError(
+                "api_evidence.json plan.request_parameters must be an object"
+            )
+        extensions = plan.get("provider_extensions", {})
+        if not isinstance(extensions, dict):
+            raise ApiEvidenceError(
+                "api_evidence.json plan.provider_extensions must be an object"
+            )
+
+        max_output = _optional_non_negative_int(
+            parameters, "max_tokens", context="plan.request_parameters"
+        )
+        if max_output == 0:
+            raise ApiEvidenceError(
+                "api_evidence.json plan.request_parameters.max_tokens must be "
+                ">= 1 when set, got 0"
+            )
+        settings = DecodeSettings(
+            max_output_tokens=max_output,
+            temperature=_optional_finite_float(
+                parameters, "temperature", context="plan.request_parameters"
+            ),
+            top_p=_optional_finite_float(
+                parameters, "top_p", context="plan.request_parameters"
+            ),
+            source="api_request_plan",
+        )
+
+        usage_raw = data.get("usage", {})
+        if not isinstance(usage_raw, dict):
+            raise ApiEvidenceError("api_evidence.json 'usage' must be an object")
+        reported = usage_raw.get("reported", False)
+        if not isinstance(reported, bool):
+            raise ApiEvidenceError(
+                f"api_evidence.json usage.reported must be a boolean, got "
+                f"{reported!r}"
+            )
+        malformed = usage_raw.get("malformed_fields", [])
+        if not isinstance(malformed, list) or not all(
+            isinstance(item, str) for item in malformed
+        ):
+            raise ApiEvidenceError(
+                "api_evidence.json usage.malformed_fields must be a list of strings"
+            )
+
+        timeline = data.get("timeline", {})
+        if not isinstance(timeline, dict):
+            raise ApiEvidenceError("api_evidence.json 'timeline' must be an object")
+
+        thinking = extensions.get("thinking")
+        thinking_type: str | None = None
+        if thinking is not None:
+            if not isinstance(thinking, dict):
+                raise ApiEvidenceError(
+                    "api_evidence.json plan.provider_extensions.thinking must be "
+                    f"an object or absent, got {thinking!r}"
+                )
+            thinking_type = _optional_str(
+                thinking, "type", context="plan.provider_extensions.thinking"
+            )
+
+        origin = _optional_str(plan, "endpoint_origin", context="plan")
+        path = _optional_str(plan, "endpoint_path", context="plan")
+        endpoint = None if origin is None else f"{origin}{path or ''}"
+
+        raw_messages = plan.get("messages", [])
+        if not isinstance(raw_messages, list):
+            raise ApiEvidenceError("api_evidence.json plan.messages must be a list")
+        messages: list[tuple[str, str]] = []
+        for index, message in enumerate(raw_messages):
+            if not isinstance(message, dict):
+                raise ApiEvidenceError(
+                    f"api_evidence.json plan.messages[{index}] must be an object"
+                )
+            context = f"plan.messages[{index}]"
+            role = _optional_str(message, "role", context=context)
+            digest = _optional_str(message, "content_sha256", context=context)
+            if role is None or digest is None:
+                raise ApiEvidenceError(
+                    f"api_evidence.json {context} must record both 'role' and "
+                    "'content_sha256'; a message with no identity cannot be "
+                    "compared"
+                )
+            messages.append((role, digest))
+
+        return cls(
+            schema_version=_optional_str(
+                data, "schema_version", context="api_evidence"
+            ),
+            run_id=_optional_str(data, "run_id", context="api_evidence"),
+            workload_hash=_optional_str(plan, "workload_hash", context="plan"),
+            config_hash=_optional_str(plan, "config_hash", context="plan"),
+            endpoint=endpoint,
+            thinking_type=thinking_type,
+            messages=tuple(messages),
+            provider=_optional_str(plan, "provider", context="plan"),
+            model_id=_optional_str(plan, "model_id", context="plan"),
+            model_revision=_optional_str(plan, "model_revision", context="plan"),
+            reasoning_effort=_optional_str(
+                extensions, "reasoning_effort", context="plan.provider_extensions"
+            ),
+            usage_reported=reported,
+            usage=TokenUsage(
+                prompt_tokens=_optional_non_negative_int(
+                    usage_raw,
+                    "prompt_tokens",
+                    context="usage",
+                    maximum=MAX_EXACT_TOKEN_COUNT,
+                ),
+                completion_tokens=_optional_non_negative_int(
+                    usage_raw,
+                    "completion_tokens",
+                    context="usage",
+                    maximum=MAX_EXACT_TOKEN_COUNT,
+                ),
+                cached_prompt_tokens=_optional_non_negative_int(
+                    usage_raw,
+                    "cached_prompt_tokens",
+                    context="usage",
+                    maximum=MAX_EXACT_TOKEN_COUNT,
+                ),
+                reasoning_tokens=_optional_non_negative_int(
+                    usage_raw,
+                    "reasoning_tokens",
+                    context="usage",
+                    maximum=MAX_EXACT_TOKEN_COUNT,
+                ),
+            ),
+            usage_malformed_fields=tuple(malformed),
+            decode_settings=settings,
+            # An offset from the start of the request cannot precede it, so
+            # a negative value is a corrupt or fabricated timeline rather
+            # than a fast one. Left unchecked it would flatter its system on
+            # every time-to-first-token comparison.
+            client_ttft_ms=_optional_finite_float(
+                timeline,
+                "first_content_token_offset_ms",
+                context="timeline",
+                minimum=0.0,
+            ),
+        )
+
+    @classmethod
+    def read_json(cls, path: Path) -> ApiEvidence:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        # ``json`` raises past its own limits with exceptions that are not
+        # ``JSONDecodeError``: an integer literal over the interpreter's digit
+        # cap raises a plain ``ValueError``, and deep nesting raises
+        # ``RecursionError``. This sidecar is the one input to this layer
+        # derived from provider-controlled bytes, which is exactly why the
+        # collector guards its own parse the same way. Without this, such a
+        # file escapes as an unhandled crash instead of excluding the run.
+        except (ValueError, RecursionError) as exc:
+            raise ApiEvidenceError(f"could not parse {path}: {exc}") from exc
+        return cls.from_dict(payload)
+
+
+def decode_settings_from_argv(argv: tuple[str, ...]) -> DecodeSettings:
+    """Read decode settings from the exact long options this project emits.
+
+    Only ``--option value`` pairs whose option name is in the tables above
+    are read, and only when the value parses cleanly. An option that appears
+    twice with conflicting values yields nothing for that field rather than
+    a coin flip, because a run whose cap is ambiguous is not a run whose cap
+    is known.
+    """
+    seen: dict[str, list[float | int]] = {}
+    for index, argument in enumerate(argv[:-1]):
+        raw = argv[index + 1]
+        if argument in _ARGV_INT_OPTIONS:
+            try:
+                value: float | int = int(raw)
+            except ValueError:
+                continue
+            if value < 1:
+                continue
+            seen.setdefault(_ARGV_INT_OPTIONS[argument], []).append(value)
+        elif argument in _ARGV_FLOAT_OPTIONS:
+            try:
+                value = float(raw)
+            except ValueError:
+                continue
+            if not math.isfinite(value):
+                continue
+            seen.setdefault(_ARGV_FLOAT_OPTIONS[argument], []).append(value)
+
+    def unique(name: str) -> Any:
+        values = seen.get(name)
+        if not values or len(set(values)) != 1:
+            return None
+        return values[0]
+
+    max_output = unique("max_output_tokens")
+    temperature = unique("temperature")
+    top_p = unique("top_p")
+    if max_output is None and temperature is None and top_p is None:
+        return DecodeSettings()
+    return DecodeSettings(
+        max_output_tokens=int(max_output) if max_output is not None else None,
+        temperature=float(temperature) if temperature is not None else None,
+        top_p=float(top_p) if top_p is not None else None,
+        source="command_argv",
+    )
+
+
+@dataclass(frozen=True)
+class SystemRun:
+    """One trustworthy run, placed in its comparable unit and its system."""
+
+    run_id: str
+    source_results_dir: str
+    unit_key: ComparableUnitKey
+    system_key: SystemKey
+    verification: RowVerification
+    verification_path: Path
+    record: ExperimentRecord
+    record_path: Path
+    decode_settings: DecodeSettings
+    api_evidence: ApiEvidence | None
+
+    @property
+    def total_ms(self) -> float | None:
+        total = self.record.timing.total
+        if total is None or not math.isfinite(total.value):
+            return None
+        return total.value
+
+    @property
+    def local_prefill_ms(self) -> float | None:
+        prefill = self.record.timing.prefill
+        if prefill is None or not math.isfinite(prefill.value):
+            return None
+        return prefill.value
+
+    @property
+    def peak_memory_bytes(self) -> float | None:
+        peak = self.record.memory.peak
+        if peak is None or not math.isfinite(peak.value):
+            return None
+        return peak.value
+
+
+@dataclass(frozen=True)
+class LoadedComparisonEvidence:
+    """Every usable run, plus everything that was set aside and why."""
+
+    runs: tuple[SystemRun, ...]
+    excluded: tuple[ExcludedRun, ...]
+
+
+def _contained_directory(candidate: Path, *, root: Path) -> Path | None:
+    """The resolved ``candidate`` when it is a directory inside ``root``.
+
+    Resolved before the containment test so a symlink aimed outside the tree
+    fails it rather than being followed out of it.
+    """
+    try:
+        resolved = candidate.resolve(strict=True)
+        anchor = root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if not resolved.is_relative_to(anchor) or not resolved.is_dir():
+        return None
+    return resolved
+
+
+def _resolve_collection_dir(
+    collection_dir: str, *, results_dir: str, run_id: str
+) -> Path | None:
+    """Resolve a recorded collection directory inside the results tree named.
+
+    Same reasoning as ``tune.loader._resolve_artifact_path``:
+    ``verify.execute_row`` always writes the collection under
+    ``<output_dir>/runs/<run_id>/collection``, so that is correct by
+    construction and is tried first.
+
+    Reading the recorded string literally would be worse than useless here. A
+    relative ``--output-dir`` records a path relative to the working
+    directory of the run, so a literal read resolves it against whichever
+    tree this process is standing in, and the API evidence of a *different*
+    system would be attached to this run. The identity checks cannot catch
+    that on their own, because a matrix ``run_id`` names the task and nothing
+    about the system, so two trees from one matrix agree on every id.
+
+    As in the shared loader, nothing outside ``results_dir`` is returned. The
+    recorded string comes from the artifact under validation, so an absolute
+    path, a ``..`` segment or a symlink in it is chosen by whoever wrote that
+    artifact. Resolution happens before the containment test, so a symlink
+    aimed out of the tree fails it instead of being followed out. When
+    nothing resolves to a directory inside the tree, ``None`` is returned
+    and the caller reports the API evidence as missing, rather than falling
+    back to a path that would be read from wherever it pointed.
+    """
+    root = Path(results_dir)
+    canonical = root / "runs" / run_id / "collection"
+    contained = _contained_directory(canonical, root=root)
+    if contained is not None:
+        return contained
+    literal = Path(collection_dir)
+    probe = literal if literal.is_absolute() else root / collection_dir
+    return _contained_directory(probe, root=root)
+
+
+def _api_evidence_for(evidence: RunEvidence) -> tuple[ApiEvidence | None, str | None]:
+    """Load the API sidecar for a run, if the verification points at one.
+
+    The surrounding artifact set is validated before the sidecar is trusted.
+    The collector writes ``artifacts.json`` last, after every other file has
+    landed, and hashes each one into it precisely so a consumer can tell a
+    complete set from an interrupted write or a file swapped independently of
+    the set it belongs to. Its own docstring says a consumer must check this
+    before trusting the directory, so this does, using the collector's
+    function rather than a private reimplementation of the same rule.
+    """
+    collection_dir = evidence.verification.collection_dir
+    hosted = evidence.final_record.runtime.provider is not None
+    if collection_dir is None:
+        if hosted:
+            # The record says a hosted provider executed this run, so the
+            # sidecar exists by construction and its absence means the
+            # evidence set is incomplete. Accepting the run anyway would
+            # publish it with no endpoint, no request identity, no
+            # provider-reported usage and no time-to-first-token, while
+            # still labelling it hosted -- and would skip the artifact-set
+            # validation entirely.
+            return None, (
+                f"final_record.runtime.provider is "
+                f"{evidence.final_record.runtime.provider!r}, so this run was "
+                "executed by a hosted API, but verification.json records no "
+                "collection directory; the API evidence for it is missing"
+            )
+        return None, None
+    directory = _resolve_collection_dir(
+        collection_dir,
+        results_dir=evidence.source_results_dir,
+        run_id=evidence.final_record.run_id,
+    )
+    if directory is None:
+        if hosted:
+            return None, (
+                f"final_record.runtime.provider is "
+                f"{evidence.final_record.runtime.provider!r}, so this run was "
+                "executed by a hosted API, but its collection directory does "
+                "not resolve to a directory inside the results directory that "
+                "was asked for; a collection reached through an absolute "
+                "path, a parent-directory segment or a symlink leaving the "
+                "tree is not this run's API evidence, so it is missing"
+            )
+        return None, None
+    sidecar = directory / API_EVIDENCE_FILENAME
+    if not sidecar.is_file():
+        if hosted:
+            return None, (
+                f"final_record.runtime.provider is "
+                f"{evidence.final_record.runtime.provider!r}, so this run was "
+                f"executed by a hosted API, but no {API_EVIDENCE_FILENAME} "
+                "was found in its collection directory; the request identity, "
+                "usage and timing for it are missing"
+            )
+        return None, None
+
+    # Reasons are rendered into a shared HTML report, so they name the
+    # artifact rather than the absolute path it lives at. The path itself is
+    # already carried, and redacted, by the excluded-run record.
+    if not (directory / ARTIFACT_MANIFEST_NAME).is_file():
+        return None, (
+            f"the collection directory holds an {API_EVIDENCE_FILENAME} but "
+            f"no {ARTIFACT_MANIFEST_NAME} completeness marker; the collector "
+            "writes that marker last, so its absence means the artifact set "
+            "was never finished and nothing in it can be trusted"
+        )
+    marker_error = _artifact_marker_identity_error(
+        directory, run_id=evidence.final_record.run_id
+    )
+    if marker_error is not None:
+        return None, marker_error
+    try:
+        complete = artifact_set_is_complete(directory)
+    except OSError as exc:  # pragma: no cover - defensive
+        return None, f"could not verify the artifact set: {exc}"
+    if not complete:
+        return None, (
+            f"the artifact set does not match its own {ARTIFACT_MANIFEST_NAME} "
+            "marker; a file was replaced or the write was interrupted, so the "
+            "usage and timing in it cannot be trusted"
+        )
+
+    try:
+        return ApiEvidence.read_json(sidecar), None
+    except (OSError, ApiEvidenceError) as exc:
+        return None, f"could not read {API_EVIDENCE_FILENAME}: {exc}"
+
+
+def _artifact_marker_identity_error(directory: Path, *, run_id: str) -> str | None:
+    """Refuse a completeness marker that belongs to a different run.
+
+    ``artifact_set_is_complete`` proves the files match the marker, not that
+    the marker describes *this* run. A whole collection directory copied from
+    another run passes that check while carrying another run's evidence, and
+    that evidence would then be read as this run's usage and timing.
+
+    The marker is read through the collector's own bounded regular-file
+    reader rather than a bare ``read_text``. That reader is what refuses a
+    symlink, a device node or a file large enough to be a denial of service,
+    and reading the marker unguarded here would have stepped around the very
+    guard the collector added for this file.
+    """
+    marker_path = directory / ARTIFACT_MANIFEST_NAME
+    raw = _read_bounded_regular_file(marker_path, _MAX_ARTIFACT_MANIFEST_BYTES)
+    if raw is None:
+        return (
+            f"{ARTIFACT_MANIFEST_NAME} is not a readable regular file within "
+            f"the {_MAX_ARTIFACT_MANIFEST_BYTES} byte limit the collector "
+            "writes it under"
+        )
+    try:
+        marker = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, ValueError, RecursionError) as exc:
+        return f"could not parse {ARTIFACT_MANIFEST_NAME}: {exc}"
+    if not isinstance(marker, dict):
+        return f"{ARTIFACT_MANIFEST_NAME} is not a JSON object"
+    recorded = marker.get("run_id")
+    if recorded is None:
+        return (
+            f"{ARTIFACT_MANIFEST_NAME} records no run_id, so there is no way "
+            "to tell whether this artifact set belongs to this run"
+        )
+    if not isinstance(recorded, str) or recorded != run_id:
+        return (
+            f"{ARTIFACT_MANIFEST_NAME} names run_id {recorded!r} but this run "
+            f"is {run_id!r}; the collection directory belongs to a different "
+            "run"
+        )
+    return None
+
+
+def _provider_agreement_error(
+    evidence: RunEvidence, api_evidence: ApiEvidence
+) -> str | None:
+    """Refuse a sidecar that does not describe the run the record describes.
+
+    The two artifacts are written by the same collector in the same call, so
+    any disagreement means one of them is stale, hand-edited, or belongs to a
+    different run that happened to be copied into this directory. Either way
+    the pair cannot be used to label a system, and every identity the two
+    artifacts share is checked before a single number is read out of either.
+    """
+    record = evidence.final_record
+
+    if api_evidence.schema_version is None:
+        return (
+            f"{API_EVIDENCE_FILENAME} records no schema_version, so there is "
+            "no way to know which contract its fields follow"
+        )
+    if api_evidence.schema_version != API_EVIDENCE_SCHEMA_VERSION:
+        return (
+            f"{API_EVIDENCE_FILENAME} declares schema_version "
+            f"{api_evidence.schema_version!r}, but this build reads "
+            f"{API_EVIDENCE_SCHEMA_VERSION!r}; refusing to read fields under a "
+            "contract that may have changed meaning"
+        )
+    if api_evidence.run_id is None:
+        return (
+            f"{API_EVIDENCE_FILENAME} records no run_id; a schema "
+            f"{API_EVIDENCE_SCHEMA_VERSION} sidecar always carries one, so "
+            "this file is not one this build can identify"
+        )
+    if api_evidence.run_id != record.run_id:
+        return (
+            f"{API_EVIDENCE_FILENAME} run_id ({api_evidence.run_id!r}) does "
+            f"not match final_record.run_id ({record.run_id!r}); the sidecar "
+            "describes a different run than the record beside it"
+        )
+    for field, sidecar_value, record_value in (
+        ("plan.model_id", api_evidence.model_id, record.model.model_id),
+        (
+            "plan.workload_hash",
+            api_evidence.workload_hash,
+            record.command.workload_hash,
+        ),
+        ("plan.config_hash", api_evidence.config_hash, record.command.config_hash),
+    ):
+        if sidecar_value is None:
+            return (
+                f"{API_EVIDENCE_FILENAME} records no {field}; a schema "
+                f"{API_EVIDENCE_SCHEMA_VERSION} sidecar always carries it, so "
+                "its absence means this file cannot be checked against the "
+                "record it sits beside"
+            )
+        if record_value is not None and sidecar_value != record_value:
+            return (
+                f"{API_EVIDENCE_FILENAME} {field} ({sidecar_value!r}) does not "
+                f"match the final record ({record_value!r})"
+            )
+    # Nullability has to agree as well as value. A sidecar that names a
+    # revision the record does not, or the reverse, describes a different
+    # thing from the record even though no direct comparison fails.
+    if (api_evidence.model_revision is None) != (record.model.model_revision is None):
+        return (
+            f"{API_EVIDENCE_FILENAME} plan.model_revision "
+            f"({api_evidence.model_revision!r}) and "
+            f"final_record.model.model_revision "
+            f"({record.model.model_revision!r}) disagree about whether a model "
+            "revision was recorded at all"
+        )
+    if (
+        api_evidence.model_revision is not None
+        and record.model.model_revision is not None
+        and api_evidence.model_revision != record.model.model_revision
+    ):
+        return (
+            f"{API_EVIDENCE_FILENAME} plan.model_revision "
+            f"({api_evidence.model_revision!r}) does not match "
+            f"final_record.model.model_revision "
+            f"({record.model.model_revision!r})"
+        )
+    if record.runtime.provider is None:
+        # The sidecar's mere existence is the proof: only a hosted-API
+        # collector writes one, and it carries provider-reported usage and a
+        # client-observed first-token offset. Meanwhile ``SystemKey`` reads
+        # locality from the record alone, so accepting the pair would label a
+        # hosted run local, publish local-only peak memory for it, and exempt
+        # it from every provider-keyed pricing lookup. Keying this on the
+        # sidecar's own ``plan.provider`` instead would leave the case where
+        # the sidecar never names its provider wide open, which is weaker
+        # than the evidence already on disk.
+        return (
+            f"this run carries {API_EVIDENCE_FILENAME}, which only a hosted "
+            "API collector writes, but final_record.runtime.provider is null; "
+            "the record claims this run was local and locality is read from "
+            "the record, so the pair cannot label a system"
+        )
+    if (
+        api_evidence.provider is not None
+        and api_evidence.provider != record.runtime.provider
+    ):
+        return (
+            f"{API_EVIDENCE_FILENAME} plan.provider "
+            f"({api_evidence.provider!r}) does not match final_record.runtime."
+            f"provider ({record.runtime.provider!r})"
+        )
+    return None
+
+
+def _run_seal_error(evidence: RunEvidence) -> str | None:
+    """Verify the run-level seal that ``workloads run-api`` writes.
+
+    ``artifact_set_is_complete`` covers only the four files the collector
+    writes into the collection directory. ``run-api`` additionally seals the
+    whole run directory, hashing the collector's marker together with
+    ``final_record.json`` and ``verification.json`` -- the record carrying
+    the graded outcome and the summary this loader actually reads. Checking
+    it here extends integrity to exactly the two artifacts a comparison
+    trusts most and that the collector's own marker never covered.
+
+    Required for hosted runs, optional for local ones. ``workloads run-api``
+    writes this seal for every row that produced a full artifact set, so a
+    hosted run without one is not something the pipeline produces: it is an
+    unsealed directory, and accepting it would let the record and the
+    verification -- the graded outcome and the summary this loader reads --
+    be edited with nothing to notice. ``workloads run`` writes no seal at
+    all, so requiring one there would exclude every local run; the local
+    exception is exactly that and nothing wider.
+    """
+    run_dir = evidence.verification_path.parent
+    marker_path = run_dir / RUN_MANIFEST_NAME
+    if not marker_path.is_file():
+        if evidence.final_record.runtime.provider is not None:
+            return (
+                f"final_record.runtime.provider is "
+                f"{evidence.final_record.runtime.provider!r}, so this run was "
+                f"executed by a hosted API and ``workloads run-api`` seals "
+                f"every such run directory, but no {RUN_MANIFEST_NAME} is "
+                "present; the record and the verification for it are covered "
+                "by no integrity marker at all"
+            )
+        return None
+    # The shared verifier reads this marker with an unbounded ``read_text``
+    # and follows symlinks. Every other integrity marker this module consumes
+    # goes through the collector's bounded no-follow reader first, and this
+    # one is no different: check it is a regular file of a sane size, and
+    # that it parses, before handing it to a parser that would otherwise
+    # read a device node or a file large enough to be a denial of service.
+    raw_seal = _read_bounded_regular_file(marker_path, _MAX_ARTIFACT_MANIFEST_BYTES)
+    if raw_seal is None:
+        return (
+            f"{RUN_MANIFEST_NAME} is not a readable regular file within the "
+            f"{_MAX_ARTIFACT_MANIFEST_BYTES} byte limit the run pipeline "
+            "writes it under"
+        )
+    try:
+        json.loads(raw_seal.decode("utf-8"))
+    except (UnicodeError, ValueError, RecursionError) as exc:
+        return f"could not parse {RUN_MANIFEST_NAME}: {exc}"
+    try:
+        sealed = run_artifacts_are_complete(
+            run_dir, expected_run_id=evidence.final_record.run_id
+        )
+    except OSError as exc:  # pragma: no cover - defensive
+        return f"could not verify the run-level seal: {exc}"
+    if sealed:
+        return None
+    return (
+        f"the run directory does not match its own {RUN_MANIFEST_NAME} seal; "
+        "the verification, the final record or the collector's own marker "
+        "was modified after the run landed, so none of them can be trusted"
+    )
+
+
+def _to_system_run(
+    evidence: RunEvidence,
+) -> tuple[SystemRun | None, ExcludedRun | None]:
+    # The artifact-set and sidecar checks run before the run-level seal so
+    # the *specific* cause is what gets reported: a missing collector marker
+    # or a mismatched sidecar necessarily breaks the seal too, and "the run
+    # directory does not match its seal" tells an operator far less than
+    # naming the file that is wrong. Nothing is trusted any earlier for it --
+    # the seal still has to pass before this run becomes evidence, and every
+    # read on the way is bounded, no-follow and hash-checked.
+    api_evidence, sidecar_error = _api_evidence_for(evidence)
+    if sidecar_error is not None:
+        return None, ExcludedRun(
+            run_id=evidence.run_id,
+            source_results_dir=evidence.source_results_dir,
+            reason=sidecar_error,
+        )
+
+    if api_evidence is not None:
+        disagreement = _provider_agreement_error(evidence, api_evidence)
+        if disagreement is not None:
+            return None, ExcludedRun(
+                run_id=evidence.run_id,
+                source_results_dir=evidence.source_results_dir,
+                reason=disagreement,
+            )
+
+    record = evidence.final_record
+    verification = evidence.verification
+    if api_evidence is not None:
+        settings = api_evidence.decode_settings
+    else:
+        settings = decode_settings_from_argv(record.command.argv)
+
+    prompt_hash = verification.verified_prompt_hash
+    if prompt_hash is None:
+        return None, ExcludedRun(
+            run_id=evidence.run_id,
+            source_results_dir=evidence.source_results_dir,
+            reason=(
+                "verification.json records no verified_prompt_hash, so this run "
+                "cannot be proved to have executed the same prompt as anything "
+                "it would be compared against"
+            ),
+        )
+
+    unit_key = ComparableUnitKey(
+        workload_id=verification.workload_id,
+        workload_version=verification.workload_version,
+        workload_prompt_hash=prompt_hash,
+        context_tier=verification.context_tier,
+        quality_metric=record.outcome.quality_metric,
+        max_output_tokens=settings.max_output_tokens,
+        temperature=settings.temperature,
+        top_p=settings.top_p,
+        # A local run records no message structure, and neither does an API
+        # run whose request was the bare prompt, so both normalize to None
+        # and stay comparable. A system prompt or a prepended conversation
+        # produces a digest instead, which separates the stratum.
+        request_shape=(
+            None
+            if api_evidence is None
+            else request_shape_for(
+                api_evidence.messages, workload_prompt_hash=prompt_hash
+            )
+        ),
+    )
+    system_key = SystemKey(
+        model_id=record.model.model_id,
+        model_revision=record.model.model_revision,
+        provider=record.runtime.provider,
+        runtime_name=record.runtime.name,
+        runtime_backend=record.runtime.backend,
+        accelerator=record.platform.accelerator,
+        quantization=record.model.quantization,
+        reasoning_effort=(
+            None if api_evidence is None else api_evidence.reasoning_effort
+        ),
+        decode_mode=verification.decode_mode,
+        endpoint=None if api_evidence is None else api_evidence.endpoint,
+        thinking_type=None if api_evidence is None else api_evidence.thinking_type,
+        # The collector's own configuration identity, carried verbatim. It
+        # covers endpoint, model, sampling, provider extensions, finish-reason
+        # vocabulary, timeout and system prompt, so a configuration
+        # difference this module does not model by name still separates two
+        # systems instead of pooling them.
+        execution_config_hash=record.command.config_hash,
+    )
+
+    seal_error = _run_seal_error(evidence)
+    if seal_error is not None:
+        return None, ExcludedRun(
+            run_id=evidence.run_id,
+            source_results_dir=evidence.source_results_dir,
+            reason=seal_error,
+        )
+
+    try:
+        # The explicit checks above name the offending field, which is what
+        # an operator needs. This catches whatever they do not.
+        #
+        # It must hash the dataclasses, not their ``sort_key()`` tuples.
+        # ``compare()`` uses the objects themselves as dict keys, and
+        # ``sort_key()`` folds every optional field through ``x or default``:
+        # a value that is both falsy and unhashable, such as ``[]`` or
+        # ``{}``, is replaced by a hashable fallback inside ``sort_key()``
+        # while staying unhashable in the dataclass. Probing the tuples would
+        # therefore pass and the dict insertion would still raise. Hashing
+        # the dataclasses covers both, since a value that hashes here also
+        # survives the ``or`` coercion.
+        hash((unit_key, system_key))
+    except TypeError as exc:
+        return None, ExcludedRun(
+            run_id=evidence.run_id,
+            source_results_dir=evidence.source_results_dir,
+            reason=(
+                "this run's identity cannot be used as a comparison key: " f"{exc}"
+            ),
+        )
+
+    return (
+        SystemRun(
+            run_id=evidence.run_id,
+            source_results_dir=evidence.source_results_dir,
+            unit_key=unit_key,
+            system_key=system_key,
+            verification=verification,
+            verification_path=evidence.verification_path,
+            record=record,
+            record_path=evidence.final_record_path,
+            decode_settings=settings,
+            api_evidence=api_evidence,
+        ),
+        None,
+    )
+
+
+def _raw_collector_directory_error(results_dir: Path) -> str | None:
+    """Explain a directory that is raw collector output, not a results tree.
+
+    ``collect-api`` and ``collect-mlx`` write a flat artifact set into
+    whatever ``--output-dir`` they are given. Pointing ``compare --results``
+    at one of those is an easy and reasonable mistake, and without this the
+    loader simply finds no ``runs/`` tree, reports no comparable units, and
+    leaves the operator to work out why.
+    """
+    if (results_dir / "runs").is_dir():
+        return None
+    markers = [
+        name
+        for name in (API_EVIDENCE_FILENAME, "record.json", ARTIFACT_MANIFEST_NAME)
+        if (results_dir / name).is_file()
+    ]
+    if not markers:
+        return None
+    return (
+        f"{results_dir} looks like raw collector output ({', '.join(markers)}) "
+        "rather than a results directory. compare reads a "
+        "`workloads run --output-dir` tree, which holds runs/<run_id>/"
+        "verification.json alongside the final_record.json it points at. A "
+        "collector directory on its own has no verification.json, which means "
+        "nothing has evaluated the response, so there is no pass rate and no "
+        "quality score to compare. Execute the workload matrix and point "
+        "--results at that output directory instead."
+    )
+
+
+def load_comparison_evidence(
+    results_dirs: tuple[Path, ...],
+) -> LoadedComparisonEvidence:
+    """Load every comparable run under every given results directory.
+
+    Each directory is loaded independently and merged under a key scoped to
+    its own resolved path, rather than under ``run_id`` alone. A matrix
+    ``run_id`` names the workload, tier and decode mode and nothing about the
+    system, so running one matrix against a local model and against a hosted
+    API yields two directories whose run ids collide entirely. Treating that
+    as a conflict would reject the exact comparison this command exists for.
+
+    Repeated *references* to one artifact are de-duplicated, so passing the
+    same directory twice, or two paths that resolve to it, stays harmless.
+    Repeated *measurements* are kept: two results trees holding the same
+    matrix row are two repetitions, which is how a policy's
+    ``min_measured_repetitions`` is satisfied in the first place.
+
+    Raises ``CompareEvidenceError`` when the input set itself is
+    untrustworthy.
+    """
+    if not results_dirs:
+        raise CompareEvidenceError(
+            "at least one results directory is required; there is nothing to "
+            "compare otherwise"
+        )
+
+    for results_dir in results_dirs:
+        mistake = _raw_collector_directory_error(results_dir)
+        if mistake is not None:
+            raise CompareEvidenceError(mistake)
+
+    runs: list[SystemRun] = []
+    excluded: list[ExcludedRun] = []
+    seen_sources: set[Path] = set()
+
+    for results_dir in results_dirs:
+        resolved = results_dir.expanduser().resolve(strict=False)
+        if resolved in seen_sources:
+            # The same tree named twice. Loading it again would double every
+            # measurement in it, which silently inflates evidence counts and
+            # narrows every variance figure derived from them.
+            continue
+        seen_sources.add(resolved)
+
+        try:
+            loaded: LoadedEvidence = load_evidence((results_dir,))
+        except (ValueError, RecursionError) as exc:
+            raise CompareEvidenceError(
+                f"could not load evidence from {results_dir}: {exc}"
+            ) from exc
+
+        excluded.extend(loaded.excluded)
+        for evidence in loaded.usable:
+            run, excluded_run = _to_system_run(evidence)
+            if run is None:
+                if excluded_run is not None:
+                    excluded.append(excluded_run)
+                continue
+            runs.append(run)
+
+    return LoadedComparisonEvidence(
+        runs=tuple(_deduplicate(runs)),
+        excluded=tuple(excluded),
+    )
+
+
+def _run_fingerprint(run: SystemRun) -> tuple[str, str, str]:
+    """A content fingerprint for one run, independent of where it was read.
+
+    The API sidecar is part of the fingerprint, not just the verification and
+    the record. Time-to-first-token, cached prompt tokens and reasoning
+    tokens are read only from the sidecar and never appear in either of the
+    other two artifacts, so two runs that agree on both of those but differ
+    on any of that evidence are genuinely different measurements. Comparing
+    only the first two would call them identical duplicates and silently drop
+    one, taking its usage and its timing with it.
+    """
+    return (
+        json.dumps(run.verification.to_dict(), sort_keys=True),
+        json.dumps(run.record.to_dict(), sort_keys=True),
+        (
+            ""
+            if run.api_evidence is None
+            else json.dumps(run.api_evidence.fingerprint(), sort_keys=True)
+        ),
+    )
+
+
+def _artifact_source(run: SystemRun) -> str:
+    """The physical artifact this run was read from, canonicalized.
+
+    Two entries that resolve to the same file are the same evidence reached
+    twice; two that resolve to different files are two pieces of evidence,
+    whatever their ids say.
+    """
+    try:
+        return str(run.verification_path.resolve(strict=False))
+    except OSError:  # pragma: no cover - defensive
+        return str(run.verification_path)
+
+
+def _deduplicate(runs: Sequence[SystemRun]) -> list[SystemRun]:
+    """Drop repeated references to one artifact, keep genuine repetitions.
+
+    Repetitions are the ordinary case and must survive. Executing one matrix
+    twice into two results directories is exactly how a policy's
+    ``min_measured_repetitions`` is satisfied, and every run in the second
+    tree shares its ``run_id`` and its whole system identity with the first,
+    because a matrix ``run_id`` names the task and nothing about the system
+    or the attempt. Treating a repeated ``(system, run_id)`` as a conflict
+    therefore rejected the normal way of collecting evidence, and made a
+    repetition count above one impossible to reach.
+
+    So identity is not what de-duplicates here; the artifact is. A run is
+    dropped only when it is the *same file* reached twice (the same
+    directory passed twice, or two paths that resolve to it), or when its
+    content is byte-identical to one already kept. Byte-identical includes
+    ``started_at``/``ended_at``, which two genuinely separate executions
+    cannot share, so that case is a copied tree rather than a repetition and
+    counting it twice would inflate the evidence count and understate every
+    variance derived from it.
+    """
+    kept: list[SystemRun] = []
+    seen_sources: set[str] = set()
+    seen_content: set[tuple[Any, str, tuple[str, str, str]]] = set()
+    for run in runs:
+        source = _artifact_source(run)
+        if source in seen_sources:
+            continue
+        content = (run.system_key.sort_key(), run.run_id, _run_fingerprint(run))
+        if content in seen_content:
+            continue
+        seen_sources.add(source)
+        seen_content.add(content)
+        kept.append(run)
+    return kept

--- a/llmtracefx/optimizer/compare/explain.py
+++ b/llmtracefx/optimizer/compare/explain.py
@@ -1,0 +1,197 @@
+"""Human-readable rendering of an already-computed ``CompareReport``.
+
+Mirrors ``tune.explain``: a pure formatter over a validated report. It never
+recomputes a value, never re-ranks anything, and never fills a gap. A metric
+that is unavailable prints as ``n/a`` with the reason available in the
+report's ``missing_evidence``, so a reader can see what was not known rather
+than being handed a plausible-looking zero.
+"""
+
+from __future__ import annotations
+
+from .policy import CompareConstraints
+from .report import CompareReport, StratumOutcome, StratumReport, SystemReport
+
+
+def _number(value: float | None, *, digits: int = 4) -> str:
+    return "n/a" if value is None else f"{value:.{digits}f}"
+
+
+def _percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def _money(value: float | None, currency: str) -> str:
+    return "n/a" if value is None else f"{value:.6g} {currency}"
+
+
+def _system_line(system: SystemReport) -> str:
+    parts = [
+        f"  #{system.rank} {system.system_key.label()}",
+        f"      objective {system.objective_name} = "
+        + f"{_number(system.objective_value)}",
+        f"      pass rate {_percent(system.pass_rate)}"
+        + f"  quality {system.quality_metric or 'n/a'} = "
+        + f"{_number(system.mean_quality_score, digits=3)}",
+        f"      latency mean {_number(system.mean_total_latency_ms, digits=2)} ms"
+        + f"  p50 {_number(system.p50_total_latency_ms, digits=2)} ms"
+        + f"  p95 {_number(system.p95_total_latency_ms, digits=2)} ms",
+    ]
+    if system.mean_ttft_ms is not None and system.ttft_basis is not None:
+        parts.append(
+            f"      ttft {_number(system.mean_ttft_ms, digits=2)} ms "
+            f"({system.ttft_basis.value})"
+        )
+    parts.append(
+        f"      correct cases/min {_number(system.correct_cases_per_minute, digits=3)}"
+    )
+    if system.usage is not None:
+        usage = system.usage
+        parts.append(
+            "      provider-reported usage: "
+            f"input={usage.input_tokens} output={usage.output_tokens} "
+            f"cached={usage.cached_input_tokens} "
+            f"reasoning={usage.reasoning_tokens} "
+            f"({usage.runs_reporting_usage}/{usage.runs_total} runs)"
+        )
+    if system.cost is not None:
+        cost = system.cost
+        label = "illustrative" if cost.rates_are_illustrative else "estimated"
+        parts.append(
+            f"      cost ({label}): total "
+            f"{_money(cost.total_amount, cost.currency)}"
+            f"  per correct case "
+            f"{_money(cost.cost_per_correct_case, cost.currency)}"
+            f"  correct per {cost.currency} "
+            f"{_number(cost.correct_cases_per_currency_unit, digits=3)}"
+        )
+    if system.system_key.is_local and system.mean_peak_memory_bytes is not None:
+        parts.append(
+            "      local peak memory "
+            f"{system.mean_peak_memory_bytes / (1024 * 1024):.1f} MB mean"
+        )
+    return "\n".join(parts)
+
+
+def _stratum_text(
+    stratum: StratumReport, *, constraints: CompareConstraints, verbose: bool
+) -> str:
+    lines = [
+        f"Comparable unit: {stratum.unit_key.label()}",
+        f"  outcome: {stratum.outcome.value} (objective {stratum.objective_name})",
+    ]
+    if stratum.outcome == StratumOutcome.RECOMMENDED and stratum.recommended:
+        lines.append(
+            f"  recommended for this unit only: "
+            f"{stratum.recommended.system_key.label()}"
+        )
+    elif stratum.inconclusive_reason:
+        lines.append(f"  inconclusive: {stratum.inconclusive_reason}")
+
+    # A verdict without the bar it cleared is not readable evidence, and the
+    # README promises each recommendation is stated with its constraints.
+    lines.append("  Constraints in force:")
+    lines.extend(f"      {item}" for item in constraints.active_summary())
+
+    if stratum.ranked:
+        lines.append("  Ranked systems:")
+        shown = stratum.ranked if verbose else stratum.ranked[:3]
+        lines.extend(_system_line(system) for system in shown)
+        if not verbose and len(stratum.ranked) > len(shown):
+            lines.append(
+                f"      ... {len(stratum.ranked) - len(shown)} more "
+                "(rerun with --explain)"
+            )
+
+    if stratum.frontier:
+        on_frontier = [
+            entry.system_key.label()
+            for entry in stratum.frontier
+            if not entry.dominated
+        ]
+        axes = ", ".join(axis.value for axis in stratum.frontier_axes)
+        lines.append(f"  Frontier ({axes}):")
+        for label in on_frontier:
+            lines.append(f"      on frontier: {label}")
+        if verbose:
+            for entry in stratum.frontier:
+                if entry.dominated:
+                    lines.append(
+                        f"      dominated:   {entry.system_key.label()} "
+                        f"(by {', '.join(entry.dominated_by)})"
+                    )
+
+    if stratum.rejected:
+        lines.append(f"  Rejected systems ({len(stratum.rejected)}):")
+        for system in stratum.rejected:
+            lines.append(f"      {system.system_key.label()}")
+            reasons = system.reasons if verbose else system.reasons[:1]
+            lines.extend(f"        - {reason}" for reason in reasons)
+            if not verbose and len(system.reasons) > 1:
+                lines.append(
+                    f"        - ... {len(system.reasons) - 1} more "
+                    "(rerun with --explain)"
+                )
+
+    if stratum.missing_evidence:
+        lines.append("  Missing evidence:")
+        lines.extend(f"      - {note}" for note in stratum.missing_evidence)
+    return "\n".join(lines)
+
+
+def format_compare_report_text(report: CompareReport, *, verbose: bool = False) -> str:
+    """Render ``report`` as plain text for a terminal."""
+    lines = [
+        f"Cross-system comparison ({report.policy.name or 'unnamed policy'})",
+        f"  generated at: {report.generated_at}",
+        f"  objective:    {report.policy.objective.value}",
+        f"  comparable units: {len(report.strata)}",
+    ]
+    if report.pricing is not None:
+        pricing = report.pricing
+        lines.append(
+            f"  pricing:      {pricing.manifest_path} "
+            f"({pricing.currency}, sha256 {pricing.manifest_sha256[:12]})"
+        )
+        if pricing.rates_are_illustrative:
+            lines.append(
+                "                rates are declared illustrative examples; "
+                "every monetary figure below is a demonstration, not a price"
+            )
+    else:
+        lines.append("  pricing:      none supplied, so no monetary values")
+
+    if not report.strata:
+        lines.append("")
+        lines.append(
+            "No comparable units were found. Nothing was compared, so nothing "
+            "is recommended."
+        )
+        return "\n".join(lines)
+
+    for stratum in report.strata:
+        lines.append("")
+        lines.append(
+            _stratum_text(
+                stratum,
+                constraints=report.policy.constraints,
+                verbose=verbose,
+            )
+        )
+
+    if report.excluded_runs:
+        lines.append("")
+        lines.append(f"Excluded runs ({len(report.excluded_runs)}):")
+        for run in report.excluded_runs:
+            lines.append(f"  {run.run_id}: {run.reason}")
+
+    lines.append("")
+    lines.append(
+        "Every recommendation above applies only to the workload, context "
+        "tier, evaluator, decode settings, objective and constraints named "
+        "with it. There is no universal winner on this page."
+    )
+    return "\n".join(lines)
+
+
+__all__ = ["format_compare_report_text"]

--- a/llmtracefx/optimizer/compare/identity.py
+++ b/llmtracefx/optimizer/compare/identity.py
@@ -1,0 +1,383 @@
+"""Comparable-unit and system identity keys for the ``compare`` command.
+
+The tuner (``optimizer.tune.identity``) answers a narrower question: which
+configuration of *one* model on *one* machine is fastest. It therefore puts
+model id, accelerator and runtime inside its ``GroupKey``, so two different
+systems can never be ranked against each other.
+
+Cross-system comparison asks the opposite question, so the split has to move:
+
+* ``ComparableUnitKey`` is the *task* two systems were both asked to perform.
+  Two runs belong to the same unit only when the workload identity, the exact
+  prompt hash, the context tier, the evaluator/quality metric, and the decode
+  settings that bound how much output was allowed are all identical. Anything
+  else is a different question and lands in a different stratum.
+* ``SystemKey`` is *what was under test*: model and model revision, provider,
+  runtime/backend, accelerator, quantization, reasoning effort, and decode
+  mode. Systems are never averaged together, and two candidates that differ
+  on any one of these fields stay distinct.
+
+Neither key is ever inferred. Every field is read from an already-validated
+``RowVerification``/``ExperimentRecord`` pair (plus, for API runs, the
+collector's own ``api_evidence.json``), and a value that was not recorded
+stays ``None`` rather than being guessed or defaulted to zero.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+COMPARE_IDENTITY_CONTEXT = "compare identity"
+
+
+class CompareIdentityError(ValueError):
+    """Raised when a comparable-unit/system key is invalid or malformed."""
+
+
+def _require_str(data: Any, key: str, *, context: str) -> str:
+    if not isinstance(data, dict) or key not in data:
+        raise CompareIdentityError(f"{context} is missing required field: {key!r}")
+    value = data[key]
+    if not isinstance(value, str) or not value:
+        raise CompareIdentityError(
+            f"{context}.{key} must be a non-empty string, got {value!r}"
+        )
+    return value
+
+
+def _optional_str(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise CompareIdentityError(
+            f"{context}.{key} must be a non-empty string or null, got {value!r}"
+        )
+    return value
+
+
+def _optional_positive_int(
+    data: dict[str, Any], key: str, *, context: str
+) -> int | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CompareIdentityError(
+            f"{context}.{key} must be an integer or null, got {value!r}"
+        )
+    if value < 1:
+        raise CompareIdentityError(f"{context}.{key} must be >= 1, got {value}")
+    return int(value)
+
+
+def _optional_finite_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CompareIdentityError(
+            f"{context}.{key} must be a number or null, got {value!r}"
+        )
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise CompareIdentityError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric):
+        raise CompareIdentityError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    return numeric
+
+
+def _format_setting(value: float | int | None) -> str:
+    if value is None:
+        return "unrecorded"
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:g}"
+
+
+#: Marks a message list that is not the plain single-user-prompt shape. The
+#: digest that follows it is over the message structure, never over any
+#: message text, which this project does not persist.
+REQUEST_SHAPE_PREFIX = "sha256:"
+
+
+def request_shape_for(
+    messages: Sequence[tuple[str, str]], *, workload_prompt_hash: str
+) -> str | None:
+    """Normalize a recorded message list into a comparable request shape.
+
+    ``messages`` is ``(role, content_sha256)`` per message, exactly as the API
+    collector persists it -- digests, never text.
+
+    Returns ``None`` for the canonical shape: a single ``user`` message whose
+    content hash is the workload prompt itself. That is precisely what a local
+    run does when it feeds a prompt file to a model, and a local run records
+    no message structure at all, so normalizing the two to ``None`` is what
+    lets a local system and a hosted one land in the same comparable unit.
+
+    Anything else -- a system prompt, a prepended conversation, a reordered or
+    duplicated message -- returns a digest instead, which no local run can
+    match. That is the intended outcome: a prompt sent under a system prompt
+    is a different question, and must be reported as a separate stratum
+    rather than compared against a bare prompt as though they were equivalent.
+    """
+    entries = list(messages)
+    if len(entries) == 1:
+        role, digest = entries[0]
+        if role == "user" and digest == workload_prompt_hash:
+            return None
+    payload = json.dumps(
+        [[role, digest] for role, digest in entries],
+        sort_keys=False,
+        separators=(",", ":"),
+    )
+    return REQUEST_SHAPE_PREFIX + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ComparableUnitKey:
+    """The identical task two systems must both have performed.
+
+    ``max_output_tokens``/``temperature``/``top_p`` are part of the identity
+    on purpose. A run capped at 128 output tokens is not the same measurement
+    as one capped at 2048, and a run whose cap was never recorded is not
+    known to match either. ``None`` therefore means "unrecorded", and it only
+    ever compares equal to another unrecorded value -- it is never treated as
+    a wildcard that silently absorbs runs with a known setting.
+
+    ``request_shape`` carries the rest of what was actually asked. A prompt
+    hash alone does not identify a request: the same user prompt sent with a
+    system prompt, or as the tail of a multi-turn conversation, is a
+    different question. See ``request_shape_for`` for how it is normalized so
+    that the ordinary single-user-prompt case still compares against a local
+    run, which has no message structure to record.
+    """
+
+    workload_id: str
+    workload_version: str
+    workload_prompt_hash: str
+    context_tier: str
+    quality_metric: str | None
+    max_output_tokens: int | None
+    temperature: float | None
+    top_p: float | None
+    request_shape: str | None = None
+
+    def label(self) -> str:
+        shape = "" if self.request_shape is None else f" shape={self.request_shape}"
+        return (
+            f"{self.workload_id}@v{self.workload_version} [{self.context_tier}] "
+            f"evaluator={self.quality_metric or 'unrecorded'} "
+            f"max_output={_format_setting(self.max_output_tokens)} "
+            f"temperature={_format_setting(self.temperature)} "
+            f"top_p={_format_setting(self.top_p)}{shape}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workload_id": self.workload_id,
+            "workload_version": self.workload_version,
+            "workload_prompt_hash": self.workload_prompt_hash,
+            "context_tier": self.context_tier,
+            "quality_metric": self.quality_metric,
+            "max_output_tokens": self.max_output_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "request_shape": self.request_shape,
+        }
+
+    def sort_key(self) -> tuple[Any, ...]:
+        # Each optional field contributes an ``is None`` flag *and* its value
+        # rather than folding "unrecorded" onto a sentinel number. A sentinel
+        # such as -1 would make an unrecorded temperature sort identically to a
+        # recorded -1.0, so two genuinely different comparable units would
+        # collide on the key that decides their order in the report.
+        return (
+            self.workload_id,
+            self.workload_version,
+            self.context_tier,
+            self.workload_prompt_hash,
+            self.quality_metric is None,
+            self.quality_metric or "",
+            self.max_output_tokens is None,
+            self.max_output_tokens or 0,
+            self.temperature is None,
+            self.temperature or 0.0,
+            self.top_p is None,
+            self.top_p or 0.0,
+            self.request_shape is None,
+            self.request_shape or "",
+        )
+
+    @classmethod
+    def from_dict(cls, data: Any) -> ComparableUnitKey:
+        if not isinstance(data, dict):
+            raise CompareIdentityError("comparable_unit_key must be a JSON object")
+        context = "comparable_unit_key"
+        return cls(
+            workload_id=_require_str(data, "workload_id", context=context),
+            workload_version=_require_str(data, "workload_version", context=context),
+            workload_prompt_hash=_require_str(
+                data, "workload_prompt_hash", context=context
+            ),
+            context_tier=_require_str(data, "context_tier", context=context),
+            quality_metric=_optional_str(data, "quality_metric", context=context),
+            max_output_tokens=_optional_positive_int(
+                data, "max_output_tokens", context=context
+            ),
+            temperature=_optional_finite_float(data, "temperature", context=context),
+            top_p=_optional_finite_float(data, "top_p", context=context),
+            request_shape=_optional_str(data, "request_shape", context=context),
+        )
+
+
+@dataclass(frozen=True)
+class SystemKey:
+    """One system under test, labeled by everything that makes it that system.
+
+    Deliberately conservative: two runs are only ever pooled into the same
+    system when every field matches exactly. A different quantization, a
+    different reasoning effort, a different model revision, a different
+    deployment endpoint or any difference at all in the recorded execution
+    configuration is a different system, never a variant of the same one to
+    be averaged in.
+
+    ``execution_config_hash`` is the collector's own identity hash over the
+    whole request configuration (endpoint, model, sampling, provider
+    extensions, finish-reason vocabulary, timeout, retained event limit and
+    system prompt). It is carried verbatim rather than recomputed, so a
+    configuration difference this module does not model by name still
+    separates two systems instead of silently pooling them. The trade is that
+    a collector field which legitimately varies per run (Z.ai's optional
+    body-level ``request_id``, for instance) will split runs that a reader
+    might consider one system; that is the safe direction to err.
+    """
+
+    model_id: str
+    model_revision: str | None
+    provider: str | None
+    runtime_name: str
+    runtime_backend: str | None
+    accelerator: str | None
+    quantization: str | None
+    reasoning_effort: str | None
+    decode_mode: str
+    endpoint: str | None = None
+    thinking_type: str | None = None
+    execution_config_hash: str | None = None
+
+    @property
+    def is_local(self) -> bool:
+        """True when no remote provider executed this system's runs.
+
+        Local-only measurements (peak memory in particular) are reported
+        for these systems and withheld for everything else, rather than
+        being compared against a value a hosted API cannot produce.
+        """
+        return self.provider is None
+
+    def label(self) -> str:
+        where = self.provider or (self.accelerator or "unknown hardware")
+        revision = f"@{self.model_revision}" if self.model_revision else ""
+        thinking = f" thinking={self.thinking_type}" if self.thinking_type else ""
+        deployment = f" endpoint={self.endpoint}" if self.endpoint else ""
+        return (
+            f"{self.model_id}{revision} via {where} "
+            f"[{self.runtime_name}/{self.runtime_backend or 'unknown'}] "
+            f"quant={self.quantization or 'unrecorded'} "
+            f"reasoning={self.reasoning_effort or 'unrecorded'}{thinking} "
+            f"decode={self.decode_mode}{deployment}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "provider": self.provider,
+            "runtime_name": self.runtime_name,
+            "runtime_backend": self.runtime_backend,
+            "accelerator": self.accelerator,
+            "quantization": self.quantization,
+            "reasoning_effort": self.reasoning_effort,
+            "decode_mode": self.decode_mode,
+            "endpoint": self.endpoint,
+            "thinking_type": self.thinking_type,
+            "execution_config_hash": self.execution_config_hash,
+            "is_local": self.is_local,
+        }
+
+    def sort_key(self) -> tuple[Any, ...]:
+        return (
+            self.model_id,
+            self.model_revision or "",
+            self.provider or "",
+            self.runtime_name,
+            self.runtime_backend or "",
+            self.accelerator or "",
+            self.quantization or "",
+            self.reasoning_effort or "",
+            self.decode_mode,
+            self.endpoint or "",
+            self.thinking_type or "",
+            self.execution_config_hash or "",
+        )
+
+    @classmethod
+    def from_dict(cls, data: Any) -> SystemKey:
+        if not isinstance(data, dict):
+            raise CompareIdentityError("system_key must be a JSON object")
+        context = "system_key"
+        key = cls(
+            model_id=_require_str(data, "model_id", context=context),
+            model_revision=_optional_str(data, "model_revision", context=context),
+            provider=_optional_str(data, "provider", context=context),
+            runtime_name=_require_str(data, "runtime_name", context=context),
+            runtime_backend=_optional_str(data, "runtime_backend", context=context),
+            accelerator=_optional_str(data, "accelerator", context=context),
+            quantization=_optional_str(data, "quantization", context=context),
+            reasoning_effort=_optional_str(data, "reasoning_effort", context=context),
+            decode_mode=_require_str(data, "decode_mode", context=context),
+            endpoint=_optional_str(data, "endpoint", context=context),
+            thinking_type=_optional_str(data, "thinking_type", context=context),
+            execution_config_hash=_optional_str(
+                data, "execution_config_hash", context=context
+            ),
+        )
+        declared_local = data.get("is_local")
+        if declared_local is not None:
+            if not isinstance(declared_local, bool):
+                raise CompareIdentityError(
+                    f"{context}.is_local must be a boolean or null, got "
+                    f"{declared_local!r}"
+                )
+            if declared_local != key.is_local:
+                raise CompareIdentityError(
+                    f"{context}.is_local ({declared_local!r}) contradicts the "
+                    f"provider field ({key.provider!r}); refusing to load a key "
+                    "whose locality claim does not follow from its own identity"
+                )
+        if key.is_local and key.endpoint is not None:
+            raise CompareIdentityError(
+                f"{context} declares no provider yet records a deployment "
+                f"endpoint ({key.endpoint!r}); a local system has no endpoint"
+            )
+        return key

--- a/llmtracefx/optimizer/compare/policy.py
+++ b/llmtracefx/optimizer/compare/policy.py
@@ -1,0 +1,539 @@
+"""Typed, strictly-validated policy for one ``compare`` run.
+
+Shares the tuner's discipline verbatim: exactly one ranking objective per
+run, and a constraint set a system must clear *before* it is ranked at all.
+There is no blended score anywhere in this module, because a single number
+mixing latency, quality and price hides which axis a recommendation actually
+came from, and that is precisely the axis a reader needs.
+
+The constraint axes that also exist in ``tune.policy.TuneConstraints`` keep
+exactly the same meaning here, and the shared vocabulary (``RowStatus``,
+``ALLOWED_REQUIRED_STATUSES``, ``MetricProvenance``) is imported from there
+rather than restated. The additions are the two things a cross-system
+comparison can constrain and a single-machine tuning run cannot: money, and
+the requirement that a priced comparison actually be priced.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..schema import MetricProvenance
+from ..tune.policy import (
+    ALLOWED_REQUIRED_STATUSES,
+    DEFAULT_REQUIRED_STATUSES,
+)
+from ..workloads.verify import RowStatus
+
+COMPARE_POLICY_SCHEMA_VERSION = "1"
+
+
+class ComparePolicyError(ValueError):
+    """Raised when a comparison policy is invalid or malformed."""
+
+
+class CompareObjective(str, Enum):
+    """The single ranking objective for one comparison run."""
+
+    MIN_MEAN_TOTAL_LATENCY_MS = "min_mean_total_latency_ms"
+    """Prefer the system with the lowest mean end-to-end ``timing.total``."""
+
+    MAX_CORRECT_CASES_PER_MINUTE = "max_correct_cases_per_minute"
+    """Prefer the highest passing-cases-per-minute throughput, using
+    ``workloads.aggregate.correct_cases_per_minute`` unchanged."""
+
+    MIN_COST_PER_CORRECT_CASE = "min_cost_per_correct_case"
+    """Prefer the lowest estimated spend per passing case. Requires a
+    pricing manifest and provider-reported usage for every ranked system."""
+
+    MAX_CORRECT_CASES_PER_CURRENCY_UNIT = "max_correct_cases_per_currency_unit"
+    """Prefer the most passing cases bought per unit of currency. Same
+    evidence requirement as ``min_cost_per_correct_case``."""
+
+    @property
+    def prefers_lower(self) -> bool:
+        return self in (
+            CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+            CompareObjective.MIN_COST_PER_CORRECT_CASE,
+        )
+
+    @property
+    def requires_cost(self) -> bool:
+        return self in (
+            CompareObjective.MIN_COST_PER_CORRECT_CASE,
+            CompareObjective.MAX_CORRECT_CASES_PER_CURRENCY_UNIT,
+        )
+
+
+def _optional_positive_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ComparePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise ComparePolicyError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric) or numeric <= 0:
+        raise ComparePolicyError(f"{context}.{key} must be > 0, got {numeric!r}")
+    return numeric
+
+
+def _optional_non_negative_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ComparePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise ComparePolicyError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric) or numeric < 0:
+        raise ComparePolicyError(f"{context}.{key} must be >= 0, got {numeric!r}")
+    return numeric
+
+
+def _optional_unit_interval(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ComparePolicyError(f"{context}.{key} must be a number, got {value!r}")
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise ComparePolicyError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric) or not 0.0 <= numeric <= 1.0:
+        raise ComparePolicyError(
+            f"{context}.{key} must be within [0, 1], got {numeric!r}"
+        )
+    return numeric
+
+
+#: Keys a compare policy may carry. Anything else is refused rather than
+#: ignored: a policy is the operator's statement of what bar they intended to
+#: apply, so silently dropping a misspelled ``max_mean_latency_ms`` publishes
+#: a comparison that cleared a constraint nobody actually set, and reads as
+#: though the bar had been enforced.
+_POLICY_KEYS = frozenset(
+    {
+        "schema_version",
+        "name",
+        "description",
+        "objective",
+        "constraints",
+    }
+)
+
+#: Same rule, one level down.
+_CONSTRAINT_KEYS = frozenset(
+    {
+        "required_statuses",
+        "allowed_provenances",
+        "min_pass_rate",
+        "min_quality_score",
+        "required_quality_metric",
+        "max_mean_total_latency_ms",
+        "max_cost_per_correct_case",
+        "min_measured_repetitions",
+        "max_coefficient_of_variation",
+    }
+)
+
+
+def _reject_unknown_keys(
+    data: dict[str, Any], allowed: frozenset[str], *, context: str
+) -> None:
+    """Refuse keys this schema does not define."""
+    unknown = sorted(key for key in data if key not in allowed)
+    if unknown:
+        raise ComparePolicyError(
+            f"{context} has unknown field(s) {unknown}; allowed fields are "
+            f"{sorted(allowed)}. A misspelled constraint would otherwise be "
+            "silently ignored and the comparison would report clearing a bar "
+            "that was never applied"
+        )
+
+
+@dataclass(frozen=True)
+class CompareConstraints:
+    """Everything a system must satisfy before it is ranked at all."""
+
+    required_statuses: frozenset[RowStatus] = field(
+        default_factory=lambda: DEFAULT_REQUIRED_STATUSES
+    )
+    min_pass_rate: float | None = None
+    min_quality_score: float | None = None
+    required_quality_metric: str | None = None
+    max_mean_total_latency_ms: float | None = None
+    max_cost_per_correct_case: float | None = None
+    allowed_provenances: frozenset[MetricProvenance] | None = None
+    min_measured_repetitions: int = 1
+    max_coefficient_of_variation: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.required_statuses:
+            raise ComparePolicyError("constraints.required_statuses must be non-empty")
+        disallowed = self.required_statuses - ALLOWED_REQUIRED_STATUSES
+        if disallowed:
+            raise ComparePolicyError(
+                "constraints.required_statuses may only contain "
+                f"{sorted(s.value for s in ALLOWED_REQUIRED_STATUSES)}, got "
+                f"disallowed value(s) {sorted(s.value for s in disallowed)}"
+            )
+        if self.min_quality_score is not None and self.required_quality_metric is None:
+            raise ComparePolicyError(
+                "constraints.required_quality_metric must be set when "
+                "constraints.min_quality_score is configured, so a system's "
+                "quality_score is never compared against a mismatched metric"
+            )
+        if isinstance(self.min_measured_repetitions, bool):
+            raise ComparePolicyError(
+                "constraints.min_measured_repetitions must be an integer, got "
+                f"{self.min_measured_repetitions!r}"
+            )
+        if self.min_measured_repetitions < 1:
+            raise ComparePolicyError(
+                "constraints.min_measured_repetitions must be >= 1"
+            )
+        for name, value in (
+            ("min_pass_rate", self.min_pass_rate),
+            ("min_quality_score", self.min_quality_score),
+            ("max_mean_total_latency_ms", self.max_mean_total_latency_ms),
+            ("max_cost_per_correct_case", self.max_cost_per_correct_case),
+            ("max_coefficient_of_variation", self.max_coefficient_of_variation),
+        ):
+            if value is not None and not math.isfinite(value):
+                raise ComparePolicyError(
+                    f"constraints.{name} must be a finite number, got {value!r}"
+                )
+        # Range rules, enforced here rather than only while parsing, because
+        # this dataclass is public: a constraint constructed directly with an
+        # unsatisfiable or meaningless bound would silently exclude every
+        # system, or admit every system, and be reported as a real threshold.
+        for name, value in (
+            ("min_pass_rate", self.min_pass_rate),
+            ("min_quality_score", self.min_quality_score),
+            ("max_coefficient_of_variation", self.max_coefficient_of_variation),
+        ):
+            if value is not None and value < 0:
+                raise ComparePolicyError(
+                    f"constraints.{name} must be >= 0, got {value!r}"
+                )
+        # A ceiling of exactly zero is not a strict bar, it is an
+        # unsatisfiable one: nothing costs nothing or takes no time, so it
+        # rejects every system while ``active_summary`` renders it as a
+        # deliberate threshold. The parser already refuses it; so does this.
+        for name, value in (
+            ("max_mean_total_latency_ms", self.max_mean_total_latency_ms),
+            ("max_cost_per_correct_case", self.max_cost_per_correct_case),
+        ):
+            if value is not None and value <= 0:
+                raise ComparePolicyError(
+                    f"constraints.{name} must be > 0, got {value!r}"
+                )
+        if self.min_pass_rate is not None and self.min_pass_rate > 1:
+            raise ComparePolicyError(
+                "constraints.min_pass_rate is a fraction between 0 and 1, got "
+                f"{self.min_pass_rate!r}"
+            )
+
+    def active_summary(self) -> tuple[str, ...]:
+        """Every constraint actually in force, as readable phrases.
+
+        A recommendation is only meaningful together with the bar a system
+        had to clear to earn it, and the README promises each one is stated
+        with the constraints it applies to. Reporting "cleared every
+        constraint" without saying which constraints those were leaves a
+        reader unable to tell a demanding comparison from a vacuous one.
+
+        Only constraints that are set are listed. An unset constraint
+        excludes nothing, so naming it would overstate the bar.
+        """
+        parts: list[str] = [
+            "required run status in "
+            + ", ".join(sorted(status.value for status in self.required_statuses))
+        ]
+        if self.allowed_provenances:
+            parts.append(
+                "timing provenance in "
+                + ", ".join(sorted(item.value for item in self.allowed_provenances))
+            )
+        if self.min_pass_rate is not None:
+            parts.append(f"pass rate >= {self.min_pass_rate}")
+        if self.min_quality_score is not None:
+            parts.append(
+                f"quality score >= {self.min_quality_score} "
+                f"on {self.required_quality_metric}"
+            )
+        elif self.required_quality_metric is not None:
+            parts.append(f"quality metric is {self.required_quality_metric}")
+        if self.max_mean_total_latency_ms is not None:
+            parts.append(f"mean total latency <= {self.max_mean_total_latency_ms} ms")
+        if self.max_cost_per_correct_case is not None:
+            parts.append(f"cost per correct case <= {self.max_cost_per_correct_case}")
+        if self.max_coefficient_of_variation is not None:
+            parts.append(
+                "coefficient of variation <= " f"{self.max_coefficient_of_variation}"
+            )
+        parts.append(f"at least {self.min_measured_repetitions} measured run(s)")
+        return tuple(parts)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required_statuses": sorted(s.value for s in self.required_statuses),
+            "min_pass_rate": self.min_pass_rate,
+            "min_quality_score": self.min_quality_score,
+            "required_quality_metric": self.required_quality_metric,
+            "max_mean_total_latency_ms": self.max_mean_total_latency_ms,
+            "max_cost_per_correct_case": self.max_cost_per_correct_case,
+            "allowed_provenances": (
+                None
+                if self.allowed_provenances is None
+                else sorted(p.value for p in self.allowed_provenances)
+            ),
+            "min_measured_repetitions": self.min_measured_repetitions,
+            "max_coefficient_of_variation": self.max_coefficient_of_variation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> CompareConstraints:
+        if not isinstance(data, dict):
+            raise ComparePolicyError("compare policy 'constraints' must be an object")
+        context = "constraints"
+        _reject_unknown_keys(data, _CONSTRAINT_KEYS, context="compare constraints")
+
+        raw_statuses = data.get(
+            "required_statuses", [s.value for s in DEFAULT_REQUIRED_STATUSES]
+        )
+        if not isinstance(raw_statuses, list) or not raw_statuses:
+            raise ComparePolicyError(
+                f"{context}.required_statuses must be a non-empty list of strings"
+            )
+        try:
+            required_statuses = frozenset(RowStatus(value) for value in raw_statuses)
+        except ValueError as exc:
+            raise ComparePolicyError(
+                f"{context}.required_statuses contains an unknown status: {exc}"
+            ) from exc
+
+        raw_provenances = data.get("allowed_provenances")
+        allowed_provenances: frozenset[MetricProvenance] | None
+        if raw_provenances is None:
+            allowed_provenances = None
+        else:
+            if not isinstance(raw_provenances, list) or not raw_provenances:
+                raise ComparePolicyError(
+                    f"{context}.allowed_provenances must be a non-empty list of "
+                    "strings, or omitted/null to allow any provenance"
+                )
+            try:
+                allowed_provenances = frozenset(
+                    MetricProvenance(value) for value in raw_provenances
+                )
+            except ValueError as exc:
+                raise ComparePolicyError(
+                    f"{context}.allowed_provenances contains an unknown "
+                    f"provenance: {exc}"
+                ) from exc
+
+        required_quality_metric = data.get("required_quality_metric")
+        if required_quality_metric is not None and not isinstance(
+            required_quality_metric, str
+        ):
+            raise ComparePolicyError(
+                f"{context}.required_quality_metric must be a string or null"
+            )
+
+        raw_repetitions = data.get("min_measured_repetitions", 1)
+        if isinstance(raw_repetitions, bool) or not isinstance(raw_repetitions, int):
+            raise ComparePolicyError(
+                f"{context}.min_measured_repetitions must be an integer"
+            )
+
+        return cls(
+            required_statuses=required_statuses,
+            min_pass_rate=_optional_unit_interval(
+                data, "min_pass_rate", context=context
+            ),
+            min_quality_score=_optional_non_negative_float(
+                data, "min_quality_score", context=context
+            ),
+            required_quality_metric=required_quality_metric,
+            max_mean_total_latency_ms=_optional_positive_float(
+                data, "max_mean_total_latency_ms", context=context
+            ),
+            max_cost_per_correct_case=_optional_positive_float(
+                data, "max_cost_per_correct_case", context=context
+            ),
+            allowed_provenances=allowed_provenances,
+            min_measured_repetitions=int(raw_repetitions),
+            max_coefficient_of_variation=_optional_non_negative_float(
+                data, "max_coefficient_of_variation", context=context
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ComparePolicy:
+    """A complete, validated comparison policy: one objective plus constraints."""
+
+    objective: CompareObjective
+    constraints: CompareConstraints = field(default_factory=CompareConstraints)
+    schema_version: str = COMPARE_POLICY_SCHEMA_VERSION
+    name: str | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "description": self.description,
+            "objective": self.objective.value,
+            "constraints": self.constraints.to_dict(),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> ComparePolicy:
+        if not isinstance(data, dict):
+            raise ComparePolicyError("compare policy must be a JSON/YAML object")
+        _reject_unknown_keys(data, _POLICY_KEYS, context="compare policy")
+        try:
+            objective = CompareObjective(data["objective"])
+        except KeyError as exc:
+            raise ComparePolicyError(
+                "compare policy is missing required field: 'objective'"
+            ) from exc
+        except ValueError as exc:
+            raise ComparePolicyError(
+                f"compare policy has an invalid objective: {exc}"
+            ) from exc
+
+        name = data.get("name")
+        if name is not None and not isinstance(name, str):
+            raise ComparePolicyError("compare policy 'name' must be a string or null")
+        description = data.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ComparePolicyError(
+                "compare policy 'description' must be a string or null"
+            )
+
+        schema_version = str(data.get("schema_version", COMPARE_POLICY_SCHEMA_VERSION))
+        if schema_version != COMPARE_POLICY_SCHEMA_VERSION:
+            raise ComparePolicyError(
+                f"unsupported compare policy schema_version {schema_version!r}, "
+                f"expected {COMPARE_POLICY_SCHEMA_VERSION!r}"
+            )
+
+        return cls(
+            schema_version=schema_version,
+            name=name,
+            description=description,
+            objective=objective,
+            constraints=CompareConstraints.from_dict(data.get("constraints", {})),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> ComparePolicy:
+        try:
+            data = json.loads(payload)
+        # ``json`` raises past its own limits with exceptions that are
+        # not ``JSONDecodeError``: an integer literal over the
+        # interpreter's digit cap raises a plain ``ValueError``, and deep
+        # nesting raises ``RecursionError``. Neither is caught by any
+        # caller, so both used to escape as a traceback from a merely
+        # malformed file.
+        except (ValueError, RecursionError) as exc:
+            raise ComparePolicyError(f"invalid JSON for compare policy: {exc}") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> ComparePolicy:
+        """Load a policy from ``.json`` or ``.yaml``/``.yml``.
+
+        Mirrors ``TunePolicy.from_file``'s extension dispatch and its
+        explicit failure on an unsupported extension or missing PyYAML.
+        """
+        policy_path = Path(path)
+        text = policy_path.read_text(encoding="utf-8")
+        suffix = policy_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise ComparePolicyError(
+                    "YAML compare policy requires PyYAML to be installed "
+                    "(`uv add pyyaml`); use a .json policy instead if it is "
+                    "unavailable"
+                ) from exc
+            try:
+                data = yaml.safe_load(text)
+            # ``yaml.YAMLError`` subclasses ``Exception``, not
+            # ``ValueError``, so neither this loader nor the CLI
+            # caught it and a merely malformed YAML file escaped as a
+            # traceback. YAML is an advertised input format for this
+            # flag, and it is far easier to malform than JSON.
+            except (yaml.YAMLError, ValueError, RecursionError) as exc:
+                raise ComparePolicyError(
+                    f"invalid YAML in {policy_path}: {exc}"
+                ) from exc
+        elif suffix == ".json":
+            try:
+                data = json.loads(text)
+            except (ValueError, RecursionError) as exc:
+                raise ComparePolicyError(
+                    f"invalid JSON in {policy_path}: {exc}"
+                ) from exc
+        else:
+            raise ComparePolicyError(
+                f"unsupported compare policy extension {suffix!r} "
+                "(use .json or .yaml)"
+            )
+        if not isinstance(data, dict):
+            raise ComparePolicyError(
+                f"compare policy in {policy_path} must be a JSON/YAML object"
+            )
+        return cls.from_dict(data)

--- a/llmtracefx/optimizer/compare/pricing.py
+++ b/llmtracefx/optimizer/compare/pricing.py
@@ -1,0 +1,456 @@
+"""Strict, versioned pricing input for cross-system cost comparison.
+
+Money is the one number in this project that cannot be measured locally, so
+it is treated as an *input* with the same suspicion as any other untrusted
+artifact rather than as a constant baked into the source:
+
+* Rates arrive only through a user-supplied manifest file. Nothing here ships
+  a live price, and nothing here fetches one.
+* Every entry carries its own ``currency``, ``effective_at`` date and a
+  ``source`` reference, so a number in a report can always be traced back to
+  what it was read from and when.
+* Matching an entry to a system is exact and unambiguous. Two entries that
+  both match one system is a refusal, never a silent "first wins".
+* A manifest whose entries are not explicitly sourced must declare
+  ``rates_are_illustrative``. Illustrative rates still produce numbers, but
+  the report labels every one of them as an example rather than a price.
+
+The exact entry used for a cost figure is recorded by id *and* by content
+hash (``PricingEntry.content_sha256``), so editing a manifest after the fact
+cannot quietly change what a published report claimed to have used.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PRICING_MANIFEST_SCHEMA_VERSION = "1"
+
+#: ISO 4217 alphabetic codes are exactly three uppercase letters. Anything
+#: else (a symbol, a lowercase code, a free-text name) is rejected so two
+#: manifests can never be compared on a currency that was never pinned
+#: down. Public so the report loader can hold a persisted currency to the
+#: identical standard rather than restating the rule.
+CURRENCY_PATTERN = re.compile(r"^[A-Z]{3}$")
+
+#: Minimal ISO-8601 date or UTC timestamp. Deliberately narrow: a price is
+#: only meaningful with a date attached, and a date this module cannot parse
+#: is not a date it should accept.
+_EFFECTIVE_AT_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)?$"
+)
+
+#: The rate fields an entry may declare, and the usage each one prices.
+RATE_FIELDS: tuple[str, ...] = (
+    "input_per_million",
+    "output_per_million",
+    "cached_input_per_million",
+    "reasoning_per_million",
+)
+
+
+class PricingError(ValueError):
+    """Raised when a pricing manifest is invalid, ambiguous, or unusable."""
+
+
+def _require(data: Any, key: str, *, context: str) -> Any:
+    if not isinstance(data, dict) or key not in data:
+        raise PricingError(f"{context} is missing required field: {key!r}")
+    return data[key]
+
+
+def _require_str(data: Any, key: str, *, context: str) -> str:
+    value = _require(data, key, context=context)
+    if not isinstance(value, str) or not value:
+        raise PricingError(f"{context}.{key} must be a non-empty string, got {value!r}")
+    return value
+
+
+def _optional_str(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise PricingError(
+            f"{context}.{key} must be a non-empty string or null, got {value!r}"
+        )
+    return value
+
+
+def _require_bool(data: dict[str, Any], key: str, *, context: str) -> bool:
+    value = _require(data, key, context=context)
+    if not isinstance(value, bool):
+        raise PricingError(f"{context}.{key} must be a boolean, got {value!r}")
+    return value
+
+
+def _optional_rate(data: dict[str, Any], key: str, *, context: str) -> float | None:
+    """Read one per-million rate, refusing anything that is not a real price.
+
+    Booleans, strings, NaN, infinities and negatives are all rejected rather
+    than coerced. Zero is allowed and meaningful (a genuinely free tier), but
+    it must be written as ``0``; a missing rate stays ``None`` and makes the
+    metric that needs it unavailable instead of free.
+    """
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PricingError(f"{context}.{key} must be a number or null, got {value!r}")
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise PricingError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric):
+        raise PricingError(
+            f"{context}.{key} must be a finite number, got {numeric!r}; a "
+            "non-finite rate would silently poison every cost derived from it"
+        )
+    if numeric < 0:
+        raise PricingError(f"{context}.{key} must be >= 0, got {numeric!r}")
+    return numeric
+
+
+def canonical_json(payload: Any) -> str:
+    """Stable JSON for hashing: sorted keys, no insignificant whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+@dataclass(frozen=True)
+class PricingEntry:
+    """One provider/model price line, with its currency, date and source."""
+
+    entry_id: str
+    provider: str
+    model_id: str
+    currency: str
+    effective_at: str
+    source: str
+    rates_are_illustrative: bool
+    model_revision: str | None = None
+    """When set, this entry only matches runs of that exact model revision."""
+    input_per_million: float | None = None
+    output_per_million: float | None = None
+    cached_input_per_million: float | None = None
+    reasoning_per_million: float | None = None
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        if not CURRENCY_PATTERN.match(self.currency):
+            raise PricingError(
+                f"pricing entry {self.entry_id!r} currency must be a three-letter "
+                f"ISO 4217 code (e.g. 'USD'), got {self.currency!r}"
+            )
+        if not _EFFECTIVE_AT_PATTERN.match(self.effective_at):
+            raise PricingError(
+                f"pricing entry {self.entry_id!r} effective_at must be an ISO-8601 "
+                f"date (YYYY-MM-DD) or UTC timestamp, got {self.effective_at!r}"
+            )
+        # Enforced here as well as in ``from_dict`` because this dataclass is
+        # public: a caller constructing one directly bypasses the loader, and
+        # a negative or non-finite rate would then silently poison every cost
+        # derived from it instead of being refused at the boundary.
+        for name in RATE_FIELDS:
+            value = getattr(self, name)
+            if value is None:
+                continue
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise PricingError(
+                    f"pricing entry {self.entry_id!r} {name} must be a number "
+                    f"or null, got {value!r}"
+                )
+            if not math.isfinite(value):
+                raise PricingError(
+                    f"pricing entry {self.entry_id!r} {name} must be a finite "
+                    f"number, got {value!r}"
+                )
+            if value < 0:
+                raise PricingError(
+                    f"pricing entry {self.entry_id!r} {name} must be >= 0, "
+                    f"got {value!r}"
+                )
+        if not any(getattr(self, name) is not None for name in RATE_FIELDS):
+            raise PricingError(
+                f"pricing entry {self.entry_id!r} declares no rate at all; an "
+                "entry that prices nothing cannot be matched to anything"
+            )
+
+    def matches(
+        self, *, provider: str | None, model_id: str, model_revision: str | None
+    ) -> bool:
+        """Exact match only. A revision-less entry matches any revision."""
+        if provider is None or provider != self.provider:
+            return False
+        if model_id != self.model_id:
+            return False
+        if self.model_revision is None:
+            return True
+        return self.model_revision == model_revision
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "provider": self.provider,
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "currency": self.currency,
+            "effective_at": self.effective_at,
+            "source": self.source,
+            "rates_are_illustrative": self.rates_are_illustrative,
+            "input_per_million": self.input_per_million,
+            "output_per_million": self.output_per_million,
+            "cached_input_per_million": self.cached_input_per_million,
+            "reasoning_per_million": self.reasoning_per_million,
+            "notes": self.notes,
+        }
+
+    @property
+    def content_sha256(self) -> str:
+        """Hash of this entry's exact content, for provenance in a report."""
+        return hashlib.sha256(
+            canonical_json(self.to_dict()).encode("utf-8")
+        ).hexdigest()
+
+    @classmethod
+    def from_dict(cls, data: Any) -> PricingEntry:
+        if not isinstance(data, dict):
+            raise PricingError("pricing entry must be a JSON object")
+        entry_id = _require_str(data, "entry_id", context="pricing entry")
+        context = f"pricing entry {entry_id!r}"
+        return cls(
+            entry_id=entry_id,
+            provider=_require_str(data, "provider", context=context),
+            model_id=_require_str(data, "model_id", context=context),
+            model_revision=_optional_str(data, "model_revision", context=context),
+            currency=_require_str(data, "currency", context=context),
+            effective_at=_require_str(data, "effective_at", context=context),
+            source=_require_str(data, "source", context=context),
+            rates_are_illustrative=_require_bool(
+                data, "rates_are_illustrative", context=context
+            ),
+            input_per_million=_optional_rate(
+                data, "input_per_million", context=context
+            ),
+            output_per_million=_optional_rate(
+                data, "output_per_million", context=context
+            ),
+            cached_input_per_million=_optional_rate(
+                data, "cached_input_per_million", context=context
+            ),
+            reasoning_per_million=_optional_rate(
+                data, "reasoning_per_million", context=context
+            ),
+            notes=_optional_str(data, "notes", context=context),
+        )
+
+
+@dataclass(frozen=True)
+class PricingManifest:
+    """A complete, validated set of price lines in one single currency."""
+
+    schema_version: str
+    currency: str
+    entries: tuple[PricingEntry, ...]
+    name: str | None = None
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PRICING_MANIFEST_SCHEMA_VERSION:
+            raise PricingError(
+                f"unsupported pricing manifest schema_version "
+                f"{self.schema_version!r}, expected "
+                f"{PRICING_MANIFEST_SCHEMA_VERSION!r}"
+            )
+        if not CURRENCY_PATTERN.match(self.currency):
+            raise PricingError(
+                "pricing manifest currency must be a three-letter ISO 4217 code "
+                f"(e.g. 'USD'), got {self.currency!r}"
+            )
+        if not self.entries:
+            raise PricingError("pricing manifest must declare at least one entry")
+
+        seen_ids: set[str] = set()
+        for entry in self.entries:
+            if entry.entry_id in seen_ids:
+                raise PricingError(
+                    f"pricing manifest contains duplicate entry_id {entry.entry_id!r}"
+                )
+            seen_ids.add(entry.entry_id)
+            if entry.currency != self.currency:
+                raise PricingError(
+                    f"pricing entry {entry.entry_id!r} is priced in "
+                    f"{entry.currency!r} but the manifest declares "
+                    f"{self.currency!r}; mixing currencies in one comparison "
+                    "would produce a meaningless total"
+                )
+
+        # Two entries that can both match the same run make every cost drawn
+        # from this manifest arbitrary, so the ambiguity is rejected at load
+        # time rather than at the first lookup that happens to hit it.
+        for index, entry in enumerate(self.entries):
+            for other in self.entries[index + 1 :]:
+                if entry.provider != other.provider or entry.model_id != other.model_id:
+                    continue
+                if (
+                    entry.model_revision is None
+                    or other.model_revision is None
+                    or entry.model_revision == other.model_revision
+                ):
+                    raise PricingError(
+                        f"pricing entries {entry.entry_id!r} and "
+                        f"{other.entry_id!r} can both match provider "
+                        f"{entry.provider!r} model {entry.model_id!r}; refusing "
+                        "an ambiguous manifest. Give each entry a distinct "
+                        "model_revision, or remove the duplicate."
+                    )
+
+    @property
+    def rates_are_illustrative(self) -> bool:
+        """True when any entry declares itself an example rather than a price."""
+        return any(entry.rates_are_illustrative for entry in self.entries)
+
+    def resolve(
+        self, *, provider: str | None, model_id: str, model_revision: str | None
+    ) -> PricingEntry | None:
+        """Find the single entry for one system, or ``None`` if unpriced.
+
+        Raises ``PricingError`` when more than one entry matches. Load-time
+        validation already rejects manifests that *can* be ambiguous, so this
+        is defense in depth for manifests built in code rather than loaded.
+        """
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.matches(
+                provider=provider, model_id=model_id, model_revision=model_revision
+            )
+        ]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise PricingError(
+                f"provider {provider!r} model {model_id!r} revision "
+                f"{model_revision!r} matches {len(matches)} pricing entries "
+                f"({', '.join(sorted(entry.entry_id for entry in matches))}); "
+                "refusing to pick one"
+            )
+        return matches[0]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "description": self.description,
+            "currency": self.currency,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+    @property
+    def content_sha256(self) -> str:
+        return hashlib.sha256(
+            canonical_json(self.to_dict()).encode("utf-8")
+        ).hexdigest()
+
+    @classmethod
+    def from_dict(cls, data: Any) -> PricingManifest:
+        if not isinstance(data, dict):
+            raise PricingError("pricing manifest must be a JSON/YAML object")
+        context = "pricing manifest"
+        entries_raw = _require(data, "entries", context=context)
+        if not isinstance(entries_raw, list):
+            raise PricingError(f"{context}.entries must be a list")
+        # ``schema_version`` is required and matched exactly rather than
+        # defaulted. Defaulting it would let a manifest written against a
+        # future or past contract load silently under this build's reading of
+        # the field names, which is precisely the mistake versioning exists
+        # to prevent. Every rate in the file feeds a published monetary
+        # figure, so an unversioned file is not a file to guess about.
+        declared = _require(data, "schema_version", context=context)
+        if not isinstance(declared, str):
+            raise PricingError(
+                f"{context}.schema_version must be a string, got {declared!r}"
+            )
+        return cls(
+            schema_version=declared,
+            name=_optional_str(data, "name", context=context),
+            description=_optional_str(data, "description", context=context),
+            currency=_require_str(data, "currency", context=context),
+            entries=tuple(PricingEntry.from_dict(item) for item in entries_raw),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> PricingManifest:
+        try:
+            data = json.loads(payload)
+        # ``json`` raises past its own limits with exceptions that are
+        # not ``JSONDecodeError``: an integer literal over the
+        # interpreter's digit cap raises a plain ``ValueError``, and deep
+        # nesting raises ``RecursionError``. Neither is caught by any
+        # caller, so both used to escape as a traceback from a merely
+        # malformed file.
+        except (ValueError, RecursionError) as exc:
+            raise PricingError(f"invalid JSON for pricing manifest: {exc}") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> PricingManifest:
+        """Load a manifest from ``.json`` or ``.yaml``/``.yml``.
+
+        Mirrors ``TunePolicy.from_file``'s extension dispatch and its explicit
+        (never silent) failure on an unsupported extension or a missing
+        PyYAML dependency.
+        """
+        manifest_path = Path(path)
+        text = manifest_path.read_text(encoding="utf-8")
+        suffix = manifest_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise PricingError(
+                    "YAML pricing manifest requires PyYAML to be installed "
+                    "(`uv add pyyaml`); use a .json manifest instead if it is "
+                    "unavailable"
+                ) from exc
+            try:
+                data = yaml.safe_load(text)
+            # ``yaml.YAMLError`` subclasses ``Exception``, not
+            # ``ValueError``, so neither this loader nor the CLI
+            # caught it and a merely malformed YAML file escaped as a
+            # traceback. YAML is an advertised input format for this
+            # flag, and it is far easier to malform than JSON.
+            except (yaml.YAMLError, ValueError, RecursionError) as exc:
+                raise PricingError(f"invalid YAML in {manifest_path}: {exc}") from exc
+        elif suffix == ".json":
+            try:
+                data = json.loads(text)
+            except (ValueError, RecursionError) as exc:
+                raise PricingError(f"invalid JSON in {manifest_path}: {exc}") from exc
+        else:
+            raise PricingError(
+                f"unsupported pricing manifest extension {suffix!r} "
+                "(use .json or .yaml)"
+            )
+        if not isinstance(data, dict):
+            raise PricingError(
+                f"pricing manifest in {manifest_path} must be a JSON/YAML object"
+            )
+        return cls.from_dict(data)

--- a/llmtracefx/optimizer/compare/report.py
+++ b/llmtracefx/optimizer/compare/report.py
@@ -1,0 +1,1180 @@
+"""Output schema for one ``compare`` run: the cross-system comparison report.
+
+Every number here traces back to a specific accepted run's canonical
+``ExperimentRecord``, the provider's own usage block, or an explicitly
+supplied pricing entry. Nothing is invented when evidence is missing: an
+unavailable measurement stays ``null`` and the reason it is unavailable is
+carried alongside it in ``missing_evidence``.
+
+``CompareReport.from_dict``/``from_json``/``read_json`` are the only
+supported ways to load a report produced elsewhere (for example by the
+``compare-report`` HTML renderer). They never trust arbitrary fields, reject
+non-finite numbers, and raise ``CompareReportValidationError`` on any
+malformed or internally inconsistent input.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..schema import MetricProvenance
+from ..tune.loader import ExcludedRun, TuneInputError
+from .cost import MONETARY_BASIS
+from .identity import ComparableUnitKey, CompareIdentityError, SystemKey
+from .policy import (
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+    ComparePolicyError,
+)
+from .pricing import CURRENCY_PATTERN
+
+COMPARE_REPORT_SCHEMA_VERSION = "1"
+
+
+class CompareReportValidationError(ValueError):
+    """Raised when a ``CompareReport`` loaded from JSON is invalid."""
+
+
+def _require(data: Any, key: str, *, context: str) -> Any:
+    if not isinstance(data, dict) or key not in data:
+        raise CompareReportValidationError(
+            f"{context} is missing required field: {key!r}"
+        )
+    return data[key]
+
+
+def _require_str(data: Any, key: str, *, context: str) -> str:
+    value = _require(data, key, context=context)
+    if not isinstance(value, str) or not value:
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a non-empty string, got {value!r}"
+        )
+    return value
+
+
+def _optional_str(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a string or null, got {value!r}"
+        )
+    return value
+
+
+def _string_tuple(data: dict[str, Any], key: str, *, context: str) -> tuple[str, ...]:
+    value = data.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a list of strings, got {value!r}"
+        )
+    return tuple(value)
+
+
+def _require_int(
+    data: dict[str, Any], key: str, *, context: str, minimum: int | None = None
+) -> int:
+    value = _require(data, key, context=context)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be an integer, got {value!r}"
+        )
+    if minimum is not None and value < minimum:
+        raise CompareReportValidationError(
+            f"{context}.{key} must be >= {minimum}, got {value}"
+        )
+    return int(value)
+
+
+def _optional_int(
+    data: dict[str, Any], key: str, *, context: str, minimum: int | None = None
+) -> int | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be an integer or null, got {value!r}"
+        )
+    if minimum is not None and value < minimum:
+        raise CompareReportValidationError(
+            f"{context}.{key} must be >= {minimum}, got {value}"
+        )
+    return int(value)
+
+
+def _require_bool(data: dict[str, Any], key: str, *, context: str) -> bool:
+    value = _require(data, key, context=context)
+    if not isinstance(value, bool):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a boolean, got {value!r}"
+        )
+    return value
+
+
+def _require_currency(data: dict[str, Any], key: str, *, context: str) -> str:
+    """Require an ISO 4217 alphabetic code, exactly as the manifest does.
+
+    A persisted report is untrusted input and this string is rendered into a
+    document. Applying the manifest's own pattern here keeps a loaded report
+    to the same standard as the manifest it claims to have come from, so a
+    hand-edited file cannot smuggle arbitrary text through the one field
+    whose validation used to stop at the manifest boundary.
+    """
+    value = _require_str(data, key, context=context)
+    if not CURRENCY_PATTERN.match(value):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a three-letter ISO 4217 code "
+            f"(e.g. 'USD'), got {value!r}"
+        )
+    return value
+
+
+def _require_finite_float(data: dict[str, Any], key: str, *, context: str) -> float:
+    value = _require(data, key, context=context)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a number, got {value!r}"
+        )
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise CompareReportValidationError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    return numeric
+
+
+def _optional_finite_float(
+    data: dict[str, Any], key: str, *, context: str
+) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a number or null, got {value!r}"
+        )
+    try:
+        numeric = float(value)
+    except OverflowError as exc:
+        # A JSON integer literal too large for a float arrives here as a
+        # Python int. ``float()`` raises ``OverflowError``, an
+        # ``ArithmeticError`` rather than a ``ValueError``, so no caller
+        # catches it and it escapes as a traceback. Every one of these
+        # inputs is a user-supplied file this module treats as untrusted,
+        # so it becomes the same typed validation failure as any other
+        # malformed value.
+        raise CompareReportValidationError(
+            f"{context}.{key} is too large to represent as a number: {exc}"
+        ) from exc
+    if not math.isfinite(numeric):
+        raise CompareReportValidationError(
+            f"{context}.{key} must be a finite number, got {numeric!r}"
+        )
+    return numeric
+
+
+class StratumOutcome(str, Enum):
+    """Whether one comparable unit produced an actionable recommendation."""
+
+    RECOMMENDED = "recommended"
+    """At least one system cleared every constraint and won on the objective."""
+
+    INCONCLUSIVE = "inconclusive"
+    """No system cleared every constraint, or the leading systems cannot be
+    told apart from measurement noise, or the evidence needed for the
+    objective is missing; see ``inconclusive_reason``."""
+
+
+class TtftBasis(str, Enum):
+    """Which measurement a reported time-to-first-token actually is.
+
+    These two are never pooled and never ranked against each other. A local
+    prefill is model prompt-processing time observed on the host. A hosted
+    API's first-content-token offset is a client-side interval that also
+    contains DNS, connection setup, TLS, request transfer and any
+    server-side queueing.
+    """
+
+    LOCAL_PREFILL = "local_prefill"
+    CLIENT_OBSERVED_STREAM = "client_observed_stream"
+
+
+class ParetoAxis(str, Enum):
+    """One axis of the evidence frontier, named with its preferred direction."""
+
+    MAX_PASS_RATE = "max_pass_rate"
+    MAX_CORRECT_CASES_PER_MINUTE = "max_correct_cases_per_minute"
+    MIN_MEAN_TOTAL_LATENCY_MS = "min_mean_total_latency_ms"
+    MIN_COST_PER_CORRECT_CASE = "min_cost_per_correct_case"
+
+    @property
+    def prefers_lower(self) -> bool:
+        return self in (
+            ParetoAxis.MIN_MEAN_TOTAL_LATENCY_MS,
+            ParetoAxis.MIN_COST_PER_CORRECT_CASE,
+        )
+
+
+@dataclass(frozen=True)
+class UsageTotals:
+    """Provider-reported token totals across one system's ranked runs."""
+
+    runs_reporting_usage: int
+    runs_total: int
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    reasoning_tokens: int | None = None
+
+    @property
+    def complete(self) -> bool:
+        """True when every ranked run of this system reported its usage."""
+        return self.runs_total > 0 and self.runs_reporting_usage == self.runs_total
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provenance": MetricProvenance.PROVIDER_REPORTED.value,
+            "runs_reporting_usage": self.runs_reporting_usage,
+            "runs_total": self.runs_total,
+            "complete": self.complete,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cached_input_tokens": self.cached_input_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> UsageTotals:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("usage must be a JSON object")
+        context = "usage"
+        declared_provenance = data.get(
+            "provenance", MetricProvenance.PROVIDER_REPORTED.value
+        )
+        if declared_provenance != MetricProvenance.PROVIDER_REPORTED.value:
+            raise CompareReportValidationError(
+                f"{context}.provenance must be "
+                f"{MetricProvenance.PROVIDER_REPORTED.value!r}; token usage is "
+                "never a client measurement"
+            )
+        totals = cls(
+            runs_reporting_usage=_require_int(
+                data, "runs_reporting_usage", context=context, minimum=0
+            ),
+            runs_total=_require_int(data, "runs_total", context=context, minimum=0),
+            input_tokens=_optional_int(
+                data, "input_tokens", context=context, minimum=0
+            ),
+            output_tokens=_optional_int(
+                data, "output_tokens", context=context, minimum=0
+            ),
+            cached_input_tokens=_optional_int(
+                data, "cached_input_tokens", context=context, minimum=0
+            ),
+            reasoning_tokens=_optional_int(
+                data, "reasoning_tokens", context=context, minimum=0
+            ),
+        )
+        if totals.runs_reporting_usage > totals.runs_total:
+            raise CompareReportValidationError(
+                f"{context}.runs_reporting_usage ({totals.runs_reporting_usage}) "
+                f"cannot exceed runs_total ({totals.runs_total})"
+            )
+        return totals
+
+
+@dataclass(frozen=True)
+class CostSummary:
+    """One system's estimated spend, always labeled as derived, never measured."""
+
+    currency: str
+    pricing_entry_id: str
+    pricing_entry_sha256: str
+    rates_are_illustrative: bool
+    total_amount: float | None = None
+    cost_per_case: float | None = None
+    cost_per_correct_case: float | None = None
+    correct_cases_per_currency_unit: float | None = None
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "currency": self.currency,
+            "estimated": True,
+            "monetary_basis": MONETARY_BASIS,
+            "pricing_entry_id": self.pricing_entry_id,
+            "pricing_entry_sha256": self.pricing_entry_sha256,
+            "rates_are_illustrative": self.rates_are_illustrative,
+            "total_amount": self.total_amount,
+            "cost_per_case": self.cost_per_case,
+            "cost_per_correct_case": self.cost_per_correct_case,
+            "correct_cases_per_currency_unit": self.correct_cases_per_currency_unit,
+            "reasons": list(self.reasons),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> CostSummary:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("cost must be a JSON object")
+        context = "cost"
+        if data.get("estimated") is not True:
+            raise CompareReportValidationError(
+                f"{context}.estimated must be true; every monetary value in this "
+                "report is derived from provider-reported usage and supplied "
+                "rates, never measured"
+            )
+        if data.get("monetary_basis", MONETARY_BASIS) != MONETARY_BASIS:
+            raise CompareReportValidationError(
+                f"{context}.monetary_basis must be {MONETARY_BASIS!r}"
+            )
+        return cls(
+            currency=_require_currency(data, "currency", context=context),
+            pricing_entry_id=_require_str(data, "pricing_entry_id", context=context),
+            pricing_entry_sha256=_require_str(
+                data, "pricing_entry_sha256", context=context
+            ),
+            rates_are_illustrative=_require_bool(
+                data, "rates_are_illustrative", context=context
+            ),
+            total_amount=_optional_finite_float(data, "total_amount", context=context),
+            cost_per_case=_optional_finite_float(
+                data, "cost_per_case", context=context
+            ),
+            cost_per_correct_case=_optional_finite_float(
+                data, "cost_per_correct_case", context=context
+            ),
+            correct_cases_per_currency_unit=_optional_finite_float(
+                data, "correct_cases_per_currency_unit", context=context
+            ),
+            reasons=_string_tuple(data, "reasons", context=context),
+        )
+
+
+@dataclass(frozen=True)
+class SystemReport:
+    """One system's measurements, evidence and rank within a comparable unit."""
+
+    system_key: SystemKey
+    rank: int
+    run_ids: tuple[str, ...]
+    verification_paths: tuple[str, ...]
+    record_paths: tuple[str, ...]
+    evidence_count: int
+    objective_name: str
+    objective_value: float
+    pass_rate: float | None = None
+    mean_quality_score: float | None = None
+    quality_metric: str | None = None
+    mean_total_latency_ms: float | None = None
+    p50_total_latency_ms: float | None = None
+    p95_total_latency_ms: float | None = None
+    stdev_total_latency_ms: float | None = None
+    coefficient_of_variation: float | None = None
+    correct_cases_per_minute: float | None = None
+    mean_ttft_ms: float | None = None
+    ttft_basis: TtftBasis | None = None
+    usage: UsageTotals | None = None
+    cost: CostSummary | None = None
+    mean_peak_memory_bytes: float | None = None
+    max_peak_memory_bytes: float | None = None
+    missing_evidence: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "system_key": self.system_key.to_dict(),
+            "system_label": self.system_key.label(),
+            "rank": self.rank,
+            "run_ids": list(self.run_ids),
+            "verification_paths": list(self.verification_paths),
+            "record_paths": list(self.record_paths),
+            "evidence_count": self.evidence_count,
+            "objective_name": self.objective_name,
+            "objective_value": self.objective_value,
+            "pass_rate": self.pass_rate,
+            "mean_quality_score": self.mean_quality_score,
+            "quality_metric": self.quality_metric,
+            "mean_total_latency_ms": self.mean_total_latency_ms,
+            "p50_total_latency_ms": self.p50_total_latency_ms,
+            "p95_total_latency_ms": self.p95_total_latency_ms,
+            "stdev_total_latency_ms": self.stdev_total_latency_ms,
+            "coefficient_of_variation": self.coefficient_of_variation,
+            "correct_cases_per_minute": self.correct_cases_per_minute,
+            "mean_ttft_ms": self.mean_ttft_ms,
+            "ttft_basis": None if self.ttft_basis is None else self.ttft_basis.value,
+            "usage": None if self.usage is None else self.usage.to_dict(),
+            "cost": None if self.cost is None else self.cost.to_dict(),
+            "mean_peak_memory_bytes": self.mean_peak_memory_bytes,
+            "max_peak_memory_bytes": self.max_peak_memory_bytes,
+            "missing_evidence": list(self.missing_evidence),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> SystemReport:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("system report must be a JSON object")
+        context = "system report"
+        try:
+            system_key = SystemKey.from_dict(
+                _require(data, "system_key", context=context)
+            )
+        except CompareIdentityError as exc:
+            raise CompareReportValidationError(
+                f"{context}.system_key is invalid: {exc}"
+            ) from exc
+
+        raw_basis = data.get("ttft_basis")
+        ttft_basis: TtftBasis | None
+        if raw_basis is None:
+            ttft_basis = None
+        else:
+            try:
+                ttft_basis = TtftBasis(raw_basis)
+            except ValueError as exc:
+                raise CompareReportValidationError(
+                    f"{context}.ttft_basis has an invalid value: {exc}"
+                ) from exc
+
+        mean_ttft = _optional_finite_float(data, "mean_ttft_ms", context=context)
+        if mean_ttft is not None and ttft_basis is None:
+            raise CompareReportValidationError(
+                f"{context} reports mean_ttft_ms without a ttft_basis; a "
+                "time-to-first-token figure is meaningless without saying which "
+                "measurement it is"
+            )
+
+        usage_raw = data.get("usage")
+        cost_raw = data.get("cost")
+        report = cls(
+            system_key=system_key,
+            rank=_require_int(data, "rank", context=context, minimum=1),
+            run_ids=_string_tuple(data, "run_ids", context=context),
+            verification_paths=_string_tuple(
+                data, "verification_paths", context=context
+            ),
+            record_paths=_string_tuple(data, "record_paths", context=context),
+            evidence_count=_require_int(
+                data, "evidence_count", context=context, minimum=0
+            ),
+            objective_name=_require_str(data, "objective_name", context=context),
+            objective_value=_require_finite_float(
+                data, "objective_value", context=context
+            ),
+            pass_rate=_optional_finite_float(data, "pass_rate", context=context),
+            mean_quality_score=_optional_finite_float(
+                data, "mean_quality_score", context=context
+            ),
+            quality_metric=_optional_str(data, "quality_metric", context=context),
+            mean_total_latency_ms=_optional_finite_float(
+                data, "mean_total_latency_ms", context=context
+            ),
+            p50_total_latency_ms=_optional_finite_float(
+                data, "p50_total_latency_ms", context=context
+            ),
+            p95_total_latency_ms=_optional_finite_float(
+                data, "p95_total_latency_ms", context=context
+            ),
+            stdev_total_latency_ms=_optional_finite_float(
+                data, "stdev_total_latency_ms", context=context
+            ),
+            coefficient_of_variation=_optional_finite_float(
+                data, "coefficient_of_variation", context=context
+            ),
+            correct_cases_per_minute=_optional_finite_float(
+                data, "correct_cases_per_minute", context=context
+            ),
+            mean_ttft_ms=mean_ttft,
+            ttft_basis=ttft_basis,
+            usage=None if usage_raw is None else UsageTotals.from_dict(usage_raw),
+            cost=None if cost_raw is None else CostSummary.from_dict(cost_raw),
+            mean_peak_memory_bytes=_optional_finite_float(
+                data, "mean_peak_memory_bytes", context=context
+            ),
+            max_peak_memory_bytes=_optional_finite_float(
+                data, "max_peak_memory_bytes", context=context
+            ),
+            missing_evidence=_string_tuple(data, "missing_evidence", context=context),
+        )
+        if not report.system_key.is_local and (
+            report.mean_peak_memory_bytes is not None
+            or report.max_peak_memory_bytes is not None
+        ):
+            raise CompareReportValidationError(
+                f"{context} reports peak memory for a system executed by "
+                f"provider {report.system_key.provider!r}; peak memory is a "
+                "local-only measurement and a hosted API cannot produce one"
+            )
+        if (
+            report.system_key.is_local
+            and report.ttft_basis == TtftBasis.CLIENT_OBSERVED_STREAM
+        ):
+            # These two claims cannot both be true. A client-observed stream
+            # offset is only ever produced by talking to a hosted service, so
+            # a system carrying one is not local, whatever its provider field
+            # says. Checked here as well as in the evidence loader because a
+            # report can arrive from anywhere.
+            raise CompareReportValidationError(
+                f"{context} claims to be local but reports a "
+                f"{TtftBasis.CLIENT_OBSERVED_STREAM.value!r} "
+                "time-to-first-token, which only a hosted service can "
+                "produce; the two claims contradict each other"
+            )
+        return report
+
+
+@dataclass(frozen=True)
+class RejectedSystemReport:
+    """One system that did not clear the constraints, and every reason why."""
+
+    system_key: SystemKey
+    run_ids: tuple[str, ...]
+    verification_paths: tuple[str, ...]
+    record_paths: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "system_key": self.system_key.to_dict(),
+            "system_label": self.system_key.label(),
+            "run_ids": list(self.run_ids),
+            "verification_paths": list(self.verification_paths),
+            "record_paths": list(self.record_paths),
+            "reasons": list(self.reasons),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> RejectedSystemReport:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError(
+                "rejected system report must be a JSON object"
+            )
+        context = "rejected system report"
+        try:
+            system_key = SystemKey.from_dict(
+                _require(data, "system_key", context=context)
+            )
+        except CompareIdentityError as exc:
+            raise CompareReportValidationError(
+                f"{context}.system_key is invalid: {exc}"
+            ) from exc
+        reasons = _string_tuple(data, "reasons", context=context)
+        if not reasons:
+            raise CompareReportValidationError(
+                f"{context} must record at least one rejection reason"
+            )
+        return cls(
+            system_key=system_key,
+            run_ids=_string_tuple(data, "run_ids", context=context),
+            verification_paths=_string_tuple(
+                data, "verification_paths", context=context
+            ),
+            record_paths=_string_tuple(data, "record_paths", context=context),
+            reasons=reasons,
+        )
+
+
+@dataclass(frozen=True)
+class FrontierEntry:
+    """One system's position on the evidence frontier for a comparable unit."""
+
+    system_key: SystemKey
+    dominated: bool
+    dominated_by: tuple[str, ...] = field(default_factory=tuple)
+    """Labels of the systems that beat this one on every frontier axis."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "system_key": self.system_key.to_dict(),
+            "system_label": self.system_key.label(),
+            "dominated": self.dominated,
+            "dominated_by": list(self.dominated_by),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> FrontierEntry:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("frontier entry must be a JSON object")
+        context = "frontier entry"
+        try:
+            system_key = SystemKey.from_dict(
+                _require(data, "system_key", context=context)
+            )
+        except CompareIdentityError as exc:
+            raise CompareReportValidationError(
+                f"{context}.system_key is invalid: {exc}"
+            ) from exc
+        entry = cls(
+            system_key=system_key,
+            dominated=_require_bool(data, "dominated", context=context),
+            dominated_by=_string_tuple(data, "dominated_by", context=context),
+        )
+        if entry.dominated and not entry.dominated_by:
+            raise CompareReportValidationError(
+                f"{context} is marked dominated but names nothing that dominates it"
+            )
+        if not entry.dominated and entry.dominated_by:
+            raise CompareReportValidationError(
+                f"{context} is not marked dominated yet names dominating systems"
+            )
+        return entry
+
+
+#: Which reported metric each objective is defined as. A stratum that claims
+#: an ``objective_value`` disagreeing with the metric it says it ranked on is
+#: internally false, and a reader has no way to tell which of the two numbers
+#: is the real one.
+#: The path is read from the ``SystemReport`` itself, or from its nested
+#: ``cost`` summary for the two monetary objectives, both of which are
+#: ordinary reported columns rather than something derived at render time.
+_OBJECTIVE_BACKING_METRIC: dict[str, tuple[str, ...]] = {
+    "min_mean_total_latency_ms": ("mean_total_latency_ms",),
+    "max_correct_cases_per_minute": ("correct_cases_per_minute",),
+    "min_cost_per_correct_case": ("cost", "cost_per_correct_case"),
+    "max_correct_cases_per_currency_unit": (
+        "cost",
+        "correct_cases_per_currency_unit",
+    ),
+}
+
+
+def _resolve_metric(system: SystemReport, path: tuple[str, ...]) -> float | None:
+    """Follow a backing-metric path, giving up on any missing hop."""
+    current: Any = system
+    for step in path:
+        current = getattr(current, step, None)
+        if current is None:
+            return None
+    return current if isinstance(current, (int, float)) else None
+
+
+#: Objectives whose best value is the smallest one.
+_OBJECTIVES_PREFERRING_LOWER = frozenset(
+    {"min_mean_total_latency_ms", "min_cost_per_correct_case"}
+)
+
+
+def _reject_false_ranking(
+    ranked: tuple[SystemReport, ...], *, objective_name: str, context: str
+) -> None:
+    """Refuse a ranking that contradicts the evidence printed beside it.
+
+    Rank order, the objective value and the metric the objective is defined
+    as are three statements about the same fact, so a file can assert all
+    three and have them disagree. That is not a schema error, which is
+    exactly why it needs checking: such a report renders cleanly and reads
+    as authoritative while recommending the system that lost.
+
+    Every objective this layer supports is defined as a column reported
+    beside it, including the two monetary ones, which read from the nested
+    cost summary rather than from the top level of the row. All four are
+    checked; a system with no cost summary simply has nothing to check
+    against and is skipped.
+    """
+    backing = _OBJECTIVE_BACKING_METRIC.get(objective_name)
+    if backing is not None:
+        for system in ranked:
+            claimed = system.objective_value
+            actual = _resolve_metric(system, backing)
+            if claimed is None or actual is None:
+                continue
+            if not math.isclose(claimed, actual, rel_tol=1e-9, abs_tol=1e-9):
+                raise CompareReportValidationError(
+                    f"{context}.ranked entry at rank {system.rank} claims "
+                    f"objective_value {claimed!r} for objective "
+                    f"{objective_name!r}, but its "
+                    f"{'.'.join(backing)} is {actual!r}; the ranking "
+                    "contradicts the evidence reported beside it"
+                )
+
+    values = [
+        (system.rank, system.objective_value)
+        for system in ranked
+        if system.objective_value is not None
+    ]
+    prefers_lower = objective_name in _OBJECTIVES_PREFERRING_LOWER
+    for (rank, value), (next_rank, next_value) in zip(values, values[1:], strict=False):
+        better = value <= next_value if prefers_lower else value >= next_value
+        if not better:
+            direction = "lowest" if prefers_lower else "highest"
+            raise CompareReportValidationError(
+                f"{context}.ranked is not ordered by {objective_name!r}: rank "
+                f"{rank} has objective_value {value!r} but rank {next_rank} "
+                f"has {next_value!r}, and this objective prefers the "
+                f"{direction} value"
+            )
+
+
+@dataclass(frozen=True)
+class StratumReport:
+    """One comparable unit: its systems, its ranking, and its frontier."""
+
+    unit_key: ComparableUnitKey
+    outcome: StratumOutcome
+    objective_name: str
+    ranked: tuple[SystemReport, ...] = field(default_factory=tuple)
+    rejected: tuple[RejectedSystemReport, ...] = field(default_factory=tuple)
+    recommended: SystemReport | None = None
+    inconclusive_reason: str | None = None
+    frontier_axes: tuple[ParetoAxis, ...] = field(default_factory=tuple)
+    frontier: tuple[FrontierEntry, ...] = field(default_factory=tuple)
+    missing_evidence: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "comparable_unit_key": self.unit_key.to_dict(),
+            "comparable_unit_label": self.unit_key.label(),
+            "outcome": self.outcome.value,
+            "objective_name": self.objective_name,
+            "recommended": (
+                None if self.recommended is None else self.recommended.to_dict()
+            ),
+            "inconclusive_reason": self.inconclusive_reason,
+            "ranked": [system.to_dict() for system in self.ranked],
+            "rejected": [system.to_dict() for system in self.rejected],
+            "frontier_axes": [axis.value for axis in self.frontier_axes],
+            "frontier": [entry.to_dict() for entry in self.frontier],
+            "missing_evidence": list(self.missing_evidence),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> StratumReport:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("stratum report must be a JSON object")
+        context = "stratum report"
+
+        try:
+            unit_key = ComparableUnitKey.from_dict(
+                _require(data, "comparable_unit_key", context=context)
+            )
+        except CompareIdentityError as exc:
+            raise CompareReportValidationError(
+                f"{context}.comparable_unit_key is invalid: {exc}"
+            ) from exc
+
+        try:
+            outcome = StratumOutcome(_require_str(data, "outcome", context=context))
+        except ValueError as exc:
+            raise CompareReportValidationError(
+                f"{context}.outcome has an invalid value: {exc}"
+            ) from exc
+
+        ranked_raw = data.get("ranked", [])
+        if not isinstance(ranked_raw, list):
+            raise CompareReportValidationError(f"{context}.ranked must be a list")
+        ranked = tuple(
+            sorted(
+                (SystemReport.from_dict(item) for item in ranked_raw),
+                key=lambda system: system.rank,
+            )
+        )
+        ranks = tuple(system.rank for system in ranked)
+        if ranks != tuple(range(1, len(ranked) + 1)):
+            raise CompareReportValidationError(
+                f"{context}.ranked ranks must be unique and contiguous starting "
+                f"at 1, got {ranks!r}"
+            )
+
+        objective_name = _require_str(data, "objective_name", context=context)
+        _reject_false_ranking(ranked, objective_name=objective_name, context=context)
+
+        rejected_raw = data.get("rejected", [])
+        if not isinstance(rejected_raw, list):
+            raise CompareReportValidationError(f"{context}.rejected must be a list")
+
+        axes_raw = data.get("frontier_axes", [])
+        if not isinstance(axes_raw, list):
+            raise CompareReportValidationError(
+                f"{context}.frontier_axes must be a list"
+            )
+        try:
+            frontier_axes = tuple(ParetoAxis(value) for value in axes_raw)
+        except ValueError as exc:
+            raise CompareReportValidationError(
+                f"{context}.frontier_axes contains an unknown axis: {exc}"
+            ) from exc
+
+        frontier_raw = data.get("frontier", [])
+        if not isinstance(frontier_raw, list):
+            raise CompareReportValidationError(f"{context}.frontier must be a list")
+        if frontier_raw and not frontier_axes:
+            raise CompareReportValidationError(
+                f"{context} places systems on a frontier without naming the axes "
+                "the frontier was computed on"
+            )
+
+        recommended_raw = data.get("recommended")
+        recommended = (
+            None if recommended_raw is None else SystemReport.from_dict(recommended_raw)
+        )
+
+        stratum = cls(
+            unit_key=unit_key,
+            outcome=outcome,
+            objective_name=_require_str(data, "objective_name", context=context),
+            ranked=ranked,
+            rejected=tuple(
+                RejectedSystemReport.from_dict(item) for item in rejected_raw
+            ),
+            recommended=recommended,
+            inconclusive_reason=_optional_str(
+                data, "inconclusive_reason", context=context
+            ),
+            frontier_axes=frontier_axes,
+            frontier=tuple(FrontierEntry.from_dict(item) for item in frontier_raw),
+            missing_evidence=_string_tuple(data, "missing_evidence", context=context),
+        )
+
+        if stratum.outcome == StratumOutcome.RECOMMENDED:
+            if stratum.recommended is None:
+                raise CompareReportValidationError(
+                    f"{context} has outcome 'recommended' but 'recommended' is null"
+                )
+            if not stratum.ranked:
+                raise CompareReportValidationError(
+                    f"{context} has outcome 'recommended' but 'ranked' is empty"
+                )
+            if stratum.recommended != stratum.ranked[0]:
+                raise CompareReportValidationError(
+                    f"{context}.recommended must equal the rank 1 ranked system"
+                )
+        else:
+            if stratum.recommended is not None:
+                raise CompareReportValidationError(
+                    f"{context} has outcome 'inconclusive' but recommended is set"
+                )
+            if stratum.inconclusive_reason is None:
+                raise CompareReportValidationError(
+                    f"{context} has outcome 'inconclusive' but "
+                    "'inconclusive_reason' is null"
+                )
+
+        objective_names = {system.objective_name for system in stratum.ranked}
+        if objective_names and objective_names != {stratum.objective_name}:
+            raise CompareReportValidationError(
+                f"{context}.ranked mixes objectives {sorted(objective_names)!r} "
+                f"but the stratum declares {stratum.objective_name!r}; a single "
+                "ranking is only ever produced for one objective"
+            )
+        return stratum
+
+
+@dataclass(frozen=True)
+class PricingProvenance:
+    """Exactly which pricing input produced every monetary value in a report."""
+
+    manifest_path: str
+    manifest_sha256: str
+    currency: str
+    rates_are_illustrative: bool
+    entry_ids_used: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest_path": self.manifest_path,
+            "manifest_sha256": self.manifest_sha256,
+            "currency": self.currency,
+            "rates_are_illustrative": self.rates_are_illustrative,
+            "entry_ids_used": list(self.entry_ids_used),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> PricingProvenance:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("pricing must be a JSON object")
+        context = "pricing"
+        return cls(
+            manifest_path=_require_str(data, "manifest_path", context=context),
+            manifest_sha256=_require_str(data, "manifest_sha256", context=context),
+            currency=_require_currency(data, "currency", context=context),
+            rates_are_illustrative=_require_bool(
+                data, "rates_are_illustrative", context=context
+            ),
+            entry_ids_used=_string_tuple(data, "entry_ids_used", context=context),
+        )
+
+
+def _reject_constraint_violating_rankings(
+    strata: tuple[StratumReport, ...], constraints: CompareConstraints
+) -> None:
+    """Refuse a ranked system that fails the constraints stored beside it.
+
+    A report carries both the bar and the systems said to have cleared it,
+    which is two claims about one fact. ``compare()`` rejects a system that
+    misses the bar, so a loaded report showing a *ranked* system below it did
+    not come from an honest run: either the constraints were edited after the
+    fact to look demanding, or the ranking was. Both read as a system having
+    earned a recommendation it did not, which is the failure this whole layer
+    exists to avoid.
+
+    A ``null`` metric is refused rather than skipped wherever ``compare()``
+    provably cannot emit one. For ``min_pass_rate``, ``min_quality_score``,
+    ``required_quality_metric`` and ``max_cost_per_correct_case`` the engine
+    rejects a system whose value is missing, so ``null`` on a *ranked* system
+    is not absent evidence, it is a report no honest run produced -- and
+    nulling the field was otherwise the simplest way to evade the check.
+
+    ``coefficient_of_variation`` is the genuine exception: it is legitimately
+    ``None`` when the mean is not positive, with no rejection, so a missing
+    value there is skipped.
+    """
+    skip_when_missing = {"coefficient_of_variation"}
+    for stratum in strata:
+        for system in stratum.ranked:
+            checks: tuple[tuple[str, float | None, str, float | None], ...] = (
+                ("pass_rate", system.pass_rate, ">=", constraints.min_pass_rate),
+                (
+                    "mean_quality_score",
+                    system.mean_quality_score,
+                    ">=",
+                    constraints.min_quality_score,
+                ),
+                (
+                    "mean_total_latency_ms",
+                    system.mean_total_latency_ms,
+                    "<=",
+                    constraints.max_mean_total_latency_ms,
+                ),
+                (
+                    "coefficient_of_variation",
+                    system.coefficient_of_variation,
+                    "<=",
+                    constraints.max_coefficient_of_variation,
+                ),
+                (
+                    "cost.cost_per_correct_case",
+                    None if system.cost is None else system.cost.cost_per_correct_case,
+                    "<=",
+                    constraints.max_cost_per_correct_case,
+                ),
+            )
+            for name, value, direction, bound in checks:
+                if bound is None:
+                    continue
+                if value is None:
+                    if name in skip_when_missing:
+                        continue
+                    raise CompareReportValidationError(
+                        f"stratum report ranked entry at rank {system.rank} "
+                        f"reports no {name}, but this report's own policy "
+                        f"constrains it ({name} {direction} {bound!r}); a "
+                        "system with no such evidence cannot be ranked as "
+                        "having cleared that bar"
+                    )
+                violated = value < bound if direction == ">=" else value > bound
+                if violated:
+                    raise CompareReportValidationError(
+                        f"stratum report ranked entry at rank {system.rank} "
+                        f"reports {name} {value!r}, which does not satisfy the "
+                        f"constraint {name} {direction} {bound!r} recorded in "
+                        "this report's own policy; a system that misses the "
+                        "bar cannot also be ranked as having cleared it"
+                    )
+            # The metric a score was earned on, not just the score. The
+            # policy already refuses ``min_quality_score`` without
+            # ``required_quality_metric`` precisely so a score is never
+            # compared against a mismatched metric; re-checking the score bar
+            # here while skipping the metric would split that pair back apart
+            # and let a report assert a bar its evidence was never graded
+            # against.
+            if (
+                constraints.required_quality_metric is not None
+                and system.quality_metric != constraints.required_quality_metric
+            ):
+                raise CompareReportValidationError(
+                    f"stratum report ranked entry at rank {system.rank} was "
+                    f"graded by {system.quality_metric!r}, but this report's "
+                    "own policy requires "
+                    f"{constraints.required_quality_metric!r}; a system "
+                    "measured by a different evaluator cannot be ranked as "
+                    "having met that bar"
+                )
+            if system.evidence_count < constraints.min_measured_repetitions:
+                raise CompareReportValidationError(
+                    f"stratum report ranked entry at rank {system.rank} is "
+                    f"backed by {system.evidence_count} run(s) but this "
+                    "report's own policy requires at least "
+                    f"{constraints.min_measured_repetitions}"
+                )
+
+
+@dataclass(frozen=True)
+class CompareReport:
+    """The complete output of one ``compare`` invocation."""
+
+    schema_version: str
+    generated_at: str
+    results_dirs: tuple[str, ...]
+    policy: ComparePolicy
+    strata: tuple[StratumReport, ...] = field(default_factory=tuple)
+    tune_report_paths: tuple[str, ...] = field(default_factory=tuple)
+    pricing: PricingProvenance | None = None
+    excluded_runs: tuple[ExcludedRun, ...] = field(default_factory=tuple)
+
+    @property
+    def has_recommendation(self) -> bool:
+        return any(
+            stratum.outcome == StratumOutcome.RECOMMENDED for stratum in self.strata
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "results_dirs": list(self.results_dirs),
+            "tune_report_paths": list(self.tune_report_paths),
+            "policy": self.policy.to_dict(),
+            "pricing": None if self.pricing is None else self.pricing.to_dict(),
+            "strata": [stratum.to_dict() for stratum in self.strata],
+            "excluded_runs": [run.to_dict() for run in self.excluded_runs],
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> CompareReport:
+        if not isinstance(data, dict):
+            raise CompareReportValidationError("compare report must be a JSON object")
+        context = "compare report"
+
+        schema_version = str(data.get("schema_version", COMPARE_REPORT_SCHEMA_VERSION))
+        if schema_version != COMPARE_REPORT_SCHEMA_VERSION:
+            raise CompareReportValidationError(
+                f"unsupported compare report schema_version {schema_version!r}, "
+                f"expected {COMPARE_REPORT_SCHEMA_VERSION!r}"
+            )
+
+        try:
+            policy = ComparePolicy.from_dict(_require(data, "policy", context=context))
+        except ComparePolicyError as exc:
+            raise CompareReportValidationError(
+                f"{context}.policy is invalid: {exc}"
+            ) from exc
+
+        strata_raw = data.get("strata", [])
+        if not isinstance(strata_raw, list):
+            raise CompareReportValidationError(f"{context}.strata must be a list")
+        strata = tuple(StratumReport.from_dict(item) for item in strata_raw)
+        _reject_constraint_violating_rankings(strata, policy.constraints)
+
+        excluded_raw = data.get("excluded_runs", [])
+        if not isinstance(excluded_raw, list):
+            raise CompareReportValidationError(
+                f"{context}.excluded_runs must be a list"
+            )
+        try:
+            excluded_runs = tuple(ExcludedRun.from_dict(item) for item in excluded_raw)
+        except TuneInputError as exc:
+            raise CompareReportValidationError(
+                f"{context}.excluded_runs is invalid: {exc}"
+            ) from exc
+
+        pricing_raw = data.get("pricing")
+        pricing = (
+            None if pricing_raw is None else PricingProvenance.from_dict(pricing_raw)
+        )
+
+        report = cls(
+            schema_version=schema_version,
+            generated_at=_require_str(data, "generated_at", context=context),
+            results_dirs=_string_tuple(data, "results_dirs", context=context),
+            tune_report_paths=_string_tuple(data, "tune_report_paths", context=context),
+            policy=policy,
+            strata=strata,
+            pricing=pricing,
+            excluded_runs=excluded_runs,
+        )
+
+        declared_objective = report.policy.objective.value
+        for stratum in report.strata:
+            if stratum.objective_name != declared_objective:
+                raise CompareReportValidationError(
+                    f"{context}.strata declares objective "
+                    f"{stratum.objective_name!r} but the policy objective is "
+                    f"{declared_objective!r}; one compare run ranks on exactly "
+                    "one objective"
+                )
+
+        if report.pricing is None:
+            for stratum in report.strata:
+                for system in stratum.ranked:
+                    if system.cost is not None:
+                        raise CompareReportValidationError(
+                            f"{context} carries cost figures but records no "
+                            "pricing provenance; a monetary value with no "
+                            "manifest behind it is unattributable"
+                        )
+        else:
+            currency = report.pricing.currency
+            for stratum in report.strata:
+                for system in stratum.ranked:
+                    if system.cost is not None and system.cost.currency != currency:
+                        raise CompareReportValidationError(
+                            f"{context} mixes currencies: system cost is in "
+                            f"{system.cost.currency!r} but the pricing manifest "
+                            f"declares {currency!r}"
+                        )
+
+        if report.policy.objective.requires_cost and report.pricing is None:
+            raise CompareReportValidationError(
+                f"{context}.policy objective {declared_objective!r} ranks on "
+                "money but the report records no pricing provenance"
+            )
+        return report
+
+    @classmethod
+    def from_json(cls, payload: str) -> CompareReport:
+        try:
+            data = json.loads(payload)
+        # ``json`` raises past its own limits with exceptions that are
+        # not ``JSONDecodeError``: an integer literal over the
+        # interpreter's digit cap raises a plain ``ValueError``, and deep
+        # nesting raises ``RecursionError``. Neither is caught by any
+        # caller, so both used to escape as a traceback from a merely
+        # malformed file.
+        except (ValueError, RecursionError) as exc:
+            raise CompareReportValidationError(
+                f"invalid JSON for compare report: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> CompareReport:
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "COMPARE_REPORT_SCHEMA_VERSION",
+    "CompareObjective",
+    "CompareReport",
+    "CompareReportValidationError",
+    "CostSummary",
+    "FrontierEntry",
+    "ParetoAxis",
+    "PricingProvenance",
+    "RejectedSystemReport",
+    "StratumOutcome",
+    "StratumReport",
+    "SystemReport",
+    "TtftBasis",
+    "UsageTotals",
+]

--- a/llmtracefx/optimizer/compare/report_html.py
+++ b/llmtracefx/optimizer/compare/report_html.py
@@ -1,0 +1,992 @@
+"""Self-contained static HTML rendering of a ``CompareReport``.
+
+A product surface over already-computed comparison evidence, not a second
+scoring system: every value rendered here comes straight from a validated
+``CompareReport`` (see ``report.py``) and nothing is recomputed, re-ranked or
+estimated at render time.
+
+The design system is *reused*, not reimplemented. The stylesheet, the
+escaping helper, the path redaction rule and the routing ornaments are
+imported from the tune report renderer, so a colour, a rule weight or a
+redaction rule can never mean one thing in a tune report and another in a
+comparison report. See ``DESIGN.md`` and ``llmtracefx.brand``.
+
+Three properties are deliberate and are covered by tests:
+
+* **Determinism.** Rendering the same report twice produces byte-identical
+  HTML. The only clock in the document is the report's own ``generated_at``.
+* **Escaping.** Every string that originates from the report JSON is passed
+  through ``html.escape`` before it reaches the document.
+* **No network.** Inline CSS, inline SVG, no JavaScript, no CDN, no external
+  reference of any kind, so the file opens from disk and is safe to attach
+  to an issue or a chat message.
+
+Local artifact paths are redacted to stable, non-identifying labels by
+default; pass ``redact_paths=False`` to include them as plain text.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from itertools import zip_longest
+from pathlib import PurePosixPath
+from urllib.parse import urlsplit
+
+from ...brand import LOCKUP_SVG
+from ..tune.report_html import (
+    DIRECTION_CONTRACT,
+    ORNAMENT_CLOSED_SVG,
+    ORNAMENT_OPEN_SVG,
+    _esc,
+    _fmt_bytes_mb,
+    _fmt_number,
+    _fmt_percent,
+    _list_items,
+    _path_label,
+    _style,
+)
+from .policy import CompareConstraints
+from .report import (
+    CompareReport,
+    CostSummary,
+    FrontierEntry,
+    RejectedSystemReport,
+    StratumOutcome,
+    StratumReport,
+    SystemReport,
+    TtftBasis,
+    UsageTotals,
+)
+
+#: How a time-to-first-token figure is described in prose, so a reader never
+#: has to know which collector produced it to know what it measures.
+_TTFT_BASIS_LABEL: dict[TtftBasis, str] = {
+    TtftBasis.LOCAL_PREFILL: "local prefill (host-observed prompt processing)",
+    TtftBasis.CLIENT_OBSERVED_STREAM: (
+        "client-observed stream offset (includes network transport and queueing)"
+    ),
+}
+
+#: Measurement columns for the ranking table, in reading order. The system
+#: identifier is deliberately not a column: it is the one value that must
+#: never be clipped, so it heads its own row group instead.
+_RANKED_COLUMNS: tuple[str, ...] = (
+    "Objective",
+    "Pass rate",
+    "Quality",
+    "Mean latency (ms)",
+    "p50 / p95 (ms)",
+    "Correct/min",
+    "Cost per correct case",
+    "Correct per unit",
+    "Evidence",
+)
+
+
+#: The opening paragraph, kept as one named constant rather than seven
+#: adjacent literals inside the ``body_parts`` list. Implicit concatenation
+#: inside a list reads as a missing comma to a reader and to CodeQL alike,
+#: which is the same reason the API collector spells its own joins out.
+_LEDE = (
+    '<p class="lede">Systems are only placed side by side when they were '
+    "asked the identical question: same workload and version, same prompt "
+    "hash, same context tier, same evaluator, same output cap and sampling. "
+    "Anything else is reported as a separate unit. Nothing here is "
+    "re-scored, no measurement is blended into an overall grade, and every "
+    "value that was not recorded stays unavailable rather than becoming "
+    "zero.</p>"
+)
+
+
+def _fmt_money(value: float | None, currency: str) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.6g} {currency}"
+
+
+def _fmt_tokens(value: int | None) -> str:
+    return "n/a" if value is None else f"{value:,}"
+
+
+def _missing_evidence_block(
+    values: Iterable[str], *, empty: str, redact_paths: bool = True
+) -> str:
+    items = [
+        f"<li>{_esc(_redact_paths_in_prose(value, redact_paths=redact_paths))}</li>"
+        for value in values
+    ]
+    if not items:
+        return f'<p class="muted">{_esc(empty)}</p>'
+    return f'<ul class="violations">{"".join(items)}</ul>'
+
+
+#: Matches the ``endpoint=<url>`` segment a hosted system carries in its
+#: label. The host is deployment infrastructure and can name a private or
+#: internal service, so it is redacted out of the rendered document by
+#: default on exactly the same terms as a local artifact path.
+_ENDPOINT_IN_LABEL = re.compile(r"(endpoint=)(\S+)")
+
+
+def _system_label(label: str, *, redact_paths: bool) -> str:
+    """Redact the deployment host from a system label.
+
+    The path is kept: it is what distinguishes one deployment route from
+    another (``/v1/chat/completions`` against a per-deployment path, say)
+    without naming the host it lives on. Applied to every rendered label,
+    including the frontier's ``dominated_by`` entries, so a host cannot
+    survive in one corner of the page after being redacted elsewhere.
+    """
+    if not redact_paths:
+        return label
+
+    def replace(match: re.Match[str]) -> str:
+        parts = urlsplit(match.group(2))
+        if not parts.scheme or not parts.netloc:
+            return match.group(0)
+        return match.group(1) + (parts.path or "/")
+
+    return _ENDPOINT_IN_LABEL.sub(replace, label)
+
+
+#: Candidate tokens for path scrubbing: any run of non-space, non-quote
+#: characters. Whether a candidate is actually a path is decided by
+#: ``_looks_like_path`` rather than by the pattern, because a regex tight
+#: enough to exclude ordinary prose like "read/parse" and loose enough to
+#: catch "acme-client/eval/runs/x/final_record.json" is unreadable.
+_PROSE_TOKEN = re.compile(r"[^\s'\"()<>]+")
+
+#: A final component is treated as a filename when it carries a short
+#: alphanumeric extension, which is what distinguishes ``a/b.json`` from the
+#: prose slash in ``read/parse``.
+_FILENAME_SUFFIX = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
+
+def _looks_like_path(token: str) -> bool:
+    """Whether a prose token is a filesystem path rather than ordinary words.
+
+    Deliberately conservative in both directions. Absolute paths and Windows
+    drive paths always count. A relative token counts when it has more than
+    one separator, or exactly one separator and a filename-looking final
+    component. That admits ``artifacts/run/runs/x/record.json`` and
+    ``run/record.json`` while leaving ``read/parse`` alone, which a naive
+    "contains a slash" rule mangles into ``readparse``.
+    """
+    if token.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", token):
+        return True
+    parts = re.split(r"[/\\]", token)
+    if len(parts) > 2:
+        return True
+    return len(parts) == 2 and bool(_FILENAME_SUFFIX.search(parts[-1]))
+
+
+def _redact_paths_in_prose(text: str, *, redact_paths: bool) -> str:
+    """Reduce any filesystem path quoted inside prose to its final component.
+
+    Exclusion and rejection reasons are assembled where the failure happened,
+    including inside shared loaders this package does not own, so despite
+    care at each site one can still quote a directory. The rendered document
+    is meant to be shareable, so rather than trusting every message to be
+    written correctly forever, the renderer scrubs them on the way out.
+
+    Relative paths matter as much as absolute ones here: the documented
+    workflow uses a relative ``--output-dir``, so a leaked ancestor is
+    typically a relative one such as a client or project directory name.
+    """
+    if not redact_paths:
+        return text
+
+    def replace(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if not _looks_like_path(token):
+            return token
+        name = PurePosixPath(token.replace("\\", "/")).name
+        if not name:
+            return "<path>"
+        # A path containing whitespace does not survive tokenisation:
+        # ``/Users/secret client/results/runs/x/record.json`` splits at the
+        # space, and the first half's basename is the private ancestor
+        # ``secret`` rather than a filename, so reducing it to its basename
+        # would publish exactly the directory name redaction exists to hide.
+        # The same is true of a bare directory path. So an anchored path is
+        # kept only when its final component looks like a file; otherwise it
+        # becomes opaque. Nothing is lost by that: a directory that is
+        # genuinely worth naming is carried as a structured field and
+        # labelled by ``_redacted_label``, not recovered from prose.
+        anchored = (
+            token.startswith("/")
+            or token.startswith("\\\\")
+            or bool(re.match(r"^[A-Za-z]:[\\/]", token))
+        )
+        if anchored and not _FILENAME_SUFFIX.search(name):
+            return "<path>"
+        return name
+
+    return _PROSE_TOKEN.sub(replace, text)
+
+
+def _redacted_label(raw: str, *, redact_paths: bool, run_id: str | None = None) -> str:
+    """Redact a path that has no verified run id to its basename alone.
+
+    The shared ``_redact_path`` falls back to the last ``runs`` segment when
+    it is given no run id. For a per-run artifact that is what you want. For
+    a results directory or a pricing manifest it is not: those paths have no
+    run id to anchor on, and if such a path happens to contain a ``runs``
+    segment anywhere -- ``/home/someone/secret-client/runs/private-eval`` --
+    the fallback keeps everything from that segment onward and publishes
+    directory names that have nothing to do with this report.
+
+    So when no run id is available, the label is the final path component and
+    nothing else. That is enough to tell two inputs apart in a report while
+    carrying no ancestor names at all.
+    """
+    if not redact_paths:
+        return raw
+    if run_id:
+        return _path_label(raw, redact_paths=True, run_id=run_id)
+    return PurePosixPath(raw.replace("\\", "/")).name or raw
+
+
+def _render_masthead(report: CompareReport, *, redact_paths: bool) -> str:
+    redaction = "paths redacted" if redact_paths else "full paths included"
+    return (
+        '<header class="masthead">'
+        f"{LOCKUP_SVG}"
+        '<p class="stamp">Cross-system comparison'
+        f"<br><b>{_esc(report.generated_at)}</b>"
+        f"<br>Schema {_esc(report.schema_version)} &middot; {redaction}</p>"
+        "</header>"
+    )
+
+
+def _counts(report: CompareReport) -> tuple[tuple[str, int, str], ...]:
+    recommended = sum(
+        1 for stratum in report.strata if stratum.outcome == StratumOutcome.RECOMMENDED
+    )
+    inconclusive = sum(
+        1 for stratum in report.strata if stratum.outcome == StratumOutcome.INCONCLUSIVE
+    )
+    ranked = sum(len(stratum.ranked) for stratum in report.strata)
+    rejected = sum(len(stratum.rejected) for stratum in report.strata)
+    excluded = len(report.excluded_runs)
+    return (
+        ("Comparable units", len(report.strata), ""),
+        ("Recommendations", recommended, "v-rec" if recommended else ""),
+        ("Inconclusive", inconclusive, "v-hold" if inconclusive else ""),
+        ("Ranked systems", ranked, ""),
+        ("Rejected systems", rejected, ""),
+        ("Excluded runs", excluded, "v-breach" if excluded else ""),
+    )
+
+
+def _render_summary(report: CompareReport) -> str:
+    divisions = "".join(
+        '<div class="division">'
+        f'<span class="v {state}">{value}</span>'
+        f'<span class="k">{_esc(label)}</span>'
+        "</div>"
+        for label, value, state in _counts(report)
+    )
+    return (
+        '<section id="summary" aria-labelledby="summary-h">'
+        '<div class="rule"><h2 id="summary-h">Summary</h2></div>'
+        f'<div class="readout">{divisions}</div>'
+        "</section>"
+    )
+
+
+def _render_unit_identity(stratum: StratumReport) -> str:
+    key = stratum.unit_key
+    rows = (
+        ("Workload", f"{key.workload_id} (v{key.workload_version})"),
+        ("Context tier", key.context_tier),
+        ("Prompt hash", key.workload_prompt_hash),
+        ("Evaluator / quality metric", key.quality_metric or "unrecorded"),
+        (
+            "Max output tokens",
+            (
+                "unrecorded"
+                if key.max_output_tokens is None
+                else str(key.max_output_tokens)
+            ),
+        ),
+        (
+            "Sampling",
+            "temperature="
+            + ("unrecorded" if key.temperature is None else f"{key.temperature:g}")
+            + ", top_p="
+            + ("unrecorded" if key.top_p is None else f"{key.top_p:g}"),
+        ),
+        ("Ranking objective", stratum.objective_name),
+    )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    return f'<dl class="spec">{items}</dl>'
+
+
+def _artifact_lists(
+    *,
+    run_ids: tuple[str, ...],
+    verification_paths: tuple[str, ...],
+    record_paths: tuple[str, ...],
+    redact_paths: bool,
+) -> str:
+    verification = _list_items(
+        _path_label(path, redact_paths=redact_paths, run_id=run_id)
+        for path, run_id in zip_longest(verification_paths, run_ids, fillvalue=None)
+        if path is not None
+    )
+    records = _list_items(
+        _path_label(path, redact_paths=redact_paths, run_id=run_id)
+        for path, run_id in zip_longest(record_paths, run_ids, fillvalue=None)
+        if path is not None
+    )
+    return (
+        f"<h4>Run IDs</h4>{_list_items(run_ids)}"
+        f"<h4>Verification artifacts</h4>{verification}"
+        f"<h4>Final record artifacts</h4>{records}"
+    )
+
+
+def _render_usage(usage: UsageTotals | None) -> str:
+    if usage is None:
+        return (
+            '<p class="muted">No provider-reported token usage. This system was '
+            "not executed by a hosted API, or the provider returned no usage "
+            "block.</p>"
+        )
+    rows = (
+        ("Input tokens", _fmt_tokens(usage.input_tokens)),
+        ("Output tokens", _fmt_tokens(usage.output_tokens)),
+        ("Cached input tokens", _fmt_tokens(usage.cached_input_tokens)),
+        ("Reasoning tokens", _fmt_tokens(usage.reasoning_tokens)),
+        (
+            "Runs reporting usage",
+            f"{usage.runs_reporting_usage} of {usage.runs_total}",
+        ),
+    )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    caveat = (
+        ""
+        if usage.complete
+        else (
+            '<p class="muted">Incomplete: at least one ranked run carried no '
+            "usage block, so any total above that depends on it is withheld "
+            "rather than partially summed.</p>"
+        )
+    )
+    return (
+        '<p class="muted">Reported by the provider, not measured by this client.'
+        "</p>"
+        f'<dl class="spec">{items}</dl>{caveat}'
+    )
+
+
+def _render_cost(cost: CostSummary | None) -> str:
+    if cost is None:
+        return (
+            '<p class="muted">No cost estimate. Either no pricing entry matched '
+            "this system, or no pricing manifest was supplied.</p>"
+        )
+    rows = (
+        ("Total", _fmt_money(cost.total_amount, cost.currency)),
+        ("Per case", _fmt_money(cost.cost_per_case, cost.currency)),
+        ("Per correct case", _fmt_money(cost.cost_per_correct_case, cost.currency)),
+        (
+            f"Correct cases per {cost.currency}",
+            _fmt_number(cost.correct_cases_per_currency_unit, digits=3),
+        ),
+        ("Pricing entry", cost.pricing_entry_id),
+        ("Pricing entry hash", cost.pricing_entry_sha256),
+    )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    marker = (
+        '<span class="state state-hold">Illustrative rates</span>'
+        if cost.rates_are_illustrative
+        else '<span class="state state-hold">Estimated</span>'
+    )
+    caveat = (
+        '<p class="muted">Every figure above is derived from provider-reported '
+        "token usage priced with supplied rates. None of it was measured, and "
+        "none of it is a quotation."
+        + (
+            " The manifest declares its rates to be illustrative examples, so "
+            "these numbers demonstrate the arithmetic and are not prices."
+            if cost.rates_are_illustrative
+            else ""
+        )
+        + "</p>"
+    )
+    reasons = (
+        f"<h4>Cost caveats</h4>{_missing_evidence_block(cost.reasons, empty='none')}"
+        if cost.reasons
+        else ""
+    )
+    return f'<p>{marker}</p>{caveat}<dl class="spec">{items}</dl>{reasons}'
+
+
+def _render_system_detail(system: SystemReport, *, redact_paths: bool) -> str:
+    ttft = (
+        "n/a"
+        if system.mean_ttft_ms is None or system.ttft_basis is None
+        else (
+            f"{_fmt_number(system.mean_ttft_ms, digits=2)} ms "
+            f"({_TTFT_BASIS_LABEL[system.ttft_basis]})"
+        )
+    )
+    memory = (
+        "local-only measurement, not available for a hosted system"
+        if not system.system_key.is_local
+        else (
+            f"{_fmt_bytes_mb(system.mean_peak_memory_bytes)} mean / "
+            f"{_fmt_bytes_mb(system.max_peak_memory_bytes)} max"
+        )
+    )
+    rows = (
+        ("Time to first token", ttft),
+        (
+            "Latency spread (stdev)",
+            _fmt_number(system.stdev_total_latency_ms, digits=2),
+        ),
+        ("Coefficient of variation", _fmt_number(system.coefficient_of_variation)),
+        ("Local peak memory", memory),
+    )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    artifacts = _artifact_lists(
+        run_ids=system.run_ids,
+        verification_paths=system.verification_paths,
+        record_paths=system.record_paths,
+        redact_paths=redact_paths,
+    )
+    return (
+        "<details><summary>Measurements, usage, cost and source artifacts"
+        "</summary>"
+        f'<dl class="spec">{items}</dl>'
+        "<h4>Provider-reported usage</h4>"
+        f"{_render_usage(system.usage)}"
+        "<h4>Estimated cost</h4>"
+        f"{_render_cost(system.cost)}"
+        "<h4>Missing evidence</h4>"
+        f"{_missing_evidence_block(system.missing_evidence, empty='Nothing missing.')}"
+        f"{artifacts}"
+        "</details>"
+    )
+
+
+def _render_ranked_table(stratum: StratumReport, *, redact_paths: bool) -> str:
+    if not stratum.ranked:
+        return (
+            '<p class="empty">No system cleared every constraint, so there is '
+            "no ranking to show.</p>"
+        )
+    header = "".join(
+        f'<th scope="col" role="columnheader" class="num">{_esc(label)}</th>'
+        for label in _RANKED_COLUMNS
+    )
+    recommended_rank = (
+        stratum.recommended.rank if stratum.recommended is not None else None
+    )
+    groups: list[str] = []
+    for system in stratum.ranked:
+        is_recommended = system.rank == recommended_rank
+        pad = "pad" if is_recommended else "pad-open"
+        marker = (
+            '<span class="state state-rec">Recommended</span>' if is_recommended else ""
+        )
+        quality = (
+            "n/a"
+            if system.quality_metric is None
+            else (
+                f"{system.quality_metric} = "
+                f"{_fmt_number(system.mean_quality_score, digits=3)}"
+            )
+        )
+        currency = system.cost.currency if system.cost is not None else ""
+        values = (
+            _fmt_number(system.objective_value),
+            _fmt_percent(system.pass_rate),
+            quality,
+            _fmt_number(system.mean_total_latency_ms, digits=2),
+            f"{_fmt_number(system.p50_total_latency_ms, digits=2)} / "
+            + f"{_fmt_number(system.p95_total_latency_ms, digits=2)}",
+            _fmt_number(system.correct_cases_per_minute, digits=3),
+            (
+                "n/a"
+                if system.cost is None
+                else _fmt_money(system.cost.cost_per_correct_case, currency)
+            ),
+            (
+                "n/a"
+                if system.cost is None
+                else _fmt_number(system.cost.correct_cases_per_currency_unit, digits=3)
+            ),
+            str(system.evidence_count),
+        )
+        # Every cell value is escaped here, at the single boundary where a
+        # value enters the document, rather than each formatter escaping its
+        # own inputs. A formatter that forgot (``_fmt_money`` interpolates the
+        # currency string straight from the report) would otherwise be the one
+        # unescaped path on the page.
+        cells = "".join(
+            f'<td role="cell" class="num" data-label="{_esc(label)}">'
+            f"{_esc(value)}</td>"
+            for label, value in zip(_RANKED_COLUMNS, values, strict=True)
+        )
+        span = len(_RANKED_COLUMNS)
+        groups.append(
+            f'<tbody role="rowgroup" class="cand{" is-rec" if is_recommended else ""}">'
+            '<tr role="row" class="cand-head">'
+            f'<th scope="rowgroup" role="rowheader" colspan="{span}">'
+            '<span class="cand-id"><span class="cand-rank">'
+            f'<span class="{pad}" aria-hidden="true"></span>#{system.rank}</span>'
+            f'<span class="cand-label">'
+            f"{_esc(_system_label(system.system_key.label(), redact_paths=redact_paths))}"
+            "</span>"
+            f"{marker}</span></th></tr>"
+            f'<tr role="row" class="cand-metrics">{cells}</tr>'
+            '<tr role="row" class="cand-evidence">'
+            f'<td role="cell" colspan="{span}">'
+            + _render_system_detail(system, redact_paths=redact_paths)
+            + "</td></tr></tbody>"
+        )
+    caption = (
+        f"{len(stratum.ranked)} system(s) cleared every constraint, ranked by "
+        f"{stratum.objective_name}. Quality columns are shown beside the "
+        "objective so a faster system is never read as a better one."
+    )
+    return (
+        '<div class="scroller"><table class="reflow" role="table">'
+        f"<caption>{_esc(caption)}</caption>"
+        f'<thead role="rowgroup"><tr role="row">{header}</tr></thead>'
+        f"{''.join(groups)}"
+        "</table></div>"
+    )
+
+
+def _render_frontier(stratum: StratumReport, *, redact_paths: bool) -> str:
+    if not stratum.frontier or not stratum.frontier_axes:
+        return (
+            "<h3>Evidence frontier</h3>"
+            '<p class="empty">No frontier could be computed: the ranked systems '
+            "share no axis on which all of them carry evidence.</p>"
+        )
+    axes = ", ".join(axis.value for axis in stratum.frontier_axes)
+    rows = "".join(
+        _render_frontier_row(entry, redact_paths=redact_paths)
+        for entry in stratum.frontier
+    )
+    return (
+        "<h3>Evidence frontier</h3>"
+        '<p class="muted">Systems that nothing else beats on every axis at once. '
+        f"Axes: <code>{_esc(axes)}</code>. Dominance is computed on point "
+        "estimates, so a system that leads only inside its noise band still "
+        "shows here as dominating; the ranking above applies the noise test and "
+        "this table does not. There is no universal winner on this page.</p>"
+        '<div class="scroller"><table class="reflow" role="table">'
+        "<caption>Each system is either on the frontier or named with every "
+        "system that dominates it.</caption>"
+        '<thead role="rowgroup"><tr role="row">'
+        '<th scope="col" role="columnheader">System</th>'
+        '<th scope="col" role="columnheader">Position</th>'
+        '<th scope="col" role="columnheader">Dominated by</th></tr></thead>'
+        f'<tbody role="rowgroup">{rows}</tbody></table></div>'
+    )
+
+
+def _render_frontier_row(entry: FrontierEntry, *, redact_paths: bool) -> str:
+    state = (
+        '<span class="state state-bad">Dominated</span>'
+        if entry.dominated
+        else '<span class="state state-ok">On frontier</span>'
+    )
+    dominated_by = (
+        _list_items(
+            _system_label(name, redact_paths=redact_paths)
+            for name in entry.dominated_by
+        )
+        if entry.dominated_by
+        else '<span class="nil">none</span>'
+    )
+    return (
+        '<tr role="row">'
+        f'<th scope="row" role="rowheader" data-label="System">'
+        f"<code>{_esc(_system_label(entry.system_key.label(), redact_paths=redact_paths))}</code></th>"
+        f'<td role="cell" data-label="Position">{state}</td>'
+        f'<td role="cell" data-label="Dominated by">{dominated_by}</td>'
+        "</tr>"
+    )
+
+
+def _render_rejected(
+    rejected: tuple[RejectedSystemReport, ...], *, redact_paths: bool
+) -> str:
+    if not rejected:
+        return (
+            "<h3>Rejected systems</h3>"
+            '<p class="empty">None. Every system in this unit cleared the '
+            "policy constraints.</p>"
+        )
+    blocks = []
+    for system in rejected:
+        reasons = "".join(
+            f"<li>{_esc(_redact_paths_in_prose(reason, redact_paths=redact_paths))}</li>"
+            for reason in system.reasons
+        )
+        artifacts = _artifact_lists(
+            run_ids=system.run_ids,
+            verification_paths=system.verification_paths,
+            record_paths=system.record_paths,
+            redact_paths=redact_paths,
+        )
+        blocks.append(
+            '<div class="reject">'
+            '<span class="state state-bad">Rejected</span>'
+            f'<div class="subject">'
+            f"{_esc(_system_label(system.system_key.label(), redact_paths=redact_paths))}"
+            "</div>"
+            f'<ul class="violations">{reasons}</ul>'
+            "<details><summary>Source run IDs and artifact paths</summary>"
+            f"{artifacts}</details>"
+            "</div>"
+        )
+    return (
+        f"<h3>Rejected systems ({len(rejected)})</h3>"
+        '<p class="muted">Each system below is listed with every constraint it '
+        "breached.</p>" + "".join(blocks)
+    )
+
+
+def _stratum_anchor(index: int) -> str:
+    return f"unit-{index}"
+
+
+def _render_constraints(constraints: CompareConstraints) -> str:
+    """The bar a system had to clear, stated with the verdict.
+
+    Without it "cleared every constraint" is unreadable: there is no way to
+    tell a demanding comparison from one that constrained nothing.
+    """
+    items = "".join(f"<li>{_esc(item)}</li>" for item in constraints.active_summary())
+    return (
+        '<div class="constraints">'
+        '<p class="muted">Constraints in force for this verdict:</p>'
+        f'<ul class="constraint-list">{items}</ul>'
+        "</div>"
+    )
+
+
+def _render_recommendation(
+    stratum: StratumReport, *, constraints: CompareConstraints, redact_paths: bool
+) -> str:
+    """The recommendation, always stated with the question it answers."""
+    key = stratum.unit_key
+    scope = (
+        f"workload <code>{_esc(key.workload_id)}</code> v{_esc(key.workload_version)} "
+        f"at context tier <code>{_esc(key.context_tier)}</code>, evaluated by "
+        f"<code>{_esc(key.quality_metric or 'unrecorded')}</code>, ranked on "
+        f"<code>{_esc(stratum.objective_name)}</code>"
+    )
+    if stratum.outcome != StratumOutcome.RECOMMENDED or stratum.recommended is None:
+        return (
+            '<div class="verdict">'
+            f"<p>No system could be recommended for {scope}.</p>"
+            f"<p>{_esc(stratum.inconclusive_reason or 'no reason recorded')}</p>"
+            f"{_render_constraints(constraints)}"
+            "</div>"
+        )
+    winner = stratum.recommended
+    runner_up = (
+        f"Ranked ahead of <code>"
+        f"{_esc(_system_label(stratum.ranked[1].system_key.label(), redact_paths=redact_paths))}"
+        "</code> "
+        f"(objective value <code>{_fmt_number(stratum.ranked[1].objective_value)}"
+        "</code>)."
+        if len(stratum.ranked) > 1
+        else "It was the only system accepted for this unit."
+    )
+    return (
+        '<div class="verdict is-rec">'
+        f"<p>For {scope}, and only for that:</p>"
+        f'<span class="subject">'
+        f"{_esc(_system_label(winner.system_key.label(), redact_paths=redact_paths))}"
+        "</span>"
+        f"<p>Won with objective value "
+        f"<code>{_fmt_number(winner.objective_value)}</code>, backed by "
+        f"{winner.evidence_count} run(s) with usable timing evidence. "
+        f"{runner_up}</p>"
+        f"{_render_constraints(constraints)}"
+        "</div>"
+    )
+
+
+def _render_stratum(
+    stratum: StratumReport,
+    *,
+    index: int,
+    constraints: CompareConstraints,
+    redact_paths: bool,
+) -> str:
+    anchor = _stratum_anchor(index)
+    state = (
+        '<span class="state state-rec">RECOMMENDED</span>'
+        if stratum.outcome == StratumOutcome.RECOMMENDED
+        else '<span class="state state-hold">INCONCLUSIVE</span>'
+    )
+    return "".join(
+        (
+            f'<section id="{anchor}" aria-labelledby="{anchor}-h">',
+            f'<div class="rule"><h2 id="{anchor}-h">'
+            + '<span class="qualifier">Comparable unit</span>'
+            + f'<span class="subject-id">{_esc(stratum.unit_key.label())}</span>'
+            + f"</h2>{state}</div>",
+            _render_unit_identity(stratum),
+            _render_recommendation(
+                stratum, constraints=constraints, redact_paths=redact_paths
+            ),
+            "<h3>Ranked systems</h3>",
+            _render_ranked_table(stratum, redact_paths=redact_paths),
+            _render_frontier(stratum, redact_paths=redact_paths),
+            _render_rejected(stratum.rejected, redact_paths=redact_paths),
+            "<h3>Missing evidence for this unit</h3>",
+            _missing_evidence_block(
+                stratum.missing_evidence,
+                empty="Nothing missing: every ranked system carried evidence for "
+                "every axis this unit was compared on.",
+            ),
+            "</section>",
+        )
+    )
+
+
+def _render_pricing(report: CompareReport, *, redact_paths: bool) -> str:
+    pricing = report.pricing
+    if pricing is None:
+        return (
+            '<section id="pricing" aria-labelledby="pricing-h">'
+            '<div class="rule"><h2 id="pricing-h">Pricing input</h2></div>'
+            '<p class="empty">No pricing manifest was supplied, so this report '
+            "contains no monetary values at all.</p>"
+            f"{ORNAMENT_OPEN_SVG}"
+            "</section>"
+        )
+    rows = (
+        (
+            "Manifest",
+            _redacted_label(pricing.manifest_path, redact_paths=redact_paths),
+        ),
+        ("Manifest hash", pricing.manifest_sha256),
+        ("Currency", pricing.currency),
+        (
+            "Entries used",
+            ", ".join(pricing.entry_ids_used) if pricing.entry_ids_used else "none",
+        ),
+    )
+    items = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>" for k, v in rows)
+    warning = (
+        '<p><span class="state state-hold">Illustrative rates</span></p>'
+        "<p>This manifest declares its rates to be examples rather than prices. "
+        "Every monetary figure in this report therefore demonstrates the "
+        "arithmetic on real usage; none of it is a quotation, and none of it "
+        "was fetched from a provider.</p>"
+        if pricing.rates_are_illustrative
+        else "<p>Rates were supplied by the operator with a source and an "
+        "effective date. They are still applied to provider-reported usage "
+        "rather than measured, so every figure derived from them is an "
+        "estimate.</p>"
+    )
+    return (
+        '<section id="pricing" aria-labelledby="pricing-h">'
+        '<div class="rule"><h2 id="pricing-h">Pricing input</h2></div>'
+        f"{warning}"
+        f'<dl class="spec">{items}</dl>'
+        "</section>"
+    )
+
+
+def _render_provenance(report: CompareReport, *, redact_paths: bool) -> str:
+    sources = _list_items(
+        _redacted_label(path, redact_paths=redact_paths) for path in report.results_dirs
+    )
+    parts = [
+        '<section id="provenance" aria-labelledby="provenance-h">',
+        '<div class="rule"><h2 id="provenance-h">Provenance</h2>'
+        + '<span class="muted">'
+        + f'{"paths redacted" if redact_paths else "full paths included"}</span></div>',
+        "<h3>Source results directories</h3>",
+        sources,
+    ]
+    if report.tune_report_paths:
+        parts.append("<h3>Corroborating tune reports</h3>")
+        parts.append(
+            _list_items(
+                _redacted_label(path, redact_paths=redact_paths)
+                for path in report.tune_report_paths
+            )
+        )
+    if report.excluded_runs:
+        rows = "".join(
+            '<tr role="row">'
+            '<th scope="row" role="rowheader" data-label="Run ID">'
+            f"<code>{_esc(run.run_id)}</code></th>"
+            '<td role="cell" data-label="Source results directory"><code>'
+            f"{_esc(_redacted_label(run.source_results_dir, redact_paths=redact_paths))}"
+            "</code></td>"
+            f'<td role="cell" data-label="Reason">'
+            f"{_esc(_redact_paths_in_prose(run.reason, redact_paths=redact_paths))}"
+            "</td>"
+            "</tr>"
+            for run in report.excluded_runs
+        )
+        parts.append(f"<h3>Excluded runs ({len(report.excluded_runs)})</h3>")
+        parts.append(
+            '<p class="muted">Runs whose evidence could not be trusted at all '
+            "(never even considered as a rejected system).</p>"
+        )
+        parts.append(
+            '<div class="scroller"><table class="reflow hazard" role="table">'
+            "<caption>Every run listed here was set aside before any system was "
+            "compared, so none of it reached the tables above.</caption>"
+            '<thead role="rowgroup"><tr role="row">'
+            '<th scope="col" role="columnheader">Run ID</th>'
+            '<th scope="col" role="columnheader">Source results directory</th>'
+            '<th scope="col" role="columnheader">Reason</th></tr></thead>'
+            f'<tbody role="rowgroup">{rows}</tbody></table></div>'
+        )
+    else:
+        parts.append("<h3>Excluded runs</h3>")
+        parts.append(
+            '<p class="empty">None. Every run found in the source directories '
+            "carried enough evidence to be compared.</p>"
+        )
+    parts.append("</section>")
+    return "".join(parts)
+
+
+def _render_transect(report: CompareReport) -> str:
+    stations = [
+        '<li><a href="#summary"><span class="station" aria-hidden="true"></span>'
+        + '<span class="label">Summary</span></a></li>'
+    ]
+    for index, stratum in enumerate(report.strata, start=1):
+        recommended = stratum.outcome == StratumOutcome.RECOMMENDED
+        station_class = "station station-rec" if recommended else "station station-hold"
+        note_class = "note" if recommended else "note note-hold"
+        note = "RECOMMENDED" if recommended else "INCONCLUSIVE"
+        stations.append(
+            f'<li><a href="#{_stratum_anchor(index)}">'
+            f'<span class="{station_class}" aria-hidden="true"></span>'
+            f'<span class="label">{_esc(stratum.unit_key.label())}</span>'
+            f'<span class="{note_class}">{note}</span></a></li>'
+        )
+    for anchor, label in (
+        ("#pricing", "Pricing input"),
+        ("#provenance", "Provenance"),
+    ):
+        stations.append(
+            f'<li><a href="{anchor}">'
+            '<span class="station" aria-hidden="true"></span>'
+            f'<span class="label">{label}</span></a></li>'
+        )
+    return (
+        '<nav class="transect" aria-label="Report contents">'
+        f"<ol>{''.join(stations)}</ol></nav>"
+    )
+
+
+def _meta_description(report: CompareReport) -> str:
+    counts = {label: value for label, value, _ in _counts(report)}
+    return (
+        f"Cross-system comparison for policy {report.policy.name or 'unnamed'}: "
+        f"{counts['Comparable units']} comparable unit(s), "
+        f"{counts['Recommendations']} recommendation(s), "
+        f"{counts['Inconclusive']} inconclusive, "
+        f"{counts['Rejected systems']} rejected system(s), "
+        f"{counts['Excluded runs']} excluded run(s). "
+        f"Generated {report.generated_at}."
+    )
+
+
+def render_compare_report_html(
+    report: CompareReport, *, redact_paths: bool = True
+) -> str:
+    """Render ``report`` as a single, self-contained, portable HTML page.
+
+    ``redact_paths`` (default ``True``) replaces every local artifact path
+    with a stable, non-identifying label, so the report is safe to share
+    without leaking a user's directory layout. Pass ``redact_paths=False``
+    to include full paths as plain text.
+    """
+    title = report.policy.name or "Cross-system comparison"
+    body_parts = [
+        '<a class="skip" href="#report">Skip to the report</a>',
+        '<div class="sheet">',
+        _render_masthead(report, redact_paths=redact_paths),
+        '<main id="report">',
+        f"<h1>{_esc(title)}</h1>",
+        _LEDE,
+        _render_transect(report),
+        _render_summary(report),
+    ]
+
+    if not report.strata:
+        body_parts.append(
+            '<section id="units" aria-labelledby="units-h">'
+            '<div class="rule"><h2 id="units-h">Comparable units</h2></div>'
+            '<p class="empty">No comparable units were found in the provided '
+            "results directories. Nothing could be compared, so nothing is "
+            "recommended.</p>"
+            '<div class="empty-spec">'
+            + "".join(
+                f'<div><span>{label}</span><span class="nil">none</span></div>'
+                for label in (
+                    "Comparable units",
+                    "Recommendations",
+                    "Ranked systems",
+                    "Rejected systems",
+                    "Frontier entries",
+                )
+            )
+            + "</div>"
+            f"{ORNAMENT_OPEN_SVG}"
+            "</section>"
+        )
+    else:
+        for index, stratum in enumerate(report.strata, start=1):
+            body_parts.append(
+                _render_stratum(
+                    stratum,
+                    index=index,
+                    constraints=report.policy.constraints,
+                    redact_paths=redact_paths,
+                )
+            )
+
+    body_parts.append(_render_pricing(report, redact_paths=redact_paths))
+    body_parts.append(_render_provenance(report, redact_paths=redact_paths))
+    body_parts.append("</main>")
+    body_parts.append(
+        f"{ORNAMENT_CLOSED_SVG}"
+        "<footer><span>Generated by <code>llmtracefx-optimizer compare-report"
+        "</code></span><span>Static HTML, no external references, safe to open "
+        "from disk</span></footer>"
+    )
+    body_parts.append("</div>")
+
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        '<meta name="color-scheme" content="light">\n'
+        '<meta name="generator" content="llmtracefx-optimizer compare-report">\n'
+        '<meta name="robots" content="noindex, nofollow">\n'
+        f'<meta name="description" content="{_esc(_meta_description(report))}">\n'
+        f"<title>{_esc(title)} &middot; LLMTraceFX cross-system comparison</title>\n"
+        f"<!--{DIRECTION_CONTRACT}-->\n"
+        f"<style>{_style()}</style>\n"
+        "</head>\n"
+        "<body>\n" + "".join(body_parts) + "\n</body>\n</html>\n"
+    )
+
+
+__all__ = ["render_compare_report_html"]

--- a/llmtracefx/optimizer/tune/loader.py
+++ b/llmtracefx/optimizer/tune/loader.py
@@ -85,11 +85,71 @@ class LoadedEvidence:
     excluded: tuple[ExcludedRun, ...]
 
 
-def _resolve_artifact_path(raw: str | None, *, results_dir: Path, run_id: str) -> Path:
-    if raw is None:
-        return results_dir / "runs" / run_id / "final_record.json"
-    path = Path(raw)
-    return path if path.is_absolute() else results_dir / raw
+def _contained_regular_file(candidate: Path, *, root: Path) -> Path | None:
+    """The resolved ``candidate`` when it is a regular file inside ``root``.
+
+    Resolution happens before the containment test, so a symlink pointing
+    out of the tree fails it rather than being followed out. ``is_file`` on
+    the resolved path additionally rejects a directory, a FIFO or a device
+    node, which would otherwise be opened and read.
+    """
+    try:
+        resolved = candidate.resolve(strict=True)
+        anchor = root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if not resolved.is_relative_to(anchor):
+        return None
+    if not resolved.is_file():
+        return None
+    return resolved
+
+
+def _resolve_artifact_path(
+    raw: str | None, *, results_dir: Path, run_id: str
+) -> Path | None:
+    """Resolve a recorded artifact path inside the results directory named.
+
+    ``verify.execute_row`` writes the record at
+    ``<output_dir>/runs/<run_id>/final_record.json`` unconditionally, so that
+    location is correct by construction for every recorded form and is tried
+    first. The recorded string is corroboration, not authority.
+
+    Anchoring on the results directory rather than on the recorded string
+    matters in both directions. A relative ``--output-dir`` records a path
+    relative to the *working directory* of that run, so reading the recorded
+    string literally would resolve it against whatever tree this process
+    happens to be standing in: run ``compare --results B`` from inside tree
+    ``A`` and you would silently get A's measurements labelled as B's, with
+    every identity check passing because a matrix ``run_id`` names the task
+    and not the system. Joining the recorded string under the results
+    directory instead doubles the prefix
+    (``artifacts/run/artifacts/run/...``) and finds nothing. The canonical
+    location avoids both.
+
+    Nothing outside ``results_dir`` is ever returned. The recorded string is
+    data from the artifact being validated, so an absolute path, a ``..``
+    segment or a symlink in it is under the control of whoever wrote that
+    artifact; honouring any of them would let one results tree serve another
+    tree's measurements while every identity check passed. When the recorded
+    string does not resolve to a regular file inside the tree, ``None`` is
+    returned and the caller reports the record as unreadable rather than
+    reading it from wherever the string pointed.
+    """
+    canonical = results_dir / "runs" / run_id / "final_record.json"
+    contained = _contained_regular_file(canonical, root=results_dir)
+    if contained is not None:
+        return contained
+    if raw is None or not isinstance(raw, str):
+        # Not a string means nothing usable to resolve. ``RowVerification``
+        # does not type-check this field, and reaching ``Path()`` with a list
+        # raises ``TypeError`` out of the middle of the loader.
+        return None
+    candidate = Path(raw)
+    # An absolute recorded path is believed only when it names something
+    # inside the tree that was actually asked for.
+    probe = candidate if candidate.is_absolute() else results_dir / raw
+    return _contained_regular_file(probe, root=results_dir)
 
 
 def _record_identity_error(
@@ -137,8 +197,10 @@ def _load_one_run(
 ) -> tuple[RunEvidence | None, ExcludedRun | None]:
     run_id = verification_path.parent.name
     try:
+        # ``read_json`` is bounded, regular-file-only and does not follow
+        # symlinks, so this needs no separate guard here.
         verification = RowVerification.read_json(verification_path)
-    except (OSError, VerifyError) as exc:
+    except (OSError, VerifyError, TypeError, ArithmeticError) as exc:
         return None, ExcludedRun(
             run_id=run_id,
             source_results_dir=str(results_dir),
@@ -170,9 +232,22 @@ def _load_one_run(
     final_record_path = _resolve_artifact_path(
         verification.final_record_path, results_dir=results_dir, run_id=run_id
     )
+    if final_record_path is None:
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=(
+                f"could not read final_record.json for run "
+                f"{verification.run_id!r}: it is not a regular file inside the "
+                "results directory. A record reached through an absolute "
+                "path, a parent-directory segment or a symlink leaving the "
+                "tree is not this tree's evidence"
+            ),
+        )
     try:
         # Preserve legacy tune diagnostics: the tuner classifies non-finite
-        # measurements with field-specific rejection reasons.
+        # measurements with field-specific rejection reasons. ``read_json``
+        # is bounded, regular-file-only and does not follow symlinks.
         record = ExperimentRecord.read_json(final_record_path, allow_non_finite=True)
     except OSError as exc:
         return None, ExcludedRun(
@@ -187,6 +262,23 @@ def _load_one_run(
             reason=(
                 f"final_record.json ({final_record_path}) failed schema "
                 f"validation: {exc}"
+            ),
+        )
+    except (ArithmeticError, ValueError, TypeError, RecursionError) as exc:
+        # A record is untrusted input, and JSON's own limits are not reported
+        # as schema failures. A numeric literal too large for a float raises
+        # ``OverflowError``, which is an ``ArithmeticError`` and so is caught
+        # by nothing above; deep nesting raises ``RecursionError``; a value
+        # of the wrong type reaches an arithmetic or a hash as ``TypeError``.
+        # None of those are conditions the caller can act on as themselves,
+        # so they become the same exclusion every other malformed record
+        # produces rather than escaping as a stack trace.
+        return None, ExcludedRun(
+            run_id=verification.run_id,
+            source_results_dir=str(results_dir),
+            reason=(
+                f"final_record.json ({final_record_path}) could not be parsed: "
+                f"{type(exc).__name__}: {exc}"
             ),
         )
 

--- a/tests/optimizer/_compare_fixtures.py
+++ b/tests/optimizer/_compare_fixtures.py
@@ -1,0 +1,559 @@
+"""Shared synthetic-artifact builder for ``compare`` tests.
+
+Not a test module (no ``test_`` prefix, so pytest never collects it). It
+builds a ``workloads run --output-dir``-shaped tree -- ``verification.json``
+plus ``final_record.json`` under ``<results_dir>/runs/<run_id>/``, and
+optionally an ``api_evidence.json`` under that run's collection directory --
+without running the verify pipeline, loading a model, or calling an API.
+
+Everything produced here is synthetic. The numbers are chosen to exercise
+specific code paths and are not measurements of any real system.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from llmtracefx.optimizer.collectors._shared import sha256_bytes
+from llmtracefx.optimizer.collectors.openai_api import (
+    API_EVIDENCE_SCHEMA_VERSION,
+    ARTIFACT_MANIFEST_NAME,
+    ARTIFACT_MANIFEST_SCHEMA_VERSION,
+)
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ExperimentRecord,
+    Measurement,
+    MemoryMetrics,
+    MetricProvenance,
+    ModelInfo,
+    OutcomeInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SpeculativeDecodingInfo,
+    TimingMetrics,
+    TokenCounts,
+    utc_now_iso,
+)
+from llmtracefx.optimizer.workloads.api_verify import RUN_MANIFEST_SCHEMA_VERSION
+from llmtracefx.optimizer.workloads.verify import RowStatus, RowVerification
+
+DEFAULT_PROMPT_HASH = "sha256:synthetic-prompt-abc"
+DEFAULT_WORKLOAD_ID = "structured-json-profile-extraction"
+DEFAULT_QUALITY_METRIC = "structured_json_exact_field_match"
+
+
+def api_evidence_payload(
+    *,
+    run_id: str,
+    provider: str = "z-ai",
+    model_id: str = "glm-5.3",
+    model_revision: str | None = None,
+    reasoning_effort: str | None = "high",
+    thinking_type: str | None = None,
+    max_output_tokens: int | None = 512,
+    temperature: float | None = 0.0,
+    top_p: float | None = 1.0,
+    usage_reported: bool = True,
+    prompt_tokens: int | None = 1000,
+    completion_tokens: int | None = 400,
+    cached_prompt_tokens: int | None = None,
+    reasoning_tokens: int | None = None,
+    first_content_token_offset_ms: float | None = 220.0,
+    malformed_fields: tuple[str, ...] = (),
+    workload_hash: str | None = DEFAULT_PROMPT_HASH,
+    config_hash: str | None = "api-cfg-hash",
+    endpoint_origin: str | None = "https://example.invalid",
+    endpoint_path: str | None = "/v1/chat/completions",
+    system_prompt_hash: str | None = None,
+    messages: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the subset of ``api_evidence.json`` the compare loader reads."""
+    request_parameters: dict[str, Any] = {}
+    if max_output_tokens is not None:
+        request_parameters["max_tokens"] = max_output_tokens
+    if temperature is not None:
+        request_parameters["temperature"] = temperature
+    if top_p is not None:
+        request_parameters["top_p"] = top_p
+
+    extensions: dict[str, Any] = {}
+    if reasoning_effort is not None:
+        extensions["reasoning_effort"] = reasoning_effort
+    if thinking_type is not None:
+        extensions["thinking"] = {"type": thinking_type}
+
+    if messages is None:
+        messages = []
+        if system_prompt_hash is not None:
+            messages.append(
+                {
+                    "role": "system",
+                    "characters": 32,
+                    "content_sha256": system_prompt_hash,
+                }
+            )
+        messages.append(
+            {
+                "role": "user",
+                "characters": 64,
+                "content_sha256": workload_hash or DEFAULT_PROMPT_HASH,
+            }
+        )
+
+    return {
+        "schema_version": API_EVIDENCE_SCHEMA_VERSION,
+        "run_id": run_id,
+        "collected_at": utc_now_iso(),
+        "plan": {
+            "schema_version": API_EVIDENCE_SCHEMA_VERSION,
+            "provider": provider,
+            "model_id": model_id,
+            "model_revision": model_revision,
+            "endpoint_origin": endpoint_origin,
+            "endpoint_path": endpoint_path,
+            "messages": messages,
+            "request_parameters": request_parameters,
+            "provider_extensions": extensions,
+            "workload_hash": workload_hash,
+            "config_hash": config_hash,
+        },
+        "success": True,
+        "usage": {
+            "reported": usage_reported,
+            "provenance": MetricProvenance.PROVIDER_REPORTED.value,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": (
+                None
+                if prompt_tokens is None or completion_tokens is None
+                else prompt_tokens + completion_tokens
+            ),
+            "cached_prompt_tokens": cached_prompt_tokens,
+            "reasoning_tokens": reasoning_tokens,
+            "malformed_fields": list(malformed_fields),
+        },
+        "timeline": {
+            "clock": "monotonic_client_perf_counter",
+            "provenance": MetricProvenance.MEASURED_WALL_CLOCK.value,
+            "first_content_token_offset_ms": first_content_token_offset_ms,
+        },
+        "statistics": {},
+        "reasoning_content_returned": reasoning_tokens is not None,
+        "reasoning_text_persisted": False,
+    }
+
+
+def write_run(
+    results_dir: Path,
+    run_id: str,
+    *,
+    status: RowStatus = RowStatus.COMPLETED,
+    workload_id: str = DEFAULT_WORKLOAD_ID,
+    workload_version: str = "1",
+    category: str = "structured_json",
+    context_tier: str = "2k",
+    decode_mode: str = "autoregressive",
+    model_id: str = "local/qwen3-8b",
+    model_family: str | None = "qwen3_next",
+    model_revision: str | None = None,
+    provider: str | None = None,
+    accelerator: str | None = "Apple M5 Pro",
+    runtime_name: str = "mlx-lm",
+    runtime_version: str | None = "0.32.2",
+    runtime_backend: str | None = "Metal",
+    quantization: str | None = "Q4",
+    seed: int | None = 0,
+    config_hash: str | None = "cfg-hash",
+    prompt_hash: str | None = DEFAULT_PROMPT_HASH,
+    total_ms: float | None = 4200.0,
+    total_provenance: MetricProvenance = MetricProvenance.MEASURED_WALL_CLOCK,
+    prefill_ms: float | None = 310.0,
+    peak_bytes: float | None = 9 * 1024**3,
+    success: bool = True,
+    quality_score: float | None = 1.0,
+    quality_metric: str | None = DEFAULT_QUALITY_METRIC,
+    max_tokens_argv: int | None = 512,
+    temperature_argv: float | None = 0.0,
+    top_p_argv: float | None = 1.0,
+    api_evidence: dict[str, Any] | None = None,
+    api_evidence_text: str | None = None,
+    write_artifact_marker: bool = True,
+    write_final_record: bool = True,
+    corrupt_final_record: bool = False,
+    reason: str | None = None,
+) -> Path:
+    """Write one synthetic run under ``results_dir/runs/<run_id>/``.
+
+    By default this is a fully passing local MLX row. Pass ``provider`` and
+    ``api_evidence`` to build a hosted-API row instead. Every axis can be
+    overridden to exercise a specific edge case.
+    """
+    run_dir = results_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    collection_dir = run_dir / "collection"
+
+    argv: list[str] = ["llmtracefx-optimizer", "collect-mlx", "--run-id", run_id]
+    if max_tokens_argv is not None:
+        argv.extend(("--max-tokens", str(max_tokens_argv)))
+    if temperature_argv is not None:
+        argv.extend(("--temperature", str(temperature_argv)))
+    if top_p_argv is not None:
+        argv.extend(("--top-p", str(top_p_argv)))
+
+    final_record_path: Path | None = None
+    if write_final_record:
+        final_record_path = run_dir / "final_record.json"
+        record = ExperimentRecord(
+            run_id=run_id,
+            started_at=utc_now_iso(),
+            platform=PlatformInfo(
+                os_name="Darwin",
+                os_version="26.0",
+                architecture="arm64",
+                accelerator=accelerator,
+            ),
+            model=ModelInfo(
+                model_id=model_id,
+                model_family=model_family,
+                model_revision=model_revision,
+                quantization=quantization,
+            ),
+            runtime=RuntimeInfo(
+                name=runtime_name,
+                version=runtime_version,
+                backend=runtime_backend,
+                provider=provider,
+            ),
+            command=CommandInfo(
+                argv=tuple(argv),
+                config_hash=config_hash,
+                workload_hash=prompt_hash,
+            ),
+            repetition=RepetitionInfo(
+                warmup_repetitions=0,
+                measured_repetitions=1,
+                repetition_index=0,
+                seed=seed,
+            ),
+            tokens=TokenCounts(input_tokens=1000, generated_tokens=400),
+            timing=TimingMetrics(
+                prefill=(
+                    None
+                    if prefill_ms is None
+                    else Measurement(
+                        value=prefill_ms,
+                        provenance=MetricProvenance.MEASURED_NATIVE,
+                        unit="ms",
+                    )
+                ),
+                total=(
+                    None
+                    if total_ms is None
+                    else Measurement(
+                        value=total_ms, provenance=total_provenance, unit="ms"
+                    )
+                ),
+            ),
+            speculative=SpeculativeDecodingInfo(enabled=False),
+            memory=MemoryMetrics(
+                peak=(
+                    None
+                    if peak_bytes is None
+                    else Measurement(
+                        value=peak_bytes,
+                        provenance=MetricProvenance.MEASURED_NATIVE,
+                        unit="bytes",
+                    )
+                )
+            ),
+            outcome=OutcomeInfo(
+                success=success,
+                quality_score=quality_score,
+                quality_metric=quality_metric,
+            ),
+        )
+        if corrupt_final_record:
+            final_record_path.write_text("not json", encoding="utf-8")
+        else:
+            record.write_json(final_record_path)
+
+    if api_evidence is not None or api_evidence_text is not None:
+        collection_dir.mkdir(parents=True, exist_ok=True)
+        payload = (
+            api_evidence_text
+            if api_evidence_text is not None
+            else json.dumps(api_evidence, indent=2)
+        )
+        artifacts: list[tuple[str, str]] = [("api_evidence.json", payload)]
+        record_text = (
+            final_record_path.read_text(encoding="utf-8")
+            if final_record_path is not None and not corrupt_final_record
+            else "{}\n"
+        )
+        # The collector's completeness marker names the whole canonical set,
+        # so a faithful fixture writes all four artifacts. Anything less is
+        # an incomplete set, which is exactly what the marker exists to catch.
+        artifacts.append(("record.json", record_text))
+        artifacts.append(("response.txt", "synthetic response\n"))
+        artifacts.append(("environment.json", '{"synthetic": true}\n'))
+        for name, text in artifacts:
+            (collection_dir / name).write_text(text, encoding="utf-8")
+        if write_artifact_marker:
+            marker = {
+                "schema_version": ARTIFACT_MANIFEST_SCHEMA_VERSION,
+                "run_id": run_id,
+                "artifacts": [
+                    {"name": name, "sha256": sha256_bytes(text.encode("utf-8"))}
+                    for name, text in artifacts
+                ],
+            }
+            (collection_dir / ARTIFACT_MANIFEST_NAME).write_text(
+                json.dumps(marker, indent=2) + "\n", encoding="utf-8"
+            )
+
+    verification = RowVerification(
+        schema_version="1",
+        run_id=run_id,
+        workload_id=workload_id,
+        workload_version=workload_version,
+        category=category,
+        context_tier=context_tier,
+        decode_mode=decode_mode,
+        status=status,
+        reason=reason,
+        recorded_prompt_hash=prompt_hash,
+        verified_prompt_hash=prompt_hash,
+        run_binding_hash="sha256:synthetic-binding",
+        resumed=(status == RowStatus.SKIPPED),
+        outcome_success=success if write_final_record else None,
+        quality_score=quality_score if write_final_record else None,
+        total_ms=total_ms if write_final_record else None,
+        started_at=utc_now_iso(),
+        ended_at=utc_now_iso(),
+        final_record_path=(
+            str(final_record_path) if final_record_path is not None else None
+        ),
+        collection_dir=str(collection_dir) if write_final_record else None,
+    )
+    (run_dir / "verification.json").write_text(verification.to_json(), encoding="utf-8")
+    return run_dir
+
+
+def write_api_run(
+    results_dir: Path,
+    run_id: str,
+    *,
+    provider: str = "z-ai",
+    model_id: str = "glm-5.3",
+    model_revision: str | None = None,
+    reasoning_effort: str | None = "high",
+    total_ms: float = 2600.0,
+    prompt_tokens: int | None = 1000,
+    completion_tokens: int | None = 400,
+    cached_prompt_tokens: int | None = None,
+    reasoning_tokens: int | None = None,
+    usage_reported: bool = True,
+    first_content_token_offset_ms: float | None = 220.0,
+    max_output_tokens: int | None = 512,
+    temperature: float | None = 0.0,
+    top_p: float | None = 1.0,
+    config_hash: str | None = "api-cfg-hash",
+    thinking_type: str | None = None,
+    system_prompt_hash: str | None = None,
+    prompt_hash: str | None = DEFAULT_PROMPT_HASH,
+    endpoint_origin: str | None = "https://example.invalid",
+    success: bool = True,
+    quality_score: float | None = 1.0,
+    write_run_seal: bool = True,
+    **kwargs: Any,
+) -> Path:
+    """Write one synthetic hosted-API run, sidecar and run seal included."""
+    run_dir = write_run(
+        results_dir,
+        run_id,
+        provider=provider,
+        model_id=model_id,
+        model_revision=model_revision,
+        accelerator=None,
+        runtime_name="openai-compatible-stream",
+        runtime_version="1",
+        runtime_backend=None,
+        quantization=None,
+        model_family=None,
+        # A hosted API reports no local prefill and no local peak memory.
+        prefill_ms=None,
+        peak_bytes=None,
+        prompt_hash=prompt_hash,
+        total_ms=total_ms,
+        success=success,
+        quality_score=quality_score,
+        max_tokens_argv=None,
+        temperature_argv=None,
+        top_p_argv=None,
+        config_hash=config_hash,
+        api_evidence=api_evidence_payload(
+            run_id=run_id,
+            provider=provider,
+            model_id=model_id,
+            model_revision=model_revision,
+            reasoning_effort=reasoning_effort,
+            thinking_type=thinking_type,
+            config_hash=config_hash,
+            workload_hash=prompt_hash,
+            system_prompt_hash=system_prompt_hash,
+            endpoint_origin=endpoint_origin,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            usage_reported=usage_reported,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cached_prompt_tokens=cached_prompt_tokens,
+            reasoning_tokens=reasoning_tokens,
+            first_content_token_offset_ms=first_content_token_offset_ms,
+        ),
+        **kwargs,
+    )
+    if write_run_seal:
+        write_run_manifest(results_dir, run_id)
+    return run_dir
+
+
+def write_run_manifest(results_dir: Path, run_id: str) -> None:
+    """Seal a run directory the way ``workloads run-api`` does.
+
+    ``run-api`` writes this last, hashing the collector's own marker together
+    with ``final_record.json`` and ``verification.json``. A hosted run
+    without it is not something the pipeline produces, so fixtures that omit
+    it were not representative of the input this layer actually receives.
+    """
+    run_dir = results_dir / "runs" / run_id
+    collection = run_dir / "collection"
+    if not (collection / "artifacts.json").is_file():
+        # ``run-api`` seals only a row that produced a full artifact set; a
+        # row whose collector marker is missing has nothing to seal.
+        return
+    payload = {
+        "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
+        "run_id": run_id,
+        "artifacts": [
+            {"name": name, "sha256": sha256_bytes(path.read_bytes())}
+            for name, path in (
+                ("collection/artifacts.json", collection / "artifacts.json"),
+                ("final_record.json", run_dir / "final_record.json"),
+                ("verification.json", run_dir / "verification.json"),
+            )
+        ],
+    }
+    (run_dir / "run.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+PRICING_MANIFEST: dict[str, Any] = {
+    "schema_version": "1",
+    "name": "synthetic illustrative rates",
+    "currency": "USD",
+    "entries": [
+        {
+            "entry_id": "glm-5.3-illustrative",
+            "provider": "z-ai",
+            "model_id": "glm-5.3",
+            "currency": "USD",
+            "effective_at": "2026-01-01",
+            "source": "illustrative example, not a published price list",
+            "rates_are_illustrative": True,
+            "input_per_million": 0.6,
+            "output_per_million": 2.2,
+        },
+        {
+            "entry_id": "glm-5.3-flash-illustrative",
+            "provider": "z-ai",
+            "model_id": "glm-5.3-flash",
+            "currency": "USD",
+            "effective_at": "2026-01-01",
+            "source": "illustrative example, not a published price list",
+            "rates_are_illustrative": True,
+            "input_per_million": 0.1,
+            "output_per_million": 0.3,
+        },
+    ],
+}
+
+
+COMPARE_POLICY: dict[str, Any] = {
+    "schema_version": "1",
+    "name": "synthetic latency comparison",
+    "objective": "min_mean_total_latency_ms",
+    "constraints": {"min_pass_rate": 0.5},
+}
+
+
+def reseal_run(results_dir: Path, run_id: str) -> None:
+    """Recompute ``run.json`` if this run has one.
+
+    A test that edits a sealed artifact to exercise one specific check would
+    otherwise trip the run seal first and be excluded for the wrong reason.
+    Tests that mean to break the seal do so explicitly.
+    """
+    if (results_dir / "runs" / run_id / "run.json").is_file():
+        write_run_manifest(results_dir, run_id)
+
+
+def write_json(path: Path, payload: Any) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def collection_dir_for(results_dir: Path, run_id: str) -> Path:
+    return results_dir / "runs" / run_id / "collection"
+
+
+def refresh_artifact_marker(collection_dir: Path) -> None:
+    """Recompute ``artifacts.json`` over whatever is currently on disk.
+
+    A test that edits ``api_evidence.json`` to exercise a specific identity
+    check would otherwise trip the completeness marker first and be excluded
+    for the wrong reason. Refreshing the marker keeps each test aimed at the
+    one check it is about.
+    """
+    names = sorted(
+        name
+        for name in (
+            "record.json",
+            "response.txt",
+            "api_evidence.json",
+            "environment.json",
+        )
+        if (collection_dir / name).is_file()
+    )
+    marker = {
+        "schema_version": ARTIFACT_MANIFEST_SCHEMA_VERSION,
+        "run_id": collection_dir.parent.name,
+        "artifacts": [
+            {"name": name, "sha256": sha256_bytes((collection_dir / name).read_bytes())}
+            for name in names
+        ],
+    }
+    (collection_dir / ARTIFACT_MANIFEST_NAME).write_text(
+        json.dumps(marker, indent=2) + "\n", encoding="utf-8"
+    )
+    run_dir = collection_dir.parent
+    if (run_dir / "run.json").is_file():
+        write_run_manifest(run_dir.parent.parent, run_dir.name)
+
+
+def edit_sidecar(results_dir: Path, run_id: str, mutate: Any) -> Path:
+    """Mutate a run's ``api_evidence.json`` and refresh the marker over it."""
+    collection = collection_dir_for(results_dir, run_id)
+    sidecar = collection / "api_evidence.json"
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    mutate(payload)
+    sidecar.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    refresh_artifact_marker(collection)
+    return sidecar

--- a/tests/optimizer/test_compare_api_evidence_contract.py
+++ b/tests/optimizer/test_compare_api_evidence_contract.py
@@ -1,0 +1,169 @@
+"""Contract tests between the API collector's artifacts and the compare loader.
+
+``compare/evidence.py`` reads ``api_evidence.json``, which the OpenAI-compatible
+collector writes and which has no loader of its own. The other compare tests
+build that sidecar from a hand-written fixture, which would keep passing if the
+collector renamed or moved a field tomorrow.
+
+These tests close that gap: they serialize evidence produced by the *real*
+collector types and feed the result straight into the compare loader, so a
+drift in either direction fails here rather than silently producing a
+comparison with no usage, no decode settings or no time-to-first-token.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.collectors import openai_api
+from llmtracefx.optimizer.compare.evidence import ApiEvidence
+from llmtracefx.optimizer.schema import utc_now_iso
+
+_ENDPOINT = "https://example.invalid/v1/chat/completions"
+
+
+def _collector_evidence(
+    *,
+    usage: openai_api.ProviderUsage,
+    reasoning_effort: str | None = "high",
+    max_output_tokens: int | None = 512,
+    temperature: float | None = 0.0,
+    top_p: float | None = 1.0,
+    first_content_token_offset_ms: float | None = 240.0,
+) -> openai_api.APIEvidence:
+    config = openai_api.APICollectionConfig(
+        run_id="api-run",
+        provider="z.ai",
+        endpoint=_ENDPOINT,
+        model_id="glm-5.3",
+        model_revision="2026-06",
+        prompt="synthetic prompt",
+        output_dir=Path("/tmp/compare-contract-does-not-matter"),
+        command_argv=("llmtracefx-optimizer", "collect-api"),
+        credential_env_var="EXAMPLE_API_KEY",
+        max_output_tokens=max_output_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        extensions=openai_api.ProviderExtensions(reasoning_effort=reasoning_effort),
+    )
+    return openai_api.APIEvidence(
+        schema_version=openai_api.API_EVIDENCE_SCHEMA_VERSION,
+        run_id="api-run",
+        collected_at=utc_now_iso(),
+        plan=openai_api.build_request_plan(
+            config, environ={"EXAMPLE_API_KEY": "secret"}
+        ),
+        success=True,
+        usage=usage,
+        timeline=openai_api.StreamTimeline(
+            first_content_token_offset_ms=first_content_token_offset_ms
+        ),
+    )
+
+
+def _round_trip(evidence: openai_api.APIEvidence) -> ApiEvidence:
+    """Serialize exactly as the collector persists it, then load it back."""
+    return ApiEvidence.from_dict(json.loads(evidence.to_json()))
+
+
+def test_the_loader_reads_a_real_collector_usage_block() -> None:
+    loaded = _round_trip(
+        _collector_evidence(
+            usage=openai_api.ProviderUsage(
+                reported=True,
+                prompt_tokens=2100,
+                completion_tokens=480,
+                total_tokens=2580,
+                cached_prompt_tokens=600,
+                reasoning_tokens=120,
+            )
+        )
+    )
+    assert loaded.usage_reported is True
+    assert loaded.usage.prompt_tokens == 2100
+    assert loaded.usage.completion_tokens == 480
+    assert loaded.usage.cached_prompt_tokens == 600
+    assert loaded.usage.reasoning_tokens == 120
+
+
+def test_an_unreported_usage_block_stays_unreported() -> None:
+    loaded = _round_trip(_collector_evidence(usage=openai_api.ProviderUsage()))
+    assert loaded.usage_reported is False
+    assert loaded.usage.prompt_tokens is None
+    assert loaded.usage.completion_tokens is None
+
+
+def test_malformed_usage_fields_survive_the_round_trip() -> None:
+    loaded = _round_trip(
+        _collector_evidence(
+            usage=openai_api.ProviderUsage(
+                reported=True,
+                prompt_tokens=10,
+                completion_tokens=5,
+                malformed_fields=("prompt_tokens_details.cached_tokens",),
+            )
+        )
+    )
+    assert loaded.usage_malformed_fields == ("prompt_tokens_details.cached_tokens",)
+
+
+def test_the_loader_reads_the_real_request_plan_decode_settings() -> None:
+    loaded = _round_trip(_collector_evidence(usage=openai_api.ProviderUsage()))
+    assert loaded.decode_settings.max_output_tokens == 512
+    assert loaded.decode_settings.temperature == pytest.approx(0.0)
+    assert loaded.decode_settings.top_p == pytest.approx(1.0)
+    assert loaded.decode_settings.source == "api_request_plan"
+
+
+def test_unset_decode_settings_stay_unrecorded_rather_than_defaulted() -> None:
+    loaded = _round_trip(
+        _collector_evidence(
+            usage=openai_api.ProviderUsage(),
+            max_output_tokens=None,
+            temperature=None,
+            top_p=None,
+        )
+    )
+    assert loaded.decode_settings.max_output_tokens is None
+    assert loaded.decode_settings.temperature is None
+    assert loaded.decode_settings.top_p is None
+
+
+def test_the_loader_reads_the_real_provider_model_and_reasoning_effort() -> None:
+    loaded = _round_trip(_collector_evidence(usage=openai_api.ProviderUsage()))
+    assert loaded.provider == "z.ai"
+    assert loaded.model_id == "glm-5.3"
+    assert loaded.model_revision == "2026-06"
+    assert loaded.reasoning_effort == "high"
+
+
+def test_an_absent_reasoning_effort_stays_none() -> None:
+    loaded = _round_trip(
+        _collector_evidence(usage=openai_api.ProviderUsage(), reasoning_effort=None)
+    )
+    assert loaded.reasoning_effort is None
+
+
+def test_the_loader_reads_the_real_client_observed_ttft() -> None:
+    loaded = _round_trip(_collector_evidence(usage=openai_api.ProviderUsage()))
+    assert loaded.client_ttft_ms == pytest.approx(240.0)
+
+
+def test_a_stream_with_no_content_token_reports_no_ttft() -> None:
+    loaded = _round_trip(
+        _collector_evidence(
+            usage=openai_api.ProviderUsage(), first_content_token_offset_ms=None
+        )
+    )
+    assert loaded.client_ttft_ms is None
+
+
+def test_the_persisted_sidecar_carries_no_credential_or_prompt_text() -> None:
+    """The compare layer inherits the collector's redaction, so pin it here."""
+    payload = _collector_evidence(usage=openai_api.ProviderUsage()).to_json()
+    assert "secret" not in payload
+    assert "synthetic prompt" not in payload
+    assert '"reasoning_text_persisted": false' in payload

--- a/tests/optimizer/test_compare_cli.py
+++ b/tests/optimizer/test_compare_cli.py
@@ -1,0 +1,432 @@
+"""End-to-end CLI tests for ``compare`` and ``compare-report``.
+
+Exercises the commands the way a user runs them, against synthetic artifact
+trees. Nothing here loads a model, calls an API, or executes a benchmark.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from _compare_fixtures import (
+    COMPARE_POLICY,
+    PRICING_MANIFEST,
+    write_api_run,
+    write_json,
+    write_run,
+)
+
+from llmtracefx.optimizer.cli import main
+from llmtracefx.optimizer.compare.report import CompareReport
+
+
+def _run(argv: list[str]) -> int:
+    try:
+        main(argv)
+    except SystemExit as exc:  # argparse/`main` translate a return code
+        return int(exc.code or 0)
+    return 0
+
+
+def _three_systems(results: Path) -> None:
+    write_run(results, "local-1", total_ms=8000.0)
+    write_api_run(results, "frontier-1", model_id="glm-5.3", total_ms=3000.0)
+    write_api_run(
+        results,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        reasoning_effort="low",
+        total_ms=1200.0,
+    )
+
+
+def test_compare_writes_a_loadable_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    output = tmp_path / "compare.json"
+
+    code = _run(
+        [
+            "compare",
+            "--results",
+            str(results),
+            "--policy",
+            str(policy),
+            "--output",
+            str(output),
+        ]
+    )
+    assert code == 0
+    report = CompareReport.read_json(output)
+    assert len(report.strata) == 1
+    assert report.has_recommendation is True
+    stdout = capsys.readouterr().out
+    assert "Cross-system comparison" in stdout
+    assert "no universal winner" in stdout
+
+
+def test_compare_with_pricing_records_the_manifest_hash(tmp_path: Path) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    pricing = write_json(tmp_path / "rates.json", PRICING_MANIFEST)
+    output = tmp_path / "compare.json"
+
+    assert (
+        _run(
+            [
+                "compare",
+                "--results",
+                str(results),
+                "--policy",
+                str(policy),
+                "--pricing",
+                str(pricing),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    report = CompareReport.read_json(output)
+    assert report.pricing is not None
+    assert report.pricing.currency == "USD"
+    assert report.pricing.rates_are_illustrative is True
+    assert len(report.pricing.manifest_sha256) == 64
+
+
+def test_compare_exits_two_when_inconclusive(tmp_path: Path) -> None:
+    results = tmp_path / "results"
+    write_api_run(results, "a", model_id="glm-5.3", total_ms=1000.0)
+    write_api_run(results, "b", model_id="glm-5.3-flash", total_ms=1000.0)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    assert _run(["compare", "--results", str(results), "--policy", str(policy)]) == 2
+
+
+def test_compare_exits_one_when_nothing_is_comparable(tmp_path: Path) -> None:
+    results = tmp_path / "empty"
+    results.mkdir()
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    assert _run(["compare", "--results", str(results), "--policy", str(policy)]) == 1
+
+
+def test_compare_rejects_an_invalid_policy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", {"objective": "be_the_best"})
+    assert _run(["compare", "--results", str(results), "--policy", str(policy)]) == 1
+    assert "Invalid compare policy" in capsys.readouterr().err
+
+
+def test_compare_rejects_an_ambiguous_pricing_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    ambiguous = json.loads(json.dumps(PRICING_MANIFEST))
+    duplicate = json.loads(json.dumps(ambiguous["entries"][0]))
+    duplicate["entry_id"] = "glm-5.3-duplicate"
+    ambiguous["entries"].append(duplicate)
+    pricing = write_json(tmp_path / "rates.json", ambiguous)
+    code = _run(
+        [
+            "compare",
+            "--results",
+            str(results),
+            "--policy",
+            str(policy),
+            "--pricing",
+            str(pricing),
+        ]
+    )
+    assert code == 1
+    assert "Invalid pricing manifest" in capsys.readouterr().err
+
+
+def test_compare_refuses_a_cost_objective_without_pricing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(
+        tmp_path / "policy.json",
+        {**COMPARE_POLICY, "objective": "min_cost_per_correct_case"},
+    )
+    assert _run(["compare", "--results", str(results), "--policy", str(policy)]) == 1
+    assert "ranks on money" in capsys.readouterr().err
+
+
+def test_compare_counts_repeated_results_dirs_as_repetitions(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two results trees for one matrix row are two measurements of it.
+
+    This is the documented way to satisfy a policy's
+    ``min_measured_repetitions``: run the matrix again into a second output
+    directory and pass both. Both trees carry the same run ids, so rejecting
+    that as a conflict made the requirement unsatisfiable.
+    """
+    local_first = tmp_path / "local-a"
+    local_second = tmp_path / "local-b"
+    hosted_first = tmp_path / "hosted-a"
+    hosted_second = tmp_path / "hosted-b"
+    write_run(local_first, "shared", total_ms=8000.0)
+    write_run(local_second, "shared", total_ms=8400.0)
+    write_api_run(hosted_first, "shared", total_ms=1200.0)
+    write_api_run(hosted_second, "shared", total_ms=1300.0)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    out = tmp_path / "report.json"
+    code = _run(
+        [
+            "compare",
+            "--results",
+            str(local_first),
+            str(local_second),
+            str(hosted_first),
+            str(hosted_second),
+            "--policy",
+            str(policy),
+            "--output",
+            str(out),
+        ]
+    )
+    assert code == 0, capsys.readouterr().err
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    ranked = payload["strata"][0]["ranked"]
+    assert len(ranked) == 2
+    # Each system carries both of its measurements rather than one of them
+    # being rejected as a conflict or silently deduplicated away.
+    assert {entry["evidence_count"] for entry in ranked} == {2}
+    assert all(len(entry["verification_paths"]) == 2 for entry in ranked)
+
+
+def _real_tune_report(path: Path) -> Path:
+    """Copy the committed example, so the path names a real tune report."""
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "optimizer"
+        / "tune-report-example.json"
+    )
+    path.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return path
+
+
+def test_compare_records_corroborating_tune_reports(tmp_path: Path) -> None:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    output = tmp_path / "compare.json"
+    tune_a = _real_tune_report(tmp_path / "tune-a.json")
+    tune_b = _real_tune_report(tmp_path / "tune-b.json")
+    assert (
+        _run(
+            [
+                "compare",
+                "--results",
+                str(results),
+                "--policy",
+                str(policy),
+                "--tune-report",
+                str(tune_a),
+                str(tune_b),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    report = CompareReport.read_json(output)
+    assert report.tune_report_paths == (str(tune_a), str(tune_b))
+
+
+@pytest.mark.parametrize("content", ["{}", "not json", None])
+def test_compare_refuses_a_tune_report_that_is_not_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], content: str | None
+) -> None:
+    """Provenance has to be true.
+
+    These paths are published under "Corroborating tune reports", so a
+    missing or malformed one asserts corroboration that does not exist. The
+    pricing manifest is content-hashed for the same reason.
+    """
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    bogus = tmp_path / "bogus.json"
+    if content is None:
+        bogus.mkdir()
+    else:
+        bogus.write_text(content, encoding="utf-8")
+
+    code = _run(
+        [
+            "compare",
+            "--results",
+            str(results),
+            "--policy",
+            str(policy),
+            "--tune-report",
+            str(bogus),
+        ]
+    )
+    assert code == 1
+    assert "tune report" in capsys.readouterr().err
+
+
+def test_explain_prints_every_rejection_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    results = tmp_path / "results"
+    write_run(results, "bad", success=False, quality_score=0.0, total_ms=90_000.0)
+    write_api_run(results, "good", total_ms=1000.0)
+    policy = write_json(
+        tmp_path / "policy.json",
+        {
+            **COMPARE_POLICY,
+            "constraints": {"min_pass_rate": 1.0, "max_mean_total_latency_ms": 5000.0},
+        },
+    )
+    _run(
+        [
+            "compare",
+            "--results",
+            str(results),
+            "--policy",
+            str(policy),
+            "--explain",
+        ]
+    )
+    stdout = capsys.readouterr().out
+    assert "pass rate" in stdout
+    assert "exceeds the maximum" in stdout
+
+
+# --- compare-report -------------------------------------------------------
+
+
+def _compare_json(tmp_path: Path, *, with_pricing: bool = False) -> Path:
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    output = tmp_path / "compare.json"
+    argv = [
+        "compare",
+        "--results",
+        str(results),
+        "--policy",
+        str(policy),
+        "--output",
+        str(output),
+    ]
+    if with_pricing:
+        argv.extend(
+            ("--pricing", str(write_json(tmp_path / "rates.json", PRICING_MANIFEST)))
+        )
+    _run(argv)
+    return output
+
+
+def test_compare_report_renders_html(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report_json = _compare_json(tmp_path)
+    html_path = tmp_path / "compare.html"
+    assert (
+        _run(
+            [
+                "compare-report",
+                "--input",
+                str(report_json),
+                "--output",
+                str(html_path),
+            ]
+        )
+        == 0
+    )
+    document = html_path.read_text(encoding="utf-8")
+    assert document.startswith("<!DOCTYPE html>")
+    assert "<script" not in document.lower()
+    stdout = capsys.readouterr().out
+    assert "Compare report HTML written to" in stdout
+    assert "redacted" in stdout
+
+
+def test_compare_report_warns_about_illustrative_rates(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report_json = _compare_json(tmp_path, with_pricing=True)
+    assert (
+        _run(
+            [
+                "compare-report",
+                "--input",
+                str(report_json),
+                "--output",
+                str(tmp_path / "compare.html"),
+            ]
+        )
+        == 0
+    )
+    assert "illustrative rates" in capsys.readouterr().out
+
+
+def test_compare_report_include_paths_is_opt_in(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report_json = _compare_json(tmp_path)
+    html_path = tmp_path / "compare.html"
+    _run(
+        [
+            "compare-report",
+            "--input",
+            str(report_json),
+            "--output",
+            str(html_path),
+            "--include-paths",
+        ]
+    )
+    assert str(tmp_path) in html_path.read_text(encoding="utf-8")
+    assert "Full local artifact paths are included" in capsys.readouterr().out
+
+
+def test_compare_report_rejects_a_malformed_input(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "compare.json"
+    bad.write_text('{"schema_version": "99"}', encoding="utf-8")
+    code = _run(
+        [
+            "compare-report",
+            "--input",
+            str(bad),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+    assert code == 1
+    assert "Invalid compare report" in capsys.readouterr().err
+
+
+def test_compare_report_reports_a_missing_input(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = _run(
+        [
+            "compare-report",
+            "--input",
+            str(tmp_path / "nope.json"),
+            "--output",
+            str(tmp_path / "out.html"),
+        ]
+    )
+    assert code == 1
+    assert "Could not read compare report input" in capsys.readouterr().err

--- a/tests/optimizer/test_compare_engine.py
+++ b/tests/optimizer/test_compare_engine.py
@@ -1,0 +1,630 @@
+"""Tests for the comparison engine: grouping, metrics, ranking and frontier.
+
+Every artifact tree in this module is synthetic. The numbers are chosen to
+exercise a specific code path and are not measurements of any real system.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _compare_fixtures import write_api_run, write_run
+
+from llmtracefx.optimizer.compare.compare import compare
+from llmtracefx.optimizer.compare.evidence import CompareEvidenceError
+from llmtracefx.optimizer.compare.policy import (
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+)
+from llmtracefx.optimizer.compare.pricing import PricingManifest
+from llmtracefx.optimizer.compare.report import (
+    CompareReport,
+    StratumOutcome,
+    TtftBasis,
+)
+from llmtracefx.optimizer.schema import MetricProvenance
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+_PRICING = PricingManifest.from_dict(
+    {
+        "schema_version": "1",
+        "currency": "USD",
+        "entries": [
+            {
+                "entry_id": "glm-5.3",
+                "provider": "z-ai",
+                "model_id": "glm-5.3",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            },
+            {
+                "entry_id": "glm-5.3-flash",
+                "provider": "z-ai",
+                "model_id": "glm-5.3-flash",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 0.1,
+                "output_per_million": 0.2,
+            },
+        ],
+    }
+)
+
+
+def _policy(
+    objective: CompareObjective = CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+    **constraint_overrides: object,
+) -> ComparePolicy:
+    return ComparePolicy(
+        objective=objective,
+        name="synthetic policy",
+        constraints=CompareConstraints(**constraint_overrides),  # type: ignore[arg-type]
+    )
+
+
+def _three_systems(results: Path) -> None:
+    """A local model, a frontier API and a flash API on the identical unit."""
+    write_run(results, "local-1", total_ms=8000.0, max_tokens_argv=512)
+    write_api_run(
+        results,
+        "frontier-1",
+        model_id="glm-5.3",
+        total_ms=3000.0,
+        prompt_tokens=1000,
+        completion_tokens=400,
+    )
+    write_api_run(
+        results,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        reasoning_effort="low",
+        total_ms=1200.0,
+        prompt_tokens=1000,
+        completion_tokens=400,
+    )
+
+
+# --- Grouping isolation ---------------------------------------------------
+
+
+def test_one_stratum_per_comparable_unit(tmp_path: Path) -> None:
+    _three_systems(tmp_path)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert len(report.strata) == 1
+    assert len(report.strata[0].ranked) == 3
+
+
+def test_different_workloads_never_share_a_stratum(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", workload_id="one")
+    write_run(tmp_path, "b", workload_id="two")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert len(report.strata) == 2
+
+
+def test_different_context_tiers_never_share_a_stratum(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", context_tier="2k")
+    write_run(tmp_path, "b", context_tier="32k")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert len(report.strata) == 2
+
+
+def test_different_prompt_hashes_never_share_a_stratum(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", prompt_hash="sha256:one")
+    write_run(tmp_path, "b", prompt_hash="sha256:two")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert len(report.strata) == 2
+
+
+def test_different_evaluators_never_share_a_stratum(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", quality_metric="exact_match")
+    write_run(tmp_path, "b", quality_metric="fuzzy_match")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert len(report.strata) == 2
+
+
+def test_unlike_systems_are_never_averaged_together(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "high-1", reasoning_effort="high", total_ms=3000.0)
+    write_api_run(tmp_path, "low-1", reasoning_effort="low", total_ms=1000.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert len(stratum.ranked) == 2
+    latencies = sorted(system.mean_total_latency_ms for system in stratum.ranked)
+    assert latencies == pytest.approx([1000.0, 3000.0])
+
+
+def test_runs_of_one_system_are_pooled(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", total_ms=1000.0)
+    write_api_run(tmp_path, "b", total_ms=3000.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    system = report.strata[0].ranked[0]
+    assert system.evidence_count == 2
+    assert system.mean_total_latency_ms == pytest.approx(2000.0)
+    assert system.p50_total_latency_ms == pytest.approx(2000.0)
+    assert system.p95_total_latency_ms == pytest.approx(3000.0)
+
+
+# --- Metrics --------------------------------------------------------------
+
+
+def test_pass_rate_and_throughput_use_the_shared_formulas(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", total_ms=30_000.0, success=True)
+    write_api_run(tmp_path, "b", total_ms=30_000.0, success=False, quality_score=0.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    system = report.strata[0].ranked[0]
+    assert system.pass_rate == pytest.approx(0.5)
+    # One passing case in 30 s of measured time is two correct cases a minute.
+    assert system.correct_cases_per_minute == pytest.approx(2.0)
+
+
+def test_local_ttft_is_labeled_as_a_local_prefill(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1", prefill_ms=310.0)
+    write_api_run(tmp_path, "api-1")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    by_local = {
+        system.system_key.is_local: system for system in report.strata[0].ranked
+    }
+    assert by_local[True].ttft_basis == TtftBasis.LOCAL_PREFILL
+    assert by_local[True].mean_ttft_ms == pytest.approx(310.0)
+    assert by_local[False].ttft_basis == TtftBasis.CLIENT_OBSERVED_STREAM
+    assert by_local[False].mean_ttft_ms == pytest.approx(220.0)
+
+
+def test_local_peak_memory_stays_local_only(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    write_api_run(tmp_path, "api-1")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    for system in report.strata[0].ranked:
+        if system.system_key.is_local:
+            assert system.mean_peak_memory_bytes is not None
+        else:
+            assert system.mean_peak_memory_bytes is None
+            assert any(
+                "local-only measurement" in note for note in system.missing_evidence
+            )
+
+
+def test_missing_measurements_stay_unavailable_never_zero(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1", first_content_token_offset_ms=None)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    system = report.strata[0].ranked[0]
+    assert system.mean_ttft_ms is None
+    assert system.ttft_basis is None
+    assert any("time-to-first-token" in note for note in system.missing_evidence)
+
+
+def test_partial_usage_reporting_withholds_the_total(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", prompt_tokens=1000, completion_tokens=400)
+    write_api_run(tmp_path, "b", prompt_tokens=None, completion_tokens=400)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    usage = report.strata[0].ranked[0].usage
+    assert usage is not None
+    assert usage.input_tokens is None
+    assert usage.output_tokens == 800
+
+
+def test_usage_absent_entirely_is_reported_as_none(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert report.strata[0].ranked[0].usage is None
+
+
+# --- Cost -----------------------------------------------------------------
+
+
+def test_cost_is_estimated_from_provider_usage_and_manifest_rates(
+    tmp_path: Path,
+) -> None:
+    write_api_run(
+        tmp_path, "api-1", prompt_tokens=1_000_000, completion_tokens=1_000_000
+    )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    cost = report.strata[0].ranked[0].cost
+    assert cost is not None
+    assert cost.total_amount == pytest.approx(3.0)
+    assert cost.cost_per_correct_case == pytest.approx(3.0)
+    assert cost.rates_are_illustrative is True
+    assert report.pricing is not None
+    assert report.pricing.entry_ids_used == ("glm-5.3",)
+
+
+def test_an_unpriced_system_gets_no_cost_and_says_so(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    system = report.strata[0].ranked[0]
+    assert system.cost is None
+    assert any("no entry for provider" in note for note in system.missing_evidence)
+
+
+def test_a_run_without_usage_blocks_the_system_total(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", prompt_tokens=1000, completion_tokens=400)
+    write_api_run(tmp_path, "b", usage_reported=False)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    cost = report.strata[0].ranked[0].cost
+    assert cost is not None
+    assert cost.total_amount is None
+    assert any("could not be priced" in reason for reason in cost.reasons)
+
+
+def test_no_pricing_manifest_means_no_monetary_values_at_all(tmp_path: Path) -> None:
+    _three_systems(tmp_path)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert report.pricing is None
+    assert all(
+        system.cost is None for stratum in report.strata for system in stratum.ranked
+    )
+
+
+def test_a_cost_objective_without_pricing_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(CompareEvidenceError, match="ranks on money"):
+        compare(
+            results_dirs=(tmp_path,),
+            policy=_policy(CompareObjective.MIN_COST_PER_CORRECT_CASE),
+        )
+
+
+def test_pricing_without_its_path_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(CompareEvidenceError, match="without its path"):
+        compare(results_dirs=(tmp_path,), policy=_policy(), pricing=_PRICING)
+
+
+def test_cost_objective_ranks_the_cheaper_system_first(tmp_path: Path) -> None:
+    write_api_run(
+        tmp_path,
+        "frontier-1",
+        model_id="glm-5.3",
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+    )
+    write_api_run(
+        tmp_path,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+    )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(CompareObjective.MIN_COST_PER_CORRECT_CASE),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.RECOMMENDED
+    assert stratum.recommended is not None
+    assert stratum.recommended.system_key.model_id == "glm-5.3-flash"
+
+
+def test_cost_constraint_rejects_an_expensive_system(tmp_path: Path) -> None:
+    write_api_run(
+        tmp_path,
+        "frontier-1",
+        model_id="glm-5.3",
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+    )
+    write_api_run(
+        tmp_path,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+    )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(max_cost_per_correct_case=1.0),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    stratum = report.strata[0]
+    assert [system.system_key.model_id for system in stratum.ranked] == [
+        "glm-5.3-flash"
+    ]
+    assert len(stratum.rejected) == 1
+    assert any(
+        "exceeds the maximum" in reason for reason in stratum.rejected[0].reasons
+    )
+
+
+def test_an_unpriced_system_cannot_slip_past_a_cost_ceiling(tmp_path: Path) -> None:
+    """A ceiling that cannot be evaluated is a rejection, never a free pass.
+
+    A provider-keyed manifest can never match a local system, so nesting the
+    ceiling inside "an entry resolved" would exempt exactly the system with no
+    cost evidence at all while holding every priced system to the limit.
+    """
+    write_run(tmp_path, "local-1", total_ms=8000.0)
+    write_api_run(
+        tmp_path,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        prompt_tokens=1_000,
+        completion_tokens=1_000,
+    )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(max_cost_per_correct_case=1.0),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    stratum = report.strata[0]
+    assert [system.system_key.model_id for system in stratum.ranked] == [
+        "glm-5.3-flash"
+    ]
+    rejected = {system.system_key.model_id for system in stratum.rejected}
+    assert rejected == {"local/qwen3-8b"}
+    assert any(
+        "no cost per correct case could be estimated" in reason
+        for system in stratum.rejected
+        for reason in system.reasons
+    )
+
+
+def test_a_cost_ceiling_without_pricing_is_refused_up_front(tmp_path: Path) -> None:
+    with pytest.raises(CompareEvidenceError, match="could never be evaluated"):
+        compare(
+            results_dirs=(tmp_path,),
+            policy=_policy(max_cost_per_correct_case=1.0),
+        )
+
+
+# --- Ranking, ties and noise ----------------------------------------------
+
+
+def test_lowest_latency_wins_the_latency_objective(tmp_path: Path) -> None:
+    _three_systems(tmp_path)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.RECOMMENDED
+    assert stratum.recommended is not None
+    assert stratum.recommended.system_key.model_id == "glm-5.3-flash"
+    assert [system.rank for system in stratum.ranked] == [1, 2, 3]
+
+
+def test_highest_throughput_wins_the_throughput_objective(tmp_path: Path) -> None:
+    _three_systems(tmp_path)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(CompareObjective.MAX_CORRECT_CASES_PER_MINUTE),
+    )
+    stratum = report.strata[0]
+    assert stratum.recommended is not None
+    assert stratum.recommended.system_key.model_id == "glm-5.3-flash"
+
+
+def test_an_exact_tie_is_inconclusive(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", model_id="glm-5.3", total_ms=1000.0)
+    write_api_run(tmp_path, "b", model_id="glm-5.3-flash", total_ms=1000.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert stratum.recommended is None
+    assert "exactly tied" in (stratum.inconclusive_reason or "")
+
+
+def test_a_difference_inside_the_noise_band_is_inconclusive(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a1", model_id="glm-5.3", total_ms=800.0)
+    write_api_run(tmp_path, "a2", model_id="glm-5.3", total_ms=1200.0)
+    write_api_run(tmp_path, "b1", model_id="glm-5.3-flash", total_ms=850.0)
+    write_api_run(tmp_path, "b2", model_id="glm-5.3-flash", total_ms=1250.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert "measurement noise" in (stratum.inconclusive_reason or "")
+
+
+def test_a_difference_beyond_the_noise_band_is_conclusive(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a1", model_id="glm-5.3", total_ms=5000.0)
+    write_api_run(tmp_path, "a2", model_id="glm-5.3", total_ms=5010.0)
+    write_api_run(tmp_path, "b1", model_id="glm-5.3-flash", total_ms=1000.0)
+    write_api_run(tmp_path, "b2", model_id="glm-5.3-flash", total_ms=1010.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert report.strata[0].outcome == StratumOutcome.RECOMMENDED
+
+
+def test_a_single_system_never_yields_a_comparison(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert "nothing was compared" in (stratum.inconclusive_reason or "")
+    assert any("at least two" in note for note in stratum.missing_evidence)
+
+
+def test_nothing_clearing_the_constraints_is_inconclusive(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", success=False, quality_score=0.0)
+    write_api_run(tmp_path, "b", success=False, quality_score=0.0)
+    report = compare(results_dirs=(tmp_path,), policy=_policy(min_pass_rate=1.0))
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert stratum.ranked == ()
+    assert len(stratum.rejected) == 2
+
+
+def test_every_violated_constraint_is_reported_not_just_the_first(
+    tmp_path: Path,
+) -> None:
+    write_run(tmp_path, "a", success=False, quality_score=0.1, total_ms=90_000.0)
+    write_api_run(tmp_path, "b", total_ms=1000.0)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(
+            min_pass_rate=1.0,
+            max_mean_total_latency_ms=1000.0,
+            min_quality_score=0.9,
+            required_quality_metric="structured_json_exact_field_match",
+        ),
+    )
+    rejected = report.strata[0].rejected
+    assert len(rejected) == 1
+    assert len(rejected[0].reasons) >= 2
+
+
+def test_a_disallowed_status_rejects_the_system(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", status=RowStatus.FAILED, success=False)
+    write_api_run(tmp_path, "b")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    reasons = [
+        reason for system in report.strata[0].rejected for reason in system.reasons
+    ]
+    assert any("not one of the required statuses" in reason for reason in reasons)
+
+
+def test_a_disallowed_provenance_rejects_the_timing_evidence(tmp_path: Path) -> None:
+    write_run(
+        tmp_path,
+        "a",
+        total_provenance=MetricProvenance.ESTIMATED,
+    )
+    write_api_run(tmp_path, "b")
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_WALL_CLOCK})
+        ),
+    )
+    reasons = [
+        reason for system in report.strata[0].rejected for reason in system.reasons
+    ]
+    assert any("not in the allowed provenance set" in reason for reason in reasons)
+
+
+def test_a_missing_timing_measurement_rejects_the_system(tmp_path: Path) -> None:
+    write_run(tmp_path, "a", total_ms=None)
+    write_api_run(tmp_path, "b")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    reasons = [
+        reason for system in report.strata[0].rejected for reason in system.reasons
+    ]
+    assert any("missing timing.total" in reason for reason in reasons)
+
+
+def test_ranking_is_deterministic_for_equal_objective_values(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", model_id="glm-5.3", total_ms=1000.0)
+    write_api_run(tmp_path, "b", model_id="glm-5.3-flash", total_ms=1000.0)
+    first = compare(results_dirs=(tmp_path,), policy=_policy())
+    second = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert [system.system_key.label() for system in first.strata[0].ranked] == [
+        system.system_key.label() for system in second.strata[0].ranked
+    ]
+
+
+# --- Frontier -------------------------------------------------------------
+
+
+def test_the_frontier_names_dominating_systems(tmp_path: Path) -> None:
+    write_api_run(
+        tmp_path, "slow", model_id="glm-5.3", total_ms=9000.0, quality_score=1.0
+    )
+    write_api_run(
+        tmp_path,
+        "fast",
+        model_id="glm-5.3-flash",
+        total_ms=1000.0,
+        quality_score=1.0,
+    )
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    by_model = {entry.system_key.model_id: entry for entry in stratum.frontier}
+    assert by_model["glm-5.3-flash"].dominated is False
+    assert by_model["glm-5.3"].dominated is True
+    assert by_model["glm-5.3"].dominated_by
+
+
+def test_a_speed_versus_quality_tradeoff_leaves_both_on_the_frontier(
+    tmp_path: Path,
+) -> None:
+    write_api_run(
+        tmp_path,
+        "accurate",
+        model_id="glm-5.3",
+        total_ms=9000.0,
+        success=True,
+        quality_score=1.0,
+    )
+    write_api_run(
+        tmp_path,
+        "quick-1",
+        model_id="glm-5.3-flash",
+        total_ms=1000.0,
+        success=True,
+        quality_score=1.0,
+    )
+    write_api_run(
+        tmp_path,
+        "quick-2",
+        model_id="glm-5.3-flash",
+        total_ms=1000.0,
+        success=False,
+        quality_score=0.0,
+    )
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    stratum = report.strata[0]
+    assert all(entry.dominated is False for entry in stratum.frontier)
+
+
+def test_axes_without_evidence_for_everyone_are_dropped(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    write_api_run(tmp_path, "api-1")
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+    )
+    stratum = report.strata[0]
+    axis_values = [axis.value for axis in stratum.frontier_axes]
+    assert "min_cost_per_correct_case" not in axis_values
+    assert any("were dropped" in note for note in stratum.missing_evidence)
+
+
+# --- Report round trip ----------------------------------------------------
+
+
+def test_the_report_round_trips_through_json(tmp_path: Path) -> None:
+    _three_systems(tmp_path)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(),
+        pricing=_PRICING,
+        pricing_manifest_path="synthetic-rates.json",
+        tune_report_paths=("tune.json",),
+    )
+    reloaded = CompareReport.from_json(report.to_json())
+    assert reloaded.to_dict() == report.to_dict()
+
+
+def test_excluded_runs_are_carried_into_the_report(tmp_path: Path) -> None:
+    write_run(tmp_path, "good")
+    write_api_run(tmp_path, "other")
+    write_run(tmp_path, "broken", corrupt_final_record=True)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert [run.run_id for run in report.excluded_runs] == ["broken"]
+
+
+def test_no_evidence_produces_an_empty_report(tmp_path: Path) -> None:
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert report.strata == ()
+    assert report.has_recommendation is False

--- a/tests/optimizer/test_compare_evidence.py
+++ b/tests/optimizer/test_compare_evidence.py
@@ -1,0 +1,573 @@
+"""Tests for comparable-unit/system identity and the offline evidence loader.
+
+Everything here is synthetic. Nothing loads a model, calls an API, or runs a
+benchmark; the fixtures write artifact trees directly.
+"""
+
+from __future__ import annotations
+
+import json
+from itertools import permutations
+from pathlib import Path
+
+import pytest
+from _compare_fixtures import (
+    api_evidence_payload,
+    collection_dir_for,
+    edit_sidecar,
+    refresh_artifact_marker,
+    reseal_run,
+    write_api_run,
+    write_run,
+)
+
+from llmtracefx.optimizer.compare.evidence import (
+    MAX_EXACT_TOKEN_COUNT,
+    ApiEvidence,
+    ApiEvidenceError,
+    CompareEvidenceError,
+    decode_settings_from_argv,
+    load_comparison_evidence,
+)
+from llmtracefx.optimizer.compare.identity import (
+    ComparableUnitKey,
+    CompareIdentityError,
+    SystemKey,
+)
+from llmtracefx.optimizer.workloads.verify import RowStatus
+
+
+def _unit(**overrides: object) -> ComparableUnitKey:
+    payload: dict[str, object] = {
+        "workload_id": "w",
+        "workload_version": "1",
+        "workload_prompt_hash": "sha256:abc",
+        "context_tier": "2k",
+        "quality_metric": "exact",
+        "max_output_tokens": 512,
+        "temperature": 0.0,
+        "top_p": 1.0,
+    }
+    payload.update(overrides)
+    return ComparableUnitKey.from_dict(payload)
+
+
+def _system(**overrides: object) -> SystemKey:
+    payload: dict[str, object] = {
+        "model_id": "glm-5.3",
+        "model_revision": None,
+        "provider": "z-ai",
+        "runtime_name": "openai-compatible-stream",
+        "runtime_backend": None,
+        "accelerator": None,
+        "quantization": None,
+        "reasoning_effort": "high",
+        "decode_mode": "autoregressive",
+    }
+    payload.update(overrides)
+    return SystemKey.from_dict(payload)
+
+
+# --- Identity keys --------------------------------------------------------
+
+
+def test_unit_key_requires_its_mandatory_fields() -> None:
+    for missing in (
+        "workload_id",
+        "workload_version",
+        "workload_prompt_hash",
+        "context_tier",
+    ):
+        payload = _unit().to_dict()
+        del payload[missing]
+        with pytest.raises(CompareIdentityError, match=missing):
+            ComparableUnitKey.from_dict(payload)
+
+
+def test_unit_key_rejects_a_non_object() -> None:
+    with pytest.raises(CompareIdentityError, match="must be a JSON object"):
+        ComparableUnitKey.from_dict(["not", "an", "object"])
+
+
+def test_unrecorded_max_output_is_not_a_wildcard() -> None:
+    recorded = _unit(max_output_tokens=512)
+    unrecorded = _unit(max_output_tokens=None)
+    assert recorded != unrecorded
+    assert "unrecorded" in unrecorded.label()
+
+
+def test_unit_key_rejects_a_zero_or_negative_output_cap() -> None:
+    with pytest.raises(CompareIdentityError, match=">= 1"):
+        _unit(max_output_tokens=0)
+
+
+def test_unit_key_rejects_non_finite_sampling_values() -> None:
+    payload = _unit().to_dict()
+    payload["temperature"] = float("nan")
+    with pytest.raises(CompareIdentityError, match="finite"):
+        ComparableUnitKey.from_dict(payload)
+
+
+def test_unit_keys_differing_on_any_axis_are_distinct() -> None:
+    base = _unit()
+    for field, value in (
+        ("workload_id", "other"),
+        ("workload_version", "2"),
+        ("workload_prompt_hash", "sha256:zzz"),
+        ("context_tier", "32k"),
+        ("quality_metric", "other"),
+        ("max_output_tokens", 128),
+        ("temperature", 0.7),
+        ("top_p", 0.9),
+    ):
+        assert _unit(**{field: value}) != base
+
+
+def test_an_unrecorded_setting_never_shares_a_sort_key_with_a_recorded_one() -> None:
+    """A sentinel-based sort key used to collide these two distinct units."""
+    unrecorded = _unit(temperature=None)
+    recorded_negative = _unit(temperature=-1.0)
+    assert unrecorded != recorded_negative
+    assert unrecorded.sort_key() != recorded_negative.sort_key()
+
+    unrecorded_cap = _unit(max_output_tokens=None)
+    assert unrecorded_cap.sort_key() != _unit(max_output_tokens=1).sort_key()
+
+
+def test_sort_keys_order_units_deterministically() -> None:
+    units = [
+        _unit(context_tier="32k"),
+        _unit(context_tier="2k"),
+        _unit(context_tier="8k"),
+    ]
+    expected = [
+        unit.to_dict() for unit in sorted(units, key=lambda unit: unit.sort_key())
+    ]
+    for arrangement in permutations(units):
+        ordered = sorted(arrangement, key=lambda unit: unit.sort_key())
+        assert [unit.to_dict() for unit in ordered] == expected
+
+
+def test_system_locality_follows_from_the_provider_field() -> None:
+    assert _system(provider=None).is_local is True
+    assert _system(provider="z-ai").is_local is False
+
+
+def test_system_key_rejects_a_contradictory_locality_claim() -> None:
+    payload = _system(provider="z-ai").to_dict()
+    payload["is_local"] = True
+    with pytest.raises(CompareIdentityError, match="contradicts the provider"):
+        SystemKey.from_dict(payload)
+
+
+def test_system_keys_differing_on_any_label_axis_are_distinct() -> None:
+    base = _system()
+    for field, value in (
+        ("model_id", "glm-5.3-flash"),
+        ("model_revision", "2026-06"),
+        ("provider", "other"),
+        ("runtime_name", "mlx-lm"),
+        ("runtime_backend", "Metal"),
+        ("accelerator", "Apple M5 Pro"),
+        ("quantization", "Q4"),
+        ("reasoning_effort", "low"),
+        ("decode_mode", "native-mtp"),
+    ):
+        assert _system(**{field: value}) != base
+
+
+def test_system_label_names_every_axis_a_reader_needs() -> None:
+    label = _system(quantization="Q4", model_revision="2026-06").label()
+    assert "glm-5.3@2026-06" in label
+    assert "z-ai" in label
+    assert "quant=Q4" in label
+    assert "reasoning=high" in label
+    assert "decode=autoregressive" in label
+
+
+# --- API evidence sidecar --------------------------------------------------
+
+
+def test_api_evidence_reads_usage_settings_and_ttft() -> None:
+    evidence = ApiEvidence.from_dict(
+        api_evidence_payload(
+            run_id="r1",
+            cached_prompt_tokens=250,
+            reasoning_tokens=90,
+        )
+    )
+    assert evidence.provider == "z-ai"
+    assert evidence.reasoning_effort == "high"
+    assert evidence.usage.prompt_tokens == 1000
+    assert evidence.usage.cached_prompt_tokens == 250
+    assert evidence.usage.reasoning_tokens == 90
+    assert evidence.decode_settings.max_output_tokens == 512
+    assert evidence.decode_settings.source == "api_request_plan"
+    assert evidence.client_ttft_ms == pytest.approx(220.0)
+
+
+def test_api_evidence_requires_a_plan() -> None:
+    with pytest.raises(ApiEvidenceError, match="'plan'"):
+        ApiEvidence.from_dict({"usage": {}})
+
+
+def test_api_evidence_rejects_a_non_integer_token_count() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["usage"]["prompt_tokens"] = "1000"
+    with pytest.raises(ApiEvidenceError, match="prompt_tokens"):
+        ApiEvidence.from_dict(payload)
+
+
+def test_api_evidence_rejects_a_negative_token_count() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["usage"]["completion_tokens"] = -1
+    with pytest.raises(ApiEvidenceError, match=">= 0"):
+        ApiEvidence.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["prompt_tokens", "completion_tokens", "cached_prompt_tokens", "reasoning_tokens"],
+)
+def test_api_evidence_rejects_a_token_count_too_large_to_bill(field: str) -> None:
+    """A count above 2**53 cannot round trip through a float.
+
+    The collector caps counts when it writes them, but this layer reads
+    artifacts written by earlier builds, and the counts are
+    provider-controlled either way. Without this bound the count reaches
+    ``estimate_run_cost`` and raises ``OverflowError``, which is an
+    ``ArithmeticError`` and so is caught by nothing downstream.
+    """
+    payload = api_evidence_payload(run_id="r1")
+    payload["usage"][field] = MAX_EXACT_TOKEN_COUNT + 1
+    with pytest.raises(ApiEvidenceError, match="exact calculation"):
+        ApiEvidence.from_dict(payload)
+
+
+def test_api_evidence_accepts_a_token_count_at_the_exact_bound() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["usage"]["prompt_tokens"] = MAX_EXACT_TOKEN_COUNT
+    assert ApiEvidence.from_dict(payload).usage.prompt_tokens == MAX_EXACT_TOKEN_COUNT
+
+
+def test_an_oversized_count_excludes_the_run_rather_than_crashing(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["usage"]["prompt_tokens"] = 10**400
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "exact calculation" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_past_the_json_integer_cap_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    """``json`` raises a plain ``ValueError``, not ``JSONDecodeError``, here."""
+    write_api_run(tmp_path, "api-1")
+    sidecar = tmp_path / "runs" / "api-1" / "collection" / "api_evidence.json"
+    huge = "1" * 5000
+    sidecar.write_text(
+        '{"plan": {"provider": "z-ai"}, "usage": {"prompt_tokens": ' + huge + "}}",
+        encoding="utf-8",
+    )
+    refresh_artifact_marker(collection_dir_for(tmp_path, "api-1"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "could not read" in loaded.excluded[0].reason
+
+
+def test_a_deeply_nested_sidecar_excludes_the_run(tmp_path: Path) -> None:
+    """Deep nesting raises ``RecursionError``, which is not a ``ValueError``."""
+    write_api_run(tmp_path, "api-1")
+    sidecar = tmp_path / "runs" / "api-1" / "collection" / "api_evidence.json"
+    depth = 200_000
+    sidecar.write_text("[" * depth + "]" * depth, encoding="utf-8")
+    refresh_artifact_marker(collection_dir_for(tmp_path, "api-1"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "could not read" in loaded.excluded[0].reason
+
+
+def test_api_evidence_rejects_a_non_finite_ttft() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["timeline"]["first_content_token_offset_ms"] = float("inf")
+    with pytest.raises(ApiEvidenceError, match="finite"):
+        ApiEvidence.from_dict(payload)
+
+
+def test_api_evidence_rejects_a_zero_output_cap() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["plan"]["request_parameters"]["max_tokens"] = 0
+    with pytest.raises(ApiEvidenceError, match=">= 1"):
+        ApiEvidence.from_dict(payload)
+
+
+def test_api_evidence_rejects_a_non_boolean_reported_flag() -> None:
+    payload = api_evidence_payload(run_id="r1")
+    payload["usage"]["reported"] = "yes"
+    with pytest.raises(ApiEvidenceError, match="usage.reported"):
+        ApiEvidence.from_dict(payload)
+
+
+# --- Decode settings from argv --------------------------------------------
+
+
+def test_decode_settings_read_the_projects_own_long_options() -> None:
+    settings = decode_settings_from_argv(
+        ("prog", "--max-tokens", "512", "--temperature", "0.2", "--top-p", "0.95")
+    )
+    assert settings.max_output_tokens == 512
+    assert settings.temperature == pytest.approx(0.2)
+    assert settings.top_p == pytest.approx(0.95)
+    assert settings.source == "command_argv"
+
+
+def test_decode_settings_are_unrecorded_when_absent() -> None:
+    settings = decode_settings_from_argv(("prog", "--run-id", "r1"))
+    assert settings.max_output_tokens is None
+    assert settings.source is None
+
+
+def test_conflicting_repeated_options_yield_nothing_rather_than_a_guess() -> None:
+    settings = decode_settings_from_argv(
+        ("prog", "--max-tokens", "512", "--max-tokens", "128")
+    )
+    assert settings.max_output_tokens is None
+
+
+def test_repeated_identical_options_are_accepted() -> None:
+    settings = decode_settings_from_argv(
+        ("prog", "--max-tokens", "512", "--max-tokens", "512")
+    )
+    assert settings.max_output_tokens == 512
+
+
+def test_unparsable_option_values_are_ignored() -> None:
+    settings = decode_settings_from_argv(("prog", "--max-tokens", "many"))
+    assert settings.max_output_tokens is None
+
+
+# --- Loading --------------------------------------------------------------
+
+
+def test_loader_requires_at_least_one_results_directory() -> None:
+    with pytest.raises(CompareEvidenceError, match="at least one"):
+        load_comparison_evidence(())
+
+
+def test_local_run_is_labeled_local_with_argv_decode_settings(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    loaded = load_comparison_evidence((tmp_path,))
+    assert len(loaded.runs) == 1
+    run = loaded.runs[0]
+    assert run.system_key.is_local is True
+    assert run.system_key.reasoning_effort is None
+    assert run.unit_key.max_output_tokens == 512
+    assert run.decode_settings.source == "command_argv"
+    assert run.local_prefill_ms == pytest.approx(310.0)
+
+
+def test_api_run_is_labeled_by_provider_and_reasoning_effort(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1", reasoning_effort="low")
+    run = load_comparison_evidence((tmp_path,)).runs[0]
+    assert run.system_key.provider == "z-ai"
+    assert run.system_key.is_local is False
+    assert run.system_key.reasoning_effort == "low"
+    assert run.decode_settings.source == "api_request_plan"
+    assert run.api_evidence is not None
+    assert run.api_evidence.usage.prompt_tokens == 1000
+
+
+def test_local_and_api_runs_share_a_unit_when_settings_match(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1", max_tokens_argv=512)
+    write_api_run(tmp_path, "api-1", max_output_tokens=512)
+    runs = load_comparison_evidence((tmp_path,)).runs
+    assert len({run.unit_key for run in runs}) == 1
+    assert len({run.system_key for run in runs}) == 2
+
+
+def test_differing_output_caps_split_the_unit(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1", max_tokens_argv=512)
+    write_api_run(tmp_path, "api-1", max_output_tokens=128)
+    runs = load_comparison_evidence((tmp_path,)).runs
+    assert len({run.unit_key for run in runs}) == 2
+
+
+def test_a_malformed_sidecar_excludes_the_run(tmp_path: Path) -> None:
+    write_run(
+        tmp_path,
+        "api-1",
+        provider="z-ai",
+        api_evidence_text="{not json",
+    )
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert len(loaded.excluded) == 1
+    assert "api_evidence.json" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_naming_another_model_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1", model_id="glm-5.3")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["model_id"] = "something-else"
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "plan.model_id" in loaded.excluded[0].reason
+    assert "does not match the final record" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_naming_another_provider_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["provider"] = "someone-else"
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "plan.provider" in loaded.excluded[0].reason
+
+
+def test_a_hosted_sidecar_over_a_provider_less_record_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    """A hosted run whose record omits the provider must not pass as local.
+
+    ``SystemKey`` reads locality from the record alone, so accepting this
+    pair would label a hosted system local, publish local-only peak memory
+    for it, and exempt it from every provider-keyed pricing lookup.
+    """
+    write_api_run(tmp_path, "api-1")
+    record_path = tmp_path / "runs" / "api-1" / "final_record.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["runtime"]["provider"] = None
+    record["memory"]["peak"] = {
+        "value": 9 * 1024**3,
+        "provenance": "measured_native",
+        "unit": "bytes",
+    }
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    reseal_run(tmp_path, "api-1")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert len(loaded.excluded) == 1
+    assert "claims this run was local" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_that_names_no_provider_still_requires_one_on_the_record(
+    tmp_path: Path,
+) -> None:
+    """The guard keys on the sidecar existing, not on it naming a provider.
+
+    Only a hosted-API collector writes an ``api_evidence.json`` at all, so a
+    sidecar that happens to omit ``plan.provider`` is still proof the run was
+    not local. Keying the check on ``plan.provider`` would leave this shape
+    wide open.
+    """
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["provider"] = None
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+
+    record_path = tmp_path / "runs" / "api-1" / "final_record.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["runtime"]["provider"] = None
+    record_path.write_text(json.dumps(record), encoding="utf-8")
+    reseal_run(tmp_path, "api-1")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "claims this run was local" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_that_names_no_provider_is_fine_when_the_record_does(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["provider"] = None
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+
+    run = load_comparison_evidence((tmp_path,)).runs[0]
+    assert run.system_key.provider == "z-ai"
+    assert run.system_key.is_local is False
+
+
+def test_a_local_run_with_no_sidecar_is_still_accepted_as_local(
+    tmp_path: Path,
+) -> None:
+    """The hosted-provider check must not catch genuinely local runs."""
+    write_run(tmp_path, "local-1")
+    run = load_comparison_evidence((tmp_path,)).runs[0]
+    assert run.system_key.is_local is True
+
+
+def test_a_corrupt_final_record_excludes_the_run(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1", corrupt_final_record=True)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert len(loaded.excluded) == 1
+
+
+def test_an_unsupported_row_is_excluded(tmp_path: Path) -> None:
+    write_run(
+        tmp_path,
+        "local-1",
+        status=RowStatus.UNSUPPORTED,
+        write_final_record=False,
+        reason="native MTP is unavailable here",
+    )
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "native MTP" in loaded.excluded[0].reason
+
+
+def test_the_same_run_measured_twice_is_kept_as_two_repetitions(
+    tmp_path: Path,
+) -> None:
+    """Two results trees holding one matrix row are two repetitions.
+
+    A matrix ``run_id`` names the task, so every repetition of a matrix
+    carries the same ids and the same system identity as the first. Calling
+    that a conflict rejected the only way repetitions are ever collected.
+    """
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    write_run(first, "shared", total_ms=1000.0)
+    write_run(second, "shared", total_ms=2000.0)
+    loaded = load_comparison_evidence((first, second))
+    assert len(loaded.runs) == 2
+    assert {run.record.timing.total.value for run in loaded.runs} == {1000.0, 2000.0}
+
+
+def test_an_exactly_duplicated_directory_is_deduplicated(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    loaded = load_comparison_evidence((tmp_path, tmp_path))
+    assert len(loaded.runs) == 1
+
+
+def test_a_relative_collection_dir_is_resolved_against_the_results_dir(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1")
+    verification_path = tmp_path / "runs" / "api-1" / "verification.json"
+    payload = json.loads(verification_path.read_text(encoding="utf-8"))
+    payload["collection_dir"] = "runs/api-1/collection"
+    verification_path.write_text(json.dumps(payload), encoding="utf-8")
+    reseal_run(tmp_path, "api-1")
+    run = load_comparison_evidence((tmp_path,)).runs[0]
+    assert run.api_evidence is not None

--- a/tests/optimizer/test_compare_hardening.py
+++ b/tests/optimizer/test_compare_hardening.py
@@ -1,0 +1,2507 @@
+"""Regressions for the findings raised in successive exact-head reviews.
+
+Each test names the finding it pins. They live together rather than scattered
+across the topical suites so the list can be checked against the review in one
+place; the topical suites still cover the surrounding behaviour.
+
+Everything here is synthetic. Nothing loads a model, calls an API, or runs a
+benchmark.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+from pathlib import Path
+
+import pytest
+from _compare_fixtures import (
+    COMPARE_POLICY,
+    collection_dir_for,
+    edit_sidecar,
+    reseal_run,
+    write_api_run,
+    write_json,
+    write_run,
+)
+
+import llmtracefx.optimizer.compare.evidence as evidence_module
+from llmtracefx.optimizer.collectors._shared import sha256_bytes
+from llmtracefx.optimizer.collectors.openai_api import ARTIFACT_MANIFEST_NAME
+from llmtracefx.optimizer.compare.compare import compare
+from llmtracefx.optimizer.compare.cost import TokenUsage, estimate_run_cost
+from llmtracefx.optimizer.compare.evidence import (
+    ApiEvidence,
+    ApiEvidenceError,
+    CompareEvidenceError,
+    load_comparison_evidence,
+)
+from llmtracefx.optimizer.compare.explain import format_compare_report_text
+from llmtracefx.optimizer.compare.identity import (
+    ComparableUnitKey,
+    CompareIdentityError,
+)
+from llmtracefx.optimizer.compare.policy import (
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+    ComparePolicyError,
+)
+from llmtracefx.optimizer.compare.pricing import (
+    PricingEntry,
+    PricingError,
+    PricingManifest,
+)
+from llmtracefx.optimizer.compare.report import (
+    CompareReport,
+    CompareReportValidationError,
+    StratumOutcome,
+)
+from llmtracefx.optimizer.compare.report_html import (
+    _redact_paths_in_prose,
+    render_compare_report_html,
+)
+from llmtracefx.optimizer.workloads.api_verify import (
+    RUN_MANIFEST_NAME,
+    RUN_MANIFEST_SCHEMA_VERSION,
+)
+
+_PRICING = PricingManifest.from_dict(
+    {
+        "schema_version": "1",
+        "currency": "USD",
+        "entries": [
+            {
+                "entry_id": "flash",
+                "provider": "z-ai",
+                "model_id": "glm-5.3-flash",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            },
+            {
+                "entry_id": "frontier",
+                "provider": "z-ai",
+                "model_id": "glm-5.3",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 3.0,
+                "output_per_million": 6.0,
+            },
+        ],
+    }
+)
+
+
+def _policy(
+    objective: CompareObjective = CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+    **constraints: object,
+) -> ComparePolicy:
+    return ComparePolicy(
+        objective=objective,
+        name="hardening",
+        constraints=CompareConstraints(**constraints),  # type: ignore[arg-type]
+    )
+
+
+# --- Finding 1: no false direct-collector ingestion claim -----------------
+
+
+def test_a_raw_collector_directory_is_rejected_with_an_explanation(
+    tmp_path: Path,
+) -> None:
+    """collect-api output has no verification.json, so nothing evaluated it."""
+    raw = tmp_path / "collector-out"
+    raw.mkdir()
+    (raw / "record.json").write_text("{}", encoding="utf-8")
+    (raw / "api_evidence.json").write_text("{}", encoding="utf-8")
+    (raw / "artifacts.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(CompareEvidenceError) as excinfo:
+        load_comparison_evidence((raw,))
+    message = str(excinfo.value)
+    assert "raw collector output" in message
+    assert "workloads run" in message
+    assert "verification.json" in message
+
+
+def test_an_ordinary_empty_directory_is_not_mistaken_for_collector_output(
+    tmp_path: Path,
+) -> None:
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+
+
+# --- Finding 2: run ids collide across systems by construction ------------
+
+
+def test_the_same_run_id_on_two_systems_is_the_ordinary_case(
+    tmp_path: Path,
+) -> None:
+    """A matrix run_id names the task, not the system, so it always collides.
+
+    This is the headline use case: one matrix executed locally and against a
+    hosted API. Treating the repeated id as a conflict would reject exactly
+    the comparison this command exists to make.
+    """
+    local = tmp_path / "local"
+    hosted = tmp_path / "hosted"
+    shared_id = "structured-json-profile-extraction-2k-autoregressive"
+    write_run(local, shared_id, total_ms=8000.0)
+    write_api_run(hosted, shared_id, total_ms=1200.0)
+
+    loaded = load_comparison_evidence((local, hosted))
+    assert len(loaded.runs) == 2
+    assert len({run.system_key for run in loaded.runs}) == 2
+    assert len({run.unit_key for run in loaded.runs}) == 1
+
+    report = compare(results_dirs=(local, hosted), policy=_policy())
+    assert len(report.strata) == 1
+    assert len(report.strata[0].ranked) == 2
+
+
+def test_the_same_run_id_twice_within_one_system_is_two_repetitions(
+    tmp_path: Path,
+) -> None:
+    """Repetitions of one matrix row must survive, not be rejected.
+
+    Executing a matrix twice into two results directories is how evidence
+    for a repetition count above one is produced, and both executions carry
+    the same ``run_id`` and the same system identity because a matrix run id
+    names the task and nothing about the system or the attempt.
+    """
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    write_run(first, "shared", total_ms=1000.0)
+    write_run(second, "shared", total_ms=2000.0)
+    loaded = load_comparison_evidence((first, second))
+    assert len(loaded.runs) == 2
+    assert {run.record.timing.total.value for run in loaded.runs} == {1000.0, 2000.0}
+
+
+def test_a_directory_named_twice_is_not_double_counted(tmp_path: Path) -> None:
+    write_run(tmp_path, "local-1")
+    loaded = load_comparison_evidence((tmp_path, tmp_path))
+    assert len(loaded.runs) == 1
+
+
+def test_two_spellings_of_one_directory_are_not_double_counted(
+    tmp_path: Path,
+) -> None:
+    write_run(tmp_path, "local-1")
+    alias = tmp_path / "sub" / ".."
+    (tmp_path / "sub").mkdir(exist_ok=True)
+    loaded = load_comparison_evidence((tmp_path, alias))
+    assert len(loaded.runs) == 1
+
+
+# --- Finding 3: full request and execution identity in the keys -----------
+
+
+def test_a_system_prompt_splits_the_comparable_unit(tmp_path: Path) -> None:
+    """The same user prompt under a system prompt is a different question."""
+    write_api_run(tmp_path, "plain", model_id="glm-5.3")
+    write_api_run(
+        tmp_path,
+        "with-system",
+        model_id="glm-5.3",
+        system_prompt_hash="sha256:a-system-prompt",
+    )
+    units = {run.unit_key for run in load_comparison_evidence((tmp_path,)).runs}
+    assert len(units) == 2
+    shapes = {unit.request_shape for unit in units}
+    assert None in shapes
+    assert any(shape is not None for shape in shapes)
+
+
+def test_a_bare_prompt_api_run_still_shares_a_unit_with_a_local_run(
+    tmp_path: Path,
+) -> None:
+    write_run(tmp_path, "local-1", max_tokens_argv=512)
+    write_api_run(tmp_path, "api-1", max_output_tokens=512)
+    units = {run.unit_key for run in load_comparison_evidence((tmp_path,)).runs}
+    assert len(units) == 1
+    assert next(iter(units)).request_shape is None
+
+
+def test_a_different_endpoint_is_a_different_system(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", endpoint_origin="https://one.invalid")
+    write_api_run(tmp_path, "b", endpoint_origin="https://two.invalid")
+    systems = {run.system_key for run in load_comparison_evidence((tmp_path,)).runs}
+    assert len(systems) == 2
+    assert {system.endpoint for system in systems} == {
+        "https://one.invalid/v1/chat/completions",
+        "https://two.invalid/v1/chat/completions",
+    }
+
+
+def test_a_different_thinking_type_is_a_different_system(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", thinking_type="enabled")
+    write_api_run(tmp_path, "b", thinking_type="disabled")
+    systems = {run.system_key for run in load_comparison_evidence((tmp_path,)).runs}
+    assert len(systems) == 2
+    assert {system.thinking_type for system in systems} == {"enabled", "disabled"}
+
+
+def test_a_different_execution_config_hash_is_a_different_system(
+    tmp_path: Path,
+) -> None:
+    """Catches a configuration difference this module does not model by name."""
+    write_api_run(tmp_path, "a", config_hash="cfg-one")
+    write_api_run(tmp_path, "b", config_hash="cfg-two")
+    systems = {run.system_key for run in load_comparison_evidence((tmp_path,)).runs}
+    assert len(systems) == 2
+    assert {system.execution_config_hash for system in systems} == {
+        "cfg-one",
+        "cfg-two",
+    }
+
+
+# --- Finding 4: validate the artifact set before trusting it --------------
+
+
+def test_a_sidecar_with_no_completeness_marker_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1", write_artifact_marker=False)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "completeness marker" in loaded.excluded[0].reason
+
+
+def test_a_tampered_artifact_set_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1")
+    response = collection_dir_for(tmp_path, "api-1") / "response.txt"
+    response.write_text("swapped out from under the marker\n", encoding="utf-8")
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "does not match its own" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_with_an_unknown_schema_version_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1")
+    edit_sidecar(tmp_path, "api-1", lambda p: p.update(schema_version="99"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "schema_version" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_with_no_schema_version_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1")
+    edit_sidecar(tmp_path, "api-1", lambda p: p.pop("schema_version"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "no schema_version" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_describing_another_run_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1")
+    edit_sidecar(tmp_path, "api-1", lambda p: p.update(run_id="some-other-run"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "describes a different run" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_describing_another_prompt_excludes_the_run(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["workload_hash"] = "sha256:a-different-prompt"
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "plan.workload_hash" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_describing_another_configuration_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["config_hash"] = "a-different-configuration"
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "plan.config_hash" in loaded.excluded[0].reason
+
+
+# --- Finding 5: a missing cached count is not zero ------------------------
+
+
+def _entry(**overrides: object) -> PricingEntry:
+    payload: dict[str, object] = {
+        "entry_id": "e",
+        "provider": "z-ai",
+        "model_id": "glm-5.3",
+        "currency": "USD",
+        "effective_at": "2026-01-01",
+        "source": "illustrative example",
+        "rates_are_illustrative": True,
+        "input_per_million": 1.0,
+        "output_per_million": 2.0,
+    }
+    payload.update(overrides)
+    return PricingEntry.from_dict(payload)
+
+
+def test_a_cached_rate_without_a_cached_count_makes_cost_unavailable() -> None:
+    """Assuming none of the prompt was cached would overstate the cost."""
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=1_000_000, completion_tokens=0),
+        _entry(cached_input_per_million=0.1),
+    )
+    assert breakdown.amount is None
+    assert any("refusing to assume" in reason for reason in breakdown.reasons)
+
+
+def test_a_cached_rate_with_a_reported_zero_still_prices() -> None:
+    """An explicit zero is evidence; an absent field is not."""
+    breakdown = estimate_run_cost(
+        TokenUsage(
+            prompt_tokens=1_000_000, completion_tokens=0, cached_prompt_tokens=0
+        ),
+        _entry(cached_input_per_million=0.1),
+    )
+    assert breakdown.amount == pytest.approx(1.0)
+
+
+def test_no_cached_rate_and_no_cached_count_is_unaffected() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=1_000_000, completion_tokens=0), _entry()
+    )
+    assert breakdown.amount == pytest.approx(1.0)
+
+
+# --- Finding 6: no partial usage totals ------------------------------------
+
+
+def test_a_run_without_usage_nulls_the_totals_rather_than_summing_the_rest(
+    tmp_path: Path,
+) -> None:
+    write_api_run(tmp_path, "a", prompt_tokens=1000, completion_tokens=400)
+    write_api_run(tmp_path, "b", usage_reported=False)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    usage = report.strata[0].ranked[0].usage
+    assert usage is not None
+    assert usage.runs_reporting_usage == 1
+    assert usage.runs_total == 2
+    assert usage.complete is False
+    # The one reporting run's 1000 must not be published as the total.
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+
+
+def test_totals_are_summed_when_every_run_reports(tmp_path: Path) -> None:
+    write_api_run(tmp_path, "a", prompt_tokens=1000, completion_tokens=400)
+    write_api_run(tmp_path, "b", prompt_tokens=1500, completion_tokens=600)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    usage = report.strata[0].ranked[0].usage
+    assert usage is not None
+    assert usage.complete is True
+    assert usage.input_tokens == 2500
+    assert usage.output_tokens == 1000
+
+
+# --- Finding 7: cost objectives use cost dispersion ------------------------
+
+
+def test_a_cost_objective_is_inconclusive_when_costs_overlap(
+    tmp_path: Path,
+) -> None:
+    """Steady latency must not make a noisy price look decisive."""
+    for index, tokens in enumerate((400_000, 1_600_000), start=1):
+        write_api_run(
+            tmp_path,
+            f"flash-{index}",
+            model_id="glm-5.3-flash",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=tokens,
+        )
+    for index, tokens in enumerate((450_000, 1_650_000), start=1):
+        write_api_run(
+            tmp_path,
+            f"frontier-{index}",
+            model_id="glm-5.3",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=tokens,
+            config_hash="frontier-cfg",
+        )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(CompareObjective.MIN_COST_PER_CORRECT_CASE),
+        pricing=_PRICING,
+        pricing_manifest_path="rates.json",
+    )
+    stratum = report.strata[0]
+    # Latency is identical across every run, so a latency-derived band would
+    # be zero and the tiny cost gap would read as a decisive win.
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert "measurement noise" in (stratum.inconclusive_reason or "")
+
+
+def test_a_cost_objective_is_conclusive_when_costs_are_far_apart(
+    tmp_path: Path,
+) -> None:
+    for index in (1, 2):
+        write_api_run(
+            tmp_path,
+            f"flash-{index}",
+            model_id="glm-5.3-flash",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=1000,
+        )
+    for index in (1, 2):
+        write_api_run(
+            tmp_path,
+            f"frontier-{index}",
+            model_id="glm-5.3",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=1_000_000,
+            config_hash="frontier-cfg",
+        )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(CompareObjective.MIN_COST_PER_CORRECT_CASE),
+        pricing=_PRICING,
+        pricing_manifest_path="rates.json",
+    )
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.RECOMMENDED
+    assert stratum.recommended is not None
+    assert stratum.recommended.system_key.model_id == "glm-5.3-flash"
+
+
+# --- Finding 9: strict numerics and an exact pricing schema version -------
+
+
+def test_pricing_requires_an_explicit_schema_version() -> None:
+    with pytest.raises(PricingError, match="schema_version"):
+        PricingManifest.from_dict(
+            {
+                "currency": "USD",
+                "entries": [_entry().to_dict()],
+            }
+        )
+
+
+def test_pricing_refuses_a_non_string_schema_version() -> None:
+    with pytest.raises(PricingError, match="must be a string"):
+        PricingManifest.from_dict(
+            {
+                "schema_version": 1,
+                "currency": "USD",
+                "entries": [_entry().to_dict()],
+            }
+        )
+
+
+def test_pricing_refuses_an_unknown_schema_version() -> None:
+    with pytest.raises(PricingError, match="unsupported pricing manifest"):
+        PricingManifest.from_dict(
+            {
+                "schema_version": "99",
+                "currency": "USD",
+                "entries": [_entry().to_dict()],
+            }
+        )
+
+
+def test_a_float_field_too_large_to_represent_is_a_validation_error() -> None:
+    """``float()`` raises OverflowError, which is not a ValueError."""
+    payload = json.loads(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "run_id": "r",
+                "plan": {"provider": "p", "messages": []},
+                "usage": {"reported": False},
+                "timeline": {},
+            }
+        )
+    )
+    payload["timeline"]["first_content_token_offset_ms"] = 10**400
+    with pytest.raises(ApiEvidenceError, match="too large to represent"):
+        ApiEvidence.from_dict(payload)
+
+
+def test_a_pricing_rate_too_large_to_represent_is_a_validation_error() -> None:
+    with pytest.raises(PricingError, match="too large to represent"):
+        PricingEntry.from_dict({**_entry().to_dict(), "input_per_million": 10**400})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("min_pass_rate", 10**400),
+        ("min_quality_score", 10**400),
+        ("max_mean_total_latency_ms", 10**400),
+    ],
+)
+def test_a_policy_threshold_too_large_to_represent_is_a_validation_error(
+    field: str, value: int
+) -> None:
+    with pytest.raises(ComparePolicyError, match="too large to represent"):
+        CompareConstraints.from_dict({field: value})
+
+
+def test_a_unit_key_sampling_value_too_large_to_represent_is_refused() -> None:
+    with pytest.raises(CompareIdentityError, match="too large to represent"):
+        ComparableUnitKey.from_dict(
+            {
+                "workload_id": "w",
+                "workload_version": "1",
+                "workload_prompt_hash": "sha256:abc",
+                "context_tier": "2k",
+                "temperature": 10**400,
+            }
+        )
+
+
+def test_a_report_measurement_too_large_to_represent_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Both the required and the optional report float readers are guarded."""
+    write_run(tmp_path, "local-1")
+    write_api_run(tmp_path, "api-1")
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    payload = json.loads(report.to_json())
+
+    optional = json.loads(json.dumps(payload))
+    optional["strata"][0]["ranked"][0]["mean_total_latency_ms"] = 10**400
+    with pytest.raises(CompareReportValidationError, match="too large to represent"):
+        CompareReport.from_dict(optional)
+
+    required = json.loads(json.dumps(payload))
+    required["strata"][0]["ranked"][0]["objective_value"] = 10**400
+    with pytest.raises(CompareReportValidationError, match="too large to represent"):
+        CompareReport.from_dict(required)
+
+
+def test_the_cli_refuses_an_unrepresentable_pricing_rate_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """This used to escape the CLI as an unhandled OverflowError traceback."""
+    from llmtracefx.optimizer.cli import main
+
+    results = tmp_path / "results"
+    write_run(results, "local-1")
+    write_api_run(results, "api-1")
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    manifest = write_json(
+        tmp_path / "rates.json",
+        {
+            "schema_version": "1",
+            "currency": "USD",
+            "entries": [{**_entry().to_dict(), "input_per_million": 10**400}],
+        },
+    )
+    try:
+        main(
+            [
+                "compare",
+                "--results",
+                str(results),
+                "--policy",
+                str(policy),
+                "--pricing",
+                str(manifest),
+            ]
+        )
+        code = 0
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    assert code == 1
+    assert "Invalid pricing manifest" in capsys.readouterr().err
+
+
+def test_the_cli_refuses_an_unrepresentable_report_value_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from llmtracefx.optimizer.cli import main
+
+    results = tmp_path / "results"
+    write_run(results, "local-1")
+    write_api_run(results, "api-1")
+    report = compare(results_dirs=(results,), policy=_policy())
+    payload = json.loads(report.to_json())
+    payload["strata"][0]["ranked"][0]["mean_total_latency_ms"] = 10**400
+    corrupted = write_json(tmp_path / "compare.json", payload)
+
+    try:
+        main(
+            [
+                "compare-report",
+                "--input",
+                str(corrupted),
+                "--output",
+                str(tmp_path / "out.html"),
+            ]
+        )
+        code = 0
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    assert code == 1
+    assert "Invalid compare report" in capsys.readouterr().err
+
+
+#: Float coercions in ``compare/`` that provably cannot raise ``OverflowError``
+#: and so need no guard. Each is listed with the reason, because an unexplained
+#: allowlist is how a ratchet quietly stops ratcheting.
+#:
+#: * ``decode_settings_from_argv`` coerces an argv **string**. ``float(str)``
+#:   returns ``inf`` on overflow rather than raising, and the surrounding
+#:   ``math.isfinite`` check drops it; only ``ValueError`` is reachable, and
+#:   that is already caught.
+#: * The ``temperature``/``top_p`` coercions in the same function receive
+#:   values already produced by that guarded string coercion, so they are
+#:   floats already and ``float(float)`` cannot overflow.
+#: * ``_percentiles`` coerces the median of an already-validated finite list.
+_UNGUARDED_FLOAT_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("evidence.py", "decode_settings_from_argv"),
+        ("compare.py", "_percentiles"),
+    }
+)
+
+
+def _enclosing_function(tree: ast.AST, node: ast.AST) -> str:
+    best = "<module>"
+    for candidate in ast.walk(tree):
+        if not isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        end = candidate.end_lineno or candidate.lineno
+        if candidate.lineno <= node.lineno <= end:  # type: ignore[attr-defined]
+            best = candidate.name
+    return best
+
+
+def _catches_overflow(handler: ast.ExceptHandler) -> bool:
+    names: list[str] = []
+    if isinstance(handler.type, ast.Name):
+        names = [handler.type.id]
+    elif isinstance(handler.type, ast.Tuple):
+        names = [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
+    return bool({"OverflowError", "ArithmeticError"} & set(names))
+
+
+def test_every_float_coercion_in_compare_is_guarded_or_allowlisted() -> None:
+    """A ratchet, so a new parser cannot reintroduce the CLI crash.
+
+    ``float()`` on a large Python int raises ``OverflowError``, which is an
+    ``ArithmeticError`` and therefore caught by none of the CLI's typed
+    handlers. Every input this package parses is a user-supplied file it
+    treats as untrusted, so a bare coercion is a traceback waiting for a
+    malformed manifest, policy or report.
+
+    The pattern matches ``float(<anything>)``, not only ``float(<name>)``, so
+    a coercion wrapped around a call cannot slip past.
+    """
+    package = Path(evidence_module.__file__).parent
+    unguarded: list[str] = []
+
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tries = [node for node in ast.walk(tree) if isinstance(node, ast.Try)]
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "float"
+                and node.args
+            ):
+                continue
+            if isinstance(node.args[0], ast.Constant):
+                continue
+            guarded = any(
+                block.body
+                and block.body[0].lineno
+                <= node.lineno
+                <= (block.body[-1].end_lineno or node.lineno)
+                and any(_catches_overflow(handler) for handler in block.handlers)
+                for block in tries
+            )
+            if guarded:
+                continue
+            where = (path.name, _enclosing_function(tree, node))
+            if where in _UNGUARDED_FLOAT_ALLOWLIST:
+                continue
+            unguarded.append(f"{path.name}:{node.lineno} in {where[1]}")
+
+    assert not unguarded, (
+        "unguarded float() coercion of untrusted input; wrap it in "
+        "try/except OverflowError raising this module's typed error, or add "
+        "it to _UNGUARDED_FLOAT_ALLOWLIST with a reason: " + ", ".join(unguarded)
+    )
+
+
+def test_the_float_guard_ratchet_would_catch_a_new_bare_coercion() -> None:
+    """The ratchet must actually bite, not just pass vacuously."""
+    source = "def parse(value):\n    numeric = float(value)\n    return numeric\n"
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "float"
+    ]
+    assert len(calls) == 1
+    assert not [node for node in ast.walk(tree) if isinstance(node, ast.Try)]
+    assert _enclosing_function(tree, calls[0]) == "parse"
+
+
+def test_the_cli_reports_a_raw_collector_directory_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from llmtracefx.optimizer.cli import main
+
+    raw = tmp_path / "collector-out"
+    raw.mkdir()
+    (raw / "api_evidence.json").write_text("{}", encoding="utf-8")
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    try:
+        main(["compare", "--results", str(raw), "--policy", str(policy)])
+        code = 0
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    assert code == 1
+    assert "raw collector output" in capsys.readouterr().err
+
+
+# --- Second review round -------------------------------------------------
+
+
+def test_a_relative_results_path_resolves_without_double_prefixing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verify` records collection_dir relative to the working directory.
+
+    Re-joining it under the results directory doubled the prefix, so every
+    hosted run silently lost its API evidence and was compared as though the
+    provider had reported nothing.
+    """
+    monkeypatch.chdir(tmp_path)
+    results = Path("artifacts/run")
+    write_api_run(results, "api-1")
+
+    verification_path = results / "runs" / "api-1" / "verification.json"
+    payload = json.loads(verification_path.read_text(encoding="utf-8"))
+    # Exactly what verify writes for a relative --output-dir.
+    payload["collection_dir"] = "artifacts/run/runs/api-1/collection"
+    payload["final_record_path"] = "artifacts/run/runs/api-1/final_record.json"
+    verification_path.write_text(json.dumps(payload), encoding="utf-8")
+    reseal_run(results, "api-1")
+
+    loaded = load_comparison_evidence((results,))
+    assert loaded.excluded == ()
+    assert len(loaded.runs) == 1
+    run = loaded.runs[0]
+    assert run.api_evidence is not None
+    assert run.api_evidence.usage.prompt_tokens == 1000
+
+
+def test_the_cli_compares_relative_results_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from llmtracefx.optimizer.cli import main
+
+    monkeypatch.chdir(tmp_path)
+    results = Path("artifacts/run")
+    write_run(results, "local-1", total_ms=8000.0)
+    write_api_run(results, "api-1", total_ms=1200.0)
+    for run_id in ("local-1", "api-1"):
+        path = results / "runs" / run_id / "verification.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["collection_dir"] = f"artifacts/run/runs/{run_id}/collection"
+        payload["final_record_path"] = f"artifacts/run/runs/{run_id}/final_record.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        reseal_run(results, run_id)
+
+    policy = write_json(Path("policy.json"), COMPARE_POLICY)
+    try:
+        main(["compare", "--results", str(results), "--policy", str(policy)])
+        code = 0
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    stdout = capsys.readouterr().out
+    assert code == 0, stdout
+    # Provider-reported usage proves the sidecar was actually found.
+    assert "provider-reported usage" in stdout
+
+
+def test_a_sidecar_missing_a_required_identity_field_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    """A v1 sidecar always carries these, so an absent one is not trustworthy."""
+    for field in ("run_id",):
+        write_api_run(tmp_path, "api-1")
+        edit_sidecar(tmp_path, "api-1", lambda p, f=field: p.pop(f))
+        loaded = load_comparison_evidence((tmp_path,))
+        assert loaded.runs == ()
+        assert "records no run_id" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize("field", ["model_id", "workload_hash", "config_hash"])
+def test_a_sidecar_missing_a_required_plan_field_excludes_the_run(
+    tmp_path: Path, field: str
+) -> None:
+    write_api_run(tmp_path, "api-1")
+    edit_sidecar(tmp_path, "api-1", lambda p, f=field: p["plan"].pop(f))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert f"records no plan.{field}" in loaded.excluded[0].reason
+
+
+def test_a_sidecar_revision_the_record_lacks_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    """Nullability must agree, not just values that both happen to exist."""
+    write_api_run(tmp_path, "api-1")
+
+    def mutate(payload: dict) -> None:
+        payload["plan"]["model_revision"] = "2026-06"
+
+    edit_sidecar(tmp_path, "api-1", mutate)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "disagree about whether a model revision" in loaded.excluded[0].reason
+
+
+def test_an_artifact_marker_from_another_run_excludes_the_run(
+    tmp_path: Path,
+) -> None:
+    """Hash completeness proves the files match, not that they are this run's."""
+    write_api_run(tmp_path, "api-1")
+    marker = collection_dir_for(tmp_path, "api-1") / "artifacts.json"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["run_id"] = "a-different-run"
+    marker.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "belongs to a different run" in loaded.excluded[0].reason
+
+
+def test_runs_differing_only_in_sidecar_evidence_are_not_deduplicated(
+    tmp_path: Path,
+) -> None:
+    """TTFT, cache and reasoning live only in the sidecar.
+
+    These two runs are distinct artifacts, so both are kept as repetitions.
+    Fingerprinting just the verification and the record would call them
+    identical, and the byte-identical rule would then drop one of them and
+    take its sidecar usage and timing with it.
+    """
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    write_api_run(first, "api-1", first_content_token_offset_ms=200.0)
+    write_api_run(second, "api-1", first_content_token_offset_ms=900.0)
+    loaded = load_comparison_evidence((first, second))
+    assert len(loaded.runs) == 2
+    ttfts = {
+        run.api_evidence.client_ttft_ms
+        for run in loaded.runs
+        if run.api_evidence is not None
+    }
+    assert ttfts == {200.0, 900.0}
+
+
+def test_byte_identical_runs_still_deduplicate(tmp_path: Path) -> None:
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    for target in (first, second):
+        write_api_run(target, "api-1", first_content_token_offset_ms=200.0)
+    # The two trees differ only in the absolute paths recorded inside them,
+    # so this is the copied-results case rather than a genuine conflict.
+    loaded = load_comparison_evidence((first,))
+    assert len(loaded.runs) == 1
+
+
+def test_an_exclusion_reason_never_publishes_an_absolute_path(
+    tmp_path: Path,
+) -> None:
+    write_run(tmp_path, "good")
+    write_api_run(tmp_path, "other")
+    write_api_run(tmp_path, "broken", write_artifact_marker=False)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    document = render_compare_report_html(report)
+    assert str(tmp_path) not in document
+    assert "Excluded runs" in document
+
+
+def test_prose_path_redaction_keeps_a_filename_and_hides_a_directory() -> None:
+    """A filename is a useful handle; an anchored directory is a leak."""
+    text = "could not read /home/alice/SECRET/runs/x/record.json here"
+    redacted = _redact_paths_in_prose(text, redact_paths=True)
+    assert "SECRET" not in redacted
+    assert "record.json here" in redacted
+    assert _redact_paths_in_prose(text, redact_paths=False) == text
+
+    directory = "the artifact set in /home/alice/SECRET/runs/x/collection is broken"
+    assert (
+        _redact_paths_in_prose(directory, redact_paths=True)
+        == "the artifact set in <path> is broken"
+    )
+
+
+def test_cost_noise_scales_per_attempt_dispersion_by_the_pass_rate(
+    tmp_path: Path,
+) -> None:
+    """cost_per_correct_case divides by correct cases, not by attempts.
+
+    With half the attempts failing, a swing of x per attempt moves the
+    objective by 2x, so the raw per-attempt dispersion understates the band.
+    """
+    for index, tokens in enumerate((400_000, 1_600_000), start=1):
+        write_api_run(
+            tmp_path,
+            f"flash-{index}",
+            model_id="glm-5.3-flash",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=tokens,
+            success=index == 1,
+            quality_score=1.0 if index == 1 else 0.0,
+        )
+    for index, tokens in enumerate((500_000, 1_700_000), start=1):
+        write_api_run(
+            tmp_path,
+            f"frontier-{index}",
+            model_id="glm-5.3",
+            total_ms=1000.0,
+            prompt_tokens=0,
+            completion_tokens=tokens,
+            config_hash="frontier-cfg",
+            success=index == 1,
+            quality_score=1.0 if index == 1 else 0.0,
+        )
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=_policy(CompareObjective.MIN_COST_PER_CORRECT_CASE, min_pass_rate=0.5),
+        pricing=_PRICING,
+        pricing_manifest_path="rates.json",
+    )
+    stratum = report.strata[0]
+    assert stratum.outcome == StratumOutcome.INCONCLUSIVE
+    assert "measurement noise" in (stratum.inconclusive_reason or "")
+
+
+@pytest.mark.parametrize(
+    ("loader", "error"),
+    [
+        ("policy", ComparePolicyError),
+        ("pricing", PricingError),
+        ("report", CompareReportValidationError),
+    ],
+)
+def test_json_limits_are_typed_errors_not_tracebacks(
+    loader: str, error: type[Exception]
+) -> None:
+    """A huge int literal raises ValueError, deep nesting RecursionError."""
+    from llmtracefx.optimizer.compare.policy import ComparePolicy
+
+    payloads = {
+        "policy": ComparePolicy.from_json,
+        "pricing": PricingManifest.from_json,
+        "report": CompareReport.from_json,
+    }
+    huge = '{"schema_version": ' + "1" * 5000 + "}"
+    deep = "[" * 200_000 + "]" * 200_000
+    for text in (huge, deep):
+        with pytest.raises(error):
+            payloads[loader](text)
+
+
+def test_a_broken_run_level_seal_excludes_the_run(tmp_path: Path) -> None:
+    """`run-api` seals verification.json and final_record.json too.
+
+    The collector's own marker covers only the four files in the collection
+    directory, leaving the graded outcome and the summary this loader reads
+    outside every integrity check. When the run-level seal is present it is
+    enforced, so editing either of those is caught.
+    """
+    write_api_run(tmp_path, "api-1")
+    run_dir = tmp_path / "runs" / "api-1"
+    collection = collection_dir_for(tmp_path, "api-1")
+    marker = {
+        "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
+        "run_id": "api-1",
+        "artifacts": [
+            {
+                "name": f"collection/{ARTIFACT_MANIFEST_NAME}",
+                "sha256": sha256_bytes(
+                    (collection / ARTIFACT_MANIFEST_NAME).read_bytes()
+                ),
+            },
+            {
+                "name": "final_record.json",
+                "sha256": sha256_bytes((run_dir / "final_record.json").read_bytes()),
+            },
+            {
+                "name": "verification.json",
+                "sha256": sha256_bytes((run_dir / "verification.json").read_bytes()),
+            },
+        ],
+    }
+    (run_dir / RUN_MANIFEST_NAME).write_text(
+        json.dumps(marker, indent=2), encoding="utf-8"
+    )
+
+    # Sealed and untouched: the run loads.
+    assert len(load_comparison_evidence((tmp_path,)).runs) == 1
+
+    # Regrade the outcome without regenerating the seal.
+    record_path = run_dir / "final_record.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["outcome"]["quality_score"] = 0.0
+    record_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "seal" in loaded.excluded[0].reason
+    assert RUN_MANIFEST_NAME in loaded.excluded[0].reason
+
+
+def test_a_local_run_without_a_run_level_seal_is_still_accepted(
+    tmp_path: Path,
+) -> None:
+    """`workloads run` writes no such marker, so it must not be required."""
+    write_run(tmp_path, "local-1")
+    assert not (tmp_path / "runs" / "local-1" / RUN_MANIFEST_NAME).exists()
+    assert len(load_comparison_evidence((tmp_path,)).runs) == 1
+
+
+# --- Third review round --------------------------------------------------
+
+
+def test_a_relative_recording_is_never_read_from_the_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Standing in one results tree must not poison a comparison of another.
+
+    A relative `--output-dir` records paths relative to the working directory
+    of *that* run. Reading them literally resolves them against whichever
+    tree this process happens to be in, and every identity check passes
+    because a matrix run_id names the task, not the system. The result is a
+    confidently labelled comparison of the wrong system.
+    """
+    here = tmp_path / "tree-a"
+    other = tmp_path / "tree-b"
+    for target, total_ms, model in (
+        (here, 1000.0, "model-a"),
+        (other, 9999.0, "model-b"),
+    ):
+        write_run(target, "shared-row", total_ms=total_ms, model_id=model)
+        path = target / "runs" / "shared-row" / "verification.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        # Exactly what a relative --output-dir records.
+        payload["final_record_path"] = "runs/shared-row/final_record.json"
+        payload["collection_dir"] = "runs/shared-row/collection"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        reseal_run(target, "shared-row")
+
+    monkeypatch.chdir(here)
+    loaded = load_comparison_evidence((other,))
+    assert len(loaded.runs) == 1
+    run = loaded.runs[0]
+    assert run.system_key.model_id == "model-b"
+    assert run.total_ms == pytest.approx(9999.0)
+
+
+def test_two_copies_of_one_matrix_tree_do_not_collapse_into_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The copied-tree case must resolve each tree against itself."""
+    monkeypatch.chdir(tmp_path)
+    mine = Path("artifacts/mine")
+    theirs = Path("incoming/theirs")
+    write_api_run(mine, "shared-row", model_id="glm-5.3", total_ms=1000.0)
+    write_api_run(
+        theirs,
+        "shared-row",
+        model_id="glm-5.3-flash",
+        total_ms=4000.0,
+        config_hash="other-cfg",
+    )
+    for target in (mine, theirs):
+        path = target / "runs" / "shared-row" / "verification.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["final_record_path"] = "runs/shared-row/final_record.json"
+        payload["collection_dir"] = "runs/shared-row/collection"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        reseal_run(target, "shared-row")
+
+    loaded = load_comparison_evidence((mine, theirs))
+    assert len(loaded.runs) == 2
+    assert {run.system_key.model_id for run in loaded.runs} == {
+        "glm-5.3",
+        "glm-5.3-flash",
+    }
+
+
+def test_a_relative_ancestor_never_survives_into_the_shared_report(
+    tmp_path: Path,
+) -> None:
+    """The documented workflow uses a relative --output-dir, so this is the
+    common leak shape, not an exotic one."""
+    results = tmp_path / "acme-secret-client" / "eval-2026"
+    write_run(results, "good")
+    write_api_run(results, "other")
+    write_run(results, "bad-1", corrupt_final_record=True)
+    report = compare(results_dirs=(results,), policy=_policy())
+    document = render_compare_report_html(report)
+    # The ancestor is the private part and must not survive anywhere.
+    assert "acme-secret-client" not in document
+    # The final component is deliberately kept: it is what tells two inputs
+    # apart in the report, and it names no ancestor.
+    assert "eval-2026" in document
+
+
+def test_the_prose_scrubber_leaves_ordinary_words_alone() -> None:
+    """A naive contains-a-slash rule mangles 'read/parse' into 'readparse'."""
+    text = "could not read/parse verification.json: boom"
+    assert _redact_paths_in_prose(text, redact_paths=True) == text
+
+
+@pytest.mark.parametrize(
+    ("text", "must_not_contain"),
+    [
+        ("failed at acme-client/eval/runs/x/record.json now", "acme-client"),
+        ("failed at /home/alice/SECRET/runs/x/collection now", "SECRET"),
+        ("failed at run/record.json now", "run/record.json"),
+    ],
+)
+def test_the_prose_scrubber_reduces_paths_to_their_final_component(
+    text: str, must_not_contain: str
+) -> None:
+    redacted = _redact_paths_in_prose(text, redact_paths=True)
+    assert must_not_contain not in redacted
+    assert redacted.startswith("failed at ")
+    assert redacted.endswith(" now")
+
+
+@pytest.mark.parametrize("suffix", ["yaml", "yml"])
+def test_a_malformed_yaml_policy_is_a_typed_error(tmp_path: Path, suffix: str) -> None:
+    """`yaml.YAMLError` is not a ValueError, so it escaped every handler."""
+    from llmtracefx.optimizer.compare.policy import ComparePolicy
+
+    path = tmp_path / f"policy.{suffix}"
+    path.write_text("objective: [unclosed", encoding="utf-8")
+    with pytest.raises(ComparePolicyError, match="invalid YAML"):
+        ComparePolicy.from_file(path)
+
+
+def test_a_malformed_yaml_pricing_manifest_is_a_typed_error(tmp_path: Path) -> None:
+    path = tmp_path / "rates.yaml"
+    path.write_text("entries: [unclosed", encoding="utf-8")
+    with pytest.raises(PricingError, match="invalid YAML"):
+        PricingManifest.from_file(path)
+
+
+def test_the_cli_refuses_a_malformed_yaml_policy_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from llmtracefx.optimizer.cli import main
+
+    results = tmp_path / "results"
+    write_run(results, "local-1")
+    write_api_run(results, "api-1")
+    policy = tmp_path / "policy.yaml"
+    policy.write_text("objective: [unclosed", encoding="utf-8")
+    try:
+        main(["compare", "--results", str(results), "--policy", str(policy)])
+        code = 0
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    assert code == 1
+    assert "Invalid compare policy" in capsys.readouterr().err
+
+
+def test_a_deeply_nested_verification_is_a_typed_error(tmp_path: Path) -> None:
+    """RecursionError is not a ValueError and escaped the loader."""
+    write_run(tmp_path, "local-1")
+    path = tmp_path / "runs" / "local-1" / "verification.json"
+    depth = 200_000
+    path.write_text("[" * depth + "]" * depth, encoding="utf-8")
+    # Either excluded with a reason or refused as a typed input error, but
+    # never a traceback.
+    try:
+        loaded = load_comparison_evidence((tmp_path,))
+    except CompareEvidenceError:
+        return
+    assert loaded.runs == ()
+
+
+# ---------------------------------------------------------------------------
+# Exact-head review, eighth round.
+#
+# The finding that drove most of this round: identity is not what
+# de-duplicates evidence, the artifact is. A matrix ``run_id`` names the task,
+# so every repetition of a matrix shares it, and keying de-duplication on
+# identity therefore rejected the ordinary way repetitions are collected.
+# ---------------------------------------------------------------------------
+
+
+def test_repetitions_from_distinct_trees_satisfy_a_repetition_requirement(
+    tmp_path: Path,
+) -> None:
+    """Finding 1. ``min_measured_repetitions`` above one must be reachable.
+
+    Three executions of one matrix row into three results directories are
+    three repetitions. Previously the second and third were either rejected
+    as conflicts (when the timings differed, which they always do) or
+    deduplicated away (when they did not), so no policy asking for more than
+    one measurement could ever be satisfied.
+    """
+    trees = []
+    for index, total in enumerate((8000.0, 8250.0, 8100.0)):
+        tree = tmp_path / f"rep-{index}"
+        write_run(tree, "shared", total_ms=total)
+        trees.append(tree)
+    hosted = []
+    for index, total in enumerate((1200.0, 1260.0, 1230.0)):
+        tree = tmp_path / f"hosted-{index}"
+        write_api_run(tree, "shared", total_ms=total)
+        hosted.append(tree)
+
+    policy = ComparePolicy.from_dict(
+        {**COMPARE_POLICY, "constraints": {"min_measured_repetitions": 3}}
+    )
+    report = compare(results_dirs=tuple(trees + hosted), policy=policy)
+    ranked = report.strata[0].ranked
+    assert len(ranked) == 2
+    assert {entry.evidence_count for entry in ranked} == {3}
+    for entry in ranked:
+        assert not any(
+            "requires at least" in reason for reason in entry.missing_evidence
+        )
+
+
+def test_one_directory_reached_through_two_paths_is_counted_once(
+    tmp_path: Path,
+) -> None:
+    """Finding 1, the other side. An alias is not a repetition."""
+    tree = tmp_path / "results"
+    write_run(tree, "local-1")
+    alias = tmp_path / "alias"
+    alias.symlink_to(tree, target_is_directory=True)
+    loaded = load_comparison_evidence((tree, alias, tree))
+    assert len(loaded.runs) == 1
+
+
+def test_a_copied_results_tree_is_not_counted_twice(tmp_path: Path) -> None:
+    """Finding 1, the third case. A copy is not a second measurement.
+
+    Two genuinely separate executions cannot share ``started_at`` and
+    ``ended_at`` down to the byte, so a byte-identical record is a copied
+    tree. Counting it as a repetition would inflate the evidence count and
+    understate every dispersion derived from it.
+    """
+    import shutil
+
+    first = tmp_path / "a"
+    write_run(first, "local-1", total_ms=1000.0)
+    second = tmp_path / "b"
+    shutil.copytree(first, second)
+    loaded = load_comparison_evidence((first, second))
+    assert len(loaded.runs) == 1
+
+
+def test_a_hosted_run_without_a_sidecar_is_excluded_loudly(tmp_path: Path) -> None:
+    """Finding 3. A hosted run with no API evidence is incomplete, not local.
+
+    The record names a provider, so the sidecar exists by construction. Its
+    absence used to be read as "this run simply has no API evidence", which
+    skipped artifact-set validation entirely and published the run with no
+    endpoint, no request identity, no provider usage and no TTFT.
+    """
+    import shutil
+
+    write_api_run(tmp_path, "api-1")
+    shutil.rmtree(collection_dir_for(tmp_path, "api-1"))
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    reason = loaded.excluded[0].reason
+    assert "hosted API" in reason
+    assert "missing" in reason
+
+
+def test_a_hosted_run_with_the_sidecar_file_removed_is_excluded(
+    tmp_path: Path,
+) -> None:
+    """Finding 3. Same rule when only the sidecar file is gone."""
+    write_api_run(tmp_path, "api-1")
+    (collection_dir_for(tmp_path, "api-1") / "api_evidence.json").unlink()
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "hosted API" in loaded.excluded[0].reason
+
+
+def test_throughput_noise_ignores_the_timings_of_failed_runs(
+    tmp_path: Path,
+) -> None:
+    """Finding 4. Correct cases per minute counts only passing timed runs.
+
+    Its noise band has to come from those same samples. This system passes
+    twice, steadily, and fails once after a minute. The failure contributes
+    nothing to the throughput figure, but it dominated the all-runs
+    coefficient of variation, and borrowing that figure inflated the noise
+    band far past the real gap between the two systems: a decisive result
+    was reported as a tie because of evidence the objective never used.
+    """
+    fast = tmp_path / "fast"
+    for index, (total, ok) in enumerate(
+        ((1000.0, True), (1005.0, True), (60000.0, False))
+    ):
+        write_run(fast / f"r{index}", "shared", total_ms=total, success=ok)
+    slow = tmp_path / "slow"
+    for index, total in enumerate((3000.0, 3010.0)):
+        write_api_run(slow / f"r{index}", "shared", total_ms=total)
+
+    dirs = tuple(sorted(fast.glob("r*"))) + tuple(sorted(slow.glob("r*")))
+    policy = ComparePolicy.from_dict(
+        {
+            **COMPARE_POLICY,
+            "objective": "max_correct_cases_per_minute",
+            "constraints": {},
+        }
+    )
+    report = compare(results_dirs=dirs, policy=policy)
+    stratum = report.strata[0]
+
+    # The dispersion of the two passing runs is three orders of magnitude
+    # smaller than the dispersion of all three, which is the whole point.
+    from statistics import mean, pstdev
+
+    passing = [1000.0, 1005.0]
+    every = [1000.0, 1005.0, 60000.0]
+    assert pstdev(passing) / mean(passing) < (pstdev(every) / mean(every)) / 100
+
+    assert stratum.outcome is StratumOutcome.RECOMMENDED
+    assert stratum.ranked[0].correct_cases_per_minute is not None
+    assert stratum.ranked[0].correct_cases_per_minute > (
+        stratum.ranked[1].correct_cases_per_minute or 0.0
+    )
+
+
+def test_prose_redaction_hides_ancestors_of_a_path_containing_whitespace() -> None:
+    """Finding 5. A space split the path and published the private half."""
+    text = (
+        "the artifact set in /Users/secret client/results/runs/x/collection "
+        "is broken"
+    )
+    redacted = _redact_paths_in_prose(text, redact_paths=True)
+    assert "secret" not in redacted
+    assert "/Users" not in redacted
+
+
+def test_prose_redaction_hides_a_unc_and_a_quoted_path() -> None:
+    """Finding 5. Windows, UNC and quoted forms redact too."""
+    unc = _redact_paths_in_prose(
+        r"could not read \\server\share\SECRET-CLIENT here", redact_paths=True
+    )
+    assert "SECRET-CLIENT" not in unc
+
+    windows = _redact_paths_in_prose(
+        r'could not read "C:\Users\SECRET\runs\x\record.json" here',
+        redact_paths=True,
+    )
+    assert "SECRET" not in windows
+    assert "record.json" in windows
+
+
+def test_a_list_valued_identity_field_is_excluded_not_a_typeerror(
+    tmp_path: Path,
+) -> None:
+    """Finding 6. Identity fields reach dict keys, so they must be strings.
+
+    Nothing upstream promises that: ``RowVerification.from_dict`` copies the
+    value through, so a list here used to surface far away as ``TypeError:
+    unhashable type: 'list'`` with no run named in the message.
+    """
+    for field in ("workload_id", "context_tier", "decode_mode"):  # noqa: B007
+        tree = tmp_path / field
+        write_run(tree, "row-1")
+        path = tree / "runs" / "row-1" / "verification.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload[field] = ["a", "b"]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        loaded = load_comparison_evidence((tree,))
+        assert loaded.runs == ()
+        assert field in loaded.excluded[0].reason
+
+
+def test_the_artifact_marker_is_read_through_the_bounded_reader(
+    tmp_path: Path,
+) -> None:
+    """Finding 7. The marker must not be read around the collector's guard.
+
+    The collector reads this file through a bounded regular-file reader that
+    refuses a symlink, a device node, or a file large enough to be a denial
+    of service. Parsing it here with a bare ``read_text`` first stepped
+    around exactly that guard.
+    """
+    source = ast.parse(
+        Path(evidence_module.__file__).read_text(encoding="utf-8"),
+        filename=evidence_module.__file__,
+    )
+    marker_fn = next(
+        node
+        for node in ast.walk(source)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_artifact_marker_identity_error"
+    )
+    calls = {
+        node.func.attr
+        for node in ast.walk(marker_fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert "read_text" not in calls, "the marker must go through the bounded reader"
+    names = {
+        node.func.id
+        for node in ast.walk(marker_fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "_read_bounded_regular_file" in names
+
+
+def test_an_oversized_artifact_marker_is_refused(tmp_path: Path) -> None:
+    """Finding 7, behaviourally. Past the limit the marker is not parsed."""
+    from llmtracefx.optimizer.collectors.openai_api import (
+        _MAX_ARTIFACT_MANIFEST_BYTES,
+    )
+
+    write_api_run(tmp_path, "api-1")
+    marker = collection_dir_for(tmp_path, "api-1") / ARTIFACT_MANIFEST_NAME
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["padding"] = "x" * (_MAX_ARTIFACT_MANIFEST_BYTES + 1024)
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    # An oversized marker also fails the completeness check, so asserting
+    # only that the run was excluded would hold with the bound removed.
+    assert "byte limit" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize("rate", [float("nan"), float("inf"), float("-inf"), -0.5, -1])
+def test_a_pricing_entry_refuses_a_bad_rate_on_direct_construction(
+    rate: float,
+) -> None:
+    """Finding 8. ``from_dict`` is not the only way in.
+
+    ``PricingEntry`` is public, so a caller can construct one directly and
+    bypass the loader's validation entirely. A negative or non-finite rate
+    accepted here poisons every cost derived from it.
+    """
+    with pytest.raises(PricingError):
+        PricingEntry(
+            entry_id="illustrative",
+            provider="example-provider",
+            model_id="example-model",
+            currency="USD",
+            effective_at="2026-01-01",
+            source="https://example.invalid/pricing",
+            rates_are_illustrative=True,
+            input_per_million=rate,
+        )
+
+
+def test_a_pricing_entry_refuses_a_non_numeric_rate_on_direct_construction() -> None:
+    """Finding 8. A string or a bool is not a rate either."""
+    for bad in ("1.0", True):
+        with pytest.raises(PricingError):
+            PricingEntry(
+                entry_id="illustrative",
+                provider="example-provider",
+                model_id="example-model",
+                currency="USD",
+                effective_at="2026-01-01",
+                source="https://example.invalid/pricing",
+                rates_are_illustrative=True,
+                output_per_million=bad,  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Exact-head review, ninth round. Containment, constructor invariants, and
+# the two ways a report can be internally false.
+# ---------------------------------------------------------------------------
+
+
+def test_an_absolute_record_path_cannot_leave_the_selected_results_tree(
+    tmp_path: Path,
+) -> None:
+    """Finding 2. The recorded path is data from the artifact being checked.
+
+    Honouring an absolute one let a results tree serve another tree's
+    measurements while every identity check passed, because a matrix
+    ``run_id`` names the task and both trees agree on it.
+    """
+    inside, outside = tmp_path / "inside", tmp_path / "outside"
+    write_run(inside, "row-1", total_ms=1000.0)
+    write_run(outside, "row-1", total_ms=9999.0)
+    (inside / "runs" / "row-1" / "final_record.json").unlink()
+    path = inside / "runs" / "row-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["final_record_path"] = str(outside / "runs" / "row-1" / "final_record.json")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((inside,))
+    assert loaded.runs == ()
+    assert "could not read final_record.json" in loaded.excluded[0].reason
+
+
+def test_a_symlinked_record_cannot_leave_the_selected_results_tree(
+    tmp_path: Path,
+) -> None:
+    """Finding 2. Resolution happens before containment, not after."""
+    inside, outside = tmp_path / "inside", tmp_path / "outside"
+    write_run(inside, "row-1", total_ms=1000.0)
+    write_run(outside, "row-1", total_ms=7777.0)
+    canonical = inside / "runs" / "row-1" / "final_record.json"
+    canonical.unlink()
+    canonical.symlink_to(outside / "runs" / "row-1" / "final_record.json")
+
+    loaded = load_comparison_evidence((inside,))
+    assert loaded.runs == ()
+
+
+def test_a_symlinked_collection_cannot_leave_the_selected_results_tree(
+    tmp_path: Path,
+) -> None:
+    """Finding 2. The same rule for the API collection directory."""
+    import shutil
+
+    inside, outside = tmp_path / "inside", tmp_path / "outside"
+    write_api_run(inside, "api-1")
+    write_api_run(outside, "api-1")
+    canonical = collection_dir_for(inside, "api-1")
+    shutil.rmtree(canonical)
+    canonical.symlink_to(collection_dir_for(outside, "api-1"), target_is_directory=True)
+
+    loaded = load_comparison_evidence((inside,))
+    assert loaded.runs == ()
+
+
+def test_an_ordinary_results_tree_still_loads(tmp_path: Path) -> None:
+    """Finding 2, the other direction: containment must not break the norm."""
+    write_run(tmp_path, "row-1", total_ms=1234.0)
+    loaded = load_comparison_evidence((tmp_path,))
+    assert len(loaded.runs) == 1
+    assert loaded.runs[0].record.timing.total.value == 1234.0
+
+
+def test_an_unrepresentable_measurement_is_excluded_not_raised(
+    tmp_path: Path,
+) -> None:
+    """Finding 6. ``OverflowError`` is an ``ArithmeticError``.
+
+    Nothing above catches it, so a numeric literal too large for a float
+    escaped the loader as a stack trace instead of excluding one run.
+    """
+    write_run(tmp_path, "row-1")
+    path = tmp_path / "runs" / "row-1" / "final_record.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["timing"]["total"]["value"] = int("9" * 400)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+
+
+def test_a_deeply_nested_run_seal_is_excluded_not_raised(tmp_path: Path) -> None:
+    """Finding 6 and 7. Deep nesting raises ``RecursionError`` while parsing.
+
+    The shared verifier reads this marker with an unbounded ``read_text``, so
+    it is bounded and parsed defensively here before being handed over.
+    """
+    from llmtracefx.optimizer.workloads.api_verify import RUN_MANIFEST_NAME
+
+    write_api_run(tmp_path, "api-1")
+    seal = tmp_path / "runs" / "api-1" / RUN_MANIFEST_NAME
+    seal.write_text("[" * 60_000 + "]" * 60_000, encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert RUN_MANIFEST_NAME in loaded.excluded[0].reason
+
+
+def test_an_oversized_run_seal_is_refused(tmp_path: Path) -> None:
+    """Finding 7. Bounded before parse, for every marker not just one."""
+    from llmtracefx.optimizer.collectors.openai_api import (
+        _MAX_ARTIFACT_MANIFEST_BYTES,
+    )
+    from llmtracefx.optimizer.workloads.api_verify import RUN_MANIFEST_NAME
+
+    write_api_run(tmp_path, "api-1")
+    seal = tmp_path / "runs" / "api-1" / RUN_MANIFEST_NAME
+    seal.write_text("x" * (_MAX_ARTIFACT_MANIFEST_BYTES + 1024), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "byte limit" in loaded.excluded[0].reason
+
+
+def test_a_negative_time_to_first_token_is_refused(tmp_path: Path) -> None:
+    """Finding 9. An offset from the start of a request cannot precede it.
+
+    Unchecked it would flatter its own system on every TTFT comparison.
+    """
+    write_api_run(tmp_path, "api-1")
+    edit_sidecar(
+        tmp_path,
+        "api-1",
+        lambda payload: payload["timeline"].__setitem__(
+            "first_content_token_offset_ms", -5.0
+        ),
+    )
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "must be >= 0" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["prompt_tokens", "completion_tokens", "cached_prompt_tokens", "reasoning_tokens"],
+)
+def test_token_usage_refuses_a_negative_count_on_direct_construction(
+    field_name: str,
+) -> None:
+    """Finding 8. A negative count subtracts from a bill."""
+    with pytest.raises(PricingError):
+        TokenUsage(**{field_name: -1})
+
+
+def test_token_usage_refuses_a_non_integer_count() -> None:
+    """Finding 8. A bool is an int in Python, and is not a token count."""
+    with pytest.raises(PricingError):
+        TokenUsage(prompt_tokens=True)  # type: ignore[arg-type]
+    with pytest.raises(PricingError):
+        TokenUsage(prompt_tokens=1.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"min_pass_rate": 5.0},
+        {"min_pass_rate": -1.0},
+        {"max_mean_total_latency_ms": -3.0},
+        {"max_cost_per_correct_case": -0.01},
+        {"max_coefficient_of_variation": -0.5},
+        # A ceiling of exactly zero is unsatisfiable rather than strict: it
+        # rejects every system while reading as a deliberate threshold.
+        {"max_mean_total_latency_ms": 0.0},
+        {"max_cost_per_correct_case": 0.0},
+        # ``bool`` is an ``int``, so this passed the ``< 1`` check and was
+        # rendered as "at least True measured run(s)".
+        {"min_measured_repetitions": True},
+    ],
+)
+def test_constraints_refuse_an_out_of_range_bound_on_direct_construction(
+    kwargs: dict[str, float],
+) -> None:
+    """Finding 8. An unsatisfiable bound is reported as a real threshold.
+
+    Constructed directly it bypassed the parser, so it would exclude every
+    system, or admit every system, while reading as a deliberate choice.
+    """
+    with pytest.raises(ComparePolicyError):
+        CompareConstraints(**kwargs)  # type: ignore[arg-type]
+
+
+def test_a_valid_constraint_set_still_constructs() -> None:
+    """Finding 8, the other direction."""
+    constraints = CompareConstraints(min_pass_rate=0.9)
+    assert constraints.min_pass_rate == 0.9
+
+
+def _report_payload(tmp_path: Path) -> dict[str, object]:
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=ComparePolicy.from_dict(
+            {**COMPARE_POLICY, "objective": "min_mean_total_latency_ms"}
+        ),
+    )
+    payload = json.loads(json.dumps(report.to_dict()))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_a_report_claiming_an_order_it_does_not_have_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Finding 11. Rank order and objective value are two claims, not one.
+
+    A file can assert both and have them disagree. That is not a schema
+    error, which is why it needs checking: such a report renders cleanly and
+    reads as authoritative while recommending the system that lost.
+    """
+    payload = _report_payload(tmp_path)
+    ranked = payload["strata"][0]["ranked"]  # type: ignore[index]
+    # Swap only the rank labels, so each entry stays self-consistent with
+    # its own backing metric and the *ordering* is the single false claim.
+    ranked[0]["rank"], ranked[1]["rank"] = ranked[1]["rank"], ranked[0]["rank"]
+    with pytest.raises(CompareReportValidationError, match="not ordered by"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_report_whose_objective_contradicts_its_metric_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Finding 11. The objective is defined as a metric printed beside it."""
+    payload = _report_payload(tmp_path)
+    payload["strata"][0]["ranked"][0]["objective_value"] = 0.001  # type: ignore[index]
+    with pytest.raises(CompareReportValidationError, match="contradicts the evidence"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_monetary_objective_is_checked_against_its_cost_column(
+    tmp_path: Path,
+) -> None:
+    """Finding 11, the monetary half.
+
+    ``cost_per_correct_case`` is an ordinary reported column, so a report
+    can name an objective value three orders of magnitude away from the cost
+    printed next to it and still be internally checkable. Exempting the
+    money objectives left exactly the hole this validation exists to close.
+    """
+    write_api_run(tmp_path / "cheap", "shared", model_id="glm-5.3-flash")
+    write_api_run(tmp_path / "dear", "shared", model_id="glm-5.3")
+    manifest = tmp_path / "pricing.json"
+    report = compare(
+        results_dirs=(tmp_path / "cheap", tmp_path / "dear"),
+        policy=ComparePolicy.from_dict(
+            {**COMPARE_POLICY, "objective": "min_cost_per_correct_case"}
+        ),
+        pricing=_PRICING,
+        pricing_manifest_path=str(manifest),
+    )
+    payload = json.loads(json.dumps(report.to_dict()))
+    ranked = payload["strata"][0]["ranked"]
+    if ranked[0].get("cost", {}).get("cost_per_correct_case") is None:
+        pytest.skip("no priced evidence in this fixture")
+
+    assert CompareReport.from_dict(json.loads(json.dumps(payload))).strata
+    ranked[0]["objective_value"] = 3e-07
+    with pytest.raises(CompareReportValidationError, match="contradicts the evidence"):
+        CompareReport.from_dict(payload)
+
+
+def test_an_honest_report_round_trips(tmp_path: Path) -> None:
+    """Finding 11, the other direction: real reports must still load."""
+    payload = _report_payload(tmp_path)
+    assert CompareReport.from_dict(payload).strata
+
+
+def test_every_verdict_states_the_constraints_it_cleared(tmp_path: Path) -> None:
+    """Finding 10. The README promises this and neither renderer did it.
+
+    "Cleared every constraint" is unreadable on its own: there is no way to
+    tell a demanding comparison from one that constrained nothing.
+    """
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    policy = ComparePolicy.from_dict(
+        {
+            **COMPARE_POLICY,
+            "constraints": {
+                "min_pass_rate": 0.5,
+                "max_mean_total_latency_ms": 30000.0,
+            },
+        }
+    )
+    report = compare(results_dirs=(tmp_path,), policy=policy)
+
+    text = format_compare_report_text(report, verbose=False)
+    assert "Constraints in force:" in text
+    assert "pass rate >= 0.5" in text
+    assert "mean total latency <= 30000.0 ms" in text
+
+    document = render_compare_report_html(report)
+    assert "Constraints in force" in document
+    assert "pass rate &gt;= 0.5" in document
+    assert "mean total latency &lt;= 30000.0 ms" in document
+
+
+def test_an_unset_constraint_is_not_claimed_as_a_bar(tmp_path: Path) -> None:
+    """Finding 10. Naming an unset constraint would overstate the bar."""
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=ComparePolicy.from_dict({**COMPARE_POLICY, "constraints": {}}),
+    )
+    text = format_compare_report_text(report, verbose=False)
+    assert "Constraints in force:" in text
+    assert "mean total latency" not in text
+    assert "cost per correct case" not in text
+
+
+@pytest.mark.parametrize(
+    ("section", "field_name"),
+    [
+        ("model", "model_id"),
+        ("model", "model_revision"),
+        ("model", "quantization"),
+        ("runtime", "name"),
+        ("runtime", "backend"),
+        ("runtime", "provider"),
+        ("platform", "accelerator"),
+        ("command", "config_hash"),
+        ("outcome", "quality_metric"),
+    ],
+)
+def test_a_list_valued_record_identity_field_is_excluded_not_a_typeerror(
+    tmp_path: Path, section: str, field_name: str
+) -> None:
+    """The record is an identity source too, not just the verification.
+
+    Nine values read off ``final_record.json`` end up inside ``SystemKey``
+    or ``ComparableUnitKey``, and so inside a dict key. The record schema
+    validates ranges and consistency but never these types, so a list in any
+    of them surfaced as ``TypeError: unhashable type`` from inside
+    de-duplication, or -- for ``quality_metric``, which ``sort_key`` folds
+    away with ``or ""`` -- survived the loader and aborted ``compare()``
+    instead. Either way the whole comparison died rather than one run being
+    excluded with a reason.
+    """
+    write_run(tmp_path, "row-1")
+    path = tmp_path / "runs" / "row-1" / "final_record.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload[section][field_name] = ["a", "b"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert field_name in loaded.excluded[0].reason
+
+
+def test_the_identity_probe_covers_what_compare_actually_hashes() -> None:
+    """The net must probe the dataclasses, not their sort keys.
+
+    ``compare()`` uses ``ComparableUnitKey`` and ``SystemKey`` themselves as
+    dict keys. ``sort_key()`` folds every optional through ``x or default``,
+    so a falsy unhashable value hashes fine as a sort key and still raises on
+    the dict insertion. A probe over sort keys would pass and the comparison
+    would die anyway.
+    """
+    unit = ComparableUnitKey(
+        workload_id="w",
+        workload_version="1",
+        workload_prompt_hash="sha256:x",
+        context_tier="2k",
+        quality_metric=[],  # type: ignore[arg-type]
+        max_output_tokens=512,
+        temperature=0.0,
+        top_p=1.0,
+        request_shape=None,
+    )
+    # The folded sort key hides it ...
+    hash(unit.sort_key())
+    # ... but the object itself, which is what becomes a dict key, does not.
+    with pytest.raises(TypeError):
+        hash(unit)
+
+
+def test_an_unhashable_identity_excludes_one_run_not_the_comparison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the loader's probe, not just the dataclass property.
+
+    Every field feeding these keys is validated upstream since the record
+    and verification schemas were hardened, so the probe is unreachable
+    through ordinary input; that is exactly what it is for -- the field that
+    is not covered yet. ``request_shape`` is used here because ``sort_key``
+    folds it, so a falsy unhashable value hashes as a sort key and only the
+    dataclass probe catches it.
+    """
+    monkeypatch.setattr(
+        evidence_module,
+        "request_shape_for",
+        lambda messages, *, workload_prompt_hash: [],
+    )
+    write_api_run(tmp_path, "api-1")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "cannot be used as a comparison key" in loaded.excluded[0].reason
+
+
+def test_a_system_graded_by_another_evaluator_is_rejected(tmp_path: Path) -> None:
+    """A quality score only means something with the metric it was earned on.
+
+    The policy refuses ``min_quality_score`` without
+    ``required_quality_metric`` for exactly this reason, so the engine must
+    actually enforce the pairing rather than compare a score against a bar
+    set for a different evaluator.
+    """
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=ComparePolicy.from_dict(
+            {
+                **COMPARE_POLICY,
+                "constraints": {
+                    "min_quality_score": 0.5,
+                    "required_quality_metric": "human_expert_blind_review",
+                },
+            }
+        ),
+    )
+    stratum = report.strata[0]
+    assert stratum.ranked == ()
+    assert stratum.rejected
+    assert any(
+        "human_expert_blind_review" in reason
+        for entry in stratum.rejected
+        for reason in entry.reasons
+    )
+
+
+def test_a_report_claiming_another_evaluators_bar_is_refused(
+    tmp_path: Path,
+) -> None:
+    """Same pairing, re-applied when the report is loaded back.
+
+    Editing only the policy block let a document assert a human-expert bar
+    while its ranked system carried a machine-checked metric, and both the
+    JSON and the rendered HTML presented that bar as having been cleared.
+    """
+    payload = _constrained_report(tmp_path)
+    constraints = payload["policy"]["constraints"]  # type: ignore[index]
+    constraints["required_quality_metric"] = "human_expert_blind_review"
+    constraints["min_quality_score"] = 0.95
+    with pytest.raises(CompareReportValidationError, match="graded by"):
+        CompareReport.from_dict(payload)
+
+
+@pytest.mark.parametrize("bad", [["x"], {"a": 1}, 7])
+def test_a_non_string_collection_dir_is_excluded_not_raised(
+    tmp_path: Path, bad: object
+) -> None:
+    """A recorded path reaches ``Path()``, not a hash.
+
+    That is why the identity checks missed it. It stays invisible while the
+    canonical ``collection/`` exists, so it only surfaced on a tree whose
+    collection had been pruned -- and then as a ``TypeError`` from the middle
+    of the loader that killed the whole comparison rather than one run.
+    """
+    import shutil
+
+    write_run(tmp_path, "row-1")
+    shutil.rmtree(collection_dir_for(tmp_path, "row-1"), ignore_errors=True)
+    path = tmp_path / "runs" / "row-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["collection_dir"] = bad
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "collection_dir" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize("bad", [["y"], {"b": 2}, 9])
+def test_a_non_string_final_record_path_is_excluded_not_raised(
+    tmp_path: Path, bad: object
+) -> None:
+    """The sibling field, in the shared loader this change already touches."""
+    write_run(tmp_path, "row-1")
+    path = tmp_path / "runs" / "row-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["final_record_path"] = bad
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "final_record_path" in loaded.excluded[0].reason
+
+
+def test_a_malformed_path_field_does_not_abort_the_whole_comparison(
+    tmp_path: Path,
+) -> None:
+    """One bad run is excluded; the healthy runs beside it still compare."""
+    import shutil
+
+    good = tmp_path / "good"
+    write_run(good, "row-1", total_ms=8000.0)
+    write_api_run(good, "row-2", total_ms=1200.0)
+
+    bad = tmp_path / "bad"
+    write_run(bad, "row-1")
+    shutil.rmtree(collection_dir_for(bad, "row-1"), ignore_errors=True)
+    path = bad / "runs" / "row-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["collection_dir"] = ["not", "a", "path"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = compare(
+        results_dirs=(good, bad), policy=ComparePolicy.from_dict(COMPARE_POLICY)
+    )
+    assert report.excluded_runs
+    assert report.strata
+
+
+# ---------------------------------------------------------------------------
+# Exact-head review, tenth round.
+# ---------------------------------------------------------------------------
+
+
+def test_a_hosted_run_without_a_run_seal_is_excluded(tmp_path: Path) -> None:
+    """``workloads run-api`` seals every run that produced a full set.
+
+    So a hosted run with no ``run.json`` is not something the pipeline
+    produces. Accepting it left the record and the verification -- the
+    graded outcome and the summary this loader actually reads -- covered by
+    no integrity marker at all.
+    """
+    from llmtracefx.optimizer.workloads.api_verify import RUN_MANIFEST_NAME
+
+    write_api_run(tmp_path, "api-1")
+    (tmp_path / "runs" / "api-1" / RUN_MANIFEST_NAME).unlink()
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    reason = loaded.excluded[0].reason
+    assert "hosted API" in reason
+    assert RUN_MANIFEST_NAME in reason
+
+
+def test_a_local_run_without_a_run_seal_is_still_accepted(tmp_path: Path) -> None:
+    """The local exception is exactly that and nothing wider.
+
+    ``workloads run`` writes no seal, so requiring one would exclude every
+    local run and make local-vs-hosted comparison impossible.
+    """
+    from llmtracefx.optimizer.workloads.api_verify import RUN_MANIFEST_NAME
+
+    write_run(tmp_path, "local-1")
+    assert not (tmp_path / "runs" / "local-1" / RUN_MANIFEST_NAME).exists()
+    loaded = load_comparison_evidence((tmp_path,))
+    assert len(loaded.runs) == 1
+
+
+def test_a_hosted_run_with_a_broken_run_seal_is_excluded(tmp_path: Path) -> None:
+    """Editing a sealed artifact without resealing must be caught."""
+    write_api_run(tmp_path, "api-1")
+    record = tmp_path / "runs" / "api-1" / "final_record.json"
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload["outcome"]["quality_score"] = 0.99
+    record.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "seal" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"constraints": {"min_pass_rate": 0.5, "max_mean_latency_ms": 100}},
+        {"constraints": {"min_pass_rate": 0.5, "minimum_pass_rate": 0.9}},
+        {"objectives": "min_mean_total_latency_ms"},
+        {"contraints": {"min_pass_rate": 0.5}},
+    ],
+)
+def test_an_unknown_policy_key_is_refused(payload: dict[str, object]) -> None:
+    """A misspelled constraint silently did nothing.
+
+    The comparison then reported clearing a bar that was never applied,
+    which reads exactly like the bar having been enforced. Every one of
+    these is a plausible typo for a real field.
+    """
+    with pytest.raises(ComparePolicyError, match="unknown field"):
+        ComparePolicy.from_dict({**COMPARE_POLICY, **payload})
+
+
+def test_a_valid_policy_is_still_accepted() -> None:
+    """The other direction: every documented field must still load."""
+    policy = ComparePolicy.from_dict(
+        {
+            "schema_version": "1",
+            "name": "n",
+            "description": "d",
+            "objective": "min_mean_total_latency_ms",
+            "constraints": {
+                "required_statuses": ["completed"],
+                "allowed_provenances": ["measured_wall_clock"],
+                "min_pass_rate": 0.5,
+                "min_quality_score": 0.5,
+                "required_quality_metric": "m",
+                "max_mean_total_latency_ms": 1000.0,
+                "max_cost_per_correct_case": 1.0,
+                "min_measured_repetitions": 1,
+                "max_coefficient_of_variation": 0.5,
+            },
+        }
+    )
+    assert policy.constraints.min_pass_rate == 0.5
+
+
+def _constrained_report(tmp_path: Path) -> dict[str, object]:
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    report = compare(
+        results_dirs=(tmp_path,),
+        policy=ComparePolicy.from_dict(
+            {
+                **COMPARE_POLICY,
+                "objective": "min_mean_total_latency_ms",
+                "constraints": {"min_pass_rate": 0.9},
+            }
+        ),
+    )
+    payload = json.loads(json.dumps(report.to_dict()))
+    assert isinstance(payload, dict)
+    return payload  # type: ignore[no-any-return]
+
+
+def test_a_ranked_system_below_its_own_policy_bar_is_refused(
+    tmp_path: Path,
+) -> None:
+    """A report carries the bar and the systems said to have cleared it.
+
+    Those are two claims about one fact, and a file can assert both and have
+    them disagree. ``compare()`` rejects a system that misses the bar, so a
+    loaded report ranking one did not come from an honest run.
+    """
+    payload = _constrained_report(tmp_path)
+    stratum = payload["strata"][0]
+    stratum["ranked"][0]["pass_rate"] = 0.1
+    if stratum.get("recommended"):
+        stratum["recommended"]["pass_rate"] = 0.1
+    with pytest.raises(CompareReportValidationError, match="does not satisfy"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_ranked_system_with_too_few_repetitions_is_refused(
+    tmp_path: Path,
+) -> None:
+    """The repetition floor is a constraint like any other."""
+    payload = _constrained_report(tmp_path)
+    payload["policy"]["constraints"]["min_measured_repetitions"] = 5
+    with pytest.raises(CompareReportValidationError, match="requires at least"):
+        CompareReport.from_dict(payload)
+
+
+def test_an_honest_constrained_report_still_round_trips(tmp_path: Path) -> None:
+    """The other direction: real reports must keep loading."""
+    payload = _constrained_report(tmp_path)
+    assert CompareReport.from_dict(payload).strata
+
+
+def test_a_symlinked_verification_is_not_followed(tmp_path: Path) -> None:
+    """The loader reads its two artifacts bounded and without following.
+
+    ``RowVerification.read_json`` and ``ExperimentRecord.read_json`` both use
+    an unbounded ``read_text`` that follows symlinks, so a link at either
+    path was read from wherever it pointed -- the same escape the
+    containment rules exist to close.
+    """
+    inside, outside = tmp_path / "inside", tmp_path / "outside"
+    write_run(inside, "row-1", total_ms=1000.0)
+    write_run(outside, "row-1", total_ms=9999.0)
+    target = inside / "runs" / "row-1" / "verification.json"
+    target.unlink()
+    target.symlink_to(outside / "runs" / "row-1" / "verification.json")
+
+    loaded = load_comparison_evidence((inside,))
+    assert loaded.runs == ()
+
+
+def test_an_oversized_verification_is_refused(tmp_path: Path) -> None:
+    """Bounded before parse, like every other artifact this layer reads."""
+    from llmtracefx.optimizer._artifact_io import MAX_METADATA_ARTIFACT_BYTES
+
+    write_run(tmp_path, "row-1")
+    path = tmp_path / "runs" / "row-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["padding"] = "x" * (MAX_METADATA_ARTIFACT_BYTES + 1024)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+
+
+@pytest.mark.parametrize(
+    ("section", "field_name"),
+    [
+        (None, "workload_id"),
+        (None, "workload_version"),
+        (None, "context_tier"),
+        (None, "decode_mode"),
+        ("model", "model_id"),
+        ("runtime", "name"),
+    ],
+)
+def test_a_null_required_identity_field_is_excluded_not_a_sort_crash(
+    tmp_path: Path, section: str | None, field_name: str
+) -> None:
+    """``None`` is hashable, so the identity probe cannot catch it.
+
+    These six are emitted raw by ``sort_key()`` rather than folded through
+    ``or ""``, because the schema requires them. A ``None`` therefore passed
+    every check and then raised ``TypeError: '<' not supported`` from inside
+    ``sorted()``, aborting the whole comparison -- or, with a single system,
+    produced a report the tool's own loader rejects.
+    """
+    write_run(tmp_path, "row-1")
+    name = "verification.json" if section is None else "final_record.json"
+    path = tmp_path / "runs" / "row-1" / name
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    target = payload if section is None else payload[section]
+    target[field_name] = None
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert field_name in loaded.excluded[0].reason
+
+
+def test_an_unwritable_compare_output_is_a_stated_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The comparison already succeeded; losing it to a traceback is worst."""
+    from llmtracefx.optimizer.cli import main
+
+    write_run(tmp_path, "a", total_ms=8000.0)
+    write_api_run(tmp_path, "b", total_ms=1200.0)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    directory = tmp_path / "not-a-file"
+    directory.mkdir()
+
+    try:
+        code = main(
+            [
+                "compare",
+                "--results",
+                str(tmp_path),
+                "--policy",
+                str(policy),
+                "--output",
+                str(directory),
+            ]
+        )
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    assert code == 1
+    assert "Could not write compare report JSON" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Exact-head review, eleventh round: guarantees that were live but unpinned,
+# so a mutation disabling them left the whole suite green.
+# ---------------------------------------------------------------------------
+
+
+def test_a_huge_but_finite_timing_never_produces_an_infinite_p50(
+    tmp_path: Path,
+) -> None:
+    """The median of two finite floats can still overflow.
+
+    ``(a + b) / 2`` is computed in float, so filtering the inputs for
+    finiteness does not make the median finite. An infinite p50 printed as
+    "p50 inf ms" and made ``to_json`` raise, because the report is written
+    with ``allow_nan=False`` -- an unhandled traceback out of the CLI on
+    ordinary artifact input.
+    """
+    for name in ("a", "b"):
+        write_run(tmp_path / name, "row-1", total_ms=1.7e308)
+    report = compare(
+        results_dirs=(tmp_path / "a", tmp_path / "b"),
+        policy=ComparePolicy.from_dict(COMPARE_POLICY),
+    )
+    # Serialising must not raise: this is the failure the CLI surfaced.
+    report.to_json()
+    for stratum in report.strata:
+        for system in stratum.ranked:
+            assert system.p50_total_latency_ms is None or math.isfinite(
+                system.p50_total_latency_ms
+            )
+
+
+def test_a_coefficient_of_variation_ceiling_actually_rejects(
+    tmp_path: Path,
+) -> None:
+    """A ceiling nobody enforces still renders as being in force."""
+    write_run(tmp_path / "a", "row-1", total_ms=1000.0)
+    write_run(tmp_path / "b", "row-1", total_ms=9000.0)
+    write_api_run(tmp_path / "c", "row-1", total_ms=1200.0)
+    report = compare(
+        results_dirs=(tmp_path / "a", tmp_path / "b", tmp_path / "c"),
+        policy=ComparePolicy.from_dict(
+            {**COMPARE_POLICY, "constraints": {"max_coefficient_of_variation": 0.05}}
+        ),
+    )
+    stratum = report.strata[0]
+    assert any(
+        "coefficient of variation" in reason
+        for entry in stratum.rejected
+        for reason in entry.reasons
+    )
+
+
+def test_a_mean_quality_score_below_the_bar_is_rejected(tmp_path: Path) -> None:
+    """The mean is what is compared, so the mean is what must be checked."""
+    write_run(tmp_path / "a", "row-1", quality_score=0.2)
+    write_run(tmp_path / "b", "row-1", quality_score=0.9)
+    write_api_run(tmp_path / "c", "row-1")
+    report = compare(
+        results_dirs=(tmp_path / "a", tmp_path / "b", tmp_path / "c"),
+        policy=ComparePolicy.from_dict(
+            {
+                **COMPARE_POLICY,
+                "constraints": {
+                    "min_quality_score": 0.9,
+                    "required_quality_metric": "structured_json_exact_field_match",
+                },
+            }
+        ),
+    )
+    stratum = report.strata[0]
+    assert any(
+        "mean quality_score" in reason
+        for entry in stratum.rejected
+        for reason in entry.reasons
+    )
+
+
+def test_a_non_finite_quality_score_is_rejected(tmp_path: Path) -> None:
+    """NaN is not a grade. Unchecked it entered the ranking."""
+    write_run(tmp_path, "row-1")
+    write_api_run(tmp_path, "api-1")
+    path = tmp_path / "runs" / "row-1" / "final_record.json"
+    raw = path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    payload["outcome"]["quality_score"] = float("nan")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = compare(
+        results_dirs=(tmp_path,), policy=ComparePolicy.from_dict(COMPARE_POLICY)
+    )
+    stratum = report.strata[0]
+    assert (
+        any(
+            "non-finite" in reason
+            for entry in stratum.rejected
+            for reason in entry.reasons
+        )
+        or not stratum.ranked
+    )
+
+
+def test_time_to_first_token_never_mixes_two_bases(tmp_path: Path) -> None:
+    """A local prefill and a client-observed stream are different quantities.
+
+    Averaging them would publish a number that is a measurement of nothing.
+    Provider identity keeps the two apart in ordinary input, so the guard is
+    exercised directly on the collector rather than through the loader.
+    """
+    from llmtracefx.optimizer.compare.compare import _collect_ttft
+
+    write_run(tmp_path / "local", "row-1")
+    write_api_run(tmp_path / "hosted", "row-1")
+    local = load_comparison_evidence((tmp_path / "local",)).runs
+    hosted = load_comparison_evidence((tmp_path / "hosted",)).runs
+    assert local and hosted
+
+    # Each basis alone reports a value.
+    local_mean, local_basis, _ = _collect_ttft(local)
+    hosted_mean, hosted_basis, _ = _collect_ttft(hosted)
+    assert local_mean is not None and local_basis is not None
+    assert hosted_mean is not None and hosted_basis is not None
+    assert local_basis != hosted_basis
+
+    # Together, neither is reported and the reason says why.
+    mixed_mean, mixed_basis, mixed_missing = _collect_ttft([*local, *hosted])
+    assert mixed_mean is None
+    assert mixed_basis is None
+    assert mixed_missing
+
+
+def test_a_hosted_run_with_no_recorded_collection_dir_is_excluded(
+    tmp_path: Path,
+) -> None:
+    """Otherwise it is published as hosted with no endpoint, usage or TTFT.
+
+    It also loses its decode settings, which silently moves it into a
+    different comparable unit.
+    """
+    write_api_run(tmp_path, "api-1")
+    path = tmp_path / "runs" / "api-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["collection_dir"] = None
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    reseal_run(tmp_path, "api-1")
+
+    loaded = load_comparison_evidence((tmp_path,))
+    assert loaded.runs == ()
+    assert "hosted API" in loaded.excluded[0].reason
+
+
+def test_an_absolute_collection_dir_cannot_leave_the_results_tree(
+    tmp_path: Path,
+) -> None:
+    """The compare-side twin of the record-path containment test.
+
+    Two trees from one matrix share every id, so the identity checks cannot
+    catch this: without containment, tree A's run is attributed tree B's
+    ``api_evidence.json``.
+    """
+    import shutil
+
+    inside, outside = tmp_path / "inside", tmp_path / "outside"
+    write_api_run(inside, "api-1", model_id="glm-5.3")
+    write_api_run(outside, "api-1", model_id="glm-5.3-flash")
+    shutil.rmtree(collection_dir_for(inside, "api-1"))
+
+    path = inside / "runs" / "api-1" / "verification.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["collection_dir"] = str(collection_dir_for(outside, "api-1"))
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    reseal_run(inside, "api-1")
+
+    loaded = load_comparison_evidence((inside,))
+    assert loaded.runs == ()
+    assert "does not resolve to a directory inside" in loaded.excluded[0].reason
+
+
+@pytest.mark.parametrize(
+    "field_name", ["pass_rate", "mean_quality_score", "quality_metric"]
+)
+def test_nulling_a_constrained_metric_does_not_evade_the_recheck(
+    tmp_path: Path, field_name: str
+) -> None:
+    """``null`` on a ranked system is not absent evidence.
+
+    ``compare()`` rejects a system whose value is missing for any of these
+    constraints, so a loaded report carrying ``null`` did not come from an
+    honest run. Skipping it made nulling the field the simplest way to evade
+    the bar entirely.
+    """
+    payload = _constrained_report(tmp_path)
+    constraints = payload["policy"]["constraints"]  # type: ignore[index]
+    constraints["required_quality_metric"] = "structured_json_exact_field_match"
+    constraints["min_quality_score"] = 0.5
+    stratum = payload["strata"][0]  # type: ignore[index]
+    stratum["ranked"][0][field_name] = None
+    if stratum.get("recommended"):
+        stratum["recommended"][field_name] = None
+    with pytest.raises(CompareReportValidationError):
+        CompareReport.from_dict(payload)

--- a/tests/optimizer/test_compare_pricing.py
+++ b/tests/optimizer/test_compare_pricing.py
@@ -1,0 +1,422 @@
+"""Tests for the versioned pricing manifest and the cost derivation from it.
+
+Everything here is synthetic. No rate in this file is a real price, and no
+test in this file contacts a provider.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.compare.cost import (
+    MAX_BILLABLE_TOKEN_COUNT,
+    MONETARY_BASIS,
+    TokenUsage,
+    correct_cases_per_currency_unit,
+    cost_per_case,
+    estimate_run_cost,
+)
+from llmtracefx.optimizer.compare.pricing import (
+    PRICING_MANIFEST_SCHEMA_VERSION,
+    PricingEntry,
+    PricingError,
+    PricingManifest,
+)
+
+
+def _entry(**overrides: object) -> PricingEntry:
+    payload: dict[str, object] = {
+        "entry_id": "example",
+        "provider": "z-ai",
+        "model_id": "glm-5.3",
+        "currency": "USD",
+        "effective_at": "2026-01-01",
+        "source": "illustrative example",
+        "rates_are_illustrative": True,
+        "input_per_million": 1.0,
+        "output_per_million": 2.0,
+    }
+    payload.update(overrides)
+    return PricingEntry.from_dict(payload)
+
+
+def _manifest(*entries: PricingEntry, currency: str = "USD") -> PricingManifest:
+    return PricingManifest(
+        schema_version=PRICING_MANIFEST_SCHEMA_VERSION,
+        currency=currency,
+        entries=entries,
+    )
+
+
+# --- Manifest schema ------------------------------------------------------
+
+
+def test_entry_requires_iso_currency_code() -> None:
+    with pytest.raises(PricingError, match="ISO 4217"):
+        _entry(currency="usd")
+    with pytest.raises(PricingError, match="ISO 4217"):
+        _entry(currency="$")
+
+
+def test_entry_requires_a_parsable_effective_date() -> None:
+    with pytest.raises(PricingError, match="effective_at"):
+        _entry(effective_at="whenever")
+    assert _entry(effective_at="2026-01-01T00:00:00Z").effective_at.endswith("Z")
+
+
+def test_entry_requires_a_source_reference() -> None:
+    payload = {
+        "entry_id": "e",
+        "provider": "p",
+        "model_id": "m",
+        "currency": "USD",
+        "effective_at": "2026-01-01",
+        "rates_are_illustrative": True,
+        "input_per_million": 1.0,
+    }
+    with pytest.raises(PricingError, match="'source'"):
+        PricingEntry.from_dict(payload)
+
+
+def test_entry_requires_an_explicit_illustrative_flag() -> None:
+    payload = {
+        "entry_id": "e",
+        "provider": "p",
+        "model_id": "m",
+        "currency": "USD",
+        "effective_at": "2026-01-01",
+        "source": "somewhere",
+        "input_per_million": 1.0,
+    }
+    with pytest.raises(PricingError, match="rates_are_illustrative"):
+        PricingEntry.from_dict(payload)
+
+
+def test_entry_with_no_rate_at_all_is_rejected() -> None:
+    with pytest.raises(PricingError, match="declares no rate"):
+        _entry(input_per_million=None, output_per_million=None)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_rates_are_rejected(bad: float) -> None:
+    with pytest.raises(PricingError, match="finite"):
+        _entry(input_per_million=bad)
+
+
+def test_negative_rates_are_rejected() -> None:
+    with pytest.raises(PricingError, match=">= 0"):
+        _entry(output_per_million=-0.01)
+
+
+def test_boolean_rates_are_rejected_rather_than_coerced() -> None:
+    with pytest.raises(PricingError, match="must be a number"):
+        _entry(input_per_million=True)
+
+
+def test_zero_is_a_legitimate_rate() -> None:
+    entry = _entry(input_per_million=0.0)
+    assert entry.input_per_million == 0.0
+
+
+def test_manifest_rejects_currency_mixing() -> None:
+    with pytest.raises(PricingError, match="mixing currencies"):
+        _manifest(_entry(currency="EUR"), currency="USD")
+
+
+def test_manifest_rejects_duplicate_entry_ids() -> None:
+    with pytest.raises(PricingError, match="duplicate entry_id"):
+        _manifest(_entry(), _entry(model_id="glm-5.3-flash"))
+
+
+def test_manifest_rejects_ambiguous_entries_at_load_time() -> None:
+    with pytest.raises(PricingError, match="ambiguous manifest"):
+        _manifest(
+            _entry(entry_id="a"),
+            _entry(entry_id="b"),
+        )
+
+
+def test_manifest_allows_distinct_revisions_for_one_model() -> None:
+    manifest = _manifest(
+        _entry(entry_id="a", model_revision="2026-01"),
+        _entry(entry_id="b", model_revision="2026-06"),
+    )
+    resolved = manifest.resolve(
+        provider="z-ai", model_id="glm-5.3", model_revision="2026-06"
+    )
+    assert resolved is not None and resolved.entry_id == "b"
+
+
+def test_manifest_rejects_a_wildcard_alongside_a_pinned_revision() -> None:
+    with pytest.raises(PricingError, match="ambiguous manifest"):
+        _manifest(
+            _entry(entry_id="wildcard"),
+            _entry(entry_id="pinned", model_revision="2026-06"),
+        )
+
+
+def test_manifest_requires_at_least_one_entry() -> None:
+    with pytest.raises(PricingError, match="at least one entry"):
+        _manifest()
+
+
+def test_manifest_rejects_unknown_schema_version() -> None:
+    with pytest.raises(PricingError, match="unsupported pricing manifest"):
+        PricingManifest(schema_version="99", currency="USD", entries=(_entry(),))
+
+
+def test_manifest_from_file_rejects_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "rates.txt"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(PricingError, match="unsupported pricing manifest extension"):
+        PricingManifest.from_file(path)
+
+
+def test_manifest_from_file_reports_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "rates.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(PricingError, match="invalid JSON"):
+        PricingManifest.from_file(path)
+
+
+def test_manifest_round_trips_through_json(tmp_path: Path) -> None:
+    manifest = _manifest(_entry())
+    path = tmp_path / "rates.json"
+    path.write_text(manifest.to_json(), encoding="utf-8")
+    assert PricingManifest.from_file(path).to_dict() == manifest.to_dict()
+
+
+# --- Matching -------------------------------------------------------------
+
+
+def test_resolve_never_matches_a_local_system_without_a_provider() -> None:
+    manifest = _manifest(_entry())
+    assert (
+        manifest.resolve(provider=None, model_id="glm-5.3", model_revision=None) is None
+    )
+
+
+def test_resolve_requires_an_exact_provider_and_model_match() -> None:
+    manifest = _manifest(_entry())
+    assert (
+        manifest.resolve(provider="Z-AI", model_id="glm-5.3", model_revision=None)
+        is None
+    )
+    assert (
+        manifest.resolve(provider="z-ai", model_id="glm-5.3-flash", model_revision=None)
+        is None
+    )
+
+
+def test_pinned_revision_entry_does_not_match_another_revision() -> None:
+    manifest = _manifest(_entry(model_revision="2026-01"))
+    assert (
+        manifest.resolve(provider="z-ai", model_id="glm-5.3", model_revision="2026-06")
+        is None
+    )
+
+
+def test_resolve_refuses_ambiguity_built_in_code() -> None:
+    # Bypasses the constructor check the same way a programmatic caller could.
+    manifest = _manifest(_entry(entry_id="a"))
+    object.__setattr__(
+        manifest, "entries", (_entry(entry_id="a"), _entry(entry_id="b"))
+    )
+    with pytest.raises(PricingError, match="refusing to pick one"):
+        manifest.resolve(provider="z-ai", model_id="glm-5.3", model_revision=None)
+
+
+def test_entry_hash_changes_when_content_changes() -> None:
+    assert _entry().content_sha256 != _entry(input_per_million=1.5).content_sha256
+
+
+def test_entry_hash_is_stable_across_key_order() -> None:
+    first = PricingEntry.from_dict(json.loads(json.dumps(_entry().to_dict())))
+    assert first.content_sha256 == _entry().content_sha256
+
+
+# --- Cost derivation ------------------------------------------------------
+
+
+def test_simple_cost_uses_per_million_rates() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=1_000_000, completion_tokens=500_000), _entry()
+    )
+    assert breakdown.amount == pytest.approx(1.0 + 1.0)
+    assert breakdown.currency == "USD"
+    assert breakdown.to_dict()["monetary_basis"] == MONETARY_BASIS
+    assert breakdown.to_dict()["estimated"] is True
+
+
+def test_missing_prompt_tokens_makes_cost_unavailable_not_zero() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=None, completion_tokens=10), _entry()
+    )
+    assert breakdown.amount is None
+    assert any("prompt_tokens" in reason for reason in breakdown.reasons)
+
+
+def test_missing_completion_tokens_makes_cost_unavailable() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=10, completion_tokens=None), _entry()
+    )
+    assert breakdown.amount is None
+    assert any("completion_tokens" in reason for reason in breakdown.reasons)
+
+
+def test_cached_tokens_are_not_double_counted() -> None:
+    entry = _entry(cached_input_per_million=0.1)
+    breakdown = estimate_run_cost(
+        TokenUsage(
+            prompt_tokens=1_000_000,
+            completion_tokens=0,
+            cached_prompt_tokens=400_000,
+        ),
+        entry,
+    )
+    # 600k billed at 1.0/M plus 400k billed at 0.1/M.
+    assert breakdown.amount == pytest.approx(0.6 + 0.04)
+    assert breakdown.billed_input_tokens == 600_000
+    assert breakdown.billed_cached_tokens == 400_000
+
+
+def test_cached_usage_without_a_cached_rate_refuses_to_guess() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=1000, completion_tokens=10, cached_prompt_tokens=500),
+        _entry(),
+    )
+    assert breakdown.amount is None
+    assert any("cached_input_per_million" in reason for reason in breakdown.reasons)
+
+
+def test_cached_tokens_exceeding_prompt_tokens_is_refused() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=10, completion_tokens=1, cached_prompt_tokens=11),
+        _entry(cached_input_per_million=0.1),
+    )
+    assert breakdown.amount is None
+    assert any("internally inconsistent" in reason for reason in breakdown.reasons)
+
+
+def test_zero_cached_tokens_does_not_require_a_cached_rate() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(
+            prompt_tokens=1_000_000, completion_tokens=0, cached_prompt_tokens=0
+        ),
+        _entry(),
+    )
+    assert breakdown.amount == pytest.approx(1.0)
+
+
+def test_unreported_reasoning_is_billed_as_output_and_flagged() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=0, completion_tokens=1_000_000), _entry()
+    )
+    assert breakdown.amount == pytest.approx(2.0)
+    assert breakdown.billed_output_tokens == 1_000_000
+    assert breakdown.billed_reasoning_tokens is None
+    assert any("no hidden reasoning cost" in reason for reason in breakdown.reasons)
+
+
+def test_reasoning_rate_without_reported_reasoning_refuses_to_infer() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=0, completion_tokens=100),
+        _entry(reasoning_per_million=5.0),
+    )
+    assert breakdown.amount is None
+    assert any("refusing to infer" in reason for reason in breakdown.reasons)
+
+
+def test_reported_reasoning_is_split_out_when_a_rate_exists() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(
+            prompt_tokens=0, completion_tokens=1_000_000, reasoning_tokens=400_000
+        ),
+        _entry(reasoning_per_million=5.0),
+    )
+    # 600k output at 2.0/M plus 400k reasoning at 5.0/M.
+    assert breakdown.amount == pytest.approx(1.2 + 2.0)
+    assert breakdown.billed_output_tokens == 600_000
+    assert breakdown.billed_reasoning_tokens == 400_000
+
+
+def test_reasoning_exceeding_completion_tokens_is_refused() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=0, completion_tokens=10, reasoning_tokens=11),
+        _entry(reasoning_per_million=5.0),
+    )
+    assert breakdown.amount is None
+    assert any("internally inconsistent" in reason for reason in breakdown.reasons)
+
+
+def test_missing_output_rate_for_nonzero_output_makes_cost_unavailable() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=10, completion_tokens=10),
+        _entry(output_per_million=None),
+    )
+    assert breakdown.amount is None
+    assert any("output_per_million" in reason for reason in breakdown.reasons)
+
+
+def test_missing_rate_for_zero_tokens_is_harmless() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=1_000_000, completion_tokens=0),
+        _entry(output_per_million=None),
+    )
+    assert breakdown.amount == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["prompt_tokens", "completion_tokens", "cached_prompt_tokens", "reasoning_tokens"],
+)
+def test_an_unbillable_token_count_is_refused_not_raised(field: str) -> None:
+    """``tokens * rate`` on a huge int raises ``OverflowError``.
+
+    That is an ``ArithmeticError``, so nothing downstream catches it and it
+    would escape ``compare`` as a raw traceback. This function is public, so
+    it holds the line itself rather than relying on the loader's bound.
+    """
+    fields: dict[str, int] = {"prompt_tokens": 10, "completion_tokens": 10}
+    fields[field] = MAX_BILLABLE_TOKEN_COUNT + 1
+    breakdown = estimate_run_cost(
+        TokenUsage(**fields), _entry(reasoning_per_million=1.0)
+    )
+    assert breakdown.amount is None
+    assert any("billed exactly" in reason for reason in breakdown.reasons)
+
+
+def test_an_enormous_count_never_raises_out_of_the_cost_helper() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=10**400, completion_tokens=5), _entry()
+    )
+    assert breakdown.amount is None
+
+
+def test_a_count_at_the_exact_bound_is_still_billed() -> None:
+    breakdown = estimate_run_cost(
+        TokenUsage(prompt_tokens=MAX_BILLABLE_TOKEN_COUNT, completion_tokens=0),
+        _entry(),
+    )
+    assert breakdown.amount is not None
+    assert math.isfinite(breakdown.amount)
+
+
+# --- Derived ratios --------------------------------------------------------
+
+
+def test_cost_per_case_is_unavailable_without_cases() -> None:
+    assert cost_per_case(1.0, 0) is None
+    assert cost_per_case(None, 5) is None
+    assert cost_per_case(2.0, 4) == pytest.approx(0.5)
+
+
+def test_correct_cases_per_currency_unit_is_undefined_at_zero_cost() -> None:
+    assert correct_cases_per_currency_unit(5, 0.0) is None
+    assert correct_cases_per_currency_unit(0, 1.0) is None
+    assert correct_cases_per_currency_unit(5, None) is None
+    assert correct_cases_per_currency_unit(4, 2.0) == pytest.approx(2.0)

--- a/tests/optimizer/test_compare_report_html.py
+++ b/tests/optimizer/test_compare_report_html.py
@@ -1,0 +1,504 @@
+"""Tests for the ``compare`` HTML renderer.
+
+The renderer is a read-only surface over a validated report, so the tests
+here are about the properties that make a rendered file safe to share:
+determinism, escaping, path redaction, no network references, and enough
+structure for a screen reader and a narrow viewport.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from _compare_fixtures import write_api_run, write_run
+
+from llmtracefx.optimizer.compare.compare import compare
+from llmtracefx.optimizer.compare.identity import ComparableUnitKey, SystemKey
+from llmtracefx.optimizer.compare.policy import (
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+)
+from llmtracefx.optimizer.compare.pricing import PricingManifest
+from llmtracefx.optimizer.compare.report import (
+    COMPARE_REPORT_SCHEMA_VERSION,
+    CompareReport,
+    CostSummary,
+    PricingProvenance,
+    StratumOutcome,
+    StratumReport,
+    SystemReport,
+    UsageTotals,
+)
+from llmtracefx.optimizer.compare.report_html import (
+    _system_label,
+    render_compare_report_html,
+)
+
+_PRICING = PricingManifest.from_dict(
+    {
+        "schema_version": "1",
+        "currency": "USD",
+        "entries": [
+            {
+                "entry_id": "glm-5.3",
+                "provider": "z-ai",
+                "model_id": "glm-5.3",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            },
+            {
+                "entry_id": "glm-5.3-flash",
+                "provider": "z-ai",
+                "model_id": "glm-5.3-flash",
+                "currency": "USD",
+                "effective_at": "2026-01-01",
+                "source": "illustrative example",
+                "rates_are_illustrative": True,
+                "input_per_million": 0.1,
+                "output_per_million": 0.2,
+            },
+        ],
+    }
+)
+
+
+def _policy(**overrides: Any) -> ComparePolicy:
+    return ComparePolicy(
+        objective=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS,
+        name="Local vs frontier vs flash",
+        constraints=CompareConstraints(**overrides),
+    )
+
+
+def _built_report(tmp_path: Path, **compare_kwargs: Any) -> CompareReport:
+    write_run(tmp_path, "local-1", total_ms=8000.0)
+    write_api_run(tmp_path, "frontier-1", model_id="glm-5.3", total_ms=3000.0)
+    write_api_run(
+        tmp_path,
+        "flash-1",
+        model_id="glm-5.3-flash",
+        reasoning_effort="low",
+        total_ms=1200.0,
+    )
+    return compare(results_dirs=(tmp_path,), policy=_policy(), **compare_kwargs)
+
+
+# --- Determinism ----------------------------------------------------------
+
+
+def test_rendering_the_same_report_twice_is_byte_identical(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    assert render_compare_report_html(report) == render_compare_report_html(report)
+
+
+def test_rendering_does_not_take_its_own_timestamp(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report)
+    assert report.generated_at in document
+    # The report's own clock is the only timestamp in the document.
+    timestamps = set(re.findall(r"\d{4}-\d{2}-\d{2}T[\d:.]+Z", document))
+    assert timestamps == {report.generated_at}
+
+
+def test_a_reloaded_report_renders_identically(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    reloaded = CompareReport.from_json(report.to_json())
+    assert render_compare_report_html(reloaded) == render_compare_report_html(report)
+
+
+# --- No network -----------------------------------------------------------
+
+
+def test_the_document_has_no_script_or_external_reference(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    lowered = document.lower()
+    for forbidden in (
+        "<script",
+        "javascript:",
+        "<iframe",
+        "<link ",
+        "@import",
+        "srcset=",
+    ):
+        assert forbidden not in lowered
+    assert "http://" not in lowered
+    assert "https://" not in lowered
+
+
+def test_the_document_declares_itself_offline_and_unindexed(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert '<meta name="robots" content="noindex, nofollow">' in document
+    assert "no external references" in document
+
+
+# --- Escaping -------------------------------------------------------------
+
+
+def _hostile_report() -> CompareReport:
+    hostile = "<script>alert('x')</script>"
+    system_key = SystemKey(
+        model_id=hostile,
+        model_revision=None,
+        provider="z-ai",
+        runtime_name=hostile,
+        runtime_backend=None,
+        accelerator=None,
+        quantization=hostile,
+        reasoning_effort=hostile,
+        decode_mode=hostile,
+    )
+    system = SystemReport(
+        system_key=system_key,
+        rank=1,
+        run_ids=(hostile,),
+        verification_paths=(f"/tmp/{hostile}/verification.json",),
+        record_paths=(f"/tmp/{hostile}/final_record.json",),
+        evidence_count=1,
+        objective_name=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+        objective_value=1.0,
+        quality_metric=hostile,
+        missing_evidence=(hostile,),
+        usage=UsageTotals(runs_reporting_usage=1, runs_total=1, input_tokens=1),
+        cost=CostSummary(
+            currency="USD",
+            pricing_entry_id=hostile,
+            pricing_entry_sha256=hostile,
+            rates_are_illustrative=True,
+            total_amount=1.0,
+            reasons=(hostile,),
+        ),
+    )
+    return CompareReport(
+        schema_version=COMPARE_REPORT_SCHEMA_VERSION,
+        generated_at="2026-01-01T00:00:00.000000Z",
+        results_dirs=(f"/tmp/{hostile}",),
+        policy=ComparePolicy(
+            objective=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS, name=hostile
+        ),
+        pricing=PricingProvenance(
+            manifest_path=f"/tmp/{hostile}/rates.json",
+            manifest_sha256=hostile,
+            currency="USD",
+            rates_are_illustrative=True,
+            entry_ids_used=(hostile,),
+        ),
+        strata=(
+            StratumReport(
+                unit_key=ComparableUnitKey(
+                    workload_id=hostile,
+                    workload_version="1",
+                    workload_prompt_hash=hostile,
+                    context_tier=hostile,
+                    quality_metric=hostile,
+                    max_output_tokens=None,
+                    temperature=None,
+                    top_p=None,
+                ),
+                outcome=StratumOutcome.RECOMMENDED,
+                objective_name=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+                ranked=(system,),
+                recommended=system,
+                missing_evidence=(hostile,),
+            ),
+        ),
+    )
+
+
+def test_hostile_strings_never_reach_the_document_unescaped() -> None:
+    document = render_compare_report_html(_hostile_report(), redact_paths=False)
+    assert "<script>alert" not in document
+    assert "&lt;script&gt;alert" in document
+
+
+def test_a_hostile_currency_cannot_inject_markup_through_a_money_cell() -> None:
+    """The money formatter interpolates the currency, so the cell must escape.
+
+    ``_fmt_money`` builds ``"<amount> <currency>"`` from report JSON, and that
+    string lands in the ranked table. Escaping only at the formatters would
+    leave this one path open, so the table escapes at the cell boundary.
+    """
+    hostile = "<img src=x onerror=alert(1)>"
+    system = SystemReport(
+        system_key=SystemKey(
+            model_id="glm-5.3",
+            model_revision=None,
+            provider="z-ai",
+            runtime_name="openai-compatible-stream",
+            runtime_backend=None,
+            accelerator=None,
+            quantization=None,
+            reasoning_effort=None,
+            decode_mode="autoregressive",
+        ),
+        rank=1,
+        run_ids=("r1",),
+        verification_paths=(),
+        record_paths=(),
+        evidence_count=1,
+        objective_name=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+        objective_value=1.0,
+        quality_metric=hostile,
+        cost=CostSummary(
+            currency=hostile,
+            pricing_entry_id="e",
+            pricing_entry_sha256="h",
+            rates_are_illustrative=True,
+            total_amount=1.0,
+            cost_per_correct_case=1.0,
+        ),
+    )
+    report = CompareReport(
+        schema_version=COMPARE_REPORT_SCHEMA_VERSION,
+        generated_at="2026-01-01T00:00:00.000000Z",
+        results_dirs=("/tmp/results",),
+        policy=ComparePolicy(
+            objective=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS, name="p"
+        ),
+        pricing=PricingProvenance(
+            manifest_path="rates.json",
+            manifest_sha256="h",
+            currency=hostile,
+            rates_are_illustrative=True,
+        ),
+        strata=(
+            StratumReport(
+                unit_key=ComparableUnitKey(
+                    workload_id="w",
+                    workload_version="1",
+                    workload_prompt_hash="sha256:abc",
+                    context_tier="2k",
+                    quality_metric=hostile,
+                    max_output_tokens=None,
+                    temperature=None,
+                    top_p=None,
+                ),
+                outcome=StratumOutcome.RECOMMENDED,
+                objective_name=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+                ranked=(system,),
+                recommended=system,
+            ),
+        ),
+    )
+    document = render_compare_report_html(report)
+    assert "<img src=x" not in document
+    assert "&lt;img src=x onerror=alert(1)&gt;" in document
+
+
+def test_the_meta_description_is_escaped() -> None:
+    document = render_compare_report_html(_hostile_report())
+    description = re.search(r'<meta name="description" content="([^"]*)"', document)
+    assert description is not None
+    assert "<" not in description.group(1)
+
+
+def test_the_title_is_escaped() -> None:
+    document = render_compare_report_html(_hostile_report())
+    title = re.search(r"<title>(.*?)</title>", document, re.S)
+    assert title is not None
+    assert "<script" not in title.group(1)
+
+
+# --- Path redaction -------------------------------------------------------
+
+
+def test_paths_are_redacted_by_default(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report)
+    assert str(tmp_path) not in document
+    assert "runs/local-1/verification.json" in document
+    assert "paths redacted" in document
+
+
+def test_include_paths_emits_the_full_path(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report, redact_paths=False)
+    assert str(tmp_path / "runs" / "local-1" / "verification.json") in document
+    assert "full paths included" in document
+
+
+def test_the_pricing_manifest_path_is_redacted_too(tmp_path: Path) -> None:
+    manifest_path = str(tmp_path / "private" / "rates.json")
+    report = _built_report(
+        tmp_path, pricing=_PRICING, pricing_manifest_path=manifest_path
+    )
+    document = render_compare_report_html(report)
+    assert manifest_path not in document
+    assert "rates.json" in document
+
+
+def test_no_prompt_or_reasoning_text_can_appear(tmp_path: Path) -> None:
+    """The report schema simply has no field that could carry one."""
+    report = _built_report(tmp_path)
+    payload = report.to_dict()
+    forbidden = ("prompt_text", "response", "reasoning_content", "messages")
+    assert not any(key in str(payload) for key in forbidden)
+
+
+# --- Content --------------------------------------------------------------
+
+
+def test_every_system_label_appears(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report)
+    for system in report.strata[0].ranked:
+        rendered = _system_label(system.system_key.label(), redact_paths=True)
+        assert rendered.replace("&", "&amp;") in document
+
+
+def test_the_deployment_host_is_redacted_by_default(tmp_path: Path) -> None:
+    """An endpoint host can name a private service, so it is not shared."""
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert "example.invalid" not in document
+    # The route is kept: it is what tells two deployments apart, and it
+    # names no host.
+    assert "endpoint=/v1/chat/completions" in document
+
+
+def test_include_paths_shows_the_full_endpoint(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path), redact_paths=False)
+    assert "https://example.invalid/v1/chat/completions" in document
+
+
+def test_endpoint_redaction_reaches_the_frontier_dominated_by_entries() -> None:
+    """A host must not survive in one corner after redaction elsewhere."""
+    label = (
+        "m via p [rt/unknown] quant=unrecorded reasoning=high decode=autoregressive "
+        "endpoint=https://private.internal/v1/chat"
+    )
+    assert _system_label(label, redact_paths=True).endswith("endpoint=/v1/chat")
+    assert "private.internal" not in _system_label(label, redact_paths=True)
+    assert _system_label(label, redact_paths=False) == label
+
+
+def test_a_label_without_an_endpoint_is_untouched() -> None:
+    label = "local/qwen3-8b via Apple M5 Pro [mlx-lm/Metal] decode=autoregressive"
+    assert _system_label(label, redact_paths=True) == label
+
+
+def test_the_recommendation_states_its_scope(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report)
+    assert "at context tier" in document
+    assert "and only for that" in document
+    assert "no universal winner" in document
+
+
+def test_the_ttft_basis_is_spelled_out(tmp_path: Path) -> None:
+    report = _built_report(tmp_path)
+    document = render_compare_report_html(report)
+    assert "local prefill" in document
+    assert "includes network transport" in document
+
+
+def test_illustrative_rates_are_labeled_as_examples(tmp_path: Path) -> None:
+    report = _built_report(
+        tmp_path, pricing=_PRICING, pricing_manifest_path="rates.json"
+    )
+    document = render_compare_report_html(report)
+    assert "Illustrative rates" in document
+    assert "none of it is a quotation" in document
+
+
+def test_a_report_without_pricing_says_so(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert "no monetary values" in document
+
+
+def test_an_empty_report_renders_an_explicit_nothing(tmp_path: Path) -> None:
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    document = render_compare_report_html(report)
+    assert "No comparable units were found" in document
+    assert "<table" not in document
+
+
+def test_excluded_runs_are_shown_with_their_reason(tmp_path: Path) -> None:
+    write_run(tmp_path, "good")
+    write_api_run(tmp_path, "other")
+    write_run(tmp_path, "broken", corrupt_final_record=True)
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    document = render_compare_report_html(report)
+    assert "Excluded runs (1)" in document
+    assert "broken" in document
+
+
+# --- Structure, accessibility and responsiveness --------------------------
+
+
+def test_the_document_is_well_formed_html(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert document.startswith("<!DOCTYPE html>\n")
+    assert document.rstrip().endswith("</html>")
+    assert document.count("<body>") == 1
+    assert document.count("</body>") == 1
+
+
+def test_every_section_is_labeled_for_a_screen_reader(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    sections = re.findall(
+        r"<section id=\"([^\"]+)\" aria-labelledby=\"([^\"]+)\"", document
+    )
+    assert sections
+    for _section_id, labelled_by in sections:
+        assert f'id="{labelled_by}"' in document
+
+
+def test_the_page_offers_a_skip_link_and_a_contents_nav(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert '<a class="skip" href="#report">' in document
+    assert '<nav class="transect" aria-label="Report contents">' in document
+    assert '<main id="report">' in document
+
+
+def test_every_table_has_a_caption_and_scoped_headers(tmp_path: Path) -> None:
+    document = render_compare_report_html(
+        _built_report(tmp_path, pricing=_PRICING, pricing_manifest_path="rates.json")
+    )
+    tables = document.count("<table")
+    assert tables >= 2
+    assert document.count("<caption>") == tables
+    assert 'scope="col"' in document
+    assert 'scope="rowgroup"' in document
+
+
+def test_measurement_cells_carry_their_column_label_for_narrow_viewports(
+    tmp_path: Path,
+) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    # The stylesheet reflows the table into stacked rows below 760px, where the
+    # only remaining column identification is the data-label attribute.
+    assert 'data-label="Mean latency (ms)"' in document
+    assert "@media (max-width: 760px)" in document
+
+
+def test_the_document_adapts_to_reduced_motion_and_print(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert "@media (prefers-reduced-motion: reduce)" in document
+    assert "@media print" in document
+
+
+def test_status_is_never_carried_by_colour_alone(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert ">RECOMMENDED<" in document or ">Recommended<" in document
+    assert "viewport" in document
+
+
+def test_the_brand_lockup_is_inline_with_an_accessible_name(tmp_path: Path) -> None:
+    document = render_compare_report_html(_built_report(tmp_path))
+    assert 'role="img" aria-label="LLMTraceFX"' in document
+    assert "<svg" in document
+
+
+@pytest.mark.parametrize("redact", [True, False])
+def test_rendering_never_raises_on_a_minimal_report(
+    tmp_path: Path, redact: bool
+) -> None:
+    report = compare(results_dirs=(tmp_path,), policy=_policy())
+    assert render_compare_report_html(report, redact_paths=redact)

--- a/tests/optimizer/test_compare_report_schema.py
+++ b/tests/optimizer/test_compare_report_schema.py
@@ -1,0 +1,612 @@
+"""Strict-loading and invariant tests for the ``compare`` report schema.
+
+A persisted report is untrusted input. Every test here feeds it something
+malformed, inconsistent, or quietly dishonest and requires an explicit
+refusal rather than a silently degraded load.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llmtracefx.optimizer.compare.identity import ComparableUnitKey, SystemKey
+from llmtracefx.optimizer.compare.policy import (
+    CompareConstraints,
+    CompareObjective,
+    ComparePolicy,
+    ComparePolicyError,
+)
+from llmtracefx.optimizer.compare.report import (
+    COMPARE_REPORT_SCHEMA_VERSION,
+    CompareReport,
+    CompareReportValidationError,
+    CostSummary,
+    FrontierEntry,
+    ParetoAxis,
+    PricingProvenance,
+    RejectedSystemReport,
+    StratumOutcome,
+    StratumReport,
+    SystemReport,
+    TtftBasis,
+    UsageTotals,
+)
+
+_UNIT = ComparableUnitKey(
+    workload_id="w",
+    workload_version="1",
+    workload_prompt_hash="sha256:abc",
+    context_tier="2k",
+    quality_metric="exact",
+    max_output_tokens=512,
+    temperature=0.0,
+    top_p=1.0,
+)
+
+_LOCAL = SystemKey(
+    model_id="local/qwen3-8b",
+    model_revision=None,
+    provider=None,
+    runtime_name="mlx-lm",
+    runtime_backend="Metal",
+    accelerator="Apple M5 Pro",
+    quantization="Q4",
+    reasoning_effort=None,
+    decode_mode="autoregressive",
+)
+
+_HOSTED = SystemKey(
+    model_id="glm-5.3",
+    model_revision=None,
+    provider="z-ai",
+    runtime_name="openai-compatible-stream",
+    runtime_backend=None,
+    accelerator=None,
+    quantization=None,
+    reasoning_effort="high",
+    decode_mode="autoregressive",
+)
+
+
+def _system(system_key: SystemKey = _LOCAL, **overrides: Any) -> SystemReport:
+    payload: dict[str, Any] = {
+        "system_key": system_key,
+        "rank": 1,
+        "run_ids": ("r1",),
+        "verification_paths": ("/tmp/results/runs/r1/verification.json",),
+        "record_paths": ("/tmp/results/runs/r1/final_record.json",),
+        "evidence_count": 1,
+        "objective_name": CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+        "objective_value": 1000.0,
+        "pass_rate": 1.0,
+        "mean_total_latency_ms": 1000.0,
+    }
+    payload.update(overrides)
+    return SystemReport(**payload)
+
+
+def _stratum(**overrides: Any) -> StratumReport:
+    system = overrides.pop("system", _system())
+    payload: dict[str, Any] = {
+        "unit_key": _UNIT,
+        "outcome": StratumOutcome.RECOMMENDED,
+        "objective_name": CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.value,
+        "ranked": (system,),
+        "recommended": system,
+    }
+    payload.update(overrides)
+    return StratumReport(**payload)
+
+
+def _report(**overrides: Any) -> CompareReport:
+    payload: dict[str, Any] = {
+        "schema_version": COMPARE_REPORT_SCHEMA_VERSION,
+        "generated_at": "2026-01-01T00:00:00.000000Z",
+        "results_dirs": ("/tmp/results",),
+        "policy": ComparePolicy(
+            objective=CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS, name="p"
+        ),
+        "strata": (_stratum(),),
+    }
+    payload.update(overrides)
+    return CompareReport(**payload)
+
+
+def _mutate(report: CompareReport, mutator: Any) -> dict[str, Any]:
+    payload = json.loads(report.to_json())
+    mutator(payload)
+    return payload
+
+
+# --- Round trip -----------------------------------------------------------
+
+
+def test_a_full_report_round_trips(tmp_path: Path) -> None:
+    report = _report(
+        pricing=PricingProvenance(
+            manifest_path="rates.json",
+            manifest_sha256="deadbeef",
+            currency="USD",
+            rates_are_illustrative=True,
+            entry_ids_used=("glm-5.3",),
+        ),
+        strata=(
+            _stratum(
+                system=_system(
+                    _HOSTED,
+                    mean_ttft_ms=220.0,
+                    ttft_basis=TtftBasis.CLIENT_OBSERVED_STREAM,
+                    usage=UsageTotals(
+                        runs_reporting_usage=1,
+                        runs_total=1,
+                        input_tokens=1000,
+                        output_tokens=400,
+                    ),
+                    cost=CostSummary(
+                        currency="USD",
+                        pricing_entry_id="glm-5.3",
+                        pricing_entry_sha256="cafebabe",
+                        rates_are_illustrative=True,
+                        total_amount=1.4,
+                        cost_per_case=1.4,
+                        cost_per_correct_case=1.4,
+                        correct_cases_per_currency_unit=0.71,
+                    ),
+                ),
+                frontier_axes=(ParetoAxis.MAX_PASS_RATE,),
+                frontier=(FrontierEntry(system_key=_HOSTED, dominated=False),),
+                rejected=(
+                    RejectedSystemReport(
+                        system_key=_LOCAL,
+                        run_ids=("r2",),
+                        verification_paths=(),
+                        record_paths=(),
+                        reasons=("pass rate 0.0 is below the required minimum 1.0",),
+                    ),
+                ),
+            ),
+        ),
+    )
+    path = tmp_path / "compare.json"
+    path.write_text(report.to_json() + "\n", encoding="utf-8")
+    assert CompareReport.read_json(path).to_dict() == report.to_dict()
+
+
+# --- Version and shape ----------------------------------------------------
+
+
+def test_unknown_schema_version_is_refused() -> None:
+    payload = _mutate(_report(), lambda p: p.update(schema_version="99"))
+    with pytest.raises(CompareReportValidationError, match="unsupported"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_non_object_report_is_refused() -> None:
+    with pytest.raises(CompareReportValidationError, match="must be a JSON object"):
+        CompareReport.from_dict([1, 2, 3])
+
+
+def test_invalid_json_is_refused() -> None:
+    with pytest.raises(CompareReportValidationError, match="invalid JSON"):
+        CompareReport.from_json("{not json")
+
+
+def test_a_missing_generated_at_is_refused() -> None:
+    payload = _mutate(_report(), lambda p: p.pop("generated_at"))
+    with pytest.raises(CompareReportValidationError, match="generated_at"):
+        CompareReport.from_dict(payload)
+
+
+# --- Numeric strictness ---------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity"])
+def test_non_finite_numbers_are_refused(bad: str) -> None:
+    raw = (
+        _report()
+        .to_json()
+        .replace('"objective_value": 1000.0', f'"objective_value": {bad}')
+    )
+    with pytest.raises(CompareReportValidationError, match="finite"):
+        CompareReport.from_json(raw)
+
+
+def test_to_json_refuses_to_emit_a_non_finite_value() -> None:
+    report = _report(strata=(_stratum(system=_system(objective_value=float("inf"))),))
+    with pytest.raises(ValueError, match="Out of range float"):
+        report.to_json()
+
+
+def test_a_string_where_a_number_belongs_is_refused() -> None:
+    payload = _mutate(
+        _report(),
+        lambda p: p["strata"][0]["ranked"][0].update(mean_total_latency_ms="fast"),
+    )
+    with pytest.raises(CompareReportValidationError, match="must be a number"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_boolean_where_a_number_belongs_is_refused() -> None:
+    payload = _mutate(
+        _report(),
+        lambda p: p["strata"][0]["ranked"][0].update(pass_rate=True),
+    )
+    with pytest.raises(CompareReportValidationError, match="must be a number"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_negative_evidence_count_is_refused() -> None:
+    payload = _mutate(
+        _report(), lambda p: p["strata"][0]["ranked"][0].update(evidence_count=-1)
+    )
+    with pytest.raises(CompareReportValidationError, match=">= 0"):
+        CompareReport.from_dict(payload)
+
+
+# --- Invariants -----------------------------------------------------------
+
+
+def test_non_contiguous_ranks_are_refused() -> None:
+    payload = _mutate(_report(), lambda p: p["strata"][0]["ranked"][0].update(rank=3))
+    with pytest.raises(CompareReportValidationError, match="contiguous"):
+        CompareReport.from_dict(payload)
+
+
+def test_a_recommended_stratum_must_carry_a_recommendation() -> None:
+    payload = _mutate(_report(), lambda p: p["strata"][0].update(recommended=None))
+    with pytest.raises(CompareReportValidationError, match="'recommended' is null"):
+        CompareReport.from_dict(payload)
+
+
+def test_the_recommendation_must_be_the_rank_one_system() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["recommended"]["objective_value"] = 5.0
+
+    with pytest.raises(CompareReportValidationError, match="must equal the rank 1"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_an_inconclusive_stratum_must_carry_a_reason() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["outcome"] = "inconclusive"
+        payload["strata"][0]["recommended"] = None
+
+    with pytest.raises(CompareReportValidationError, match="inconclusive_reason"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_an_inconclusive_stratum_may_not_also_recommend() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["outcome"] = "inconclusive"
+        payload["strata"][0]["inconclusive_reason"] = "tied"
+
+    with pytest.raises(CompareReportValidationError, match="recommended is set"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_a_stratum_may_not_mix_objectives() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        for system in (
+            payload["strata"][0]["ranked"][0],
+            payload["strata"][0]["recommended"],
+        ):
+            system["objective_name"] = "max_correct_cases_per_minute"
+
+    with pytest.raises(CompareReportValidationError, match="mixes objectives"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_a_stratum_objective_must_match_the_policy_objective() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["objective_name"] = "max_correct_cases_per_minute"
+        payload["strata"][0]["ranked"][0][
+            "objective_name"
+        ] = "max_correct_cases_per_minute"
+        payload["strata"][0]["recommended"][
+            "objective_name"
+        ] = "max_correct_cases_per_minute"
+
+    with pytest.raises(CompareReportValidationError, match="one objective"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_a_hosted_system_may_not_report_local_peak_memory() -> None:
+    report = _report(
+        strata=(_stratum(system=_system(_HOSTED, mean_peak_memory_bytes=1.0)),)
+    )
+    with pytest.raises(CompareReportValidationError, match="local-only measurement"):
+        CompareReport.from_json(report.to_json())
+
+
+def test_a_local_system_may_not_report_a_client_observed_ttft() -> None:
+    """Being local and having a network-inclusive TTFT are contradictory."""
+    report = _report(
+        strata=(
+            _stratum(
+                system=_system(
+                    _LOCAL,
+                    mean_ttft_ms=220.0,
+                    ttft_basis=TtftBasis.CLIENT_OBSERVED_STREAM,
+                )
+            ),
+        )
+    )
+    with pytest.raises(CompareReportValidationError, match="contradict each other"):
+        CompareReport.from_json(report.to_json())
+
+
+def test_a_local_system_may_report_a_local_prefill_ttft() -> None:
+    report = _report(
+        strata=(
+            _stratum(
+                system=_system(
+                    _LOCAL,
+                    mean_ttft_ms=310.0,
+                    ttft_basis=TtftBasis.LOCAL_PREFILL,
+                )
+            ),
+        )
+    )
+    assert CompareReport.from_json(report.to_json()).to_dict() == report.to_dict()
+
+
+def test_a_ttft_without_a_basis_is_refused() -> None:
+    payload = _mutate(
+        _report(), lambda p: p["strata"][0]["ranked"][0].update(mean_ttft_ms=220.0)
+    )
+    with pytest.raises(CompareReportValidationError, match="which measurement it is"):
+        CompareReport.from_dict(payload)
+
+
+def test_an_unknown_ttft_basis_is_refused() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["ranked"][0]["mean_ttft_ms"] = 220.0
+        payload["strata"][0]["ranked"][0]["ttft_basis"] = "vibes"
+
+    with pytest.raises(CompareReportValidationError, match="ttft_basis"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_usage_may_not_claim_a_client_measurement() -> None:
+    with pytest.raises(CompareReportValidationError, match="never a client"):
+        UsageTotals.from_dict(
+            {
+                "provenance": "measured_wall_clock",
+                "runs_reporting_usage": 1,
+                "runs_total": 1,
+            }
+        )
+
+
+def test_usage_reporting_more_runs_than_exist_is_refused() -> None:
+    with pytest.raises(CompareReportValidationError, match="cannot exceed runs_total"):
+        UsageTotals.from_dict({"runs_reporting_usage": 3, "runs_total": 1})
+
+
+def test_cost_must_declare_itself_estimated() -> None:
+    with pytest.raises(CompareReportValidationError, match="must be true"):
+        CostSummary.from_dict(
+            {
+                "currency": "USD",
+                "estimated": False,
+                "pricing_entry_id": "e",
+                "pricing_entry_sha256": "h",
+                "rates_are_illustrative": True,
+            }
+        )
+
+
+def test_a_persisted_report_must_carry_an_iso_currency_code() -> None:
+    """Loading applies the manifest's own currency rule to a saved report."""
+    with pytest.raises(CompareReportValidationError, match="ISO 4217"):
+        CostSummary.from_dict(
+            {
+                "currency": "<script>alert(1)</script>",
+                "estimated": True,
+                "pricing_entry_id": "e",
+                "pricing_entry_sha256": "h",
+                "rates_are_illustrative": True,
+            }
+        )
+    with pytest.raises(CompareReportValidationError, match="ISO 4217"):
+        PricingProvenance.from_dict(
+            {
+                "manifest_path": "rates.json",
+                "manifest_sha256": "h",
+                "currency": "usd",
+                "rates_are_illustrative": True,
+            }
+        )
+
+
+def test_cost_must_declare_the_derivation_it_came_from() -> None:
+    with pytest.raises(CompareReportValidationError, match="monetary_basis"):
+        CostSummary.from_dict(
+            {
+                "currency": "USD",
+                "estimated": True,
+                "monetary_basis": "measured",
+                "pricing_entry_id": "e",
+                "pricing_entry_sha256": "h",
+                "rates_are_illustrative": True,
+            }
+        )
+
+
+def test_cost_without_pricing_provenance_is_refused() -> None:
+    report = _report(
+        strata=(
+            _stratum(
+                system=_system(
+                    _HOSTED,
+                    cost=CostSummary(
+                        currency="USD",
+                        pricing_entry_id="e",
+                        pricing_entry_sha256="h",
+                        rates_are_illustrative=True,
+                        total_amount=1.0,
+                    ),
+                )
+            ),
+        )
+    )
+    with pytest.raises(CompareReportValidationError, match="unattributable"):
+        CompareReport.from_json(report.to_json())
+
+
+def test_currency_mixing_between_cost_and_manifest_is_refused() -> None:
+    report = _report(
+        pricing=PricingProvenance(
+            manifest_path="rates.json",
+            manifest_sha256="h",
+            currency="USD",
+            rates_are_illustrative=True,
+        ),
+        strata=(
+            _stratum(
+                system=_system(
+                    _HOSTED,
+                    cost=CostSummary(
+                        currency="EUR",
+                        pricing_entry_id="e",
+                        pricing_entry_sha256="h",
+                        rates_are_illustrative=True,
+                        total_amount=1.0,
+                    ),
+                )
+            ),
+        ),
+    )
+    with pytest.raises(CompareReportValidationError, match="mixes currencies"):
+        CompareReport.from_json(report.to_json())
+
+
+def test_a_cost_objective_report_without_pricing_is_refused() -> None:
+    report = _report(
+        policy=ComparePolicy(objective=CompareObjective.MIN_COST_PER_CORRECT_CASE),
+        strata=(
+            _stratum(
+                objective_name=CompareObjective.MIN_COST_PER_CORRECT_CASE.value,
+                system=_system(
+                    objective_name=CompareObjective.MIN_COST_PER_CORRECT_CASE.value
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(CompareReportValidationError, match="ranks on money"):
+        CompareReport.from_json(report.to_json())
+
+
+def test_a_rejected_system_must_record_a_reason() -> None:
+    with pytest.raises(CompareReportValidationError, match="at least one rejection"):
+        RejectedSystemReport.from_dict(
+            {"system_key": _LOCAL.to_dict(), "run_ids": [], "reasons": []}
+        )
+
+
+def test_a_dominated_frontier_entry_must_name_its_dominator() -> None:
+    with pytest.raises(CompareReportValidationError, match="names nothing"):
+        FrontierEntry.from_dict(
+            {"system_key": _LOCAL.to_dict(), "dominated": True, "dominated_by": []}
+        )
+
+
+def test_an_undominated_entry_may_not_name_dominators() -> None:
+    with pytest.raises(CompareReportValidationError, match="yet names dominating"):
+        FrontierEntry.from_dict(
+            {
+                "system_key": _LOCAL.to_dict(),
+                "dominated": False,
+                "dominated_by": ["something"],
+            }
+        )
+
+
+def test_a_frontier_without_declared_axes_is_refused() -> None:
+    def mutate(payload: dict[str, Any]) -> None:
+        payload["strata"][0]["frontier"] = [
+            {"system_key": _LOCAL.to_dict(), "dominated": False, "dominated_by": []}
+        ]
+        payload["strata"][0]["frontier_axes"] = []
+
+    with pytest.raises(CompareReportValidationError, match="without naming the axes"):
+        CompareReport.from_dict(_mutate(_report(), mutate))
+
+
+def test_an_unknown_frontier_axis_is_refused() -> None:
+    payload = _mutate(
+        _report(), lambda p: p["strata"][0].update(frontier_axes=["max_vibes"])
+    )
+    with pytest.raises(CompareReportValidationError, match="unknown axis"):
+        CompareReport.from_dict(payload)
+
+
+# --- Policy ---------------------------------------------------------------
+
+
+def test_policy_requires_an_objective() -> None:
+    with pytest.raises(ComparePolicyError, match="'objective'"):
+        ComparePolicy.from_dict({"constraints": {}})
+
+
+def test_policy_rejects_an_unknown_objective() -> None:
+    with pytest.raises(ComparePolicyError, match="invalid objective"):
+        ComparePolicy.from_dict({"objective": "be_the_best"})
+
+
+def test_policy_rejects_a_quality_floor_without_a_named_metric() -> None:
+    with pytest.raises(ComparePolicyError, match="required_quality_metric"):
+        CompareConstraints(min_quality_score=0.9)
+
+
+def test_policy_rejects_a_disallowed_required_status() -> None:
+    with pytest.raises(ComparePolicyError, match="may only contain"):
+        CompareConstraints.from_dict({"required_statuses": ["failed"]})
+
+
+def test_policy_rejects_a_non_finite_threshold() -> None:
+    with pytest.raises(ComparePolicyError, match="must be > 0"):
+        CompareConstraints.from_dict({"max_mean_total_latency_ms": float("inf")})
+
+
+def test_policy_rejects_a_pass_rate_outside_the_unit_interval() -> None:
+    with pytest.raises(ComparePolicyError, match=r"within \[0, 1\]"):
+        CompareConstraints.from_dict({"min_pass_rate": 1.5})
+
+
+def test_policy_rejects_zero_measured_repetitions() -> None:
+    with pytest.raises(ComparePolicyError, match=">= 1"):
+        CompareConstraints(min_measured_repetitions=0)
+
+
+def test_policy_from_file_rejects_an_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "policy.txt"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(ComparePolicyError, match="unsupported compare policy"):
+        ComparePolicy.from_file(path)
+
+
+def test_policy_round_trips_through_a_file(tmp_path: Path) -> None:
+    policy = ComparePolicy(
+        objective=CompareObjective.MAX_CORRECT_CASES_PER_CURRENCY_UNIT,
+        name="round trip",
+        constraints=CompareConstraints(min_pass_rate=0.8),
+    )
+    path = tmp_path / "policy.json"
+    path.write_text(policy.to_json(), encoding="utf-8")
+    assert ComparePolicy.from_file(path).to_dict() == policy.to_dict()
+
+
+def test_cost_objectives_declare_that_they_need_money() -> None:
+    assert CompareObjective.MIN_COST_PER_CORRECT_CASE.requires_cost is True
+    assert CompareObjective.MAX_CORRECT_CASES_PER_CURRENCY_UNIT.requires_cost is True
+    assert CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.requires_cost is False
+
+
+def test_minimising_objectives_declare_their_direction() -> None:
+    assert CompareObjective.MIN_MEAN_TOTAL_LATENCY_MS.prefers_lower is True
+    assert CompareObjective.MAX_CORRECT_CASES_PER_MINUTE.prefers_lower is False


### PR DESCRIPTION
> **Now targets `main`.** #12 merged as squash `5eb171f`, so this is no longer stacked. Only this branch's own compare commit was replayed onto `main` (`git rebase --onto origin/main <commit>^`, since a plain rebase would try to reapply #12's now-squashed history). It carries **no collector code**: `main` owns all of that. Diff is 26 files, **+12056 / -3**. The three deletions are all in `llmtracefx/optimizer/tune/loader.py`, the only pre-existing shared file this PR modifies; see the path-resolution note below.

## What this is

`tune` answers "which configuration of this model on this machine is fastest". This adds `compare`, which answers a different question: **how a local model actually stacks up against a hosted frontier API and a cheap flash API on work they have all already done.**

It reads only artifacts that already exist. It loads no model, calls no API, deploys nothing to Modal, and runs no benchmark. It consumes `workloads run` results directories plus the `api_evidence.json` sidecars #12's collector already writes, and produces a versioned JSON report and a self-contained branded HTML rendering of it.

```bash
uv run llmtracefx-optimizer compare \
  --results artifacts/qwen3.8-local-run artifacts/glm-5.3-run artifacts/glm-5.3-flash-run \
  --policy examples/optimizer/compare-policy-local-vs-api-latency.json \
  --pricing examples/optimizer/pricing-manifest-illustrative.json \
  --output artifacts/cross-system-compare.json

uv run llmtracefx-optimizer compare-report \
  --input artifacts/cross-system-compare.json \
  --output artifacts/cross-system-compare.html
```

## The honesty constraints, which are the point

The easiest way to produce a cross-system chart is also the fastest way to produce a dishonest one. Every design decision below exists to make the dishonest version impossible rather than merely discouraged.

**Systems are only compared when they answered the identical question.** The comparable unit is workload id and version, the exact prompt hash, context tier, evaluator/quality metric, maximum output tokens, and sampling. Differing identities become separate strata, never one average. An unrecorded setting is not a wildcard: a run whose output cap was never recorded is only compared against runs whose cap is equally unrecorded, because "unknown" is not "512".

**Systems keep their labels** (model and revision, provider, runtime/backend, accelerator, quantization, reasoning effort, decode mode) and unlike candidates are never pooled.

**Local prefill and a hosted API's client-observed first-token offset are different measurements.** The second includes DNS, connection setup, TLS, transfer and queueing. They are labelled, never averaged, and never ranked on.

**Peak memory stays local-only.** A hosted API cannot produce one, so the field is absent rather than zero, and the schema refuses a report that claims otherwise.

**A missing value stays unavailable.** Never backfilled with a zero, because a zero wins latency and cost rankings for free.

**Pricing is an input, not a constant.** No rate is baked in and nothing is fetched at runtime. Rates arrive through a versioned manifest that must declare currency, `effective_at` and `source` per entry. Ambiguous provider/model matches, non-finite or negative rates, mixed currencies and duplicate ids are all refused. The exact entry is recorded by id **and** content hash, so editing the manifest afterwards cannot quietly change what a published report claimed to have used.

Cost keeps provider accounting and client timing apart and labels every value estimated. `prompt_tokens` already includes cached tokens, so a declared cached rate bills them separately instead of double-charging; cached usage with no cached rate is refused rather than guessed at full price or at zero. `completion_tokens` already includes reasoning tokens, billed at the output rate by default. **If the provider omits reasoning usage, no hidden reasoning cost is inferred** — the omission is recorded.

**Ranking is constraints-first and single-objective**, never a blended score: `min_mean_total_latency_ms`, `max_correct_cases_per_minute`, `min_cost_per_correct_case`, `max_correct_cases_per_currency_unit`. `pass_rate` and `correct_cases_per_minute` are imported from `workloads.aggregate` — the same functions `tune` uses — rather than restated, and the tie/noise test mirrors `tune.tuner`'s. Exact ties, differences inside the combined noise band, and units where only one system produced evidence are all reported **inconclusive** with the reason.

**No universal winner.** Each unit publishes a Pareto-style frontier over the axes every ranked system has evidence for, naming which systems dominate which. Axes not everyone has are dropped and listed as missing evidence. Every recommendation states the workload, context tier, evaluator, decode settings, objective and constraints it applies to, and nothing else.

**Privacy.** Artifact paths redacted by default (`--include-paths` opts out). No prompt text, response text, reasoning content or credential can reach the report — the schema has no field that could carry one. Inline CSS and SVG, no JavaScript, no CDN, no external reference; every string escaped; rendering is byte-identical across processes and hash seeds.

## What is in the diff

| Area | File |
| --- | --- |
| Comparable-unit and system identity | `compare/identity.py` |
| Versioned pricing manifest | `compare/pricing.py` |
| Cost derivation | `compare/cost.py` |
| Offline evidence loader (reuses `tune.loader`) | `compare/evidence.py` |
| Policy: one objective plus constraints | `compare/policy.py` |
| Engine: strata, ranking, frontier | `compare/compare.py` |
| Strict versioned report schema | `compare/report.py` |
| Branded HTML renderer | `compare/report_html.py` |
| Text explainer | `compare/explain.py` |
| `compare` / `compare-report` subcommands | `optimizer/cli.py` |

The HTML renderer **reuses** the existing design system rather than forking it: the stylesheet, escaping helper, path-redaction rule and routing ornaments are imported from the tune report renderer, so a colour or a redaction rule cannot mean one thing there and another here.

Nothing in `optimizer/tune/` is modified, and the tuner's grouping rules are untouched.

## Examples, clearly marked synthetic

`examples/optimizer/compare-report-example.json` is a synthetic non-benchmark report exercising every section: two strata, a genuine speed-versus-reliability trade-off with two systems on the frontier, a dominated local system, a rejected system, illustrative cost figures, and an excluded run. `pricing-manifest-illustrative.json` sets `rates_are_illustrative: true` on every entry, and the HTML prints that back on the page. Both policies are included.

## Validation

- Full suite **1837 passed** on `main`; 241 of those are compare tests across eight modules covering strict schema and load, duplicates and conflicts, malformed and non-finite values, missing usage and prices, grouping isolation on every axis, the formulas, tie and noise logic, path redaction, HTML escaping, determinism, responsiveness and accessibility.
- A contract test suite pins the loader against the **real** collector's serialized `api_evidence.json` rather than a hand-built fixture, so a collector field rename fails loudly here instead of silently producing a comparison with no usage. It is run first on every rebase.
- Quality ratchet green against `main`: ruff, black, isort, mypy.
- All CI checks pass, including CodeQL.
- Determinism verified byte-identical across processes with differing `PYTHONHASHSEED`; the committed example still round-trips and renders identically.

## Rebase history

Rebased four times as the parent moved, with this PR's own commit content unchanged each time:

- Onto `02a994b`. #12 had independently made the same `SecureArgumentParser` argv widening this branch needed, and bumped mypy 1.16.1 to 2.3.1, so the redundant commit was dropped and everything revalidated.
- Onto `7980b1f`, then `0acef74`. Clean applies.
- Onto `main` at `5eb171f`, after #12 was squash-merged.

The last one crossed the largest gap: this branch was written against #12 at `0acef74`, but #12 continued through `b066a9f` and `e3efdb5` before squashing. Checks done for that gap:

- The contract suite passes against the collector as it now exists on `main`.
- `git diff 0acef74..origin/main -- llmtracefx/optimizer/collectors/openai_api.py` shows no field the compare layer reads changed name, shape or nullability. The only lines touching `completion_tokens`/`reasoning_tokens` are inside the collector's own token-rate diagnostic.
- The `2**53` bound agrees across all three definitions: the collector's `_MAX_EXACT_TOKEN_COUNT`, `compare/evidence.py`, and `compare/cost.py`.
- The collector still has exactly one `RuntimeInfo(...)` construction, always passing a required non-empty `provider`, so `_provider_agreement_error` excludes nothing legitimate.

## Independent review

Reviewed repeatedly at every stage; **twenty-three issues found and fixed**. Rather than list them all, the ones worth knowing about:

**The two that would have shipped a wrong answer.**

- *A comparison could silently read the wrong results tree.* Fixing an earlier double-prefix bug, I made path resolution prefer the recorded string literally, which resolved a relative recording against the **process's working directory** instead of the results tree the operator named. Two trees produced with the same relative `--output-dir` collide on that string, which is the ordinary local-vs-API workflow. Two reviewers independently reproduced it: running `compare --results ../sysB/results` from inside `sysA` returned sysA's model, sysA's latency and sysA's token usage, and the second system vanished from the report with **no diagnostic**, because both trees resolved to the same artifacts and de-duplicated. Every hardening check passed, because each validated the substituted pair against itself. Both resolvers now anchor on `results_dir/runs/<run_id>/...`, which `verify` writes unconditionally and which the run-level seal covers, so the recorded string is corroboration rather than authority.
- *`run_id` collides across systems by construction.* A matrix `run_id` is `<workload>-<tier>-<decode_mode>`: it names the task and nothing about the system, so comparing a local results directory against a hosted one collided on every single run and the shared loader refused the whole comparison. Directories are now loaded independently and merged under a source-scoped key; only a conflict within one system identity is refused.

**The one that corrupted the report's own output.** The path scrubber matched the slash in any namespaced model id, so this PR's committed example rendered `example-local/qwen3-8b` as `example-localqwen3-8b`, and `correct cases/min` as `correct casesmin`. The one line an operator must act on named a model that does not exist. Scrubbing is now gated on a path predicate rather than on "contains a slash".

**The rest, in brief.** Currency HTML injection plus a missing ISO-4217 check on load; a cost ceiling that exempted every unpriced system, which includes every local one; a hosted run labelled local; unbounded token counts causing an uncaught `OverflowError` and silent precision loss above 2^53; incomplete request and execution identity in the grouping keys; an unvalidated sidecar artifact set; a missing cached count treated as zero; partial usage totals published as complete; latency variance used to judge price; leaky default redaction; and untyped `json.loads`/`yaml.safe_load`/`OverflowError` failures escaping the CLI as tracebacks.

**Guards against recurrence.** An API-evidence contract suite pins the loader against the *real* collector's serialized output, so a field rename fails loudly rather than silently producing a comparison with no usage; it runs first on every rebase. An AST ratchet asserts every `float()` coercion in the package is guarded or allowlisted with a written reason, and was verified to fail on an injected bare coercion.

Final exact-head review at `2889153`: **no remaining high-confidence problems, ready to merge.**

## Status

Open and unmerged, ready for merge on the maintainer's call.






