### PR TITLE
Add safe, evidence-honest Metal/xctrace trace collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1797,12 +1797,13 @@ time, memory bandwidth, occupancy, GPU power, GPU energy or GPU memory
 footprint. Metal System Trace advertises tables whose names gesture at some
 of these, but deriving those numbers needs modelling assumptions this project
 has not validated against ground truth, so they stay absent rather than
-approximated. `ExperimentRecord.validate` enforces the rule structurally: a
-metric may carry `measured_native` provenance only when a table schema was
-genuinely parsed, and any metric name containing `utilization`, `occupancy`,
-`bandwidth`, `busy_percent`, `kernel_time`, `gpu_power`, `gpu_energy` or
-`gpu_memory` is rejected outright, so a fabricated hardware number cannot be
-persisted even by a caller that tries.
+approximated. `ExperimentRecord.validate` enforces this structurally, with an
+allowlist rather than a denylist: only the four metric names above may be
+persisted, each with exactly the unit and provenance it declares, each
+requiring the table it is derived from to appear in `parsed_schemas`, and
+`parsed_schemas` itself must be a subset of the schemas the trace actually
+advertised. A fabricated hardware number therefore cannot be persisted even by
+a caller that tries.
 
 Two further limits worth stating plainly:
 
@@ -1838,22 +1839,33 @@ measurement.
   so they cannot break out of the query.
 - **Bounded and cleaned up.** Each recording has a host deadline strictly
   greater than `--time-limit`, leaving room for xctrace to finalize the
-  bundle. The child runs in its own process group, and a timeout escalates
-  SIGINT then SIGTERM then SIGKILL across the whole group, because
-  `xctrace record --launch` starts the profiled program itself.
+  bundle. The child runs in its own process group, whose id is captured at
+  spawn so it stays reachable after xctrace itself exits, and teardown
+  escalates SIGINT then SIGTERM then SIGKILL until the group is actually
+  empty. The leader exiting is not treated as cleanup: `xctrace record
+  --launch` starts the profiled program itself, and that program can outlive
+  xctrace or ignore SIGINT.
 - **Failures are preserved,** not cleaned away: stdout, stderr, run metadata
-  and any partial bundle stay on disk.
+  and any partial bundle stay on disk. A trace path collision is resolved
+  before anything is written, so a refused rerun leaves an earlier run's
+  artifacts byte for byte intact rather than mixing the two.
 - **No prompt or completion capture.** `--target-stdin` and `--target-stdout`
   are never constructed, so the profiled program's own input and output never
   flow through xctrace into captured logs. `--all-processes` is never used,
   and attaching is offered by numeric pid only, since attaching by name
   resolves ambiguously.
-- **Credential redaction.** `--env` values and the profiled command's own
-  arguments whose names look like credentials (`token`, `secret`, `password`,
-  `api_key`, `access_key`, `private_key`, `credential`) are replaced with
-  `<redacted>` in every argv this project stores or prints, while the real
-  value still reaches the process. So `env HF_TOKEN=... python bench.py` is
-  persisted with the token masked.
+- **Credential redaction.** Secrets are redacted from every argv this project
+  stores or prints, in all three shapes they arrive in: `NAME=value`,
+  `--api-key=value`, and `--api-key value` (where the following argument is
+  replaced even if it starts with a dash). Name matching is case and separator
+  insensitive, so `--API_KEY` and `--api-key` are the same. It deliberately
+  distinguishes credentials from quantities: `--hf-token` is redacted,
+  `--max-tokens` and `--token-count` are not, because destroying ordinary
+  inference parameters would defeat the reproducibility the recorded argv
+  exists to provide. The real value still reaches the process. One documented
+  limit: a value attached to a single-dash short option (`-ksecret`) is not
+  detected, because it cannot be told apart from a cluster of short flags
+  without knowing the target program's own option grammar.
 - **Identity is not ingested.** A trace's table of contents contains the
   device's display name (routinely a person's name), its hardware UUID, and
   the target's full argument list. None of these are read. Only the launched

--- a/README.md
+++ b/README.md
@@ -1865,13 +1865,21 @@ measurement.
   `--api-key=value`, and `--api-key value` (where the following argument is
   replaced even if it starts with a dash). Name matching is case and separator
   insensitive, so `--API_KEY` and `--api-key` are the same. It deliberately
-  distinguishes credentials from quantities: `--hf-token` is redacted,
-  `--max-tokens` and `--token-count` are not, because destroying ordinary
-  inference parameters would defeat the reproducibility the recorded argv
-  exists to provide. The real value still reaches the process. One documented
-  limit: a value attached to a single-dash short option (`-ksecret`) is not
-  detected, because it cannot be told apart from a cluster of short flags
-  without knowing the target program's own option grammar.
+  distinguishes credentials from quantities and settings: `--hf-token` and
+  `--basic-auth` are redacted, while `--max-tokens`, `--token-count` and
+  `--auth-mode` are not, because destroying ordinary parameters would defeat
+  the reproducibility the recorded argv exists to provide. The real value
+  still reaches the process.
+
+  **Treat this as a safety net, not a guarantee.** It classifies option names,
+  so it can only catch spellings it recognizes, and it cannot see a secret
+  embedded in a positional argument. Two limits are pinned by tests: a value
+  attached to a single-dash short option (`-ksecret`) is not detected, and a
+  name ending in a configuration or location suffix (`--auth-mode`,
+  `--private-key-path`) is treated as naming a setting or a file. The reliable
+  protection is not to put secrets on the command line at all: pass them
+  through the profiled program's environment, or have it read them from a
+  file.
 - **Identity is not ingested.** A trace's table of contents contains the
   device's display name (routinely a person's name), its hardware UUID, and
   the target's full argument list. None of these are read. Only the launched

--- a/README.md
+++ b/README.md
@@ -1709,6 +1709,159 @@ implemented and tested against a fake runtime so it is ready to wrap a
 genuinely stable, metrics-differentiated API if one is published upstream --
 no production adapter claims that today.
 
+### Apple Instruments / Metal traces via `xctrace`
+
+`llmtracefx-optimizer instruments` wraps Apple's Instruments CLI to record a
+**Metal System Trace** around a local inference command and turn the
+resulting `.trace` bundle into canonical `ExperimentRecord` evidence.
+
+**Setup.** `xctrace` ships only with the full Xcode, never with Command Line
+Tools alone. On a Command Line Tools machine `/usr/bin/xctrace` still exists
+and is executable, so a plain "is it on PATH" check is misleading; the
+capability probe therefore always invokes the tool:
+
+```bash
+# Install Xcode from the Mac App Store, then select it:
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+sudo xcodebuild -runFirstLaunch      # run these yourself; the project
+sudo xcodebuild -license accept      # never invokes sudo on your behalf
+
+uv run llmtracefx-optimizer instruments capability
+```
+
+`capability` exits `0` when supported, `3` when a known cause blocks it, and
+`1` on error. Each cause is reported separately with its own remediation
+rather than collapsed into "unavailable": not macOS, not arm64, xctrace
+absent from PATH, Command Line Tools only, license not accepted, first launch
+incomplete, template unavailable, permission denied, and probe failed for an
+unrecognized reason.
+
+**Dry run first.** `plan` validates everything and executes nothing, printing
+the exact argv and the exact artifact paths it would write:
+
+```bash
+uv run llmtracefx-optimizer instruments plan \
+  --output-trace artifacts/metal/run.trace \
+  --output-dir artifacts/metal \
+  --time-limit 45s \
+  -- ./your-inference-command --tokens 128
+```
+
+**Record and import.** `record` performs the capture and then exports and
+parses it; `import` does the export and parse half against a `.trace` bundle
+you already have:
+
+```bash
+uv run llmtracefx-optimizer instruments record \
+  --output-trace artifacts/metal/run.trace \
+  --output-dir artifacts/metal \
+  --time-limit 45s \
+  -- ./your-inference-command --tokens 128
+
+uv run llmtracefx-optimizer instruments import \
+  --trace artifacts/metal/run.trace --output-dir artifacts/metal
+```
+
+#### What is actually measured
+
+Validated live on this hardware, and reproducible with the commands above:
+
+| Fact | Value |
+| --- | --- |
+| Tool | `xctrace version 16.0 (17F113)` |
+| Host | macOS 26.6.2 (25G83), Apple M5 Pro, arm64 |
+| Template | `Metal System Trace` |
+| Table schemas advertised by one capture | 82 |
+| Table this project parses | `metal-gpu-intervals` |
+
+The four metrics emitted, all with provenance `measured_native` and all
+scoped to a single pid:
+
+- `metal_gpu_interval_count` -- GPU intervals attributed to the profiled
+  process.
+- `metal_gpu_interval_duration_sum` (ms) -- the sum of those intervals'
+  durations.
+- `metal_gpu_interval_wall_span` (ms) -- last interval end minus first
+  interval start for that process.
+- `metal_gpu_interval_count_all_processes` -- the trace-wide interval count,
+  so the attributed share is visible rather than implied.
+
+Correctness of the parser was cross-checked against a workload that issues a
+known number of GPU dispatches: 400, 250, 120 and 77 dispatches produced
+exactly 400, 250, 120 and 77 attributed intervals.
+
+#### What is explicitly not claimed
+
+This wrapper reports **no** GPU utilization, GPU busy percentage, kernel
+time, memory bandwidth, occupancy, GPU power, GPU energy or GPU memory
+footprint. Metal System Trace advertises tables whose names gesture at some
+of these, but deriving those numbers needs modelling assumptions this project
+has not validated against ground truth, so they stay absent rather than
+approximated. `ExperimentRecord.validate` enforces the rule structurally: a
+metric may carry `measured_native` provenance only when a table schema was
+genuinely parsed, so a fabricated hardware number cannot be persisted.
+
+Two further limits worth stating plainly:
+
+- `metal_gpu_interval_duration_sum` is **not** GPU busy time and **not** a
+  utilization numerator. Metal runs Vertex, Fragment and Compute channels
+  concurrently, so overlapping intervals are counted more than once and the
+  sum can exceed wall-clock time.
+- Metal System Trace records GPU work for **every** process on the system.
+  A capture of a trivial local Metal program also contained intervals
+  belonging to `WindowServer` and `com.apple.WebKit.GPU`, and in one capture
+  81% of all intervals were `WindowServer`'s. Metrics are therefore always
+  attributed per pid; without a target pid, no scalar metric is emitted at
+  all. Nothing here is a benchmark result or a comparison between runtimes.
+
+The other 81 schemas found in a capture are listed in
+`instruments.unsupported_schemas` so the gap is explicit. Instruments
+evidence is kept separate from `memory` and `power`, which carry
+runtime-allocator and host-side values (the MLX allocator's active, cache and
+peak bytes), so a bookkeeping figure can never be mistaken for a profiler
+measurement.
+
+#### Safety and privacy
+
+- **Traces are never overwritten.** The output path is resolved (symlinks and
+  `..` collapsed, and case-insensitively on a default macOS filesystem) and
+  refused if anything exists there. `--append-run` is never passed.
+- **No shell.** Every invocation is an argv list, so no template name, path
+  or inference argument can be reinterpreted as shell syntax. Schema names
+  are validated against a conservative character set before entering an XPath
+  so they cannot break out of the query.
+- **Bounded and cleaned up.** Each recording has a host deadline strictly
+  greater than `--time-limit`, leaving room for xctrace to finalize the
+  bundle. The child runs in its own process group, and a timeout escalates
+  SIGINT then SIGTERM then SIGKILL across the whole group, because
+  `xctrace record --launch` starts the profiled program itself.
+- **Failures are preserved,** not cleaned away: stdout, stderr, run metadata
+  and any partial bundle stay on disk.
+- **No prompt or completion capture.** `--target-stdin` and `--target-stdout`
+  are never constructed, so the profiled program's own input and output never
+  flow through xctrace into captured logs. `--all-processes` is never used,
+  and attaching is offered by numeric pid only, since attaching by name
+  resolves ambiguously.
+- **Credential redaction.** `--env` values whose names look like credentials
+  (`token`, `secret`, `password`, `api_key`, `access_key`, `private_key`,
+  `credential`) are replaced with `<redacted>` in every argv this project
+  stores or prints, while the real value still reaches the process.
+- **Identity is not ingested.** A trace's table of contents contains the
+  device's display name (routinely a person's name), its hardware UUID, and
+  the target's full argument list. None of these are read. Only the launched
+  process's own pid and name are, because attribution is impossible without
+  them, and records store the trace bundle's basename rather than an absolute
+  path.
+- **Malformed input is refused.** Exports declaring a `DOCTYPE` or `ENTITY`
+  are rejected before parsing (entity expansion denial of service), oversized
+  exports are refused with a suggestion to shorten `--time-limit`, and a row
+  whose value count or engineering types disagree with the declared schema is
+  an error rather than being mapped onto the wrong columns.
+
+The test suite covers all of the above without Xcode installed, by injecting
+the subprocess and process-launch boundaries and parsing small synthetic
+export fixtures.
+
 ### Deterministic code/JSON/reasoning workload matrix
 
 `llmtracefx.optimizer.workloads` pins a small, versioned, redistributable

--- a/README.md
+++ b/README.md
@@ -1832,7 +1832,9 @@ measurement.
 
 - **Traces are never overwritten.** The output path is resolved (symlinks and
   `..` collapsed, and case-insensitively on a default macOS filesystem) and
-  refused if anything exists there. `--append-run` is never passed.
+  claimed with a single atomic `O_CREAT | O_EXCL` reservation that is held for
+  the whole run, so two concurrent recordings cannot both pass a check and
+  then race into the same path. `--append-run` is never passed.
 - **No shell.** Every invocation is an argv list, so no template name, path
   or inference argument can be reinterpreted as shell syntax. Schema names
   are validated against a conservative character set before entering an XPath
@@ -1848,7 +1850,11 @@ measurement.
 - **Failures are preserved,** not cleaned away: stdout, stderr, run metadata
   and any partial bundle stay on disk. A trace path collision is resolved
   before anything is written, so a refused rerun leaves an earlier run's
-  artifacts byte for byte intact rather than mixing the two.
+  artifacts byte for byte intact rather than mixing the two, and the CLI says
+  plainly that nothing was written instead of naming an evidence file it did
+  not produce. Imports stage their exports and promote them together, so a
+  failed export cannot leave one run's table of contents beside another run's
+  evidence.
 - **No prompt or completion capture.** `--target-stdin` and `--target-stdout`
   are never constructed, so the profiled program's own input and output never
   flow through xctrace into captured logs. `--all-processes` is never used,

--- a/README.md
+++ b/README.md
@@ -1901,6 +1901,9 @@ measurement.
   GPU table, which lists every process that produced a GPU interval. The
   derived artifacts do not: `instruments_evidence.json` and `trace_toc.json`
   carry only your own process's pid and counts, never another process's name.
+  When a pid is ambiguous the evidence note reports how many labels conflicted
+  but not what they were; the labels appear only in the error shown to whoever
+  ran the command.
 - **One run per artifact directory.** The trace path and the output directory
   are both claimed with atomic `O_CREAT | O_EXCL` reservations held for the
   whole run, so two concurrent runs cannot interleave metadata or exports even

--- a/README.md
+++ b/README.md
@@ -1848,13 +1848,18 @@ measurement.
   --launch` starts the profiled program itself, and that program can outlive
   xctrace or ignore SIGINT.
 - **Failures are preserved,** not cleaned away: stdout, stderr, run metadata
-  and any partial bundle stay on disk. A trace path collision is resolved
-  before anything is written, so a refused rerun leaves an earlier run's
-  artifacts byte for byte intact rather than mixing the two, and the CLI says
-  plainly that nothing was written instead of naming an evidence file it did
-  not produce. Imports stage their exports and promote them together, so a
-  failed export cannot leave one run's table of contents beside another run's
-  evidence.
+  and any partial bundle stay on disk. The whole request is validated before
+  the first byte is written, so an invalid time limit or output path leaves
+  nothing behind, and a refused rerun leaves an earlier run's artifacts byte
+  for byte intact rather than mixing the two. The CLI says plainly that
+  nothing was written instead of naming an evidence file it did not produce.
+  Imports stage their exports and promote them together, and a run that fails
+  before promoting clears the exported files an earlier run left, so a
+  directory never holds one run's metadata beside another run's GPU table.
+- **A run that measured nothing does not exit 0.** `instruments record`
+  returns a nonzero status when the export failed, and when the profiled
+  program survived every stop signal, while still recording truthfully in the
+  metadata that the recording itself completed.
 - **No prompt or completion capture.** `--target-stdin` and `--target-stdout`
   are never constructed, so the profiled program's own input and output never
   flow through xctrace into captured logs. `--all-processes` is never used,
@@ -1880,12 +1885,23 @@ measurement.
   protection is not to put secrets on the command line at all: pass them
   through the profiled program's environment, or have it read them from a
   file.
-- **Identity is not ingested.** A trace's table of contents contains the
-  device's display name (routinely a person's name), its hardware UUID, and
-  the target's full argument list. None of these are read. Only the launched
-  process's own pid and name are, because attribution is impossible without
-  them, and records store the trace bundle's basename rather than an absolute
-  path.
+- **Identity is not ingested, and not copied.** A trace's table of contents
+  contains the device's display name (routinely a person's name), its hardware
+  UUID, and the target's full argument list. None are read, and the copy of
+  the table of contents written into your output directory has all three
+  stripped, since the raw file would otherwise carry them even though the
+  parser ignored them. Only the launched process's own pid and name are kept,
+  because attribution is impossible without them, and records store the trace
+  bundle's basename rather than an absolute path.
+- **The `.trace` bundle itself is sensitive.** It is raw evidence, so nothing
+  in it is sanitized: it contains the device name and UUID, the profiled
+  command's arguments, and the names of every other process that used the GPU
+  while it was recording. Treat a bundle like a memory dump. Do not attach one
+  to a public issue.
+- **One run per artifact directory.** The trace path and the output directory
+  are both claimed with atomic `O_CREAT | O_EXCL` reservations held for the
+  whole run, so two concurrent runs cannot interleave metadata or exports even
+  when their trace names differ.
 - **Malformed input is refused.** Exports declaring a `DOCTYPE` or `ENTITY`
   are rejected before parsing (entity expansion denial of service), oversized
   exports are refused with a suggestion to shorten `--time-limit`, and a row

--- a/README.md
+++ b/README.md
@@ -1799,7 +1799,10 @@ of these, but deriving those numbers needs modelling assumptions this project
 has not validated against ground truth, so they stay absent rather than
 approximated. `ExperimentRecord.validate` enforces the rule structurally: a
 metric may carry `measured_native` provenance only when a table schema was
-genuinely parsed, so a fabricated hardware number cannot be persisted.
+genuinely parsed, and any metric name containing `utilization`, `occupancy`,
+`bandwidth`, `busy_percent`, `kernel_time`, `gpu_power`, `gpu_energy` or
+`gpu_memory` is rejected outright, so a fabricated hardware number cannot be
+persisted even by a caller that tries.
 
 Two further limits worth stating plainly:
 
@@ -1811,8 +1814,11 @@ Two further limits worth stating plainly:
   A capture of a trivial local Metal program also contained intervals
   belonging to `WindowServer` and `com.apple.WebKit.GPU`, and in one capture
   81% of all intervals were `WindowServer`'s. Metrics are therefore always
-  attributed per pid; without a target pid, no scalar metric is emitted at
-  all. Nothing here is a benchmark result or a comparison between runtimes.
+  attributed per pid, read from the `<process>` cell's structured `pid` child
+  rather than scraped from its display label. Without a target pid, and when
+  one pid appears under two different labels (pid reuse, or a process that
+  renamed itself), no scalar metric is emitted at all. Nothing here is a
+  benchmark result or a comparison between runtimes.
 
 The other 81 schemas found in a capture are listed in
 `instruments.unsupported_schemas` so the gap is explicit. Instruments
@@ -1842,10 +1848,12 @@ measurement.
   flow through xctrace into captured logs. `--all-processes` is never used,
   and attaching is offered by numeric pid only, since attaching by name
   resolves ambiguously.
-- **Credential redaction.** `--env` values whose names look like credentials
-  (`token`, `secret`, `password`, `api_key`, `access_key`, `private_key`,
-  `credential`) are replaced with `<redacted>` in every argv this project
-  stores or prints, while the real value still reaches the process.
+- **Credential redaction.** `--env` values and the profiled command's own
+  arguments whose names look like credentials (`token`, `secret`, `password`,
+  `api_key`, `access_key`, `private_key`, `credential`) are replaced with
+  `<redacted>` in every argv this project stores or prints, while the real
+  value still reaches the process. So `env HF_TOKEN=... python bench.py` is
+  persisted with the token masked.
 - **Identity is not ingested.** A trace's table of contents contains the
   device's display name (routinely a person's name), its hardware UUID, and
   the target's full argument list. None of these are read. Only the launched

--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,10 @@ measurement.
   in it is sanitized: it contains the device name and UUID, the profiled
   command's arguments, and the names of every other process that used the GPU
   while it was recording. Treat a bundle like a memory dump. Do not attach one
-  to a public issue.
+  to a public issue. The same applies to `trace_table.xml`, the raw exported
+  GPU table, which lists every process that produced a GPU interval. The
+  derived artifacts do not: `instruments_evidence.json` and `trace_toc.json`
+  carry only your own process's pid and counts, never another process's name.
 - **One run per artifact directory.** The trace path and the output directory
   are both claimed with atomic `O_CREAT | O_EXCL` reservations held for the
   whole run, so two concurrent runs cannot interleave metadata or exports even

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -7,6 +7,8 @@ Subcommands:
     collect-api      Stream one OpenAI-compatible chat completion (e.g. Z.ai GLM)
                      and record normalized, credential-free evidence.
     native-mtp       Native Qwen MTP capability report / evidence collection.
+    instruments      Apple Instruments (xctrace) capability report, dry-run
+                     plan, Metal trace recording, and trace import.
     parse-llama-cpp  Convert llama.cpp text output into a canonical ExperimentRecord.
     doctor speculative  Diagnose whether speculative decoding/MTP is a net regression.
     workloads        Generate a deterministic code/JSON/reasoning workload matrix,
@@ -66,6 +68,23 @@ from .collectors.openai_api import (
     redact_text_for_dry_run,
 )
 from .doctor.speculative import diagnose_speculative_regression
+from .instruments import (
+    METAL_SYSTEM_TRACE_TEMPLATE,
+    InstrumentsCommandError,
+    InstrumentsExportError,
+    InstrumentsRecordError,
+    SubprocessCommandRunner,
+    SubprocessProcessLauncher,
+    detect_xctrace_capability,
+)
+from .instruments.process import InstrumentsProcessError
+from .instruments.workflow import (
+    DEFAULT_TABLE_SCHEMA,
+    capability_exit_code,
+    import_trace,
+    plan_trace,
+    record_trace,
+)
 from .manifest import collect_environment_manifest
 from .optimize_summary import (
     OPTIMIZE_SUMMARY_SCHEMA_VERSION,
@@ -521,6 +540,134 @@ def _cmd_native_mtp_collect(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
     return 1
+
+
+def _instruments_target_command(args: argparse.Namespace) -> tuple[str, ...]:
+    """Extract the profiled program's argv from a trailing ``-- cmd ...``.
+
+    argparse leaves the separator in place for REMAINDER, so a leading
+    ``--`` is stripped. The command is never joined into a string and is
+    never passed through a shell.
+    """
+    command = list(getattr(args, "target_command", []) or [])
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise InstrumentsCommandError(
+            "no program to profile. Append the command after '--', for "
+            "example: instruments record --output-trace run.trace "
+            "--output-dir out -- ./my-inference-script --tokens 128"
+        )
+    return tuple(command)
+
+
+def _cmd_instruments_capability(args: argparse.Namespace) -> int:
+    try:
+        report = detect_xctrace_capability(
+            runner=SubprocessCommandRunner(), template=args.template
+        )
+    except InstrumentsProcessError as exc:
+        print(f"Failed to probe xctrace: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        report.write_json(args.output)
+        print(f"xctrace capability report written to {args.output}")
+    else:
+        print(report.to_json())
+    if not report.supported:
+        print(f"xctrace unavailable: {report.reason}", file=sys.stderr)
+        if report.remediation:
+            print(f"Remediation: {report.remediation}", file=sys.stderr)
+    return capability_exit_code(report.capability)
+
+
+def _cmd_instruments_plan(args: argparse.Namespace) -> int:
+    try:
+        command = _instruments_target_command(args)
+        plan = plan_trace(
+            runner=SubprocessCommandRunner(),
+            command=command,
+            output_trace=Path(args.output_trace),
+            output_dir=Path(args.output_dir),
+            template=args.template,
+            time_limit=args.time_limit,
+        )
+    except (InstrumentsCommandError, InstrumentsProcessError) as exc:
+        print(f"Failed to plan a trace: {exc}", file=sys.stderr)
+        return 1
+
+    print(plan.to_json())
+    print(
+        "\nDry run: nothing was recorded and no file was written.",
+        file=sys.stderr,
+    )
+    if not plan.ready:
+        for prerequisite in plan.prerequisites:
+            print(f"Unmet prerequisite: {prerequisite}", file=sys.stderr)
+        return 3
+    return 0
+
+
+def _cmd_instruments_record(args: argparse.Namespace) -> int:
+    try:
+        command = _instruments_target_command(args)
+        collection = record_trace(
+            runner=SubprocessCommandRunner(),
+            launcher=SubprocessProcessLauncher(),
+            command=command,
+            output_trace=Path(args.output_trace),
+            output_dir=Path(args.output_dir),
+            template=args.template,
+            time_limit=args.time_limit,
+            table_schema=None if args.no_export else args.table_schema,
+        )
+    except (
+        InstrumentsCommandError,
+        InstrumentsExportError,
+        InstrumentsProcessError,
+        InstrumentsRecordError,
+        OSError,
+    ) as exc:
+        print(f"Failed to record a trace: {exc}", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output_dir)
+    print(f"Instruments evidence written to {output_dir / 'instruments_evidence.json'}")
+    if collection.succeeded:
+        if collection.message:
+            print(collection.message)
+        return 0
+    print(f"Recording did not complete: {collection.message}", file=sys.stderr)
+    print(f"Artifacts preserved in {output_dir}", file=sys.stderr)
+    return 1
+
+
+def _cmd_instruments_import(args: argparse.Namespace) -> int:
+    try:
+        collection = import_trace(
+            runner=SubprocessCommandRunner(),
+            trace_path=Path(args.trace),
+            output_dir=Path(args.output_dir),
+            template=args.template,
+            table_schema=None if args.no_export else args.table_schema,
+        )
+    except (
+        InstrumentsExportError,
+        InstrumentsProcessError,
+        OSError,
+    ) as exc:
+        print(f"Failed to import the trace: {exc}", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output_dir)
+    print(f"Instruments evidence written to {output_dir / 'instruments_evidence.json'}")
+    if collection.message:
+        print(collection.message)
+    if not collection.capability.supported:
+        print(f"xctrace unavailable: {collection.capability.reason}", file=sys.stderr)
+        return 3
+    return 0
 
 
 def _cmd_parse_llama_cpp(args: argparse.Namespace) -> int:
@@ -2380,6 +2527,119 @@ def build_parser() -> argparse.ArgumentParser:
         help="Explicit accelerator name; otherwise left unset",
     )
     native_mtp_collect_parser.set_defaults(func=_cmd_native_mtp_collect)
+
+    instruments_parser = subparsers.add_parser(
+        "instruments",
+        help=(
+            "Apple Instruments (xctrace) capability report, dry-run plan, "
+            "Metal trace recording, and trace import"
+        ),
+    )
+    instruments_subparsers = instruments_parser.add_subparsers(
+        dest="instruments_command", required=True
+    )
+
+    instruments_capability_parser = instruments_subparsers.add_parser(
+        "capability",
+        help=(
+            "Report whether xctrace can record the requested template here "
+            "(exit 0 if supported, 3 if not, 1 on error)"
+        ),
+    )
+    instruments_capability_parser.add_argument(
+        "--template",
+        default=METAL_SYSTEM_TRACE_TEMPLATE,
+        help="Instruments template to check for (default: %(default)s)",
+    )
+    instruments_capability_parser.add_argument(
+        "--output",
+        default=None,
+        help="Write the capability report JSON to this path instead of stdout",
+    )
+    instruments_capability_parser.set_defaults(func=_cmd_instruments_capability)
+
+    instruments_plan_parser = instruments_subparsers.add_parser(
+        "plan",
+        help=(
+            "Dry run: validate the recording, print the exact argv and "
+            "output paths, and execute nothing (exit 0 if ready, 3 if a "
+            "prerequisite is unmet)"
+        ),
+    )
+    instruments_plan_parser.add_argument("--output-trace", required=True)
+    instruments_plan_parser.add_argument("--output-dir", required=True)
+    instruments_plan_parser.add_argument(
+        "--template", default=METAL_SYSTEM_TRACE_TEMPLATE
+    )
+    instruments_plan_parser.add_argument(
+        "--time-limit",
+        default="60s",
+        help="xctrace --time-limit value, e.g. 30s or 2m (default: %(default)s)",
+    )
+    instruments_plan_parser.add_argument(
+        "target_command",
+        nargs=argparse.REMAINDER,
+        help="-- followed by the program to profile and its arguments",
+    )
+    instruments_plan_parser.set_defaults(func=_cmd_instruments_plan)
+
+    instruments_record_parser = instruments_subparsers.add_parser(
+        "record",
+        help=(
+            "Record a Metal trace of a locally supplied command, then "
+            "export and parse it into canonical evidence"
+        ),
+    )
+    instruments_record_parser.add_argument(
+        "--output-trace",
+        required=True,
+        help="Path ending in .trace. Refused if anything already exists there",
+    )
+    instruments_record_parser.add_argument("--output-dir", required=True)
+    instruments_record_parser.add_argument(
+        "--template", default=METAL_SYSTEM_TRACE_TEMPLATE
+    )
+    instruments_record_parser.add_argument("--time-limit", default="60s")
+    instruments_record_parser.add_argument(
+        "--table-schema",
+        default=DEFAULT_TABLE_SCHEMA,
+        help="Trace table to export after recording (default: %(default)s)",
+    )
+    instruments_record_parser.add_argument(
+        "--no-export",
+        action="store_true",
+        help="Record only; do not export or parse any table",
+    )
+    instruments_record_parser.add_argument(
+        "target_command",
+        nargs=argparse.REMAINDER,
+        help="-- followed by the program to profile and its arguments",
+    )
+    instruments_record_parser.set_defaults(func=_cmd_instruments_record)
+
+    instruments_import_parser = instruments_subparsers.add_parser(
+        "import",
+        help=(
+            "Export and parse an existing .trace bundle into canonical "
+            "Instruments evidence"
+        ),
+    )
+    instruments_import_parser.add_argument(
+        "--trace", required=True, help="Existing .trace bundle to read"
+    )
+    instruments_import_parser.add_argument("--output-dir", required=True)
+    instruments_import_parser.add_argument(
+        "--template", default=METAL_SYSTEM_TRACE_TEMPLATE
+    )
+    instruments_import_parser.add_argument(
+        "--table-schema", default=DEFAULT_TABLE_SCHEMA
+    )
+    instruments_import_parser.add_argument(
+        "--no-export",
+        action="store_true",
+        help="Read the table of contents only; export no table",
+    )
+    instruments_import_parser.set_defaults(func=_cmd_instruments_import)
 
     parse_parser = subparsers.add_parser(
         "parse-llama-cpp",

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -642,6 +642,16 @@ def _cmd_instruments_record(args: argparse.Namespace) -> int:
         if collection.message:
             print(collection.message)
         return 0
+    if collection.export_failed:
+        # The recording itself completed, so saying it did not would be
+        # wrong, but the run produced no measurement and must not exit 0.
+        print(f"Recorded, but the export failed: {collection.message}", file=sys.stderr)
+        print(
+            "The trace bundle is on disk and can be exported later with "
+            "`instruments import`.",
+            file=sys.stderr,
+        )
+        return 1
     print(f"Recording did not complete: {collection.message}", file=sys.stderr)
     if collection.wrote_artifacts:
         print(f"Artifacts preserved in {output_dir}", file=sys.stderr)

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -633,13 +633,28 @@ def _cmd_instruments_record(args: argparse.Namespace) -> int:
         return 1
 
     output_dir = Path(args.output_dir)
-    print(f"Instruments evidence written to {output_dir / 'instruments_evidence.json'}")
+    if collection.wrote_artifacts:
+        print(
+            "Instruments evidence written to "
+            f"{output_dir / 'instruments_evidence.json'}"
+        )
     if collection.succeeded:
         if collection.message:
             print(collection.message)
         return 0
     print(f"Recording did not complete: {collection.message}", file=sys.stderr)
-    print(f"Artifacts preserved in {output_dir}", file=sys.stderr)
+    if collection.wrote_artifacts:
+        print(f"Artifacts preserved in {output_dir}", file=sys.stderr)
+    else:
+        # Saying "evidence written" here would point the reader at a
+        # previous run's metrics as though this run had produced them,
+        # which is exactly what refusing to write was protecting.
+        print(
+            "Nothing was written. Any files already in "
+            f"{output_dir} belong to an earlier run and were left "
+            "untouched.",
+            file=sys.stderr,
+        )
     return 1
 
 

--- a/llmtracefx/optimizer/instruments/__init__.py
+++ b/llmtracefx/optimizer/instruments/__init__.py
@@ -1,0 +1,140 @@
+"""Apple Instruments (``xctrace``) capability, recording and export.
+
+Public surface for the Metal/Instruments evidence path. See the module
+docstrings for the verified behavior each layer relies on:
+
+* :mod:`.capability` distinguishes every reason a trace cannot be taken.
+* :mod:`.commands` builds shell-free, validated argv.
+* :mod:`.recorder` runs a recording under a deadline and preserves what
+  it produced.
+* :mod:`.export` parses ``xctrace export`` output strictly.
+* :mod:`.evidence` decides what may be claimed as a metric.
+"""
+
+from __future__ import annotations
+
+from .capability import (
+    CAPABILITY_SCHEMA_VERSION,
+    METAL_SYSTEM_TRACE_TEMPLATE,
+    InstrumentsCapabilityError,
+    XctraceCapability,
+    XctraceCapabilityReport,
+    classify_xctrace_failure,
+    default_xctrace_path,
+    detect_xctrace_capability,
+    parse_templates,
+    parse_version,
+)
+from .commands import (
+    AttachTarget,
+    EnvironmentAssignment,
+    ExportPlan,
+    InstrumentsCommandError,
+    LaunchTarget,
+    RecordPlan,
+    RecordTarget,
+    build_list_templates_argv,
+    build_version_argv,
+    duration_to_seconds,
+    redact_argv,
+    table_xpath,
+    validate_schema_name,
+    validate_time_limit,
+    validate_window,
+)
+from .evidence import (
+    TraceEvidenceInputs,
+    build_instruments_evidence,
+    unsupported_evidence,
+)
+from .export import (
+    FORBIDDEN_METRIC_NAMES,
+    MAX_EXPORT_BYTES,
+    SUPPORTED_TABLE_SCHEMAS,
+    ExportedRow,
+    ExportedTable,
+    InstrumentsExportError,
+    MetalGpuIntervalSummary,
+    ProcessGpuIntervals,
+    TableColumn,
+    TraceRun,
+    TraceTableOfContents,
+    parse_exported_table,
+    parse_table_of_contents,
+    read_export_text,
+    summarize_metal_gpu_intervals,
+)
+from .process import (
+    CommandResult,
+    CommandRunner,
+    InstrumentsProcessError,
+    ManagedProcess,
+    ProcessLauncher,
+    SubprocessCommandRunner,
+    SubprocessProcessLauncher,
+)
+from .recorder import (
+    InstrumentsRecordError,
+    RecordResult,
+    RecordStatus,
+    check_output_collision,
+    run_record,
+)
+
+__all__ = [
+    "AttachTarget",
+    "CAPABILITY_SCHEMA_VERSION",
+    "CommandResult",
+    "CommandRunner",
+    "EnvironmentAssignment",
+    "ExportPlan",
+    "ExportedRow",
+    "ExportedTable",
+    "FORBIDDEN_METRIC_NAMES",
+    "InstrumentsCapabilityError",
+    "InstrumentsCommandError",
+    "InstrumentsExportError",
+    "InstrumentsProcessError",
+    "InstrumentsRecordError",
+    "LaunchTarget",
+    "MAX_EXPORT_BYTES",
+    "METAL_SYSTEM_TRACE_TEMPLATE",
+    "ManagedProcess",
+    "MetalGpuIntervalSummary",
+    "ProcessGpuIntervals",
+    "ProcessLauncher",
+    "RecordPlan",
+    "RecordResult",
+    "RecordStatus",
+    "RecordTarget",
+    "SUPPORTED_TABLE_SCHEMAS",
+    "SubprocessCommandRunner",
+    "SubprocessProcessLauncher",
+    "TableColumn",
+    "TraceEvidenceInputs",
+    "TraceRun",
+    "TraceTableOfContents",
+    "XctraceCapability",
+    "XctraceCapabilityReport",
+    "build_instruments_evidence",
+    "build_list_templates_argv",
+    "build_version_argv",
+    "check_output_collision",
+    "classify_xctrace_failure",
+    "default_xctrace_path",
+    "detect_xctrace_capability",
+    "duration_to_seconds",
+    "parse_exported_table",
+    "parse_table_of_contents",
+    "parse_templates",
+    "parse_version",
+    "read_export_text",
+    "redact_argv",
+    "run_record",
+    "summarize_metal_gpu_intervals",
+    "table_xpath",
+    "unsupported_evidence",
+    "validate_schema_name",
+    "validate_time_limit",
+    "validate_window",
+]

--- a/llmtracefx/optimizer/instruments/__init__.py
+++ b/llmtracefx/optimizer/instruments/__init__.py
@@ -51,6 +51,7 @@ from .export import (
     FORBIDDEN_METRIC_NAMES,
     MAX_EXPORT_BYTES,
     SUPPORTED_TABLE_SCHEMAS,
+    AmbiguousProcessError,
     ExportedRow,
     ExportedTable,
     InstrumentsExportError,
@@ -82,6 +83,7 @@ from .recorder import (
 )
 
 __all__ = [
+    "AmbiguousProcessError",
     "AttachTarget",
     "CAPABILITY_SCHEMA_VERSION",
     "CommandResult",

--- a/llmtracefx/optimizer/instruments/capability.py
+++ b/llmtracefx/optimizer/instruments/capability.py
@@ -1,0 +1,555 @@
+"""Capability detection for Apple's Instruments CLI (``xctrace``).
+
+The point of this module is to answer, precisely, *why* a Metal trace
+cannot be taken, instead of collapsing every failure into a single
+"unavailable". Each distinguishable cause is its own
+:class:`XctraceCapability` value with a fix the caller can act on.
+
+There is deliberately no broad ``except Exception`` and no silent
+fallback anywhere in this module. An unrecognized failure becomes
+:attr:`XctraceCapability.PROBE_FAILED`, carrying the real exit status,
+rather than being reported as some nearby state that happens to look
+plausible.
+
+Verified against a local install (recorded in ``checked_signals`` at
+detection time, not hardcoded as a claim):
+
+* ``xctrace version`` prints ``xctrace version 16.0 (17F113)`` and exits
+  0 when a full Xcode is selected.
+* With only Command Line Tools selected, the shim at ``/usr/bin/xctrace``
+  exists and is executable, so a mere "is it on PATH" check passes while
+  every real invocation fails with ``xcode-select: error: tool 'xctrace'
+  requires Xcode, but active developer directory
+  '/Library/Developer/CommandLineTools' is a command line tools
+  instance``. That is why presence on PATH is never treated as support.
+* ``xctrace list templates`` prints ``== Standard Templates ==`` followed
+  by one template name per line, then an optional ``== Custom Templates
+  ==`` section.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text
+from .process import CommandResult, CommandRunner, InstrumentsProcessError
+
+
+def default_xctrace_path() -> str | None:
+    """Locate xctrace on PATH, or ``None`` when it is absent.
+
+    Finding it proves only that a file exists: on a machine with just
+    Command Line Tools this returns ``/usr/bin/xctrace``, a shim that
+    fails on every invocation. Callers must still probe.
+    """
+    return shutil.which("xctrace")
+
+
+CAPABILITY_SCHEMA_VERSION = "1"
+
+#: Instruments template this project records Metal evidence with.
+#: Present in Xcode 16.0's ``xctrace list templates`` output.
+METAL_SYSTEM_TRACE_TEMPLATE = "Metal System Trace"
+
+#: Seconds allowed for a capability probe. These are metadata queries
+#: that normally return in well under a second; the bound exists so a
+#: wedged tool cannot hang a caller indefinitely.
+PROBE_TIMEOUT_SECONDS = 60.0
+
+
+class InstrumentsCapabilityError(RuntimeError):
+    """Raised when a capability report cannot be built or parsed."""
+
+
+class XctraceCapability(str, Enum):
+    """Why Instruments evidence is or is not collectable here."""
+
+    SUPPORTED = "supported"
+    """xctrace ran, and the requested template exists."""
+
+    UNSUPPORTED_OS = "unsupported_os"
+    """Not macOS. Instruments and xctrace are macOS only."""
+
+    UNSUPPORTED_ARCHITECTURE = "unsupported_architecture"
+    """Not arm64. This project only validates Apple Silicon GPU
+    evidence, so it refuses to imply support it has not exercised."""
+
+    XCTRACE_NOT_FOUND = "xctrace_not_found"
+    """No xctrace executable on PATH at all."""
+
+    COMMAND_LINE_TOOLS_ONLY = "command_line_tools_only"
+    """xctrace resolves to the Command Line Tools shim. The binary
+    exists but refuses to run because no full Xcode is selected."""
+
+    LICENSE_NOT_ACCEPTED = "license_not_accepted"
+    """Xcode is installed but its license has not been agreed to."""
+
+    FIRST_LAUNCH_REQUIRED = "first_launch_required"
+    """Xcode's one time first launch setup has not completed."""
+
+    TEMPLATE_UNAVAILABLE = "template_unavailable"
+    """xctrace works, but the requested template is not installed."""
+
+    PERMISSION_DENIED = "permission_denied"
+    """The OS refused the recording (entitlements, hardened runtime,
+    or profiling permission)."""
+
+    PROBE_FAILED = "probe_failed"
+    """xctrace failed for a reason this module does not recognize. The
+    exit status and a classification hint are preserved rather than
+    guessed at."""
+
+    @property
+    def is_supported(self) -> bool:
+        return self is XctraceCapability.SUPPORTED
+
+
+#: Substring patterns mapped to the capability they prove, matched
+#: case-insensitively against combined stdout/stderr. Ordered: the
+#: Command Line Tools check runs before the generic "requires Xcode"
+#: check because its message contains both phrases.
+_ERROR_PATTERNS: tuple[tuple[tuple[str, ...], XctraceCapability], ...] = (
+    (
+        ("command line tools instance",),
+        XctraceCapability.COMMAND_LINE_TOOLS_ONLY,
+    ),
+    (
+        ("requires xcode", "active developer directory"),
+        XctraceCapability.COMMAND_LINE_TOOLS_ONLY,
+    ),
+    (
+        ("xcode-select: error: unable to find utility",),
+        XctraceCapability.COMMAND_LINE_TOOLS_ONLY,
+    ),
+    (
+        ("license",),
+        XctraceCapability.LICENSE_NOT_ACCEPTED,
+    ),
+    (
+        ("runfirstlaunch",),
+        XctraceCapability.FIRST_LAUNCH_REQUIRED,
+    ),
+    (
+        ("first launch",),
+        XctraceCapability.FIRST_LAUNCH_REQUIRED,
+    ),
+    (
+        ("operation not permitted",),
+        XctraceCapability.PERMISSION_DENIED,
+    ),
+    (
+        ("not permitted to",),
+        XctraceCapability.PERMISSION_DENIED,
+    ),
+    (
+        ("permission denied",),
+        XctraceCapability.PERMISSION_DENIED,
+    ),
+    (
+        ("failed to attach",),
+        XctraceCapability.PERMISSION_DENIED,
+    ),
+    (
+        ("get-task-allow",),
+        XctraceCapability.PERMISSION_DENIED,
+    ),
+)
+
+
+def classify_xctrace_failure(text: str) -> XctraceCapability | None:
+    """Map known Apple error text to a capability, or ``None``.
+
+    ``None`` means "not recognized". Callers must escalate that to
+    :attr:`XctraceCapability.PROBE_FAILED` rather than substituting a
+    convenient guess.
+    """
+    haystack = text.casefold()
+    for needles, capability in _ERROR_PATTERNS:
+        if all(needle in haystack for needle in needles):
+            return capability
+    return None
+
+
+def parse_templates(stdout: str) -> tuple[str, ...]:
+    """Parse ``xctrace list templates`` output into template names.
+
+    The real format is section headers delimited by ``==`` with one
+    template name per line between them. Blank lines and headers are
+    dropped; surrounding whitespace on names is stripped because the
+    custom templates section indents its entries.
+    """
+    names: list[str] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("=="):
+            continue
+        names.append(line)
+    # dict.fromkeys keeps first-seen order while removing duplicates,
+    # which can occur when a custom template shadows a standard name.
+    return tuple(dict.fromkeys(names))
+
+
+def parse_version(stdout: str) -> str | None:
+    """Extract the version string from ``xctrace version`` output.
+
+    Returns the whole trimmed first non-empty line, for example
+    ``xctrace version 16.0 (17F113)``. Kept verbatim rather than parsed
+    into components so the evidence records exactly what the tool said.
+    """
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if line:
+            return line
+    return None
+
+
+@dataclass(frozen=True)
+class XctraceCapabilityReport:
+    """Whether this machine can produce Instruments evidence right now.
+
+    A standalone artifact rather than an ``ExperimentRecord``: capability
+    is a property of the installed toolchain, not of a measured run.
+    """
+
+    schema_version: str
+    capability: XctraceCapability
+    reason: str
+    remediation: str | None
+    os_name: str
+    architecture: str
+    xctrace_path: str | None
+    xctrace_version: str | None
+    requested_template: str | None
+    available_templates: tuple[str, ...]
+    checked_signals: tuple[str, ...]
+
+    @property
+    def supported(self) -> bool:
+        return self.capability.is_supported
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "capability": self.capability.value,
+            "supported": self.supported,
+            "reason": self.reason,
+            "remediation": self.remediation,
+            "os_name": self.os_name,
+            "architecture": self.architecture,
+            "xctrace_path": self.xctrace_path,
+            "xctrace_version": self.xctrace_version,
+            "requested_template": self.requested_template,
+            "available_templates": list(self.available_templates),
+            "checked_signals": list(self.checked_signals),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    def write_json(self, path: str | Path) -> None:
+        atomic_write_text(Path(path), self.to_json() + "\n")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> XctraceCapabilityReport:
+        try:
+            capability = XctraceCapability(data["capability"])
+        except KeyError as exc:
+            raise InstrumentsCapabilityError(
+                f"XctraceCapabilityReport is missing required field: {exc}"
+            ) from exc
+        except ValueError as exc:
+            raise InstrumentsCapabilityError(
+                f"XctraceCapabilityReport has an unknown capability: {exc}"
+            ) from exc
+        try:
+            return cls(
+                schema_version=str(
+                    data.get("schema_version", CAPABILITY_SCHEMA_VERSION)
+                ),
+                capability=capability,
+                reason=data["reason"],
+                remediation=data.get("remediation"),
+                os_name=data["os_name"],
+                architecture=data["architecture"],
+                xctrace_path=data.get("xctrace_path"),
+                xctrace_version=data.get("xctrace_version"),
+                requested_template=data.get("requested_template"),
+                available_templates=tuple(data.get("available_templates", ())),
+                checked_signals=tuple(data.get("checked_signals", ())),
+            )
+        except KeyError as exc:
+            raise InstrumentsCapabilityError(
+                f"XctraceCapabilityReport is missing required field: {exc}"
+            ) from exc
+
+
+_REMEDIATION: dict[XctraceCapability, str] = {
+    XctraceCapability.UNSUPPORTED_OS: (
+        "Instruments and xctrace ship only with Xcode on macOS. There is "
+        "no remediation on this platform."
+    ),
+    XctraceCapability.UNSUPPORTED_ARCHITECTURE: (
+        "Run on an Apple Silicon (arm64) Mac. This project has only "
+        "validated its Metal evidence path on Apple Silicon and will not "
+        "imply support for hardware it has not exercised."
+    ),
+    XctraceCapability.XCTRACE_NOT_FOUND: (
+        "Install Xcode from the Mac App Store, then select it with "
+        "`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`."
+    ),
+    XctraceCapability.COMMAND_LINE_TOOLS_ONLY: (
+        "A full Xcode is required; Command Line Tools alone do not ship "
+        "xctrace. Install Xcode, then run "
+        "`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`."
+    ),
+    XctraceCapability.LICENSE_NOT_ACCEPTED: (
+        "Accept the Xcode license: `sudo xcodebuild -license accept`. "
+        "This needs administrator rights, so run it yourself; this "
+        "project never invokes sudo on your behalf."
+    ),
+    XctraceCapability.FIRST_LAUNCH_REQUIRED: (
+        "Complete Xcode's first launch setup: "
+        "`sudo xcodebuild -runFirstLaunch`. This needs administrator "
+        "rights, so run it yourself; this project never invokes sudo on "
+        "your behalf."
+    ),
+    XctraceCapability.PERMISSION_DENIED: (
+        "macOS refused the recording. Profile a binary you built locally "
+        "(hardened runtime binaries need the get-task-allow entitlement), "
+        "and prefer launching the target rather than attaching to it."
+    ),
+}
+
+
+def _report(
+    capability: XctraceCapability,
+    *,
+    reason: str,
+    os_name: str,
+    architecture: str,
+    checked: tuple[str, ...],
+    xctrace_path: str | None = None,
+    xctrace_version: str | None = None,
+    requested_template: str | None = None,
+    available_templates: tuple[str, ...] = (),
+) -> XctraceCapabilityReport:
+    return XctraceCapabilityReport(
+        schema_version=CAPABILITY_SCHEMA_VERSION,
+        capability=capability,
+        reason=reason,
+        remediation=_REMEDIATION.get(capability),
+        os_name=os_name,
+        architecture=architecture,
+        xctrace_path=xctrace_path,
+        xctrace_version=xctrace_version,
+        requested_template=requested_template,
+        available_templates=available_templates,
+        checked_signals=checked,
+    )
+
+
+def _describe(result: CommandResult) -> str:
+    """Summarize a probe result without echoing its output.
+
+    Deliberately records only the exit status and whether it timed out.
+    Instruments error text can contain device names and file paths, and
+    this string is persisted into the capability report.
+    """
+    if result.timed_out:
+        return "timed out"
+    return f"exit {result.returncode}"
+
+
+def detect_xctrace_capability(
+    *,
+    runner: CommandRunner,
+    template: str | None = METAL_SYSTEM_TRACE_TEMPLATE,
+    os_name: str | None = None,
+    architecture: str | None = None,
+    path_resolver: Callable[[], str | None] | None = None,
+    timeout_seconds: float = PROBE_TIMEOUT_SECONDS,
+) -> XctraceCapabilityReport:
+    """Determine whether ``xctrace`` can record ``template`` here.
+
+    ``path_resolver`` returns the xctrace path, or ``None`` when there
+    is none. It is a callable rather than a plain string so that "not
+    installed" is expressible: a ``None`` *path* argument would be
+    ambiguous between "absent" and "look it up for me".
+
+    Every argument beyond ``runner`` exists so tests can pin the
+    environment. In production all of them are resolved from the host.
+    """
+    resolved_os = platform.system() if os_name is None else os_name
+    resolved_arch = platform.machine() if architecture is None else architecture
+    checked: list[str] = [
+        f"os_name={resolved_os}",
+        f"architecture={resolved_arch}",
+    ]
+
+    if resolved_os != "Darwin":
+        return _report(
+            XctraceCapability.UNSUPPORTED_OS,
+            reason=(
+                f"xctrace requires macOS; this host reports "
+                f"os_name={resolved_os!r}."
+            ),
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            requested_template=template,
+        )
+
+    if resolved_arch != "arm64":
+        return _report(
+            XctraceCapability.UNSUPPORTED_ARCHITECTURE,
+            reason=(
+                f"this project only collects Metal evidence on Apple "
+                f"Silicon; this host reports architecture="
+                f"{resolved_arch!r}."
+            ),
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            requested_template=template,
+        )
+
+    resolve = default_xctrace_path if path_resolver is None else path_resolver
+    resolved_path = resolve()
+    checked.append(f"xctrace_on_path={resolved_path is not None}")
+    if resolved_path is None:
+        return _report(
+            XctraceCapability.XCTRACE_NOT_FOUND,
+            reason="no xctrace executable was found on PATH.",
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            requested_template=template,
+        )
+
+    # Presence on PATH proves nothing: the Command Line Tools shim at
+    # /usr/bin/xctrace exists and is executable but refuses to run.
+    # Only an actual invocation settles it.
+    try:
+        version_result = runner.run(
+            [resolved_path, "version"], timeout_seconds=timeout_seconds
+        )
+    except InstrumentsProcessError as exc:
+        return _report(
+            XctraceCapability.PROBE_FAILED,
+            reason=f"could not execute xctrace: {exc}",
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            xctrace_path=resolved_path,
+            requested_template=template,
+        )
+
+    checked.append(f"xctrace_version_probe={_describe(version_result)}")
+    version_text: str | None = None
+    if version_result.returncode == 0 and not version_result.timed_out:
+        version_text = parse_version(version_result.stdout)
+    else:
+        classified = classify_xctrace_failure(version_result.combined_output)
+        if classified is not None:
+            return _report(
+                classified,
+                reason=(
+                    f"`xctrace version` failed ({_describe(version_result)}) "
+                    f"and its output identifies this as {classified.value}."
+                ),
+                os_name=resolved_os,
+                architecture=resolved_arch,
+                checked=tuple(checked),
+                xctrace_path=resolved_path,
+                requested_template=template,
+            )
+        # `version` is not in the documented subcommand list, so a
+        # failure here is not conclusive on its own. Fall through to the
+        # documented `list templates` probe rather than guessing.
+
+    try:
+        templates_result = runner.run(
+            [resolved_path, "list", "templates"], timeout_seconds=timeout_seconds
+        )
+    except InstrumentsProcessError as exc:
+        return _report(
+            XctraceCapability.PROBE_FAILED,
+            reason=f"could not execute `xctrace list templates`: {exc}",
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            xctrace_path=resolved_path,
+            xctrace_version=version_text,
+            requested_template=template,
+        )
+
+    checked.append(f"xctrace_list_templates={_describe(templates_result)}")
+    if templates_result.timed_out or templates_result.returncode != 0:
+        classified = classify_xctrace_failure(templates_result.combined_output)
+        capability = (
+            XctraceCapability.PROBE_FAILED if classified is None else classified
+        )
+        reason = f"`xctrace list templates` failed ({_describe(templates_result)})"
+        if classified is None:
+            reason += (
+                " and its output matched no known cause. The failure is "
+                "reported as-is rather than guessed at."
+            )
+        else:
+            reason += f" and its output identifies this as {classified.value}."
+        return _report(
+            capability,
+            reason=reason + ".",
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            xctrace_path=resolved_path,
+            xctrace_version=version_text,
+            requested_template=template,
+        )
+
+    available = parse_templates(templates_result.stdout)
+    checked.append(f"template_count={len(available)}")
+
+    if template is not None and template not in available:
+        return _report(
+            XctraceCapability.TEMPLATE_UNAVAILABLE,
+            reason=(
+                f"xctrace works, but the template {template!r} is not "
+                f"installed. Run `xctrace list templates` to see the "
+                f"{len(available)} templates this Xcode provides."
+            ),
+            os_name=resolved_os,
+            architecture=resolved_arch,
+            checked=tuple(checked),
+            xctrace_path=resolved_path,
+            xctrace_version=version_text,
+            requested_template=template,
+            available_templates=available,
+        )
+
+    return _report(
+        XctraceCapability.SUPPORTED,
+        reason=(
+            "xctrace responded to `list templates`"
+            + (
+                f" and provides the template {template!r}."
+                if template is not None
+                else "."
+            )
+        ),
+        os_name=resolved_os,
+        architecture=resolved_arch,
+        checked=tuple(checked),
+        xctrace_path=resolved_path,
+        xctrace_version=version_text,
+        requested_template=template,
+        available_templates=available,
+    )

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -81,6 +81,8 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "bearer",
         "authorization",
         "jwt",
+        "totp",
+        "otp",
     }
 )
 

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -85,7 +85,9 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "totp",
         "otp",
         "pw",
+        "pwd",
         "pass",
+        "netrc",
     }
 )
 

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -80,6 +80,7 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "apikey",
         "bearer",
         "authorization",
+        "auth",
         "jwt",
         "totp",
         "otp",
@@ -153,12 +154,34 @@ _TOKEN_QUANTITY_SEGMENTS: frozenset[str] = frozenset(
     }
 )
 
-#: Trailing segments that make a name refer to a *location* rather than
-#: to a secret. ``--private-key-path /etc/k.pem`` names a file; the path
-#: is not the credential, and redacting it would lose reproducibility
-#: for no privacy gain.
-_LOCATION_SUFFIXES: frozenset[str] = frozenset(
-    {"path", "file", "dir", "directory", "url", "uri", "endpoint", "name"}
+#: Trailing segments that make a name refer to something other than a
+#: secret: where one lives, or how one is configured.
+#: ``--private-key-path /etc/k.pem`` names a file and ``--auth-mode
+#: none`` names a setting. Neither is the credential, and redacting them
+#: would lose reproducibility for no privacy gain.
+_NON_SECRET_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # locations
+        "path",
+        "file",
+        "dir",
+        "directory",
+        "url",
+        "uri",
+        "endpoint",
+        "name",
+        # configuration descriptors
+        "mode",
+        "type",
+        "kind",
+        "format",
+        "scheme",
+        "method",
+        "version",
+        "timeout",
+        "enabled",
+        "required",
+    }
 )
 
 REDACTED = "<redacted>"
@@ -187,16 +210,17 @@ def _is_credential_name(name: str) -> bool:
     ``--max-tokens`` (a benign quantity), so the two are separated
     rather than redacting both and corrupting the second.
 
-    Conversely a name ending in a location suffix refers to where a
-    secret lives, not to the secret: ``--private-key-path`` is a
-    filename worth keeping for reproducibility.
+    Conversely a name ending in a location or configuration suffix
+    refers to where a secret lives or how it is used, not to the secret:
+    ``--private-key-path`` is a filename and ``--auth-mode`` is a
+    setting, both worth keeping for reproducibility.
     """
     normalized = _normalize_option_name(name)
     if not normalized:
         return False
     segments = normalized.split("_")
     tail = segments[-1]
-    if len(segments) > 1 and tail in _LOCATION_SUFFIXES:
+    if len(segments) > 1 and tail in _NON_SECRET_SUFFIXES:
         return False
 
     segment_set = set(segments)

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -138,8 +138,15 @@ _CREDENTIAL_PHRASES: tuple[str, ...] = (
 #: secret. curl's `--user` and `--proxy-user` are the common ones. They
 #: are listed explicitly because `user` on its own is a username, which
 #: is not a secret and must stay readable.
+#: Long forms only. `-u` is curl's short spelling, but it is python's
+#: unbuffered switch, sort's unique switch and docker's uid switch, none
+#: of which take a credential. Treating it as value-taking would replace
+#: the next unrelated argument, which is the exact defect that removing
+#: `netrc` fixed, and `python -u infer.py` is the likeliest command this
+#: project will ever record. Single-dash short options stay outside the
+#: classifier, as the module docstring already states.
 _USER_CREDENTIAL_NAMES: frozenset[str] = frozenset(
-    {"user", "proxy_user", "proxy_credential", "u"}
+    {"user", "proxy_user", "proxy_credential"}
 )
 
 #: Segments that mark a ``token`` name as a *quantity* rather than a

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -79,7 +79,7 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "credentials",
         "apikey",
         "bearer",
-        "auth",
+        "authorization",
     }
 )
 
@@ -124,6 +124,14 @@ _TOKEN_QUANTITY_SEGMENTS: frozenset[str] = frozenset(
     }
 )
 
+#: Trailing segments that make a name refer to a *location* rather than
+#: to a secret. ``--private-key-path /etc/k.pem`` names a file; the path
+#: is not the credential, and redacting it would lose reproducibility
+#: for no privacy gain.
+_LOCATION_SUFFIXES: frozenset[str] = frozenset(
+    {"path", "file", "dir", "directory", "url", "uri", "endpoint", "name"}
+)
+
 REDACTED = "<redacted>"
 
 
@@ -144,23 +152,32 @@ def _normalize_option_name(name: str) -> str:
 def _is_credential_name(name: str) -> bool:
     """Whether a name's value should be treated as a secret.
 
-    Deliberately not a plain substring match. ``token`` appears in both
-    ``--hf-token`` (a secret) and ``--max-tokens`` (a benign quantity),
-    so the two are separated rather than redacting both and corrupting
-    the second.
+    Deliberately not a plain substring match, in both directions.
+
+    ``token`` appears in both ``--hf-token`` (a secret) and
+    ``--max-tokens`` (a benign quantity), so the two are separated
+    rather than redacting both and corrupting the second.
+
+    Conversely a name ending in a location suffix refers to where a
+    secret lives, not to the secret: ``--private-key-path`` is a
+    filename worth keeping for reproducibility.
     """
     normalized = _normalize_option_name(name)
     if not normalized:
         return False
-    segments = set(normalized.split("_"))
+    segments = normalized.split("_")
+    tail = segments[-1]
+    if len(segments) > 1 and tail in _LOCATION_SUFFIXES:
+        return False
 
-    if segments & _CREDENTIAL_SEGMENTS:
+    segment_set = set(segments)
+    if segment_set & _CREDENTIAL_SEGMENTS:
         return True
     if any(phrase in normalized for phrase in _CREDENTIAL_PHRASES):
         return True
-    if normalized in {"key", "token", "pat"}:
+    if normalized in {"key", "token", "pat", "auth"}:
         return True
-    if "token" in segments and not (segments & _TOKEN_QUANTITY_SEGMENTS):
+    if "token" in segment_set and not (segment_set & _TOKEN_QUANTITY_SEGMENTS):
         # `hf_token`, `service_token`. Plural `tokens` is a count, and
         # so is anything carrying a quantity qualifier.
         return True

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -257,6 +257,11 @@ class RecordPlan:
             raise InstrumentsCommandError("xctrace_path must be non-empty")
         if not self.template:
             raise InstrumentsCommandError("template must be non-empty")
+        # Expand `~` once, here, so the path this plan validates is
+        # byte-for-byte the path that reaches xctrace. Leaving it
+        # unexpanded would let the collision check and mkdir target
+        # $HOME while xctrace created a literal './~' directory.
+        object.__setattr__(self, "output_trace", self.output_trace.expanduser())
         if self.output_trace.suffix != ".trace":
             raise InstrumentsCommandError(
                 f"output trace path must end in '.trace', got "
@@ -313,7 +318,11 @@ class RecordPlan:
             # This must stay last.
             argv.append("--launch")
             argv.append("--")
-            argv.extend(self.target.argv)
+            # The profiled command is user supplied and can carry a
+            # secret (for example `env HF_TOKEN=... python bench.py`),
+            # so it goes through the same redaction as --env before
+            # being persisted or printed.
+            argv.extend(redact_argv(self.target.argv) if redacted else self.target.argv)
         return tuple(argv)
 
     def to_argv(self) -> tuple[str, ...]:

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -87,7 +87,6 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "pw",
         "pwd",
         "pass",
-        "netrc",
     }
 )
 
@@ -133,6 +132,14 @@ _CREDENTIAL_PHRASES: tuple[str, ...] = (
     # Connection strings and DSNs routinely embed the password inline.
     "connection_string",
     "dsn",
+)
+
+#: Names whose value is a `user:password` pair rather than a bare
+#: secret. curl's `--user` and `--proxy-user` are the common ones. They
+#: are listed explicitly because `user` on its own is a username, which
+#: is not a secret and must stay readable.
+_USER_CREDENTIAL_NAMES: frozenset[str] = frozenset(
+    {"user", "proxy_user", "proxy_credential", "u"}
 )
 
 #: Segments that mark a ``token`` name as a *quantity* rather than a
@@ -245,6 +252,11 @@ def _is_credential_name(name: str) -> bool:
     if any(phrase in normalized for phrase in _CREDENTIAL_PHRASES):
         return True
     if normalized in {"key", "token", "pat", "auth"}:
+        return True
+    if normalized in _USER_CREDENTIAL_NAMES:
+        # `--user alice:hunter2`. The username half is not a secret, but
+        # the pair cannot be split without knowing the target program's
+        # grammar, so the whole value goes.
         return True
     if tail == "key":
         # `ssh_key`, `deploy_key`, `session_key`. Default to treating an

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -84,6 +84,8 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "jwt",
         "totp",
         "otp",
+        "pw",
+        "pass",
     }
 )
 
@@ -126,6 +128,9 @@ _CREDENTIAL_PHRASES: tuple[str, ...] = (
     "refresh_token",
     "session_token",
     "id_token",
+    # Connection strings and DSNs routinely embed the password inline.
+    "connection_string",
+    "dsn",
 )
 
 #: Segments that mark a ``token`` name as a *quantity* rather than a
@@ -181,6 +186,15 @@ _NON_SECRET_SUFFIXES: frozenset[str] = frozenset(
         "timeout",
         "enabled",
         "required",
+        # quantities
+        "count",
+        "size",
+        "length",
+        "limit",
+        "level",
+        "retries",
+        "attempts",
+        "interval",
     }
 )
 
@@ -575,11 +589,21 @@ def redact_argv(argv: Sequence[str]) -> tuple[str, ...]:
         element is always replaced, including when it starts with a
         dash, since a credential can legitimately look like an option.
 
-    Not recognized, and documented rather than guessed at: a value
-    attached to a single-dash short option (``-ksk-live``). There is no
-    way to tell that from a cluster of short flags without knowing the
-    target program's own option grammar, and guessing would corrupt
-    legitimate arguments.
+    **This is a safety net, not a guarantee.** It classifies option
+    names, so it can only catch spellings it recognizes. It will miss a
+    secret passed under an unusual name, and it cannot see one embedded
+    in a positional argument. Two known limits are pinned by tests: a
+    value attached to a single-dash short option (``-ksk-live``) is not
+    detected, because it cannot be told from a cluster of short flags
+    without the target program's own option grammar; and a name ending
+    in a configuration or location suffix (``--auth-mode``,
+    ``--private-key-path``) is treated as naming a setting or a file
+    rather than a secret, which is right for those and would be wrong
+    for a name that broke the convention.
+
+    The reliable protection is not to put secrets on the command line at
+    all: pass them through the environment of the profiled program, or
+    read them from a file it opens itself.
     """
     redacted: list[str] = []
     redact_next = False

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -80,6 +80,33 @@ _CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
         "apikey",
         "bearer",
         "authorization",
+        "jwt",
+    }
+)
+
+#: Segments that make a trailing ``key`` a lookup key rather than a
+#: cryptographic one. ``--sort-key name`` is not a secret; ``--ssh-key``
+#: is. Listing the benign qualifiers rather than the credential ones
+#: means an unrecognized ``*-key`` option is treated as sensitive.
+_BENIGN_KEY_QUALIFIERS: frozenset[str] = frozenset(
+    {
+        "sort",
+        "cache",
+        "group",
+        "partition",
+        "primary",
+        "foreign",
+        "index",
+        "map",
+        "lookup",
+        "shard",
+        "route",
+        "order",
+        "id",
+        "column",
+        "row",
+        "object",
+        "hash",
     }
 )
 
@@ -177,6 +204,12 @@ def _is_credential_name(name: str) -> bool:
         return True
     if normalized in {"key", "token", "pat", "auth"}:
         return True
+    if tail == "key":
+        # `ssh_key`, `deploy_key`, `session_key`. Default to treating an
+        # unrecognized `*-key` as sensitive, since the cost of redacting
+        # a lookup key is far lower than the cost of persisting a
+        # private one.
+        return len(segments) < 2 or segments[-2] not in _BENIGN_KEY_QUALIFIERS
     if "token" in segment_set and not (segment_set & _TOKEN_QUANTITY_SEGMENTS):
         # `hf_token`, `service_token`. Plural `tokens` is a count, and
         # so is anything carrying a quantity qualifier.

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -67,19 +67,61 @@ _UNIT_SECONDS: dict[str, float] = {
 #: quoted string in a generated XPath predicate and inject a new one.
 _SCHEMA_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]*$")
 
-#: Environment variable names whose values are redacted from any argv
-#: this project stores or prints. Matched case-insensitively as
-#: substrings, so ``HF_TOKEN`` and ``OPENAI_API_KEY`` both match.
-_CREDENTIAL_NAME_MARKERS: tuple[str, ...] = (
-    "token",
-    "secret",
-    "password",
-    "passwd",
+#: Segments that mark a name as a credential on their own.
+_CREDENTIAL_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "secret",
+        "secrets",
+        "password",
+        "passwd",
+        "passphrase",
+        "credential",
+        "credentials",
+        "apikey",
+        "bearer",
+        "auth",
+    }
+)
+
+#: Normalized phrases that mark a name as a credential.
+_CREDENTIAL_PHRASES: tuple[str, ...] = (
     "api_key",
-    "apikey",
     "access_key",
+    "secret_key",
     "private_key",
-    "credential",
+    "signing_key",
+    "encryption_key",
+    "auth_token",
+    "access_token",
+    "refresh_token",
+    "session_token",
+    "id_token",
+)
+
+#: Segments that mark a ``token`` name as a *quantity* rather than a
+#: credential. This matters more here than in most projects: an LLM
+#: inference command is full of ``--max-tokens``, ``--num-tokens`` and
+#: ``--token-count``, and redacting those would destroy the
+#: reproducibility the recorded argv exists to provide.
+_TOKEN_QUANTITY_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "max",
+        "min",
+        "num",
+        "n",
+        "count",
+        "per",
+        "budget",
+        "new",
+        "input",
+        "output",
+        "context",
+        "prompt",
+        "generated",
+        "total",
+        "limit",
+        "size",
+    }
 )
 
 REDACTED = "<redacted>"
@@ -87,6 +129,42 @@ REDACTED = "<redacted>"
 
 class InstrumentsCommandError(ValueError):
     """Raised when a requested xctrace invocation would be unsafe."""
+
+
+def _normalize_option_name(name: str) -> str:
+    """Reduce an option or variable name to a comparable form.
+
+    ``--API-Key`` and ``api_key`` and ``HF_TOKEN`` all normalize into the
+    lowercase underscore form the tables above are written in, so case
+    and separator aliases do not need separate entries.
+    """
+    return name.lstrip("-").replace("-", "_").casefold()
+
+
+def _is_credential_name(name: str) -> bool:
+    """Whether a name's value should be treated as a secret.
+
+    Deliberately not a plain substring match. ``token`` appears in both
+    ``--hf-token`` (a secret) and ``--max-tokens`` (a benign quantity),
+    so the two are separated rather than redacting both and corrupting
+    the second.
+    """
+    normalized = _normalize_option_name(name)
+    if not normalized:
+        return False
+    segments = set(normalized.split("_"))
+
+    if segments & _CREDENTIAL_SEGMENTS:
+        return True
+    if any(phrase in normalized for phrase in _CREDENTIAL_PHRASES):
+        return True
+    if normalized in {"key", "token", "pat"}:
+        return True
+    if "token" in segments and not (segments & _TOKEN_QUANTITY_SEGMENTS):
+        # `hf_token`, `service_token`. Plural `tokens` is a count, and
+        # so is anything carrying a quantity qualifier.
+        return True
+    return False
 
 
 def validate_time_limit(value: str) -> str:
@@ -155,11 +233,6 @@ def table_xpath(schema_name: str, *, run_number: int = 1) -> str:
     schema = validate_schema_name(schema_name)
     run = validate_run_number(run_number)
     return f'/trace-toc/run[@number="{run}"]/data/table[@schema="{schema}"]'
-
-
-def _is_credential_name(name: str) -> bool:
-    folded = name.casefold()
-    return any(marker in folded for marker in _CREDENTIAL_NAME_MARKERS)
 
 
 @dataclass(frozen=True)
@@ -251,6 +324,12 @@ class RecordPlan:
     writes and finalizes the ``.trace`` bundle, and that step is not
     instant. The host timeout must therefore be strictly greater than
     ``time_limit`` or every recording would be torn down mid-save."""
+    stop_grace_seconds: float = 30.0
+    """Seconds allowed after each stop signal before escalating.
+
+    Applies per signal in the SIGINT, SIGTERM, SIGKILL sequence, and
+    also bounds how long the recorder waits for the whole process group
+    to empty after each one."""
 
     def __post_init__(self) -> None:
         if not self.xctrace_path:
@@ -274,6 +353,8 @@ class RecordPlan:
             raise InstrumentsCommandError("run_name must be non-empty when set")
         if self.grace_seconds <= 0:
             raise InstrumentsCommandError("grace_seconds must be > 0")
+        if self.stop_grace_seconds <= 0:
+            raise InstrumentsCommandError("stop_grace_seconds must be > 0")
         if self.environment and not isinstance(self.target, LaunchTarget):
             # xctrace help record: "Specifying environment variables or
             # stream redirection is only available when using launch
@@ -403,16 +484,44 @@ def build_version_argv(xctrace_path: str) -> tuple[str, ...]:
 
 
 def redact_argv(argv: Sequence[str]) -> tuple[str, ...]:
-    """Redact credential-looking ``NAME=VALUE`` tokens in an argv.
+    """Redact credential-bearing tokens anywhere in an argv.
 
-    Used for argv that did not come from a :class:`RecordPlan`, such as
-    a reconstructed CLI invocation.
+    Three shapes are recognized, because a secret reaches a command in
+    all three and redacting only the first leaves the other two in
+    plain text in every artifact this project writes:
+
+    ``NAME=value``
+        The environment style, with or without leading dashes.
+    ``--api-key=value``
+        A long option carrying its value after ``=``.
+    ``--api-key value``
+        A long option whose value is the *next* argv element. The next
+        element is always replaced, including when it starts with a
+        dash, since a credential can legitimately look like an option.
+
+    Not recognized, and documented rather than guessed at: a value
+    attached to a single-dash short option (``-ksk-live``). There is no
+    way to tell that from a cluster of short flags without knowing the
+    target program's own option grammar, and guessing would corrupt
+    legitimate arguments.
     """
     redacted: list[str] = []
+    redact_next = False
     for item in argv:
+        if redact_next:
+            redacted.append(REDACTED)
+            redact_next = False
+            continue
+
         name, separator, _ = item.partition("=")
         if separator and name and _is_credential_name(name):
             redacted.append(f"{name}={REDACTED}")
-        else:
+            continue
+
+        if item.startswith("-") and _is_credential_name(item):
             redacted.append(item)
+            redact_next = True
+            continue
+
+        redacted.append(item)
     return tuple(redacted)

--- a/llmtracefx/optimizer/instruments/commands.py
+++ b/llmtracefx/optimizer/instruments/commands.py
@@ -1,0 +1,409 @@
+"""Safe, shell-free ``xctrace`` command construction.
+
+Everything here returns an argv tuple. Nothing in this package ever
+builds a command string or passes ``shell=True``, so no template name,
+file path or user-supplied inference argument can be reinterpreted as
+shell syntax.
+
+Flag spellings and semantics below were taken from the local
+``xctrace help record`` and ``xctrace help export`` output on
+``xctrace version 16.0 (17F113)``:
+
+* ``record``: ``--output``, ``--append-run``, ``--run-name``,
+  ``--template <path|name>``, ``--device <name|UDID>``, ``--instrument``,
+  ``--time-limit <time[ms|s|m|h]>``, ``--window <duration[ms|s|m]>``,
+  ``--package``, ``--all-processes``, ``--attach <pid|name>``,
+  ``--launch -- command [arguments]``, ``--target-stdin``,
+  ``--target-stdout``, ``--env <VAR=value>``, ``--notify-tracing-started``,
+  ``--no-prompt``.
+* ``export``: ``--input``, ``--output``, ``--toc``, ``--xpath``, ``--har``.
+  The help text states TOC and XPath "cannot be specified together".
+* On ``--output``: "If trace file already exists, then --append-run needs
+  to be specified to add a run to it." xctrace therefore refuses to
+  overwrite on its own; the collision check in :mod:`.recorder` is a
+  pre-flight that fails earlier and more clearly.
+* Omitting ``--device`` records on the host. This package never passes
+  ``--device``, so it can never be pointed at someone else's machine.
+
+Deliberate omissions, each a safety decision rather than an oversight:
+
+``--all-processes``
+    Captures every process on the system. Refused outright.
+``--attach <name>``
+    Attaching by name resolves ambiguously when several processes share
+    a name. Only attaching by numeric pid is offered.
+``--target-stdin`` / ``--target-stdout``
+    Would route the profiled program's own input and output through
+    xctrace and into this project's captured log files. For an LLM
+    workload that is prompt and completion text, so neither flag is
+    constructed here at all.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: ``--time-limit`` accepts ms, s, m or h per ``xctrace help record``.
+TIME_LIMIT_UNITS: tuple[str, ...] = ("ms", "s", "m", "h")
+
+#: ``--window`` accepts ms, s or m. It notably does not accept h.
+WINDOW_UNITS: tuple[str, ...] = ("ms", "s", "m")
+
+_TIME_LIMIT_RE = re.compile(r"^(?P<amount>\d+)(?P<unit>ms|s|m|h)$")
+_WINDOW_RE = re.compile(r"^(?P<amount>\d+)(?P<unit>ms|s|m)$")
+
+_UNIT_SECONDS: dict[str, float] = {
+    "ms": 0.001,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+}
+
+#: A trace table schema name, as it appears in a TOC ``schema=``
+#: attribute. Constrained so a schema name can never terminate the
+#: quoted string in a generated XPath predicate and inject a new one.
+_SCHEMA_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]*$")
+
+#: Environment variable names whose values are redacted from any argv
+#: this project stores or prints. Matched case-insensitively as
+#: substrings, so ``HF_TOKEN`` and ``OPENAI_API_KEY`` both match.
+_CREDENTIAL_NAME_MARKERS: tuple[str, ...] = (
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+    "credential",
+)
+
+REDACTED = "<redacted>"
+
+
+class InstrumentsCommandError(ValueError):
+    """Raised when a requested xctrace invocation would be unsafe."""
+
+
+def validate_time_limit(value: str) -> str:
+    """Validate a ``--time-limit`` value such as ``10s`` or ``500ms``."""
+    if _TIME_LIMIT_RE.match(value) is None:
+        raise InstrumentsCommandError(
+            f"invalid --time-limit {value!r}: expected a whole number "
+            f"followed by one of {', '.join(TIME_LIMIT_UNITS)}, e.g. '30s'"
+        )
+    return value
+
+
+def validate_window(value: str) -> str:
+    """Validate a ``--window`` value such as ``5s``."""
+    if _WINDOW_RE.match(value) is None:
+        raise InstrumentsCommandError(
+            f"invalid --window {value!r}: expected a whole number followed "
+            f"by one of {', '.join(WINDOW_UNITS)}, e.g. '5s'. Note that "
+            f"xctrace accepts 'h' for --time-limit but not for --window."
+        )
+    return value
+
+
+def duration_to_seconds(value: str) -> float:
+    """Convert a validated xctrace duration into seconds."""
+    match = _TIME_LIMIT_RE.match(value)
+    if match is None:
+        raise InstrumentsCommandError(
+            f"cannot convert {value!r} to seconds: not a valid xctrace duration"
+        )
+    return int(match.group("amount")) * _UNIT_SECONDS[match.group("unit")]
+
+
+def validate_schema_name(value: str) -> str:
+    """Validate a trace table schema name before it enters an XPath.
+
+    Schema names reach this from a TOC or straight from the command
+    line. Without this check a value such as ``a"] | //*[@x="`` would
+    close the predicate's quoted string and append an attacker-chosen
+    query, so anything outside the conservative character set is
+    rejected instead of escaped.
+    """
+    if not _SCHEMA_NAME_RE.match(value):
+        raise InstrumentsCommandError(
+            f"invalid trace table schema name {value!r}: expected a name "
+            "matching [A-Za-z][A-Za-z0-9._-]*, e.g. 'metal-gpu-intervals'"
+        )
+    return value
+
+
+def validate_run_number(value: int) -> int:
+    """Validate a trace run number before it enters an XPath."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise InstrumentsCommandError(
+            f"invalid trace run number {value!r}: expected an integer >= 1"
+        )
+    return value
+
+
+def table_xpath(schema_name: str, *, run_number: int = 1) -> str:
+    """Build the XPath that selects one table from a trace's TOC.
+
+    Matches the form documented in ``xctrace help export``:
+    ``/trace-toc/run[@number="1"]/data/table[@schema="my-table-schema"]``.
+    """
+    schema = validate_schema_name(schema_name)
+    run = validate_run_number(run_number)
+    return f'/trace-toc/run[@number="{run}"]/data/table[@schema="{schema}"]'
+
+
+def _is_credential_name(name: str) -> bool:
+    folded = name.casefold()
+    return any(marker in folded for marker in _CREDENTIAL_NAME_MARKERS)
+
+
+@dataclass(frozen=True)
+class EnvironmentAssignment:
+    """One ``--env VAR=value`` pair for the launched process."""
+
+    name: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.name or "=" in self.name:
+            raise InstrumentsCommandError(
+                f"invalid environment variable name {self.name!r}: must be "
+                "non-empty and must not contain '='"
+            )
+
+    def as_argument(self) -> str:
+        return f"{self.name}={self.value}"
+
+    def as_redacted_argument(self) -> str:
+        """The pair with a credential-looking value replaced.
+
+        Applied whenever the argv is stored or printed, so a token
+        passed through ``--env`` never reaches an experiment record.
+        """
+        if _is_credential_name(self.name):
+            return f"{self.name}={REDACTED}"
+        return self.as_argument()
+
+
+@dataclass(frozen=True)
+class LaunchTarget:
+    """Launch and profile a program. ``argv`` is the program plus args."""
+
+    argv: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.argv or not all(
+            isinstance(item, str) and item for item in self.argv
+        ):
+            raise InstrumentsCommandError(
+                "launch target argv must be a non-empty sequence of "
+                "non-empty strings"
+            )
+
+
+@dataclass(frozen=True)
+class AttachTarget:
+    """Attach to an already running process by numeric pid."""
+
+    pid: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.pid, bool) or not isinstance(self.pid, int):
+            raise InstrumentsCommandError(
+                f"attach pid must be an integer, got {self.pid!r}"
+            )
+        if self.pid <= 0:
+            raise InstrumentsCommandError(
+                f"attach pid must be a positive integer, got {self.pid}"
+            )
+
+
+RecordTarget = LaunchTarget | AttachTarget
+
+
+@dataclass(frozen=True)
+class RecordPlan:
+    """A fully resolved, validated ``xctrace record`` invocation.
+
+    Building one of these performs every check that does not need to
+    touch the filesystem, so ``plan`` mode can surface problems without
+    recording anything.
+    """
+
+    xctrace_path: str
+    template: str
+    output_trace: Path
+    target: RecordTarget
+    time_limit: str = "60s"
+    window: str | None = None
+    run_name: str | None = None
+    environment: tuple[EnvironmentAssignment, ...] = ()
+    no_prompt: bool = True
+    grace_seconds: float = 90.0
+    """Extra seconds allowed past ``time_limit`` before the host gives up.
+
+    xctrace keeps running after the recording window closes while it
+    writes and finalizes the ``.trace`` bundle, and that step is not
+    instant. The host timeout must therefore be strictly greater than
+    ``time_limit`` or every recording would be torn down mid-save."""
+
+    def __post_init__(self) -> None:
+        if not self.xctrace_path:
+            raise InstrumentsCommandError("xctrace_path must be non-empty")
+        if not self.template:
+            raise InstrumentsCommandError("template must be non-empty")
+        if self.output_trace.suffix != ".trace":
+            raise InstrumentsCommandError(
+                f"output trace path must end in '.trace', got "
+                f"{self.output_trace.name!r}"
+            )
+        validate_time_limit(self.time_limit)
+        if self.window is not None:
+            validate_window(self.window)
+        if self.run_name is not None and not self.run_name:
+            raise InstrumentsCommandError("run_name must be non-empty when set")
+        if self.grace_seconds <= 0:
+            raise InstrumentsCommandError("grace_seconds must be > 0")
+        if self.environment and not isinstance(self.target, LaunchTarget):
+            # xctrace help record: "Specifying environment variables or
+            # stream redirection is only available when using launch
+            # option."
+            raise InstrumentsCommandError(
+                "--env is only supported when launching a process; it has "
+                "no effect when attaching to an existing pid"
+            )
+
+    @property
+    def timeout_seconds(self) -> float:
+        """Host-side wall-clock bound for the whole recording."""
+        return duration_to_seconds(self.time_limit) + self.grace_seconds
+
+    def _argv(self, *, redacted: bool) -> tuple[str, ...]:
+        argv: list[str] = [self.xctrace_path, "record"]
+        argv.extend(("--template", self.template))
+        argv.extend(("--output", str(self.output_trace)))
+        argv.extend(("--time-limit", self.time_limit))
+        if self.window is not None:
+            argv.extend(("--window", self.window))
+        if self.run_name is not None:
+            argv.extend(("--run-name", self.run_name))
+        if self.no_prompt:
+            argv.append("--no-prompt")
+        for assignment in self.environment:
+            argv.append("--env")
+            argv.append(
+                assignment.as_redacted_argument()
+                if redacted
+                else assignment.as_argument()
+            )
+
+        # --device is never passed, so the host is always the target.
+        # --append-run is never passed, so xctrace refuses to touch an
+        # existing bundle rather than adding a run to it.
+        if isinstance(self.target, AttachTarget):
+            argv.extend(("--attach", str(self.target.pid)))
+        else:
+            # xctrace help record shows --launch as the trailing form,
+            # and everything after `--` belongs to the target program.
+            # This must stay last.
+            argv.append("--launch")
+            argv.append("--")
+            argv.extend(self.target.argv)
+        return tuple(argv)
+
+    def to_argv(self) -> tuple[str, ...]:
+        """The argv actually handed to the OS, with real env values."""
+        return self._argv(redacted=False)
+
+    def to_redacted_argv(self) -> tuple[str, ...]:
+        """The argv safe to persist and print.
+
+        Deterministic: the same plan always reconstructs the same
+        sequence, so a record's stored command can be compared across
+        runs. Credential-looking ``--env`` values are replaced.
+        """
+        return self._argv(redacted=True)
+
+
+@dataclass(frozen=True)
+class ExportPlan:
+    """A validated ``xctrace export`` invocation.
+
+    Exactly one of ``toc`` or ``schema_name`` is used, because the help
+    text states the two modes cannot be combined.
+    """
+
+    xctrace_path: str
+    input_trace: Path
+    output_path: Path
+    toc: bool = False
+    schema_name: str | None = None
+    run_number: int = 1
+    timeout_seconds: float = 600.0
+    extra_checks: tuple[str, ...] = field(default=(), repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.xctrace_path:
+            raise InstrumentsCommandError("xctrace_path must be non-empty")
+        if self.toc and self.schema_name is not None:
+            raise InstrumentsCommandError(
+                "xctrace export cannot combine --toc with --xpath; request "
+                "one mode or the other"
+            )
+        if not self.toc and self.schema_name is None:
+            raise InstrumentsCommandError(
+                "xctrace export needs either --toc or a table schema name"
+            )
+        if self.schema_name is not None:
+            validate_schema_name(self.schema_name)
+            validate_run_number(self.run_number)
+        if self.timeout_seconds <= 0:
+            raise InstrumentsCommandError("timeout_seconds must be > 0")
+
+    def to_argv(self) -> tuple[str, ...]:
+        argv: list[str] = [self.xctrace_path, "export"]
+        argv.extend(("--input", str(self.input_trace)))
+        argv.extend(("--output", str(self.output_path)))
+        if self.toc:
+            argv.append("--toc")
+        else:
+            assert self.schema_name is not None  # guarded in __post_init__
+            argv.extend(
+                ("--xpath", table_xpath(self.schema_name, run_number=self.run_number))
+            )
+        return tuple(argv)
+
+
+def build_list_templates_argv(xctrace_path: str) -> tuple[str, ...]:
+    """Argv for ``xctrace list templates``."""
+    if not xctrace_path:
+        raise InstrumentsCommandError("xctrace_path must be non-empty")
+    return (xctrace_path, "list", "templates")
+
+
+def build_version_argv(xctrace_path: str) -> tuple[str, ...]:
+    """Argv for ``xctrace version``."""
+    if not xctrace_path:
+        raise InstrumentsCommandError("xctrace_path must be non-empty")
+    return (xctrace_path, "version")
+
+
+def redact_argv(argv: Sequence[str]) -> tuple[str, ...]:
+    """Redact credential-looking ``NAME=VALUE`` tokens in an argv.
+
+    Used for argv that did not come from a :class:`RecordPlan`, such as
+    a reconstructed CLI invocation.
+    """
+    redacted: list[str] = []
+    for item in argv:
+        name, separator, _ = item.partition("=")
+        if separator and name and _is_credential_name(name):
+            redacted.append(f"{name}={REDACTED}")
+        else:
+            redacted.append(item)
+    return tuple(redacted)

--- a/llmtracefx/optimizer/instruments/evidence.py
+++ b/llmtracefx/optimizer/instruments/evidence.py
@@ -21,8 +21,8 @@ from ..schema import InstrumentsEvidence, Measurement, MetricProvenance
 from .capability import XctraceCapabilityReport
 from .export import (
     SUPPORTED_TABLE_SCHEMAS,
+    AmbiguousProcessError,
     ExportedTable,
-    InstrumentsExportError,
     MetalGpuIntervalSummary,
     ProcessGpuIntervals,
     summarize_metal_gpu_intervals,
@@ -121,11 +121,14 @@ def build_instruments_evidence(inputs: TraceEvidenceInputs) -> InstrumentsEviden
                 entry = None
                 try:
                     entry = summary.for_process(inputs.target_pid)
-                except InstrumentsExportError as exc:
+                except AmbiguousProcessError as exc:
                     # An ambiguous pid is a refusal, not a crash: the
                     # trace is still valid evidence, there is just no
                     # honest way to attribute a scalar to one process.
-                    notes.append(str(exc))
+                    # The summary omits the conflicting labels, which
+                    # name other processes and must not be persisted
+                    # into a derived artifact.
+                    notes.append(exc.summary)
                 else:
                     if entry is None:
                         notes.append(

--- a/llmtracefx/optimizer/instruments/evidence.py
+++ b/llmtracefx/optimizer/instruments/evidence.py
@@ -22,6 +22,7 @@ from .capability import XctraceCapabilityReport
 from .export import (
     SUPPORTED_TABLE_SCHEMAS,
     ExportedTable,
+    InstrumentsExportError,
     MetalGpuIntervalSummary,
     ProcessGpuIntervals,
     summarize_metal_gpu_intervals,
@@ -117,13 +118,22 @@ def build_instruments_evidence(inputs: TraceEvidenceInputs) -> InstrumentsEviden
                     "would misattribute other processes' GPU work."
                 )
             else:
-                entry = summary.for_process(inputs.target_pid)
-                if entry is None:
-                    notes.append(
-                        f"pid {inputs.target_pid} contributed no GPU "
-                        "intervals to this trace, so no metric was derived"
-                    )
+                entry = None
+                try:
+                    entry = summary.for_process(inputs.target_pid)
+                except InstrumentsExportError as exc:
+                    # An ambiguous pid is a refusal, not a crash: the
+                    # trace is still valid evidence, there is just no
+                    # honest way to attribute a scalar to one process.
+                    notes.append(str(exc))
                 else:
+                    if entry is None:
+                        notes.append(
+                            f"pid {inputs.target_pid} contributed no GPU "
+                            "intervals to this trace, so no metric was "
+                            "derived"
+                        )
+                if entry is not None:
                     metrics = metrics_for_process(summary, entry)
                     notes.append(
                         f"metrics describe pid {inputs.target_pid} only "
@@ -146,6 +156,31 @@ def build_instruments_evidence(inputs: TraceEvidenceInputs) -> InstrumentsEviden
         unsupported_schemas=unsupported,
         metrics=metrics,
         notes=" ".join(notes) if notes else None,
+    )
+
+
+def failed_recording_evidence(
+    capability: XctraceCapabilityReport, *, template: str, reason: str
+) -> InstrumentsEvidence:
+    """Evidence recorded when a supported toolchain still failed to record.
+
+    Distinct from :func:`unsupported_evidence`: capability succeeded, so
+    reusing the capability reason here would persist an affirmatively
+    misleading note ("xctrace provides the template") on an artifact
+    that represents a failed recording. The recorder's own message is
+    carried instead.
+    """
+    return InstrumentsEvidence(
+        tool="xctrace",
+        tool_version=capability.xctrace_version,
+        capability=capability.capability.value,
+        template=template,
+        trace_bundle_name=None,
+        available_schemas=(),
+        parsed_schemas=(),
+        unsupported_schemas=(),
+        metrics={},
+        notes=f"no trace was produced: {reason}",
     )
 
 

--- a/llmtracefx/optimizer/instruments/evidence.py
+++ b/llmtracefx/optimizer/instruments/evidence.py
@@ -184,6 +184,40 @@ def failed_recording_evidence(
     )
 
 
+def failed_export_evidence(
+    capability: XctraceCapabilityReport,
+    *,
+    template: str,
+    trace_bundle_name: str,
+    reason: str,
+) -> InstrumentsEvidence:
+    """Evidence for a trace that recorded but could not be exported.
+
+    Distinct from :func:`failed_recording_evidence`, which says no trace
+    was produced. Here one was, it is on disk, and it can still be
+    exported later, so its name is kept and the note points at the
+    recovery path. Saying "no trace was produced" about a bundle that
+    exists would deny the only recoverable artifact the run left.
+    """
+    return InstrumentsEvidence(
+        tool="xctrace",
+        tool_version=capability.xctrace_version,
+        capability=capability.capability.value,
+        template=template,
+        trace_bundle_name=trace_bundle_name,
+        available_schemas=(),
+        parsed_schemas=(),
+        unsupported_schemas=(),
+        metrics={},
+        notes=(
+            f"the trace was recorded but could not be exported, so no "
+            f"metric was derived: {reason}. The bundle is on disk and can "
+            f"be exported later with `instruments import --trace "
+            f"{trace_bundle_name}`."
+        ),
+    )
+
+
 def unsupported_evidence(
     capability: XctraceCapabilityReport, *, template: str
 ) -> InstrumentsEvidence:

--- a/llmtracefx/optimizer/instruments/evidence.py
+++ b/llmtracefx/optimizer/instruments/evidence.py
@@ -1,0 +1,171 @@
+"""Turn parsed trace artifacts into canonical ``InstrumentsEvidence``.
+
+This is the only place that decides what counts as a claimable metric.
+The rule it enforces: a number is emitted only when a strict parser
+produced it from an exported table, and it is named for exactly what it
+measures.
+
+What is deliberately never produced here, despite Metal System Trace
+advertising tables whose names gesture at them: GPU utilization, GPU
+busy percentage, kernel time, memory bandwidth, occupancy, GPU power and
+GPU memory footprint. Each would need modelling assumptions this project
+has not validated against ground truth, so each stays absent instead of
+being approximated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..schema import InstrumentsEvidence, Measurement, MetricProvenance
+from .capability import XctraceCapabilityReport
+from .export import (
+    SUPPORTED_TABLE_SCHEMAS,
+    ExportedTable,
+    MetalGpuIntervalSummary,
+    ProcessGpuIntervals,
+    summarize_metal_gpu_intervals,
+)
+
+#: Nanoseconds per millisecond. Trace durations are integer nanoseconds.
+_NS_PER_MS = 1_000_000.0
+
+
+@dataclass(frozen=True)
+class TraceEvidenceInputs:
+    """Everything needed to build evidence for one recorded trace."""
+
+    capability: XctraceCapabilityReport
+    trace_bundle_name: str
+    template: str
+    available_schemas: tuple[str, ...]
+    table: ExportedTable | None = None
+    """A parsed table, when one was exported and understood."""
+    target_pid: int | None = None
+    """Which process the metrics should describe.
+
+    Metal System Trace captures GPU work system wide. Without a target
+    pid there is no honest way to attribute intervals to the workload
+    under test, so no scalar metric is emitted."""
+
+
+def _partition_schemas(
+    available: tuple[str, ...], parsed: tuple[str, ...]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    parsed_set = set(parsed)
+    unsupported = tuple(schema for schema in available if schema not in parsed_set)
+    return parsed, unsupported
+
+
+def metrics_for_process(
+    summary: MetalGpuIntervalSummary, entry: ProcessGpuIntervals
+) -> dict[str, Measurement]:
+    """Build the metric set for one process's GPU intervals.
+
+    Names are chosen so that no reader can mistake them for utilization
+    or throughput. ``duration_sum`` in particular sums intervals that
+    Metal runs concurrently across channels, so it exceeds wall-clock
+    GPU busy time and is never presented as a fraction of anything.
+    """
+    return {
+        "metal_gpu_interval_count": Measurement(
+            value=float(entry.interval_count),
+            provenance=MetricProvenance.MEASURED_NATIVE,
+            unit="intervals",
+        ),
+        "metal_gpu_interval_duration_sum": Measurement(
+            value=entry.duration_sum_ns / _NS_PER_MS,
+            provenance=MetricProvenance.MEASURED_NATIVE,
+            unit="ms",
+        ),
+        "metal_gpu_interval_wall_span": Measurement(
+            value=entry.wall_span_ns / _NS_PER_MS,
+            provenance=MetricProvenance.MEASURED_NATIVE,
+            unit="ms",
+        ),
+        "metal_gpu_interval_count_all_processes": Measurement(
+            value=float(summary.total_interval_count),
+            provenance=MetricProvenance.MEASURED_NATIVE,
+            unit="intervals",
+        ),
+    }
+
+
+def build_instruments_evidence(inputs: TraceEvidenceInputs) -> InstrumentsEvidence:
+    """Assemble evidence, leaving unmeasurable quantities absent."""
+    capability = inputs.capability
+    parsed_schemas: tuple[str, ...] = ()
+    metrics: dict[str, Measurement] = {}
+    notes: list[str] = []
+
+    table = inputs.table
+    if table is not None:
+        if table.schema_name not in SUPPORTED_TABLE_SCHEMAS:
+            notes.append(
+                f"table {table.schema_name!r} was exported but this project "
+                "has no strict summarizer for it, so no metric was derived"
+            )
+        else:
+            parsed_schemas = (table.schema_name,)
+            summary = summarize_metal_gpu_intervals(table)
+            if inputs.target_pid is None:
+                notes.append(
+                    "no target pid was supplied, so the "
+                    f"{summary.total_interval_count} parsed GPU intervals "
+                    "were left unattributed. Metal System Trace records "
+                    "every process on the system, so a system-wide total "
+                    "would misattribute other processes' GPU work."
+                )
+            else:
+                entry = summary.for_process(inputs.target_pid)
+                if entry is None:
+                    notes.append(
+                        f"pid {inputs.target_pid} contributed no GPU "
+                        "intervals to this trace, so no metric was derived"
+                    )
+                else:
+                    metrics = metrics_for_process(summary, entry)
+                    notes.append(
+                        f"metrics describe pid {inputs.target_pid} only "
+                        f"({entry.interval_count} of "
+                        f"{summary.total_interval_count} intervals in the "
+                        "trace). duration_sum adds concurrent Metal "
+                        "channels together and is not GPU busy time or "
+                        "utilization."
+                    )
+
+    parsed, unsupported = _partition_schemas(inputs.available_schemas, parsed_schemas)
+    return InstrumentsEvidence(
+        tool="xctrace",
+        tool_version=capability.xctrace_version,
+        capability=capability.capability.value,
+        template=inputs.template,
+        trace_bundle_name=inputs.trace_bundle_name,
+        available_schemas=inputs.available_schemas,
+        parsed_schemas=parsed,
+        unsupported_schemas=unsupported,
+        metrics=metrics,
+        notes=" ".join(notes) if notes else None,
+    )
+
+
+def unsupported_evidence(
+    capability: XctraceCapabilityReport, *, template: str
+) -> InstrumentsEvidence:
+    """Evidence recorded when no trace could be taken at all.
+
+    Carries the capability state and its reason so a downstream reader
+    sees why the measurement is missing instead of finding a silent gap.
+    """
+    return InstrumentsEvidence(
+        tool="xctrace",
+        tool_version=capability.xctrace_version,
+        capability=capability.capability.value,
+        template=template,
+        trace_bundle_name=None,
+        available_schemas=(),
+        parsed_schemas=(),
+        unsupported_schemas=(),
+        metrics={},
+        notes=capability.reason,
+    )

--- a/llmtracefx/optimizer/instruments/export.py
+++ b/llmtracefx/optimizer/instruments/export.py
@@ -83,6 +83,32 @@ class InstrumentsExportError(ValueError):
     """Raised when exported XML is missing, malformed or unsupported."""
 
 
+class AmbiguousProcessError(InstrumentsExportError):
+    """Raised when one pid appears under several process labels.
+
+    Carries two wordings on purpose. ``str(...)`` names the conflicting
+    labels, which is what an operator debugging their own machine needs
+    to see on stderr. :attr:`summary` omits them, and is what gets
+    persisted, because the labels belong to other processes and a
+    derived artifact must not name them.
+    """
+
+    def __init__(self, pid: int, labels: tuple[str, ...]) -> None:
+        self.pid = pid
+        self.labels = labels
+        self.summary = (
+            f"pid {pid} is ambiguous in this trace: it appears under "
+            f"{len(labels)} different process labels. Refusing to "
+            "attribute GPU intervals to one of them."
+        )
+        super().__init__(
+            f"pid {pid} is ambiguous in this trace: it appears under "
+            f"{len(labels)} different process labels "
+            f"({', '.join(labels)}). Refusing to attribute GPU intervals "
+            "to one of them."
+        )
+
+
 def _parse_xml(text: str, *, source: str) -> ElementTree.Element:
     """Parse XML with entity-expansion inputs refused up front.
 
@@ -638,11 +664,8 @@ class MetalGpuIntervalSummary:
         if not matches:
             return None
         if len(matches) > 1:
-            labels = ", ".join(sorted(entry.process_label for entry in matches))
-            raise InstrumentsExportError(
-                f"pid {pid} is ambiguous in this trace: it appears under "
-                f"{len(matches)} different process labels ({labels}). "
-                "Refusing to attribute GPU intervals to one of them."
+            raise AmbiguousProcessError(
+                pid, tuple(sorted(entry.process_label for entry in matches))
             )
         return matches[0]
 

--- a/llmtracefx/optimizer/instruments/export.py
+++ b/llmtracefx/optimizer/instruments/export.py
@@ -1,0 +1,609 @@
+"""Strict parsers for ``xctrace export`` output.
+
+Two formats are handled, both verified against real output from
+``xctrace version 16.0 (17F113)`` on macOS 26.6.2 (Apple M5 Pro):
+
+Table of contents (``xctrace export --toc``)
+    ``<trace-toc>`` containing ``<run number="N">`` elements. Each run
+    carries ``<info><summary>`` metadata and a ``<data>`` list of
+    ``<table schema="..."/>`` entries.
+
+Table data (``xctrace export --xpath ...``)
+    ``<trace-query-result>`` containing ``<node>`` elements. Each node
+    holds one ``<schema name="...">`` with ordered ``<col>`` definitions,
+    followed by ``<row>`` elements.
+
+Two properties of the real format drive the whole design:
+
+1. **Rows are positional.** A row's Nth direct child corresponds to the
+   schema's Nth ``<col>``, and the child's tag equals that column's
+   ``<engineering-type>``. Verified across every row of a real
+   ``metal-gpu-intervals`` export (2460 rows, 18 of 18 children each,
+   tags matching the declared engineering types in order). The parser
+   enforces both invariants and fails loudly rather than mapping values
+   onto the wrong columns.
+
+2. **Values are reference-deduplicated.** A repeated value is emitted
+   once with an ``id`` and afterwards referenced as ``<tag ref="id"/>``.
+   The same real export contained 2460 rows but 43818 ``ref``
+   attributes, so a parser that ignored references would silently drop
+   the overwhelming majority of every row's content.
+
+Privacy: the TOC also contains the device's display name (which
+routinely embeds a person's name), its hardware UUID, and the launched
+process's full argument list. None of those are read by
+:func:`parse_table_of_contents`, so they cannot reach an experiment
+record or a log line.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+#: Refuse inputs above this size rather than loading them into memory.
+#: A real 0.87 second Metal System Trace exported a 2.7 MB
+#: ``metal-gpu-intervals`` table, so this leaves ample headroom while
+#: still bounding a runaway export.
+MAX_EXPORT_BYTES = 256 * 1024 * 1024
+
+#: Metal System Trace table schemas this project knows how to summarize.
+#: Everything else found in a trace is reported as present but
+#: unsupported rather than guessed at.
+SUPPORTED_TABLE_SCHEMAS: tuple[str, ...] = ("metal-gpu-intervals",)
+
+#: Metric names this project must never emit. Metal System Trace does
+#: expose tables whose names gesture at these ideas, but none of them
+#: can be derived from an exported table without modelling assumptions
+#: this project has not validated. Asserted by the test suite.
+FORBIDDEN_METRIC_NAMES: tuple[str, ...] = (
+    "gpu_utilization",
+    "gpu_busy_percent",
+    "gpu_kernel_time",
+    "memory_bandwidth",
+    "bandwidth_gb_s",
+    "occupancy",
+    "gpu_power",
+    "gpu_energy",
+    "gpu_memory_bytes",
+)
+
+_DOCTYPE_RE = re.compile(r"<!\s*(DOCTYPE|ENTITY)", re.IGNORECASE)
+
+
+class InstrumentsExportError(ValueError):
+    """Raised when exported XML is missing, malformed or unsupported."""
+
+
+def _parse_xml(text: str, *, source: str) -> ElementTree.Element:
+    """Parse XML with entity-expansion inputs refused up front.
+
+    :mod:`xml.etree.ElementTree` does not resolve external entities, but
+    it will happily expand internal ones, which is the "billion laughs"
+    denial of service. Real xctrace output contains no doctype at all,
+    so refusing any input that declares one costs nothing and removes
+    the class of attack entirely.
+    """
+    if _DOCTYPE_RE.search(text):
+        raise InstrumentsExportError(
+            f"{source} declares a DOCTYPE or ENTITY. Real xctrace output "
+            "never does, and entity expansion is refused."
+        )
+    try:
+        return ElementTree.fromstring(text)
+    except ElementTree.ParseError as exc:
+        raise InstrumentsExportError(f"{source} is not valid XML: {exc}") from exc
+
+
+def read_export_text(path: str | Path) -> str:
+    """Read an export file, refusing absent or oversized inputs."""
+    target = Path(path)
+    if not target.exists():
+        raise InstrumentsExportError(f"export file does not exist: {target}")
+    if not target.is_file():
+        raise InstrumentsExportError(f"export path is not a file: {target}")
+    size = target.stat().st_size
+    if size > MAX_EXPORT_BYTES:
+        raise InstrumentsExportError(
+            f"export file is {size} bytes, above the {MAX_EXPORT_BYTES} byte "
+            "limit. Re-record with a shorter --time-limit."
+        )
+    try:
+        return target.read_text(encoding="utf-8")
+    except UnicodeError as exc:
+        raise InstrumentsExportError(
+            f"export file is not valid UTF-8: {target}: {exc}"
+        ) from exc
+
+
+# --- Table of contents ------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TraceRun:
+    """One recorded run inside a ``.trace`` bundle.
+
+    Only allowlisted fields are captured. ``target_pid`` and
+    ``target_process_name`` describe the process this project asked
+    xctrace to launch, and are read because metric attribution is
+    impossible without them. The device display name (which routinely
+    embeds a person's name), the device hardware UUID, and the target
+    process's full argument list also live in the TOC and are
+    deliberately not read.
+    """
+
+    number: int
+    template_name: str | None = None
+    instruments_version: str | None = None
+    duration_seconds: float | None = None
+    end_reason: str | None = None
+    target_pid: int | None = None
+    target_process_name: str | None = None
+    schemas: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "template_name": self.template_name,
+            "instruments_version": self.instruments_version,
+            "duration_seconds": self.duration_seconds,
+            "end_reason": self.end_reason,
+            "target_pid": self.target_pid,
+            "target_process_name": self.target_process_name,
+            "schemas": list(self.schemas),
+        }
+
+
+@dataclass(frozen=True)
+class TraceTableOfContents:
+    """Parsed ``xctrace export --toc`` output."""
+
+    runs: tuple[TraceRun, ...]
+
+    @property
+    def schema_names(self) -> tuple[str, ...]:
+        """Every distinct table schema across all runs, sorted."""
+        names: set[str] = set()
+        for run in self.runs:
+            names.update(run.schemas)
+        return tuple(sorted(names))
+
+    def run_by_number(self, number: int) -> TraceRun | None:
+        for run in self.runs:
+            if run.number == number:
+                return run
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"runs": [run.to_dict() for run in self.runs]}
+
+
+def _optional_float(value: str | None, *, field: str) -> float | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError as exc:
+        raise InstrumentsExportError(
+            f"trace TOC {field} is not a number: {value!r}"
+        ) from exc
+
+
+def _text_or_none(parent: ElementTree.Element | None, path: str) -> str | None:
+    if parent is None:
+        return None
+    found = parent.find(path)
+    if found is None or found.text is None:
+        return None
+    stripped = found.text.strip()
+    return stripped or None
+
+
+def parse_table_of_contents(xml_text: str) -> TraceTableOfContents:
+    """Parse ``xctrace export --toc`` XML into a schema inventory."""
+    root = _parse_xml(xml_text, source="trace table of contents")
+    if root.tag != "trace-toc":
+        raise InstrumentsExportError(
+            f"expected a <trace-toc> document, got <{root.tag}>. This does "
+            "not look like `xctrace export --toc` output."
+        )
+
+    runs: list[TraceRun] = []
+    for run_element in root.findall("run"):
+        raw_number = run_element.get("number")
+        if raw_number is None:
+            raise InstrumentsExportError("trace TOC <run> is missing @number")
+        try:
+            number = int(raw_number)
+        except ValueError as exc:
+            raise InstrumentsExportError(
+                f"trace TOC <run> @number is not an integer: {raw_number!r}"
+            ) from exc
+
+        summary = run_element.find("info/summary")
+        target_process = run_element.find("info/target/process")
+        target_pid: int | None = None
+        target_process_name: str | None = None
+        if target_process is not None:
+            raw_pid = target_process.get("pid")
+            if raw_pid is not None:
+                try:
+                    target_pid = int(raw_pid)
+                except ValueError as exc:
+                    raise InstrumentsExportError(
+                        f"trace TOC target process @pid is not an integer: "
+                        f"{raw_pid!r}"
+                    ) from exc
+            target_process_name = target_process.get("name")
+
+        schemas = tuple(
+            dict.fromkeys(
+                schema
+                for schema in (
+                    table.get("schema") for table in run_element.findall("data/table")
+                )
+                if schema
+            )
+        )
+        runs.append(
+            TraceRun(
+                number=number,
+                template_name=_text_or_none(summary, "template-name"),
+                instruments_version=_text_or_none(summary, "instruments-version"),
+                duration_seconds=_optional_float(
+                    _text_or_none(summary, "duration"), field="duration"
+                ),
+                end_reason=_text_or_none(summary, "end-reason"),
+                target_pid=target_pid,
+                target_process_name=target_process_name,
+                schemas=schemas,
+            )
+        )
+
+    if not runs:
+        raise InstrumentsExportError(
+            "trace TOC contains no <run> elements; the trace bundle has no "
+            "recorded runs to export"
+        )
+    return TraceTableOfContents(runs=tuple(runs))
+
+
+# --- Table data -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TableColumn:
+    """One ``<col>`` definition from an exported table's schema."""
+
+    mnemonic: str
+    name: str | None
+    engineering_type: str
+
+
+@dataclass(frozen=True)
+class CellValue:
+    """One resolved cell, after any ``ref`` indirection was followed."""
+
+    tag: str
+    text: str | None
+    fmt: str | None
+
+    def as_int(self, *, field: str) -> int:
+        if self.text is None:
+            raise InstrumentsExportError(
+                f"exported value for {field!r} has no text content"
+            )
+        try:
+            return int(self.text.strip())
+        except ValueError as exc:
+            raise InstrumentsExportError(
+                f"exported value for {field!r} is not an integer: " f"{self.text!r}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class ExportedRow:
+    """One table row, keyed by column mnemonic."""
+
+    values: dict[str, CellValue]
+
+    def get(self, mnemonic: str) -> CellValue | None:
+        return self.values.get(mnemonic)
+
+    def require(self, mnemonic: str) -> CellValue:
+        value = self.values.get(mnemonic)
+        if value is None:
+            raise InstrumentsExportError(f"exported row has no column {mnemonic!r}")
+        return value
+
+
+@dataclass(frozen=True)
+class ExportedTable:
+    """A fully parsed exported table."""
+
+    schema_name: str
+    columns: tuple[TableColumn, ...]
+    rows: tuple[ExportedRow, ...]
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def column_mnemonics(self) -> tuple[str, ...]:
+        return tuple(column.mnemonic for column in self.columns)
+
+
+def _build_id_index(root: ElementTree.Element) -> dict[str, ElementTree.Element]:
+    """Index every element that defines an ``id``.
+
+    Definitions can appear anywhere, including nested inside a composite
+    value such as ``formatted-label``, so the whole document is walked.
+    """
+    index: dict[str, ElementTree.Element] = {}
+    for element in root.iter():
+        identifier = element.get("id")
+        if identifier is not None:
+            index.setdefault(identifier, element)
+    return index
+
+
+def _resolve(
+    element: ElementTree.Element,
+    index: dict[str, ElementTree.Element],
+) -> ElementTree.Element:
+    """Follow ``ref`` indirection to the element that defines the value.
+
+    Chains are followed, and a cycle or dangling reference is an error
+    rather than a silently empty value.
+    """
+    seen: set[str] = set()
+    current = element
+    while True:
+        reference = current.get("ref")
+        if reference is None:
+            return current
+        if reference in seen:
+            raise InstrumentsExportError(
+                f"exported table has a cyclic ref chain at id {reference!r}"
+            )
+        seen.add(reference)
+        target = index.get(reference)
+        if target is None:
+            raise InstrumentsExportError(
+                f"exported table references undefined id {reference!r}"
+            )
+        current = target
+
+
+def _parse_columns(schema_element: ElementTree.Element) -> tuple[TableColumn, ...]:
+    columns: list[TableColumn] = []
+    for col in schema_element.findall("col"):
+        mnemonic = _text_or_none(col, "mnemonic")
+        engineering_type = _text_or_none(col, "engineering-type")
+        if mnemonic is None or engineering_type is None:
+            raise InstrumentsExportError(
+                "exported table column is missing <mnemonic> or " "<engineering-type>"
+            )
+        columns.append(
+            TableColumn(
+                mnemonic=mnemonic,
+                name=_text_or_none(col, "name"),
+                engineering_type=engineering_type,
+            )
+        )
+    if not columns:
+        raise InstrumentsExportError("exported table schema declares no <col> elements")
+    return tuple(columns)
+
+
+def parse_exported_table(
+    xml_text: str, *, expected_schema: str | None = None
+) -> ExportedTable:
+    """Parse ``xctrace export --xpath ...`` XML into typed rows.
+
+    ``expected_schema``, when given, must match the schema the document
+    declares. A mismatch means the export did not return the table that
+    was asked for, which is treated as an error rather than parsed
+    anyway.
+    """
+    root = _parse_xml(xml_text, source="trace table export")
+    if root.tag != "trace-query-result":
+        raise InstrumentsExportError(
+            f"expected a <trace-query-result> document, got <{root.tag}>. "
+            "This does not look like `xctrace export --xpath` output."
+        )
+
+    node = root.find("node")
+    if node is None:
+        raise InstrumentsExportError(
+            "trace export contains no <node>; the XPath selected nothing. "
+            "Check the schema name against `xctrace export --toc`."
+        )
+
+    schema_element = node.find("schema")
+    if schema_element is None:
+        raise InstrumentsExportError(
+            "trace export <node> has no <schema>; this table is not "
+            "exportable in the row/column form this project parses"
+        )
+    schema_name = schema_element.get("name")
+    if not schema_name:
+        raise InstrumentsExportError("trace export <schema> is missing @name")
+    if expected_schema is not None and schema_name != expected_schema:
+        raise InstrumentsExportError(
+            f"trace export returned schema {schema_name!r} but "
+            f"{expected_schema!r} was requested"
+        )
+
+    columns = _parse_columns(schema_element)
+    index = _build_id_index(root)
+
+    rows: list[ExportedRow] = []
+    for row_number, row_element in enumerate(node.findall("row"), start=1):
+        children = list(row_element)
+        if len(children) != len(columns):
+            raise InstrumentsExportError(
+                f"row {row_number} of table {schema_name!r} has "
+                f"{len(children)} values but the schema declares "
+                f"{len(columns)} columns. Refusing to map values onto "
+                "columns positionally when the counts disagree."
+            )
+        values: dict[str, CellValue] = {}
+        # strict=True is belt and braces: the length check above
+        # already guarantees the two sequences match.
+        for column, child in zip(columns, children, strict=True):
+            if child.tag != column.engineering_type:
+                raise InstrumentsExportError(
+                    f"row {row_number} of table {schema_name!r} has "
+                    f"<{child.tag}> where column {column.mnemonic!r} "
+                    f"declares engineering type "
+                    f"{column.engineering_type!r}"
+                )
+            resolved = _resolve(child, index)
+            values[column.mnemonic] = CellValue(
+                tag=resolved.tag,
+                text=resolved.text,
+                fmt=resolved.get("fmt"),
+            )
+        rows.append(ExportedRow(values=values))
+
+    return ExportedTable(schema_name=schema_name, columns=columns, rows=tuple(rows))
+
+
+# --- Summaries derived only from parsed rows --------------------------
+
+
+@dataclass(frozen=True)
+class ProcessGpuIntervals:
+    """GPU interval statistics for one process in a trace.
+
+    Every field is a direct consequence of parsed rows. Note what is
+    absent: there is no utilization, occupancy, bandwidth or power
+    figure, because none of those can be derived from this table without
+    assumptions this project has not validated.
+    """
+
+    process_label: str
+    """The trace's own label for the process, e.g. ``probe (14717)``."""
+    pid: int | None
+    interval_count: int
+    duration_sum_ns: int
+    """Sum of every interval's duration.
+
+    Metal runs several channels (Vertex, Fragment, Compute) that overlap
+    in time, so this sum counts concurrent work more than once. It is
+    therefore *not* GPU busy time and *not* a utilization numerator."""
+    wall_span_ns: int
+    """Last interval end minus first interval start, for this process."""
+
+
+@dataclass(frozen=True)
+class MetalGpuIntervalSummary:
+    """Per-process breakdown of a ``metal-gpu-intervals`` table.
+
+    Metal System Trace records GPU work for every process on the system,
+    not only the one that was launched. A real capture of a trivial
+    local Metal program also contained intervals belonging to
+    ``WindowServer`` and ``com.apple.WebKit.GPU``. Attribution is
+    therefore kept per process, and a caller must name the process it
+    means rather than receive a system-wide total labelled as its own.
+    """
+
+    total_interval_count: int
+    per_process: tuple[ProcessGpuIntervals, ...]
+
+    def for_process(self, pid: int) -> ProcessGpuIntervals | None:
+        for entry in self.per_process:
+            if entry.pid == pid:
+                return entry
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_interval_count": self.total_interval_count,
+            "per_process": [
+                {
+                    "process_label": entry.process_label,
+                    "pid": entry.pid,
+                    "interval_count": entry.interval_count,
+                    "duration_sum_ns": entry.duration_sum_ns,
+                    "wall_span_ns": entry.wall_span_ns,
+                }
+                for entry in self.per_process
+            ],
+        }
+
+
+def _process_pid(value: CellValue) -> int | None:
+    """Extract a pid from a resolved ``process`` cell's ``fmt`` label.
+
+    The label has the shape ``name (pid)``. Returning ``None`` when it
+    does not match keeps an unparsable label from becoming a wrong pid.
+    """
+    if value.fmt is None:
+        return None
+    match = re.search(r"\((\d+)\)\s*$", value.fmt)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def summarize_metal_gpu_intervals(table: ExportedTable) -> MetalGpuIntervalSummary:
+    """Aggregate a parsed ``metal-gpu-intervals`` table by process."""
+    if table.schema_name != "metal-gpu-intervals":
+        raise InstrumentsExportError(
+            f"expected a 'metal-gpu-intervals' table, got " f"{table.schema_name!r}"
+        )
+    required = {"start", "duration", "process"}
+    missing = required.difference(table.column_mnemonics)
+    if missing:
+        raise InstrumentsExportError(
+            "metal-gpu-intervals table is missing required columns: "
+            + ", ".join(sorted(missing))
+        )
+
+    counts: dict[str, int] = {}
+    duration_sums: dict[str, int] = {}
+    first_start: dict[str, int] = {}
+    last_end: dict[str, int] = {}
+    pids: dict[str, int | None] = {}
+
+    for row in table.rows:
+        process = row.require("process")
+        label = process.fmt or "<unknown process>"
+        start = row.require("start").as_int(field="start")
+        duration = row.require("duration").as_int(field="duration")
+        if duration < 0:
+            raise InstrumentsExportError(
+                f"metal-gpu-intervals row has a negative duration: {duration}"
+            )
+        end = start + duration
+
+        counts[label] = counts.get(label, 0) + 1
+        duration_sums[label] = duration_sums.get(label, 0) + duration
+        pids.setdefault(label, _process_pid(process))
+        if label not in first_start or start < first_start[label]:
+            first_start[label] = start
+        if label not in last_end or end > last_end[label]:
+            last_end[label] = end
+
+    per_process = tuple(
+        ProcessGpuIntervals(
+            process_label=label,
+            pid=pids[label],
+            interval_count=counts[label],
+            duration_sum_ns=duration_sums[label],
+            wall_span_ns=last_end[label] - first_start[label],
+        )
+        for label in sorted(counts, key=lambda key: (-counts[key], key))
+    )
+    return MetalGpuIntervalSummary(
+        total_interval_count=sum(counts.values()), per_process=per_process
+    )

--- a/llmtracefx/optimizer/instruments/export.py
+++ b/llmtracefx/optimizer/instruments/export.py
@@ -39,7 +39,7 @@ record or a log line.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
@@ -293,17 +293,25 @@ class CellValue:
     tag: str
     text: str | None
     fmt: str | None
+    children: dict[str, CellValue] = field(default_factory=dict)
+    """Resolved direct children, keyed by tag.
 
-    def as_int(self, *, field: str) -> int:
+    Composite values carry structured sub-values: a ``process`` cell has
+    a ``pid`` child. Reading that structure is strictly more reliable
+    than scraping the human-readable display label, so it is kept rather
+    than discarded."""
+
+    def as_int(self, *, field_name: str) -> int:
         if self.text is None:
             raise InstrumentsExportError(
-                f"exported value for {field!r} has no text content"
+                f"exported value for {field_name!r} has no text content"
             )
         try:
             return int(self.text.strip())
         except ValueError as exc:
             raise InstrumentsExportError(
-                f"exported value for {field!r} is not an integer: " f"{self.text!r}"
+                f"exported value for {field_name!r} is not an integer: "
+                f"{self.text!r}"
             ) from exc
 
 
@@ -400,7 +408,45 @@ def _parse_columns(schema_element: ElementTree.Element) -> tuple[TableColumn, ..
         )
     if not columns:
         raise InstrumentsExportError("exported table schema declares no <col> elements")
+    mnemonics = [column.mnemonic for column in columns]
+    duplicates = sorted({name for name in mnemonics if mnemonics.count(name) > 1})
+    if duplicates:
+        # Rows are keyed by mnemonic, so a repeated one would let a later
+        # column silently overwrite an earlier one and make require()
+        # hand back a different column's value.
+        raise InstrumentsExportError(
+            "exported table schema declares duplicate column mnemonics: "
+            + ", ".join(duplicates)
+        )
     return tuple(columns)
+
+
+def _cell_from(
+    element: ElementTree.Element, index: dict[str, ElementTree.Element]
+) -> CellValue:
+    """Build a cell from a resolved element, resolving its children too.
+
+    Only direct children are resolved, which is enough to read a
+    structured sub-value such as a ``process`` cell's ``pid`` without
+    walking an unbounded tree.
+    """
+    children: dict[str, CellValue] = {}
+    for child in element:
+        resolved_child = _resolve(child, index)
+        children.setdefault(
+            resolved_child.tag,
+            CellValue(
+                tag=resolved_child.tag,
+                text=resolved_child.text,
+                fmt=resolved_child.get("fmt"),
+            ),
+        )
+    return CellValue(
+        tag=element.tag,
+        text=element.text,
+        fmt=element.get("fmt"),
+        children=children,
+    )
 
 
 def parse_exported_table(
@@ -420,12 +466,21 @@ def parse_exported_table(
             "This does not look like `xctrace export --xpath` output."
         )
 
-    node = root.find("node")
-    if node is None:
+    nodes = root.findall("node")
+    if not nodes:
         raise InstrumentsExportError(
             "trace export contains no <node>; the XPath selected nothing. "
             "Check the schema name against `xctrace export --toc`."
         )
+    if len(nodes) > 1:
+        # Parsing only the first node would report a subset of the rows
+        # as though it were the whole table.
+        raise InstrumentsExportError(
+            f"trace export contains {len(nodes)} <node> elements. This "
+            "project exports one table at a time and refuses to report "
+            "one node's rows as the whole result."
+        )
+    node = nodes[0]
 
     schema_element = node.find("schema")
     if schema_element is None:
@@ -459,19 +514,24 @@ def parse_exported_table(
         # strict=True is belt and braces: the length check above
         # already guarantees the two sequences match.
         for column, child in zip(columns, children, strict=True):
-            if child.tag != column.engineering_type:
-                raise InstrumentsExportError(
-                    f"row {row_number} of table {schema_name!r} has "
-                    f"<{child.tag}> where column {column.mnemonic!r} "
-                    f"declares engineering type "
-                    f"{column.engineering_type!r}"
-                )
             resolved = _resolve(child, index)
-            values[column.mnemonic] = CellValue(
-                tag=resolved.tag,
-                text=resolved.text,
-                fmt=resolved.get("fmt"),
-            )
+            # Both tags are checked. The referencing element's tag caught
+            # inline mismatches, but in real output almost every cell is
+            # a <tag ref="N"/>, so checking only that would leave the
+            # engineering-type contract enforced on a tiny minority of
+            # the data and let a ref point at a value of the wrong type.
+            for tag, source in (
+                (child.tag, "value"),
+                (resolved.tag, "referenced value"),
+            ):
+                if tag != column.engineering_type:
+                    raise InstrumentsExportError(
+                        f"row {row_number} of table {schema_name!r} has a "
+                        f"{source} <{tag}> where column "
+                        f"{column.mnemonic!r} declares engineering type "
+                        f"{column.engineering_type!r}"
+                    )
+            values[column.mnemonic] = _cell_from(resolved, index)
         rows.append(ExportedRow(values=values))
 
     return ExportedTable(schema_name=schema_name, columns=columns, rows=tuple(rows))
@@ -520,10 +580,25 @@ class MetalGpuIntervalSummary:
     per_process: tuple[ProcessGpuIntervals, ...]
 
     def for_process(self, pid: int) -> ProcessGpuIntervals | None:
-        for entry in self.per_process:
-            if entry.pid == pid:
-                return entry
-        return None
+        """The single entry for ``pid``, or ``None`` if it has none.
+
+        Raises when more than one entry shares the pid. That happens if
+        a pid was reused within the capture or a process changed its
+        name, and picking one of them would attribute another process's
+        GPU work to the caller's, which is exactly the misattribution
+        this module exists to prevent.
+        """
+        matches = [entry for entry in self.per_process if entry.pid == pid]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            labels = ", ".join(sorted(entry.process_label for entry in matches))
+            raise InstrumentsExportError(
+                f"pid {pid} is ambiguous in this trace: it appears under "
+                f"{len(matches)} different process labels ({labels}). "
+                "Refusing to attribute GPU intervals to one of them."
+            )
+        return matches[0]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -542,11 +617,22 @@ class MetalGpuIntervalSummary:
 
 
 def _process_pid(value: CellValue) -> int | None:
-    """Extract a pid from a resolved ``process`` cell's ``fmt`` label.
+    """Read a pid from a resolved ``process`` cell.
 
-    The label has the shape ``name (pid)``. Returning ``None`` when it
-    does not match keeps an unparsable label from becoming a wrong pid.
+    Prefers the structured ``<pid>`` child that real xctrace output
+    carries. The ``name (pid)`` display label is only a fallback for
+    exports that omit the child, and ``None`` is returned rather than a
+    guess when neither is usable, so an unreadable process never becomes
+    a wrong pid.
     """
+    pid_child = value.children.get("pid")
+    if pid_child is not None and pid_child.text is not None:
+        try:
+            return int(pid_child.text.strip())
+        except ValueError:
+            # Fall through to the label rather than failing the whole
+            # table for one unreadable pid element.
+            pass
     if value.fmt is None:
         return None
     match = re.search(r"\((\d+)\)\s*$", value.fmt)
@@ -569,40 +655,44 @@ def summarize_metal_gpu_intervals(table: ExportedTable) -> MetalGpuIntervalSumma
             + ", ".join(sorted(missing))
         )
 
-    counts: dict[str, int] = {}
-    duration_sums: dict[str, int] = {}
-    first_start: dict[str, int] = {}
-    last_end: dict[str, int] = {}
-    pids: dict[str, int | None] = {}
+    # Keyed on (pid, label) rather than the label alone. Two processes
+    # can share a display label, and one pid can appear under two labels
+    # after a pid is reused or a process changes its name; keying on the
+    # pair keeps both cases as distinct entries so neither is silently
+    # merged into the other.
+    Key = tuple[int | None, str]
+    counts: dict[Key, int] = {}
+    duration_sums: dict[Key, int] = {}
+    first_start: dict[Key, int] = {}
+    last_end: dict[Key, int] = {}
 
     for row in table.rows:
         process = row.require("process")
-        label = process.fmt or "<unknown process>"
-        start = row.require("start").as_int(field="start")
-        duration = row.require("duration").as_int(field="duration")
+        key: Key = (_process_pid(process), process.fmt or "<unknown process>")
+        start = row.require("start").as_int(field_name="start")
+        duration = row.require("duration").as_int(field_name="duration")
         if duration < 0:
             raise InstrumentsExportError(
                 f"metal-gpu-intervals row has a negative duration: {duration}"
             )
         end = start + duration
 
-        counts[label] = counts.get(label, 0) + 1
-        duration_sums[label] = duration_sums.get(label, 0) + duration
-        pids.setdefault(label, _process_pid(process))
-        if label not in first_start or start < first_start[label]:
-            first_start[label] = start
-        if label not in last_end or end > last_end[label]:
-            last_end[label] = end
+        counts[key] = counts.get(key, 0) + 1
+        duration_sums[key] = duration_sums.get(key, 0) + duration
+        if key not in first_start or start < first_start[key]:
+            first_start[key] = start
+        if key not in last_end or end > last_end[key]:
+            last_end[key] = end
 
     per_process = tuple(
         ProcessGpuIntervals(
-            process_label=label,
-            pid=pids[label],
-            interval_count=counts[label],
-            duration_sum_ns=duration_sums[label],
-            wall_span_ns=last_end[label] - first_start[label],
+            process_label=key[1],
+            pid=key[0],
+            interval_count=counts[key],
+            duration_sum_ns=duration_sums[key],
+            wall_span_ns=last_end[key] - first_start[key],
         )
-        for label in sorted(counts, key=lambda key: (-counts[key], key))
+        for key in sorted(counts, key=lambda item: (-counts[item], item[1]))
     )
     return MetalGpuIntervalSummary(
         total_interval_count=sum(counts.values()), per_process=per_process

--- a/llmtracefx/optimizer/instruments/export.py
+++ b/llmtracefx/optimizer/instruments/export.py
@@ -50,6 +50,11 @@ from xml.etree import ElementTree
 #: still bounding a runaway export.
 MAX_EXPORT_BYTES = 256 * 1024 * 1024
 
+#: Upper bound for a single interval's start or duration, in
+#: nanoseconds. One year, which no plausible trace approaches. Exists
+#: because a Python int is unbounded while a float is not.
+MAX_INTERVAL_NANOSECONDS = 365 * 24 * 60 * 60 * 1_000_000_000
+
 #: Metal System Trace table schemas this project knows how to summarize.
 #: Everything else found in a trace is reported as present but
 #: unsupported rather than guessed at.
@@ -203,6 +208,47 @@ def _text_or_none(parent: ElementTree.Element | None, path: str) -> str | None:
         return None
     stripped = found.text.strip()
     return stripped or None
+
+
+#: Attributes stripped from a trace's table of contents before it is
+#: written anywhere. Observed in real ``xctrace 16.0`` output:
+#: ``<device name="Jane's MacBook Pro" uuid="74656D9E-..."/>`` and
+#: ``<process arguments="--api-key sk-live ..."/>``. The parser never
+#: read these, but the raw XML was copied into the output directory
+#: verbatim, so the file itself carried them.
+TOC_SENSITIVE_ATTRIBUTES: tuple[tuple[str, str], ...] = (
+    ("device", "name"),
+    ("device", "uuid"),
+    ("process", "arguments"),
+)
+
+_XML_DECLARATION = '<?xml version="1.0"?>\n'
+
+_SANITIZED_NOTE = (
+    "<!-- Sanitized by llmtracefx: the device display name, the device "
+    "hardware UUID and the target process argument list were removed. "
+    "The .trace bundle this was exported from still contains them. -->\n"
+)
+
+
+def sanitize_table_of_contents(xml_text: str) -> str:
+    """Strip identifying attributes from a table of contents document.
+
+    A TOC names the machine's owner (macOS device names are routinely
+    "Jane's MacBook Pro"), its hardware UUID, and the full argument list
+    of the profiled process, which is the one place a credential passed
+    on the command line would survive redaction.
+
+    Everything else is kept, including the template, duration, schema
+    inventory and the target's pid and name, because attribution needs
+    them.
+    """
+    root = _parse_xml(xml_text, source="trace table of contents")
+    for tag, attribute in TOC_SENSITIVE_ATTRIBUTES:
+        for element in root.iter(tag):
+            element.attrib.pop(attribute, None)
+    body = ElementTree.tostring(root, encoding="unicode")
+    return _XML_DECLARATION + _SANITIZED_NOTE + body + "\n"
 
 
 def parse_table_of_contents(xml_text: str) -> TraceTableOfContents:
@@ -674,6 +720,16 @@ def summarize_metal_gpu_intervals(table: ExportedTable) -> MetalGpuIntervalSumma
         if duration < 0:
             raise InstrumentsExportError(
                 f"metal-gpu-intervals row has a negative duration: {duration}"
+            )
+        if duration > MAX_INTERVAL_NANOSECONDS or start > MAX_INTERVAL_NANOSECONDS:
+            # Python ints are unbounded, so a malformed cell can hold a
+            # value no float can represent. Converting it to
+            # milliseconds later would raise OverflowError from deep
+            # inside evidence building, far from the bad input.
+            raise InstrumentsExportError(
+                "metal-gpu-intervals row has an implausible timestamp or "
+                f"duration: start={start} duration={duration} exceeds "
+                f"{MAX_INTERVAL_NANOSECONDS} ns"
             )
         end = start + duration
 

--- a/llmtracefx/optimizer/instruments/process.py
+++ b/llmtracefx/optimizer/instruments/process.py
@@ -1,0 +1,225 @@
+"""Injectable subprocess boundaries for the Instruments/``xctrace`` layer.
+
+Two separate boundaries, because the two use cases need different things:
+
+``CommandRunner``
+    Short, bounded, capture-everything probes such as ``xctrace version``
+    and ``xctrace list templates``. Fully buffered, one shot.
+
+``ProcessLauncher``
+    A long-running ``xctrace record`` that writes a trace bundle, has to
+    be stoppable by signal, and must not leave orphaned children behind.
+
+Both are protocols so tests can drive the whole collector without Xcode
+installed. The real implementations are the only place in this package
+that touches :mod:`subprocess`, and neither one ever uses a shell: every
+invocation is an argv list, so nothing a caller supplies can be
+reinterpreted as shell syntax.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Protocol
+
+
+class InstrumentsProcessError(RuntimeError):
+    """Raised when a probe or recording process cannot be started."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Captured result of one short, bounded command."""
+
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+    @property
+    def combined_output(self) -> str:
+        """stdout and stderr joined, for pattern classification only.
+
+        Callers classify known Apple error strings against this. It is
+        never persisted verbatim into an experiment record.
+        """
+        return f"{self.stdout}\n{self.stderr}"
+
+
+class CommandRunner(Protocol):
+    """Runs one short command to completion and captures its output."""
+
+    def run(self, argv: Sequence[str], *, timeout_seconds: float) -> CommandResult: ...
+
+
+class ManagedProcess(Protocol):
+    """A spawned recording process that can be waited on and signalled."""
+
+    @property
+    def pid(self) -> int: ...
+
+    @property
+    def returncode(self) -> int | None: ...
+
+    def wait(self, timeout_seconds: float) -> int:
+        """Wait for exit. Raise ``subprocess.TimeoutExpired`` on timeout.
+
+        Implementations must raise exactly that type, because it is what
+        :mod:`subprocess` raises and what the recorder catches. Raising
+        a different timeout type would escape the recorder's handler.
+        """
+        ...
+
+    def signal_group(self, signal_number: int) -> None:
+        """Signal the whole process group, not just the direct child.
+
+        ``xctrace record --launch`` starts the target program itself, so
+        signalling only the direct child can leave that target running.
+        """
+        ...
+
+
+class ProcessLauncher(Protocol):
+    """Spawns a recording process in its own process group."""
+
+    def spawn(
+        self,
+        argv: Sequence[str],
+        *,
+        stdout: IO[bytes],
+        stderr: IO[bytes],
+        cwd: Path | None,
+        env: dict[str, str] | None,
+    ) -> ManagedProcess: ...
+
+
+class SubprocessCommandRunner:
+    """Real :mod:`subprocess` implementation of :class:`CommandRunner`."""
+
+    def run(self, argv: Sequence[str], *, timeout_seconds: float) -> CommandResult:
+        argv_tuple = tuple(argv)
+        if not argv_tuple:
+            raise InstrumentsProcessError("argv must not be empty")
+        try:
+            completed = subprocess.run(
+                list(argv_tuple),
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                shell=False,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return CommandResult(
+                argv=argv_tuple,
+                returncode=-1,
+                stdout=_as_text(exc.stdout),
+                stderr=_as_text(exc.stderr),
+                timed_out=True,
+            )
+        except OSError as exc:
+            raise InstrumentsProcessError(
+                f"could not execute {argv_tuple[0]!r}: {exc}"
+            ) from exc
+        return CommandResult(
+            argv=argv_tuple,
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+        )
+
+
+def _as_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+class _PopenManagedProcess:
+    """Adapts :class:`subprocess.Popen` to :class:`ManagedProcess`."""
+
+    def __init__(self, popen: subprocess.Popen[bytes]) -> None:
+        self._popen = popen
+
+    @property
+    def pid(self) -> int:
+        return self._popen.pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self._popen.returncode
+
+    def wait(self, timeout_seconds: float) -> int:
+        return self._popen.wait(timeout=timeout_seconds)
+
+    def signal_group(self, signal_number: int) -> None:
+        # The child was spawned with start_new_session=True, so it leads
+        # its own process group whose id equals its pid. Signalling the
+        # group reaches the program xctrace launched as well.
+        #
+        # ProcessLookupError means the group is already gone, which is
+        # the desired end state, so it is not an error here. It is
+        # caught specifically rather than as a bare except.
+        try:
+            os.killpg(os.getpgid(self._popen.pid), signal_number)
+        except ProcessLookupError:
+            return
+        except PermissionError as exc:
+            raise InstrumentsProcessError(
+                f"not permitted to signal process group for pid "
+                f"{self._popen.pid}: {exc}"
+            ) from exc
+
+
+class SubprocessProcessLauncher:
+    """Real :mod:`subprocess` implementation of :class:`ProcessLauncher`."""
+
+    def spawn(
+        self,
+        argv: Sequence[str],
+        *,
+        stdout: IO[bytes],
+        stderr: IO[bytes],
+        cwd: Path | None,
+        env: dict[str, str] | None,
+    ) -> ManagedProcess:
+        argv_tuple = tuple(argv)
+        if not argv_tuple:
+            raise InstrumentsProcessError("argv must not be empty")
+        try:
+            popen = subprocess.Popen(
+                list(argv_tuple),
+                stdout=stdout,
+                stderr=stderr,
+                stdin=subprocess.DEVNULL,
+                cwd=cwd,
+                env=env,
+                shell=False,
+                # Own session/process group, so a timeout can tear down
+                # xctrace and the program it launched together.
+                start_new_session=True,
+            )
+        except OSError as exc:
+            raise InstrumentsProcessError(
+                f"could not start {argv_tuple[0]!r}: {exc}"
+            ) from exc
+        return _PopenManagedProcess(popen)
+
+
+#: Signal order used to stop a recording. SIGINT first because that is
+#: the mechanism Instruments users and Chromium's profiling docs rely on
+#: to end a recording with a valid trace bundle; escalation follows only
+#: if the process ignores it.
+STOP_SIGNAL_ESCALATION: tuple[int, ...] = (
+    signal.SIGINT,
+    signal.SIGTERM,
+    signal.SIGKILL,
+)

--- a/llmtracefx/optimizer/instruments/process.py
+++ b/llmtracefx/optimizer/instruments/process.py
@@ -67,6 +67,18 @@ class ManagedProcess(Protocol):
     @property
     def returncode(self) -> int | None: ...
 
+    @property
+    def pgid(self) -> int:
+        """Process group id, captured at spawn.
+
+        Captured rather than looked up on demand: once the leader exits
+        and is reaped, ``os.getpgid(pid)`` fails, but the group can still
+        contain the program xctrace launched. Looking it up lazily would
+        therefore lose the ability to signal exactly the survivors that
+        matter most.
+        """
+        ...
+
     def wait(self, timeout_seconds: float) -> int:
         """Wait for exit. Raise ``subprocess.TimeoutExpired`` on timeout.
 
@@ -81,6 +93,14 @@ class ManagedProcess(Protocol):
 
         ``xctrace record --launch`` starts the target program itself, so
         signalling only the direct child can leave that target running.
+        """
+        ...
+
+    def group_alive(self) -> bool:
+        """Whether any process remains in the group.
+
+        The leader exiting is not the same as the group being empty. A
+        recording is only cleaned up when this returns ``False``.
         """
         ...
 
@@ -148,10 +168,24 @@ class _PopenManagedProcess:
 
     def __init__(self, popen: subprocess.Popen[bytes]) -> None:
         self._popen = popen
+        # The child was spawned with start_new_session=True, so it leads
+        # a new session and its process group id equals its pid. That is
+        # captured here, while the leader is certainly still alive,
+        # because os.getpgid stops working the moment it is reaped.
+        try:
+            self._pgid = os.getpgid(popen.pid)
+        except (ProcessLookupError, PermissionError):
+            # Already gone, or not visible. setsid guarantees pgid ==
+            # pid, so that remains the correct group to signal.
+            self._pgid = popen.pid
 
     @property
     def pid(self) -> int:
         return self._popen.pid
+
+    @property
+    def pgid(self) -> int:
+        return self._pgid
 
     @property
     def returncode(self) -> int | None:
@@ -161,22 +195,35 @@ class _PopenManagedProcess:
         return self._popen.wait(timeout=timeout_seconds)
 
     def signal_group(self, signal_number: int) -> None:
-        # The child was spawned with start_new_session=True, so it leads
-        # its own process group whose id equals its pid. Signalling the
-        # group reaches the program xctrace launched as well.
+        # Signals the group captured at spawn, which reaches the program
+        # xctrace launched even after xctrace itself has exited.
         #
         # ProcessLookupError means the group is already gone, which is
         # the desired end state, so it is not an error here. It is
         # caught specifically rather than as a bare except.
         try:
-            os.killpg(os.getpgid(self._popen.pid), signal_number)
+            os.killpg(self._pgid, signal_number)
         except ProcessLookupError:
             return
         except PermissionError as exc:
             raise InstrumentsProcessError(
-                f"not permitted to signal process group for pid "
-                f"{self._popen.pid}: {exc}"
+                f"not permitted to signal process group {self._pgid}: {exc}"
             ) from exc
+
+    def group_alive(self) -> bool:
+        """Whether the group still has members.
+
+        Signal 0 performs the permission and existence checks without
+        delivering anything. A PermissionError means the group exists
+        but is not ours, which still counts as alive.
+        """
+        try:
+            os.killpg(self._pgid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
 
 
 class SubprocessProcessLauncher:

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -1,0 +1,300 @@
+"""Run ``xctrace record`` safely and preserve what it produced.
+
+Safety properties, each of which has a test:
+
+Never overwrite
+    The output path is resolved (symlinks and ``..`` collapsed) and
+    refused if anything already exists there. xctrace itself also
+    refuses, requiring ``--append-run``, but this pre-flight fails
+    earlier, names the colliding path, and never lets ``--append-run``
+    be passed implicitly.
+
+Bounded
+    Every recording has a host-side wall-clock deadline that is strictly
+    greater than the requested ``--time-limit``, leaving room for
+    xctrace to finalize the bundle.
+
+Cleaned up
+    The child is spawned in its own process group. ``xctrace record
+    --launch`` starts the profiled program itself, so a timeout signals
+    the whole group, escalating SIGINT then SIGTERM then SIGKILL. SIGINT
+    comes first because it is how a recording is normally stopped with
+    the bundle left valid.
+
+Evidence preserving
+    stdout, stderr and run metadata are always written, including on
+    failure and timeout, and a partially written ``.trace`` bundle is
+    left in place rather than cleaned away.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text
+from ..schema import utc_now_iso
+from .capability import XctraceCapability, classify_xctrace_failure
+from .commands import RecordPlan
+from .process import (
+    STOP_SIGNAL_ESCALATION,
+    InstrumentsProcessError,
+    ManagedProcess,
+    ProcessLauncher,
+)
+
+RECORD_METADATA_SCHEMA_VERSION = "1"
+
+#: Seconds to wait after each stop signal before escalating.
+SIGNAL_ESCALATION_GRACE_SECONDS = 30.0
+
+#: Bytes of captured stderr read back purely to classify a failure.
+#: The text is never persisted into a record; only the resulting
+#: capability label is.
+_CLASSIFY_TAIL_BYTES = 64 * 1024
+
+
+class RecordStatus(str, Enum):
+    """How a recording attempt ended."""
+
+    COMPLETED = "completed"
+    """xctrace exited 0 and the trace bundle exists."""
+
+    FAILED = "failed"
+    """xctrace exited non-zero, or exited 0 without leaving a bundle."""
+
+    TIMED_OUT = "timed_out"
+    """The host deadline elapsed and the process group was torn down."""
+
+    REFUSED = "refused"
+    """A pre-flight check failed. Nothing was executed."""
+
+    @property
+    def ran(self) -> bool:
+        return self is not RecordStatus.REFUSED
+
+
+class InstrumentsRecordError(RuntimeError):
+    """Raised when a recording cannot be attempted at all."""
+
+
+@dataclass(frozen=True)
+class RecordResult:
+    """Outcome of one recording attempt, plus where its artifacts are."""
+
+    status: RecordStatus
+    argv: tuple[str, ...]
+    """The redacted argv. Safe to persist and print."""
+    trace_path: Path
+    message: str
+    started_at: str
+    ended_at: str | None = None
+    duration_seconds: float | None = None
+    returncode: int | None = None
+    stdout_path: Path | None = None
+    stderr_path: Path | None = None
+    trace_exists: bool = False
+    failure_capability: XctraceCapability | None = None
+    """Set when a failure's output identified a specific cause."""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status is RecordStatus.COMPLETED
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RECORD_METADATA_SCHEMA_VERSION,
+            "status": self.status.value,
+            "argv": list(self.argv),
+            "trace_name": self.trace_path.name,
+            "trace_exists": self.trace_exists,
+            "message": self.message,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_seconds": self.duration_seconds,
+            "returncode": self.returncode,
+            "stdout_name": (
+                None if self.stdout_path is None else self.stdout_path.name
+            ),
+            "stderr_name": (
+                None if self.stderr_path is None else self.stderr_path.name
+            ),
+            "failure_capability": (
+                None
+                if self.failure_capability is None
+                else self.failure_capability.value
+            ),
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+    def write_json(self, path: str | Path) -> None:
+        atomic_write_text(Path(path), self.to_json() + "\n")
+
+
+def check_output_collision(output_trace: Path) -> Path:
+    """Resolve the trace path and refuse if anything is already there.
+
+    ``strict=False`` resolution collapses symlinks and ``..`` for the
+    part of the path that exists, so ``a/../b.trace`` and ``b.trace``
+    cannot be treated as different destinations. On the case-insensitive
+    filesystem macOS ships by default, ``Probe.trace`` and
+    ``probe.trace`` also collide here, which is the intended behavior.
+    """
+    resolved = output_trace.expanduser().resolve()
+    if resolved.exists():
+        kind = "directory" if resolved.is_dir() else "file"
+        raise InstrumentsRecordError(
+            f"refusing to record over an existing {kind}: {resolved}. "
+            "Traces are raw evidence and are never overwritten. Choose a "
+            "different --output path, or move the existing bundle aside."
+        )
+    return resolved
+
+
+def _classify_failure_tail(stderr_path: Path) -> XctraceCapability | None:
+    """Classify a failure from captured stderr without persisting it."""
+    try:
+        with stderr_path.open("rb") as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            handle.seek(max(0, size - _CLASSIFY_TAIL_BYTES))
+            tail = handle.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    return classify_xctrace_failure(tail)
+
+
+def _stop_process_group(process: ManagedProcess) -> int | None:
+    """Signal the group, escalating until it exits."""
+    for signal_number in STOP_SIGNAL_ESCALATION:
+        try:
+            process.signal_group(signal_number)
+        except InstrumentsProcessError:
+            # Not permitted to signal the group. Escalation cannot help,
+            # so stop trying rather than looping on the same refusal.
+            return process.returncode
+        try:
+            return process.wait(SIGNAL_ESCALATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            continue
+    return process.returncode
+
+
+def run_record(
+    plan: RecordPlan,
+    *,
+    launcher: ProcessLauncher,
+    artifacts_dir: Path,
+) -> RecordResult:
+    """Execute ``plan``, preserving artifacts whatever the outcome."""
+    redacted_argv = plan.to_redacted_argv()
+    started_at = utc_now_iso()
+
+    try:
+        resolved_trace = check_output_collision(plan.output_trace)
+    except InstrumentsRecordError as exc:
+        return RecordResult(
+            status=RecordStatus.REFUSED,
+            argv=redacted_argv,
+            trace_path=plan.output_trace,
+            message=str(exc),
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+        )
+
+    artifacts = Path(artifacts_dir)
+    artifacts.mkdir(parents=True, exist_ok=True)
+    resolved_trace.parent.mkdir(parents=True, exist_ok=True)
+    stdout_path = artifacts / "xctrace_record_stdout.txt"
+    stderr_path = artifacts / "xctrace_record_stderr.txt"
+
+    start = time.perf_counter()
+    status = RecordStatus.FAILED
+    returncode: int | None = None
+    message = ""
+
+    with (
+        stdout_path.open("wb") as stdout_handle,
+        stderr_path.open("wb") as stderr_handle,
+    ):
+        try:
+            process = launcher.spawn(
+                plan.to_argv(),
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                cwd=None,
+                env=None,
+            )
+        except InstrumentsProcessError as exc:
+            return RecordResult(
+                status=RecordStatus.FAILED,
+                argv=redacted_argv,
+                trace_path=resolved_trace,
+                message=f"could not start xctrace: {exc}",
+                started_at=started_at,
+                ended_at=utc_now_iso(),
+                duration_seconds=time.perf_counter() - start,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+            )
+
+        try:
+            returncode = process.wait(plan.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            status = RecordStatus.TIMED_OUT
+            returncode = _stop_process_group(process)
+            message = (
+                f"recording exceeded its {plan.timeout_seconds:g}s host "
+                f"deadline (--time-limit {plan.time_limit} plus "
+                f"{plan.grace_seconds:g}s finalization grace) and the "
+                "process group was stopped. Artifacts are preserved."
+            )
+
+    ended_at = utc_now_iso()
+    duration = time.perf_counter() - start
+    trace_exists = resolved_trace.exists()
+    failure_capability: XctraceCapability | None = None
+
+    if status is not RecordStatus.TIMED_OUT:
+        if returncode == 0 and trace_exists:
+            status = RecordStatus.COMPLETED
+            message = f"recorded {resolved_trace.name}"
+        elif returncode == 0:
+            status = RecordStatus.FAILED
+            message = (
+                "xctrace exited 0 but no trace bundle exists at "
+                f"{resolved_trace}. Nothing was recorded."
+            )
+        else:
+            status = RecordStatus.FAILED
+            failure_capability = _classify_failure_tail(stderr_path)
+            message = f"xctrace exited {returncode}"
+            if failure_capability is not None:
+                message += f" ({failure_capability.value})"
+            message += f". See {stderr_path.name} for the tool's own output."
+    elif returncode is not None and returncode != 0:
+        failure_capability = _classify_failure_tail(stderr_path)
+
+    result = RecordResult(
+        status=status,
+        argv=redacted_argv,
+        trace_path=resolved_trace,
+        message=message,
+        started_at=started_at,
+        ended_at=ended_at,
+        duration_seconds=duration,
+        returncode=returncode,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        trace_exists=trace_exists,
+        failure_capability=failure_capability,
+    )
+    result.write_json(artifacts / "xctrace_record.json")
+    return result

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -108,10 +108,17 @@ class RecordResult:
     trace_exists: bool = False
     failure_capability: XctraceCapability | None = None
     """Set when a failure's output identified a specific cause."""
+    cleanup_failed: bool = False
+    """True when processes this run started are still running.
+
+    Kept separate from ``status``, which describes the recording. A
+    recording can complete while the program it launched survives every
+    stop signal, and a run that leaked a process is not a success even
+    though its trace is valid."""
 
     @property
     def succeeded(self) -> bool:
-        return self.status is RecordStatus.COMPLETED
+        return self.status is RecordStatus.COMPLETED and not self.cleanup_failed
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -136,6 +143,7 @@ class RecordResult:
                 if self.failure_capability is None
                 else self.failure_capability.value
             ),
+            "cleanup_failed": self.cleanup_failed,
         }
 
     def to_json(self, *, indent: int | None = 2) -> str:
@@ -172,6 +180,38 @@ def check_output_collision(output_trace: Path) -> Path:
 def reservation_path_for(resolved_trace: Path) -> Path:
     """Where the exclusive claim for ``resolved_trace`` lives."""
     return resolved_trace.with_name(f".{resolved_trace.name}.reservation")
+
+
+@contextmanager
+def reserve_output_dir(output_dir: Path) -> Iterator[Path]:
+    """Claim an artifact directory exclusively for one run.
+
+    Reserving only the trace path is not enough: two runs writing
+    different traces into the same ``--output-dir`` would still race on
+    the shared metadata and on the export staging directory, and the
+    loser could overwrite the winner's evidence. The claim is the same
+    atomic ``O_CREAT | O_EXCL`` primitive.
+    """
+    resolved = output_dir.expanduser().resolve()
+    resolved.mkdir(parents=True, exist_ok=True)
+    marker = resolved / ".llmtracefx-run.reservation"
+    try:
+        descriptor = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise InstrumentsRecordError(
+            f"another run already reserved the artifact directory "
+            f"{resolved} ({marker.name}). Wait for it to finish, or "
+            "delete that marker if no run is active."
+        ) from exc
+    except OSError as exc:
+        raise InstrumentsRecordError(f"could not reserve {resolved}: {exc}") from exc
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(f"pid={os.getpid()} started_at={utc_now_iso()}\n")
+        yield resolved
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            marker.unlink()
 
 
 @contextmanager
@@ -390,6 +430,7 @@ def _run_record_reserved(
                 returncode, group_empty = _stop_process_group(
                     process, grace_seconds=plan.stop_grace_seconds
                 )
+                survivors_cleared_ok = group_empty
                 outcome = (
                     "the process group was stopped"
                     if group_empty
@@ -473,6 +514,7 @@ def _run_record_reserved(
         stderr_path=stderr_path,
         trace_exists=trace_exists,
         failure_capability=failure_capability,
+        cleanup_failed=not survivors_cleared_ok,
     )
     result.write_json(artifacts / "xctrace_record.json")
     return result

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -185,8 +185,15 @@ def _wait_for_group_exit(process: ManagedProcess, deadline_seconds: float) -> bo
         time.sleep(GROUP_POLL_INTERVAL_SECONDS)
 
 
-def _stop_process_group(process: ManagedProcess, *, grace_seconds: float) -> int | None:
+def _stop_process_group(
+    process: ManagedProcess, *, grace_seconds: float
+) -> tuple[int | None, bool]:
     """Escalate signals until the whole group is gone.
+
+    Returns the leader's exit status and whether the group actually
+    emptied. That second value is not cosmetic: a group that survives
+    SIGKILL, or one this process is not permitted to signal, must not be
+    described in a persisted artifact as having been stopped.
 
     The leader exiting is deliberately *not* the stop condition.
     ``xctrace record --launch`` starts the profiled program itself, and
@@ -203,7 +210,7 @@ def _stop_process_group(process: ManagedProcess, *, grace_seconds: float) -> int
         except InstrumentsProcessError:
             # Not permitted to signal the group. Escalation cannot help,
             # so stop trying rather than looping on the same refusal.
-            return returncode
+            return returncode, not process.group_alive()
 
         # Reap the leader if it has not been reaped yet, so its exit
         # status is available, then wait on the group as a whole.
@@ -213,8 +220,8 @@ def _stop_process_group(process: ManagedProcess, *, grace_seconds: float) -> int
             pass
 
         if _wait_for_group_exit(process, grace_seconds):
-            return returncode
-    return returncode
+            return returncode, True
+    return returncode, False
 
 
 def run_record(
@@ -251,6 +258,7 @@ def run_record(
     message = ""
     spawn_failed = False
     survivors_stopped = False
+    survivors_cleared_ok = True
 
     with (
         stdout_path.open("wb") as stdout_handle,
@@ -277,14 +285,22 @@ def run_record(
                 returncode = process.wait(plan.timeout_seconds)
             except subprocess.TimeoutExpired:
                 status = RecordStatus.TIMED_OUT
-                returncode = _stop_process_group(
+                returncode, group_empty = _stop_process_group(
                     process, grace_seconds=plan.stop_grace_seconds
+                )
+                outcome = (
+                    "the process group was stopped"
+                    if group_empty
+                    else (
+                        "the process group could NOT be stopped and may "
+                        f"still be running (pgid {process.pgid})"
+                    )
                 )
                 message = (
                     f"recording exceeded its {plan.timeout_seconds:g}s host "
                     f"deadline (--time-limit {plan.time_limit} plus "
-                    f"{plan.grace_seconds:g}s finalization grace) and the "
-                    "process group was stopped. Artifacts are preserved."
+                    f"{plan.grace_seconds:g}s finalization grace) and "
+                    f"{outcome}. Artifacts are preserved."
                 )
             except BaseException:
                 # Anything other than a timeout (an unexpected error, or
@@ -334,9 +350,10 @@ def run_record(
         failure_capability = _classify_failure_tail(stderr_path)
 
     if survivors_stopped:
-        message += (
-            " xctrace exited while the program it launched was still "
+        message += " xctrace exited while the program it launched was still " + (
             "running; that process group was stopped."
+            if survivors_cleared_ok
+            else "running, and that process group could NOT be stopped."
         )
 
     result = RecordResult(

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -420,7 +420,9 @@ def _run_record_reserved(
                 # would clean it up.
                 if process.group_alive():
                     survivors_stopped = True
-                    _stop_process_group(process, grace_seconds=plan.stop_grace_seconds)
+                    _, survivors_cleared_ok = _stop_process_group(
+                        process, grace_seconds=plan.stop_grace_seconds
+                    )
 
     ended_at = utc_now_iso()
     duration = time.perf_counter() - start

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -53,6 +53,9 @@ RECORD_METADATA_SCHEMA_VERSION = "1"
 #: Seconds to wait after each stop signal before escalating.
 SIGNAL_ESCALATION_GRACE_SECONDS = 30.0
 
+#: How often to re-check whether the process group has emptied.
+GROUP_POLL_INTERVAL_SECONDS = 0.05
+
 #: Bytes of captured stderr read back purely to classify a failure.
 #: The text is never persisted into a record; only the resulting
 #: capability label is.
@@ -171,20 +174,47 @@ def _classify_failure_tail(stderr_path: Path) -> XctraceCapability | None:
     return classify_xctrace_failure(tail)
 
 
-def _stop_process_group(process: ManagedProcess) -> int | None:
-    """Signal the group, escalating until it exits."""
+def _wait_for_group_exit(process: ManagedProcess, deadline_seconds: float) -> bool:
+    """Poll until the process group is empty or the deadline passes."""
+    deadline = time.monotonic() + deadline_seconds
+    while True:
+        if not process.group_alive():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(GROUP_POLL_INTERVAL_SECONDS)
+
+
+def _stop_process_group(process: ManagedProcess, *, grace_seconds: float) -> int | None:
+    """Escalate signals until the whole group is gone.
+
+    The leader exiting is deliberately *not* the stop condition.
+    ``xctrace record --launch`` starts the profiled program itself, and
+    that program can outlive xctrace: it may ignore SIGINT, or simply be
+    slower to notice it. Returning as soon as the leader was reaped
+    would leave the target and any of its descendants running, holding
+    the pipes this recorder opened, with nothing left that knows how to
+    reach them.
+    """
+    returncode = process.returncode
     for signal_number in STOP_SIGNAL_ESCALATION:
         try:
             process.signal_group(signal_number)
         except InstrumentsProcessError:
             # Not permitted to signal the group. Escalation cannot help,
             # so stop trying rather than looping on the same refusal.
-            return process.returncode
+            return returncode
+
+        # Reap the leader if it has not been reaped yet, so its exit
+        # status is available, then wait on the group as a whole.
         try:
-            return process.wait(SIGNAL_ESCALATION_GRACE_SECONDS)
+            returncode = process.wait(grace_seconds)
         except subprocess.TimeoutExpired:
-            continue
-    return process.returncode
+            pass
+
+        if _wait_for_group_exit(process, grace_seconds):
+            return returncode
+    return returncode
 
 
 def run_record(
@@ -219,6 +249,8 @@ def run_record(
     status = RecordStatus.FAILED
     returncode: int | None = None
     message = ""
+    spawn_failed = False
+    survivors_stopped = False
 
     with (
         stdout_path.open("wb") as stdout_handle,
@@ -233,43 +265,55 @@ def run_record(
                 env=None,
             )
         except InstrumentsProcessError as exc:
-            return RecordResult(
-                status=RecordStatus.FAILED,
-                argv=redacted_argv,
-                trace_path=resolved_trace,
-                message=f"could not start xctrace: {exc}",
-                started_at=started_at,
-                ended_at=utc_now_iso(),
-                duration_seconds=time.perf_counter() - start,
-                stdout_path=stdout_path,
-                stderr_path=stderr_path,
-            )
-
-        try:
-            returncode = process.wait(plan.timeout_seconds)
-        except subprocess.TimeoutExpired:
-            status = RecordStatus.TIMED_OUT
-            returncode = _stop_process_group(process)
-            message = (
-                f"recording exceeded its {plan.timeout_seconds:g}s host "
-                f"deadline (--time-limit {plan.time_limit} plus "
-                f"{plan.grace_seconds:g}s finalization grace) and the "
-                "process group was stopped. Artifacts are preserved."
-            )
-        except BaseException:
-            # Anything other than a timeout (an unexpected error, or a
-            # KeyboardInterrupt while waiting) still propagates, but the
-            # recording must not be left running detached. It is in its
-            # own session, so nothing else would ever reap it.
-            _stop_process_group(process)
-            raise
+            # Falls through to the shared persistence below rather than
+            # returning here. Returning early skipped the metadata
+            # write, which both lost the record of this failure and let
+            # a previous run's xctrace_record.json survive next to this
+            # run's freshly truncated stdout and stderr.
+            spawn_failed = True
+            message = f"could not start xctrace: {exc}"
+        else:
+            try:
+                returncode = process.wait(plan.timeout_seconds)
+            except subprocess.TimeoutExpired:
+                status = RecordStatus.TIMED_OUT
+                returncode = _stop_process_group(
+                    process, grace_seconds=plan.stop_grace_seconds
+                )
+                message = (
+                    f"recording exceeded its {plan.timeout_seconds:g}s host "
+                    f"deadline (--time-limit {plan.time_limit} plus "
+                    f"{plan.grace_seconds:g}s finalization grace) and the "
+                    "process group was stopped. Artifacts are preserved."
+                )
+            except BaseException:
+                # Anything other than a timeout (an unexpected error, or
+                # a KeyboardInterrupt while waiting) still propagates,
+                # but the recording must not be left running detached.
+                # It is in its own session, so nothing else would ever
+                # reap it.
+                _stop_process_group(process, grace_seconds=plan.stop_grace_seconds)
+                raise
+            else:
+                # The leader exited on its own, which is not the same as
+                # the group being empty. xctrace can fail early while the
+                # program it launched keeps running, and that program is
+                # in a session this process started, so nothing else
+                # would clean it up.
+                if process.group_alive():
+                    survivors_stopped = True
+                    _stop_process_group(process, grace_seconds=plan.stop_grace_seconds)
 
     ended_at = utc_now_iso()
     duration = time.perf_counter() - start
     trace_exists = resolved_trace.exists()
     failure_capability: XctraceCapability | None = None
 
-    if status is not RecordStatus.TIMED_OUT:
+    if spawn_failed:
+        # Message already set. Nothing was executed, so there is no exit
+        # status to classify and no bundle to look for.
+        status = RecordStatus.FAILED
+    elif status is not RecordStatus.TIMED_OUT:
         if returncode == 0 and trace_exists:
             status = RecordStatus.COMPLETED
             message = f"recorded {resolved_trace.name}"
@@ -288,6 +332,12 @@ def run_record(
             message += f". See {stderr_path.name} for the tool's own output."
     elif returncode is not None and returncode != 0:
         failure_capability = _classify_failure_tail(stderr_path)
+
+    if survivors_stopped:
+        message += (
+            " xctrace exited while the program it launched was still "
+            "running; that process group was stopped."
+        )
 
     result = RecordResult(
         status=status,

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -29,9 +29,13 @@ Evidence preserving
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import subprocess
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -149,6 +153,10 @@ def check_output_collision(output_trace: Path) -> Path:
     cannot be treated as different destinations. On the case-insensitive
     filesystem macOS ships by default, ``Probe.trace`` and
     ``probe.trace`` also collide here, which is the intended behavior.
+
+    This is a check, so on its own it is subject to a check-then-use
+    race. Callers that go on to record must hold a
+    :func:`reserve_trace_path` reservation, which closes it.
     """
     resolved = output_trace.expanduser().resolve()
     if resolved.exists():
@@ -159,6 +167,62 @@ def check_output_collision(output_trace: Path) -> Path:
             "different --output path, or move the existing bundle aside."
         )
     return resolved
+
+
+def reservation_path_for(resolved_trace: Path) -> Path:
+    """Where the exclusive claim for ``resolved_trace`` lives."""
+    return resolved_trace.with_name(f".{resolved_trace.name}.reservation")
+
+
+@contextmanager
+def reserve_trace_path(output_trace: Path) -> Iterator[Path]:
+    """Claim a trace output path exclusively for the whole run.
+
+    Checking that a path is free and then recording into it is a
+    check-then-use race: two runs can both pass the check, and a
+    concurrent writer can create the bundle in between. The claim here
+    is a single atomic ``O_CREAT | O_EXCL`` file creation, which the
+    filesystem guarantees exactly one caller wins, and it is held until
+    the recording finishes rather than released immediately.
+
+    The reservation marker sits beside the bundle as a dotfile and is
+    always removed on exit, including on failure. A leftover marker from
+    a killed process is reported as a conflict naming its path, which is
+    recoverable by deleting it, rather than being silently ignored.
+    """
+    resolved = check_output_collision(output_trace)
+    # The parent has to exist to hold the marker, and it has to exist
+    # for the bundle regardless. Creating it is not an artifact.
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    marker = reservation_path_for(resolved)
+
+    try:
+        descriptor = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise InstrumentsRecordError(
+            f"another recording already reserved {resolved.name} "
+            f"({marker}). Wait for it to finish, or delete that marker if "
+            "no recording is running."
+        ) from exc
+    except OSError as exc:
+        raise InstrumentsRecordError(f"could not reserve {resolved}: {exc}") from exc
+
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(f"pid={os.getpid()} started_at={utc_now_iso()}\n")
+        # Re-check after the claim: a writer could have created the
+        # bundle between the check above and the claim. Winning the
+        # marker means nobody else can now, so this is the last window.
+        if resolved.exists():
+            kind = "directory" if resolved.is_dir() else "file"
+            raise InstrumentsRecordError(
+                f"refusing to record over an existing {kind}: {resolved}. "
+                "It appeared while this run was starting."
+            )
+        yield resolved
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            marker.unlink()
 
 
 def _classify_failure_tail(stderr_path: Path) -> XctraceCapability | None:
@@ -229,13 +293,39 @@ def run_record(
     *,
     launcher: ProcessLauncher,
     artifacts_dir: Path,
+    reserved_trace: Path | None = None,
 ) -> RecordResult:
-    """Execute ``plan``, preserving artifacts whatever the outcome."""
+    """Execute ``plan``, preserving artifacts whatever the outcome.
+
+    ``reserved_trace`` is the resolved path from an outer
+    :func:`reserve_trace_path`. Callers that already hold the
+    reservation pass it so the claim spans their artifact writes as well
+    as the recording; callers that do not get one acquired here for the
+    duration of the recording.
+    """
     redacted_argv = plan.to_redacted_argv()
     started_at = utc_now_iso()
 
+    if reserved_trace is not None:
+        return _run_record_reserved(
+            plan,
+            launcher=launcher,
+            artifacts_dir=artifacts_dir,
+            resolved_trace=reserved_trace,
+            redacted_argv=redacted_argv,
+            started_at=started_at,
+        )
+
     try:
-        resolved_trace = check_output_collision(plan.output_trace)
+        with reserve_trace_path(plan.output_trace) as resolved_trace:
+            return _run_record_reserved(
+                plan,
+                launcher=launcher,
+                artifacts_dir=artifacts_dir,
+                resolved_trace=resolved_trace,
+                redacted_argv=redacted_argv,
+                started_at=started_at,
+            )
     except InstrumentsRecordError as exc:
         return RecordResult(
             status=RecordStatus.REFUSED,
@@ -245,6 +335,18 @@ def run_record(
             started_at=started_at,
             ended_at=utc_now_iso(),
         )
+
+
+def _run_record_reserved(
+    plan: RecordPlan,
+    *,
+    launcher: ProcessLauncher,
+    artifacts_dir: Path,
+    resolved_trace: Path,
+    redacted_argv: tuple[str, ...],
+    started_at: str,
+) -> RecordResult:
+    """Record into a path whose reservation is already held."""
 
     artifacts = Path(artifacts_dir)
     artifacts.mkdir(parents=True, exist_ok=True)

--- a/llmtracefx/optimizer/instruments/recorder.py
+++ b/llmtracefx/optimizer/instruments/recorder.py
@@ -256,6 +256,13 @@ def run_record(
                 f"{plan.grace_seconds:g}s finalization grace) and the "
                 "process group was stopped. Artifacts are preserved."
             )
+        except BaseException:
+            # Anything other than a timeout (an unexpected error, or a
+            # KeyboardInterrupt while waiting) still propagates, but the
+            # recording must not be left running detached. It is in its
+            # own session, so nothing else would ever reap it.
+            _stop_process_group(process)
+            raise
 
     ended_at = utc_now_iso()
     duration = time.perf_counter() - start

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -59,6 +59,7 @@ from .recorder import (
     RecordResult,
     RecordStatus,
     check_output_collision,
+    reserve_trace_path,
     run_record,
 )
 
@@ -208,14 +209,26 @@ def record_trace(
     unsupported evidence artifact rather than attempting a recording
     that is known to fail.
     """
-    # The collision check runs before anything is written. Doing it
-    # inside run_record (after the capability report had already landed)
-    # meant a rerun into a directory that still held a trace refused the
+    # The trace path is reserved before anything is written, and the
+    # reservation is held for the whole run. Doing this inside
+    # run_record (after the capability report had already landed) meant
+    # a rerun into a directory that still held a trace refused the
     # recording but had by then overwritten capability_report.json and
     # instruments_evidence.json, leaving one run's trace beside another
-    # run's metadata.
+    # run's metadata. A bare check would also still race a concurrent
+    # writer, so the claim is atomic and outlives the check.
     try:
-        check_output_collision(output_trace)
+        with reserve_trace_path(output_trace) as reserved_trace:
+            return _record_reserved(
+                runner=runner,
+                launcher=launcher,
+                command=command,
+                reserved_trace=reserved_trace,
+                output_dir=output_dir,
+                template=template,
+                time_limit=time_limit,
+                table_schema=table_schema,
+            )
     except InstrumentsRecordError as exc:
         capability = detect_xctrace_capability(runner=runner, template=template)
         return TraceCollection(
@@ -235,6 +248,20 @@ def record_trace(
             wrote_artifacts=False,
         )
 
+
+def _record_reserved(
+    *,
+    runner: CommandRunner,
+    launcher: ProcessLauncher,
+    command: tuple[str, ...],
+    reserved_trace: Path,
+    output_dir: Path,
+    template: str,
+    time_limit: str,
+    table_schema: str | None,
+) -> TraceCollection:
+    """Record into a trace path whose reservation is already held."""
+    output_trace = reserved_trace
     output_dir.mkdir(parents=True, exist_ok=True)
     capability = detect_xctrace_capability(runner=runner, template=template)
     capability.write_json(output_dir / "capability_report.json")
@@ -259,7 +286,12 @@ def record_trace(
         target=LaunchTarget(argv=command),
         time_limit=time_limit,
     )
-    result = run_record(plan, launcher=launcher, artifacts_dir=output_dir)
+    result = run_record(
+        plan,
+        launcher=launcher,
+        artifacts_dir=output_dir,
+        reserved_trace=reserved_trace,
+    )
 
     if result.status is not RecordStatus.COMPLETED:
         evidence = failed_recording_evidence(

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from ..collectors._shared import atomic_write_text
-from ..schema import InstrumentsEvidence
+from ..schema import InstrumentsEvidence, utc_now_iso
 from .capability import (
     METAL_SYSTEM_TRACE_TEMPLATE,
     XctraceCapability,
@@ -181,6 +181,8 @@ class TraceCollection:
     toc: TraceTableOfContents | None = None
     table: ExportedTable | None = None
     message: str = ""
+    wrote_artifacts: bool = True
+    """False when the run was refused before touching the filesystem."""
 
     @property
     def succeeded(self) -> bool:
@@ -204,6 +206,33 @@ def record_trace(
     unsupported evidence artifact rather than attempting a recording
     that is known to fail.
     """
+    # The collision check runs before anything is written. Doing it
+    # inside run_record (after the capability report had already landed)
+    # meant a rerun into a directory that still held a trace refused the
+    # recording but had by then overwritten capability_report.json and
+    # instruments_evidence.json, leaving one run's trace beside another
+    # run's metadata.
+    try:
+        check_output_collision(output_trace)
+    except InstrumentsRecordError as exc:
+        capability = detect_xctrace_capability(runner=runner, template=template)
+        return TraceCollection(
+            capability=capability,
+            record=RecordResult(
+                status=RecordStatus.REFUSED,
+                argv=(),
+                trace_path=output_trace,
+                message=str(exc),
+                started_at=utc_now_iso(),
+                ended_at=utc_now_iso(),
+            ),
+            evidence=failed_recording_evidence(
+                capability, template=template, reason=str(exc)
+            ),
+            message=str(exc),
+            wrote_artifacts=False,
+        )
+
     output_dir.mkdir(parents=True, exist_ok=True)
     capability = detect_xctrace_capability(runner=runner, template=template)
     capability.write_json(output_dir / "capability_report.json")

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -39,6 +39,7 @@ from .commands import (
 from .evidence import (
     TraceEvidenceInputs,
     build_instruments_evidence,
+    failed_recording_evidence,
     unsupported_evidence,
 )
 from .export import (
@@ -230,7 +231,9 @@ def record_trace(
     result = run_record(plan, launcher=launcher, artifacts_dir=output_dir)
 
     if result.status is not RecordStatus.COMPLETED:
-        evidence = unsupported_evidence(capability, template=template)
+        evidence = failed_recording_evidence(
+            capability, template=template, reason=result.message
+        )
         _write_evidence(output_dir, evidence)
         return TraceCollection(
             capability=capability,

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -43,6 +43,7 @@ from .commands import (
 from .evidence import (
     TraceEvidenceInputs,
     build_instruments_evidence,
+    failed_export_evidence,
     failed_recording_evidence,
     unsupported_evidence,
 )
@@ -55,7 +56,7 @@ from .export import (
     parse_table_of_contents,
     read_export_text,
 )
-from .process import CommandRunner, ProcessLauncher
+from .process import CommandRunner, InstrumentsProcessError, ProcessLauncher
 from .recorder import (
     InstrumentsRecordError,
     RecordResult,
@@ -191,10 +192,19 @@ class TraceCollection:
     message: str = ""
     wrote_artifacts: bool = True
     """False when the run was refused before touching the filesystem."""
+    export_failed: bool = False
+    """True when the trace recorded but could not be exported.
+
+    Kept separate from ``record.status``, which correctly says the
+    recording completed. The run as a whole did not succeed, because it
+    produced no measurement, and an exit code that said otherwise would
+    let a CI job record a green run with zero GPU metrics."""
 
     @property
     def succeeded(self) -> bool:
-        return self.record is not None and self.record.succeeded
+        return (
+            self.record is not None and self.record.succeeded and not self.export_failed
+        )
 
 
 def record_trace(
@@ -319,16 +329,28 @@ def _record_reserved(
             template=template,
             table_schema=table_schema,
         )
-    except InstrumentsExportError as exc:
+    except (
+        InstrumentsExportError,
+        InstrumentsProcessError,
+        OSError,
+    ) as exc:
         # The recording succeeded, so this run has already written its
         # capability report and record metadata into output_dir. Letting
-        # the export failure propagate would leave those beside a
-        # previous run's evidence and GPU metrics, which is exactly the
-        # mixing the staging directory prevents on the export side.
-        # Writing this run's evidence replaces them.
+        # any of these propagate would leave those beside a previous
+        # run's evidence and GPU metrics, which is exactly the mixing
+        # the staging directory prevents on the export side. Writing
+        # this run's evidence replaces them.
+        #
+        # All three are reachable: the export tool can fail (export
+        # error), become unexecutable between the capability probe and
+        # the export (process error), or the staging and evidence writes
+        # can fail (OSError).
         reason = f"the trace was recorded but could not be exported: {exc}"
-        evidence = failed_recording_evidence(
-            capability, template=template, reason=reason
+        evidence = failed_export_evidence(
+            capability,
+            template=template,
+            trace_bundle_name=result.trace_path.name,
+            reason=str(exc),
         )
         _write_evidence(output_dir, evidence)
         return TraceCollection(
@@ -336,6 +358,7 @@ def _record_reserved(
             record=result,
             evidence=evidence,
             message=reason,
+            export_failed=True,
         )
     return TraceCollection(
         capability=capability,

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -18,6 +18,8 @@ The three workflows mirror the three CLI subcommands:
 from __future__ import annotations
 
 import json
+import os
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -289,6 +291,18 @@ def record_trace(
     )
 
 
+def _promote_staged(staging: Path, output_dir: Path) -> None:
+    """Move a completed staging set into place, then remove staging.
+
+    Every file is written before any is promoted, so output_dir never
+    holds a half-updated mixture of two runs. Each individual move is an
+    atomic replace within the same directory tree.
+    """
+    for staged in sorted(staging.iterdir()):
+        os.replace(staged, output_dir / staged.name)
+    shutil.rmtree(staging, ignore_errors=True)
+
+
 def _write_evidence(output_dir: Path, evidence: InstrumentsEvidence) -> None:
     atomic_write_text(
         output_dir / "instruments_evidence.json",
@@ -326,8 +340,17 @@ def import_trace(
     if not trace_path.exists():
         raise InstrumentsExportError(f"trace bundle does not exist: {trace_path}")
 
+    # Exports land in a staging directory and are promoted together
+    # only once evidence has been built. xctrace writes trace_toc.xml
+    # and trace_table.xml itself, mid-flight, so exporting straight into
+    # output_dir meant a failure between the two left this run's TOC
+    # sitting beside a previous run's evidence.
     xctrace = resolved_capability.xctrace_path or "xctrace"
-    toc_path = output_dir / "trace_toc.xml"
+    staging = output_dir / ".import-staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    toc_path = staging / "trace_toc.xml"
     toc_plan = ExportPlan(
         xctrace_path=xctrace,
         input_trace=trace_path,
@@ -356,7 +379,7 @@ def import_trace(
                 "so no metric was derived"
             )
         else:
-            table_path = output_dir / "trace_table.xml"
+            table_path = staging / "trace_table.xml"
             table_plan = ExportPlan(
                 xctrace_path=xctrace,
                 input_trace=trace_path,
@@ -391,10 +414,14 @@ def import_trace(
             target_pid=run.target_pid,
         )
     )
-    _write_evidence(output_dir, evidence)
     atomic_write_text(
-        output_dir / "trace_toc.json", json.dumps(toc.to_dict(), indent=2) + "\n"
+        staging / "instruments_evidence.json",
+        json.dumps(evidence.to_dict(), indent=2) + "\n",
     )
+    atomic_write_text(
+        staging / "trace_toc.json", json.dumps(toc.to_dict(), indent=2) + "\n"
+    )
+    _promote_staged(staging, output_dir)
     return TraceCollection(
         capability=resolved_capability,
         record=None,

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -1,0 +1,378 @@
+"""End-to-end workflows composing capability, record and export.
+
+Kept out of the CLI module so each workflow is testable without
+argparse, and so the CLI handlers stay thin.
+
+The three workflows mirror the three CLI subcommands:
+
+:func:`plan_trace`
+    Resolve and validate everything, execute nothing. Reports the exact
+    argv, the exact output paths, and any unmet prerequisite.
+:func:`record_trace`
+    Everything :func:`plan_trace` does, then actually record.
+:func:`import_trace`
+    Read an existing ``.trace`` bundle, export its table of contents and
+    optionally one table, and build canonical evidence from it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..collectors._shared import atomic_write_text
+from ..schema import InstrumentsEvidence
+from .capability import (
+    METAL_SYSTEM_TRACE_TEMPLATE,
+    XctraceCapability,
+    XctraceCapabilityReport,
+    detect_xctrace_capability,
+)
+from .commands import (
+    ExportPlan,
+    InstrumentsCommandError,
+    LaunchTarget,
+    RecordPlan,
+)
+from .evidence import (
+    TraceEvidenceInputs,
+    build_instruments_evidence,
+    unsupported_evidence,
+)
+from .export import (
+    SUPPORTED_TABLE_SCHEMAS,
+    ExportedTable,
+    InstrumentsExportError,
+    TraceTableOfContents,
+    parse_exported_table,
+    parse_table_of_contents,
+    read_export_text,
+)
+from .process import CommandRunner, ProcessLauncher
+from .recorder import (
+    InstrumentsRecordError,
+    RecordResult,
+    RecordStatus,
+    check_output_collision,
+    run_record,
+)
+
+#: Default table exported after a recording. The only Metal schema this
+#: project has a strict summarizer for.
+DEFAULT_TABLE_SCHEMA = "metal-gpu-intervals"
+
+
+@dataclass(frozen=True)
+class TracePlan:
+    """A validated, unexecuted recording plan plus its prerequisites."""
+
+    capability: XctraceCapabilityReport
+    record_plan: RecordPlan | None
+    prerequisites: tuple[str, ...]
+    """Unmet conditions. Empty means the plan is ready to run."""
+    output_paths: dict[str, str]
+    error: str | None = None
+
+    @property
+    def ready(self) -> bool:
+        return not self.prerequisites and self.record_plan is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ready": self.ready,
+            "capability": self.capability.capability.value,
+            "capability_reason": self.capability.reason,
+            "remediation": self.capability.remediation,
+            "prerequisites": list(self.prerequisites),
+            "argv": (
+                None
+                if self.record_plan is None
+                else list(self.record_plan.to_redacted_argv())
+            ),
+            "host_timeout_seconds": (
+                None if self.record_plan is None else self.record_plan.timeout_seconds
+            ),
+            "output_paths": dict(self.output_paths),
+            "error": self.error,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
+
+
+def _artifact_paths(output_dir: Path, trace: Path) -> dict[str, str]:
+    return {
+        "trace_bundle": str(trace),
+        "record_metadata": str(output_dir / "xctrace_record.json"),
+        "record_stdout": str(output_dir / "xctrace_record_stdout.txt"),
+        "record_stderr": str(output_dir / "xctrace_record_stderr.txt"),
+        "capability_report": str(output_dir / "capability_report.json"),
+        "toc_xml": str(output_dir / "trace_toc.xml"),
+        "table_xml": str(output_dir / "trace_table.xml"),
+        "evidence": str(output_dir / "instruments_evidence.json"),
+    }
+
+
+def plan_trace(
+    *,
+    runner: CommandRunner,
+    command: tuple[str, ...],
+    output_trace: Path,
+    output_dir: Path,
+    template: str = METAL_SYSTEM_TRACE_TEMPLATE,
+    time_limit: str = "60s",
+) -> TracePlan:
+    """Validate a recording without executing anything.
+
+    Never spawns the target program and never creates a trace. The only
+    subprocesses are the capability probes, which are read-only metadata
+    queries against xctrace itself.
+    """
+    capability = detect_xctrace_capability(runner=runner, template=template)
+    prerequisites: list[str] = []
+    if not capability.supported:
+        detail = capability.reason
+        if capability.remediation:
+            detail += f" Fix: {capability.remediation}"
+        prerequisites.append(detail)
+
+    paths = _artifact_paths(output_dir, output_trace)
+
+    # A collision is a prerequisite, not a hard error: the plan should
+    # still show what it would have run.
+    try:
+        check_output_collision(output_trace)
+    except InstrumentsRecordError as exc:
+        prerequisites.append(str(exc))
+
+    record_plan: RecordPlan | None = None
+    error: str | None = None
+    try:
+        record_plan = RecordPlan(
+            xctrace_path=capability.xctrace_path or "xctrace",
+            template=template,
+            output_trace=output_trace,
+            target=LaunchTarget(argv=command),
+            time_limit=time_limit,
+        )
+    except InstrumentsCommandError as exc:
+        error = str(exc)
+        prerequisites.append(f"invalid recording request: {exc}")
+
+    return TracePlan(
+        capability=capability,
+        record_plan=record_plan,
+        prerequisites=tuple(prerequisites),
+        output_paths=paths,
+        error=error,
+    )
+
+
+@dataclass(frozen=True)
+class TraceCollection:
+    """Result of recording and importing one trace."""
+
+    capability: XctraceCapabilityReport
+    record: RecordResult | None
+    evidence: InstrumentsEvidence
+    toc: TraceTableOfContents | None = None
+    table: ExportedTable | None = None
+    message: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.record is not None and self.record.succeeded
+
+
+def record_trace(
+    *,
+    runner: CommandRunner,
+    launcher: ProcessLauncher,
+    command: tuple[str, ...],
+    output_trace: Path,
+    output_dir: Path,
+    template: str = METAL_SYSTEM_TRACE_TEMPLATE,
+    time_limit: str = "60s",
+    table_schema: str | None = DEFAULT_TABLE_SCHEMA,
+) -> TraceCollection:
+    """Record a trace, then import it into canonical evidence.
+
+    When capability detection says no, this records an explicit
+    unsupported evidence artifact rather than attempting a recording
+    that is known to fail.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    capability = detect_xctrace_capability(runner=runner, template=template)
+    capability.write_json(output_dir / "capability_report.json")
+
+    if not capability.supported:
+        evidence = unsupported_evidence(capability, template=template)
+        _write_evidence(output_dir, evidence)
+        return TraceCollection(
+            capability=capability,
+            record=None,
+            evidence=evidence,
+            message=(
+                f"xctrace is not usable here ({capability.capability.value}): "
+                f"{capability.reason}"
+            ),
+        )
+
+    plan = RecordPlan(
+        xctrace_path=capability.xctrace_path or "xctrace",
+        template=template,
+        output_trace=output_trace,
+        target=LaunchTarget(argv=command),
+        time_limit=time_limit,
+    )
+    result = run_record(plan, launcher=launcher, artifacts_dir=output_dir)
+
+    if result.status is not RecordStatus.COMPLETED:
+        evidence = unsupported_evidence(capability, template=template)
+        _write_evidence(output_dir, evidence)
+        return TraceCollection(
+            capability=capability,
+            record=result,
+            evidence=evidence,
+            message=result.message,
+        )
+
+    collection = import_trace(
+        runner=runner,
+        capability=capability,
+        trace_path=result.trace_path,
+        output_dir=output_dir,
+        template=template,
+        table_schema=table_schema,
+    )
+    return TraceCollection(
+        capability=capability,
+        record=result,
+        evidence=collection.evidence,
+        toc=collection.toc,
+        table=collection.table,
+        message=collection.message or result.message,
+    )
+
+
+def _write_evidence(output_dir: Path, evidence: InstrumentsEvidence) -> None:
+    atomic_write_text(
+        output_dir / "instruments_evidence.json",
+        json.dumps(evidence.to_dict(), indent=2) + "\n",
+    )
+
+
+def import_trace(
+    *,
+    runner: CommandRunner,
+    trace_path: Path,
+    output_dir: Path,
+    capability: XctraceCapabilityReport | None = None,
+    template: str = METAL_SYSTEM_TRACE_TEMPLATE,
+    table_schema: str | None = DEFAULT_TABLE_SCHEMA,
+) -> TraceCollection:
+    """Export and parse an existing ``.trace`` bundle into evidence."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_capability = (
+        detect_xctrace_capability(runner=runner, template=template)
+        if capability is None
+        else capability
+    )
+
+    if not resolved_capability.supported:
+        evidence = unsupported_evidence(resolved_capability, template=template)
+        _write_evidence(output_dir, evidence)
+        return TraceCollection(
+            capability=resolved_capability,
+            record=None,
+            evidence=evidence,
+            message=resolved_capability.reason,
+        )
+
+    if not trace_path.exists():
+        raise InstrumentsExportError(f"trace bundle does not exist: {trace_path}")
+
+    xctrace = resolved_capability.xctrace_path or "xctrace"
+    toc_path = output_dir / "trace_toc.xml"
+    toc_plan = ExportPlan(
+        xctrace_path=xctrace,
+        input_trace=trace_path,
+        output_path=toc_path,
+        toc=True,
+    )
+    toc_result = runner.run(
+        toc_plan.to_argv(), timeout_seconds=toc_plan.timeout_seconds
+    )
+    if toc_result.returncode != 0 or toc_result.timed_out:
+        raise InstrumentsExportError(
+            f"`xctrace export --toc` failed (exit {toc_result.returncode}) for "
+            f"{trace_path.name}"
+        )
+
+    toc = parse_table_of_contents(read_export_text(toc_path))
+    run = toc.runs[0]
+
+    table: ExportedTable | None = None
+    messages: list[str] = []
+    if table_schema is not None:
+        if table_schema not in run.schemas:
+            messages.append(
+                f"table {table_schema!r} is not present in this trace's "
+                f"table of contents ({len(run.schemas)} schemas available), "
+                "so no metric was derived"
+            )
+        else:
+            table_path = output_dir / "trace_table.xml"
+            table_plan = ExportPlan(
+                xctrace_path=xctrace,
+                input_trace=trace_path,
+                output_path=table_path,
+                schema_name=table_schema,
+                run_number=run.number,
+            )
+            table_result = runner.run(
+                table_plan.to_argv(), timeout_seconds=table_plan.timeout_seconds
+            )
+            if table_result.returncode != 0 or table_result.timed_out:
+                raise InstrumentsExportError(
+                    f"`xctrace export --xpath` failed (exit "
+                    f"{table_result.returncode}) for schema {table_schema!r}"
+                )
+            table = parse_exported_table(
+                read_export_text(table_path), expected_schema=table_schema
+            )
+            if table_schema not in SUPPORTED_TABLE_SCHEMAS:
+                messages.append(
+                    f"table {table_schema!r} was exported and parsed but has "
+                    "no strict summarizer, so no metric was derived"
+                )
+
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=resolved_capability,
+            trace_bundle_name=trace_path.name,
+            template=run.template_name or template,
+            available_schemas=run.schemas,
+            table=table,
+            target_pid=run.target_pid,
+        )
+    )
+    _write_evidence(output_dir, evidence)
+    atomic_write_text(
+        output_dir / "trace_toc.json", json.dumps(toc.to_dict(), indent=2) + "\n"
+    )
+    return TraceCollection(
+        capability=resolved_capability,
+        record=None,
+        evidence=evidence,
+        toc=toc,
+        table=table,
+        message=" ".join(messages),
+    )
+
+
+def capability_exit_code(capability: XctraceCapability) -> int:
+    """0 when supported, 3 when a known cause blocks it."""
+    return 0 if capability.is_supported else 3

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 import os
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -66,6 +68,9 @@ from .recorder import (
 #: Default table exported after a recording. The only Metal schema this
 #: project has a strict summarizer for.
 DEFAULT_TABLE_SCHEMA = "metal-gpu-intervals"
+
+#: Scratch directory used while exporting, removed on every exit.
+STAGING_DIR_NAME = ".import-staging"
 
 
 @dataclass(frozen=True)
@@ -323,16 +328,41 @@ def _record_reserved(
     )
 
 
-def _promote_staged(staging: Path, output_dir: Path) -> None:
-    """Move a completed staging set into place, then remove staging.
+@contextmanager
+def _staging_dir(output_dir: Path) -> Iterator[Path]:
+    """A scratch directory that never outlives this call.
 
-    Every file is written before any is promoted, so output_dir never
-    holds a half-updated mixture of two runs. Each individual move is an
-    atomic replace within the same directory tree.
+    Without the ``finally``, a failed export left the partial staging
+    set sitting in the user's output directory until the next run
+    happened to clear it.
+    """
+    staging = output_dir / STAGING_DIR_NAME
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    try:
+        yield staging
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _promote_staged(staging: Path, output_dir: Path) -> None:
+    """Move a completed staging set into place.
+
+    Every file is written before any is promoted, so a failed export
+    cannot leave one run's table of contents beside another run's
+    evidence. Each individual move is an atomic replace within the same
+    filesystem. The loop itself is not atomic as a whole: an error
+    partway leaves some files promoted. That is deliberate and is still
+    strictly better than the alternative, because the promoted files all
+    belong to this run, whereas exporting in place mixed two runs.
     """
     for staged in sorted(staging.iterdir()):
+        if staged.is_dir():
+            raise InstrumentsExportError(
+                f"unexpected directory in the export staging set: " f"{staged.name}"
+            )
         os.replace(staged, output_dir / staged.name)
-    shutil.rmtree(staging, ignore_errors=True)
 
 
 def _write_evidence(output_dir: Path, evidence: InstrumentsEvidence) -> None:
@@ -378,10 +408,31 @@ def import_trace(
     # output_dir meant a failure between the two left this run's TOC
     # sitting beside a previous run's evidence.
     xctrace = resolved_capability.xctrace_path or "xctrace"
-    staging = output_dir / ".import-staging"
-    if staging.exists():
-        shutil.rmtree(staging)
-    staging.mkdir(parents=True)
+    with _staging_dir(output_dir) as staging:
+        return _export_and_build(
+            runner=runner,
+            xctrace=xctrace,
+            trace_path=trace_path,
+            output_dir=output_dir,
+            staging=staging,
+            resolved_capability=resolved_capability,
+            template=template,
+            table_schema=table_schema,
+        )
+
+
+def _export_and_build(
+    *,
+    runner: CommandRunner,
+    xctrace: str,
+    trace_path: Path,
+    output_dir: Path,
+    staging: Path,
+    resolved_capability: XctraceCapabilityReport,
+    template: str,
+    table_schema: str | None,
+) -> TraceCollection:
+    """Export into ``staging`` and promote once evidence is built."""
     toc_path = staging / "trace_toc.xml"
     toc_plan = ExportPlan(
         xctrace_path=xctrace,

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -17,6 +17,7 @@ The three workflows mirror the three CLI subcommands:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -55,6 +56,7 @@ from .export import (
     parse_exported_table,
     parse_table_of_contents,
     read_export_text,
+    sanitize_table_of_contents,
 )
 from .process import CommandRunner, InstrumentsProcessError, ProcessLauncher
 from .recorder import (
@@ -62,6 +64,7 @@ from .recorder import (
     RecordResult,
     RecordStatus,
     check_output_collision,
+    reserve_output_dir,
     reserve_trace_path,
     run_record,
 )
@@ -69,6 +72,10 @@ from .recorder import (
 #: Default table exported after a recording. The only Metal schema this
 #: project has a strict summarizer for.
 DEFAULT_TABLE_SCHEMA = "metal-gpu-intervals"
+
+#: Seconds allowed after each stop signal before escalating. Mirrors
+#: RecordPlan's own default; exposed so a caller can tighten it.
+DEFAULT_STOP_GRACE_SECONDS = 30.0
 
 #: Scratch directory used while exporting, removed on every exit.
 STAGING_DIR_NAME = ".import-staging"
@@ -133,6 +140,7 @@ def plan_trace(
     output_dir: Path,
     template: str = METAL_SYSTEM_TRACE_TEMPLATE,
     time_limit: str = "60s",
+    stop_grace_seconds: float = DEFAULT_STOP_GRACE_SECONDS,
 ) -> TracePlan:
     """Validate a recording without executing anything.
 
@@ -166,6 +174,7 @@ def plan_trace(
             output_trace=output_trace,
             target=LaunchTarget(argv=command),
             time_limit=time_limit,
+            stop_grace_seconds=stop_grace_seconds,
         )
     except InstrumentsCommandError as exc:
         error = str(exc)
@@ -217,6 +226,7 @@ def record_trace(
     template: str = METAL_SYSTEM_TRACE_TEMPLATE,
     time_limit: str = "60s",
     table_schema: str | None = DEFAULT_TABLE_SCHEMA,
+    stop_grace_seconds: float = DEFAULT_STOP_GRACE_SECONDS,
 ) -> TraceCollection:
     """Record a trace, then import it into canonical evidence.
 
@@ -233,7 +243,13 @@ def record_trace(
     # run's metadata. A bare check would also still race a concurrent
     # writer, so the claim is atomic and outlives the check.
     try:
-        with reserve_trace_path(output_trace) as reserved_trace:
+        # Trace first, then the artifact directory. A trace collision is
+        # the common refusal and must not create the artifact directory
+        # on its way to being refused.
+        with (
+            reserve_trace_path(output_trace) as reserved_trace,
+            reserve_output_dir(output_dir),
+        ):
             return _record_reserved(
                 runner=runner,
                 launcher=launcher,
@@ -243,6 +259,7 @@ def record_trace(
                 template=template,
                 time_limit=time_limit,
                 table_schema=table_schema,
+                stop_grace_seconds=stop_grace_seconds,
             )
     except InstrumentsRecordError as exc:
         capability = detect_xctrace_capability(runner=runner, template=template)
@@ -274,15 +291,34 @@ def _record_reserved(
     template: str,
     time_limit: str,
     table_schema: str | None,
+    stop_grace_seconds: float = DEFAULT_STOP_GRACE_SECONDS,
 ) -> TraceCollection:
     """Record into a trace path whose reservation is already held."""
     output_trace = reserved_trace
-    output_dir.mkdir(parents=True, exist_ok=True)
     capability = detect_xctrace_capability(runner=runner, template=template)
+
+    # Everything that can be rejected is rejected before the first byte
+    # is written. Building the plan validates the trace suffix, the time
+    # limit and the target command, and it used to happen after
+    # capability_report.json had already landed, so an invalid request
+    # left an artifact behind describing a run that never started.
+    plan: RecordPlan | None = None
+    if capability.supported:
+        plan = RecordPlan(
+            xctrace_path=capability.xctrace_path or "xctrace",
+            template=template,
+            output_trace=output_trace,
+            target=LaunchTarget(argv=command),
+            time_limit=time_limit,
+            stop_grace_seconds=stop_grace_seconds,
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
     capability.write_json(output_dir / "capability_report.json")
 
-    if not capability.supported:
+    if not capability.supported or plan is None:
         evidence = unsupported_evidence(capability, template=template)
+        _clear_stale_exports(output_dir)
         _write_evidence(output_dir, evidence)
         return TraceCollection(
             capability=capability,
@@ -294,13 +330,6 @@ def _record_reserved(
             ),
         )
 
-    plan = RecordPlan(
-        xctrace_path=capability.xctrace_path or "xctrace",
-        template=template,
-        output_trace=output_trace,
-        target=LaunchTarget(argv=command),
-        time_limit=time_limit,
-    )
     result = run_record(
         plan,
         launcher=launcher,
@@ -312,6 +341,7 @@ def _record_reserved(
         evidence = failed_recording_evidence(
             capability, template=template, reason=result.message
         )
+        _clear_stale_exports(output_dir)
         _write_evidence(output_dir, evidence)
         return TraceCollection(
             capability=capability,
@@ -331,7 +361,9 @@ def _record_reserved(
         )
     except (
         InstrumentsExportError,
+        InstrumentsCommandError,
         InstrumentsProcessError,
+        ArithmeticError,
         OSError,
     ) as exc:
         # The recording succeeded, so this run has already written its
@@ -352,6 +384,7 @@ def _record_reserved(
             trace_bundle_name=result.trace_path.name,
             reason=str(exc),
         )
+        _clear_stale_exports(output_dir)
         _write_evidence(output_dir, evidence)
         return TraceCollection(
             capability=capability,
@@ -412,6 +445,22 @@ def _promote_staged(staging: Path, output_dir: Path) -> None:
                 f"unexpected directory in the export staging set: " f"{staged.name}"
             )
         os.replace(staged, output_dir / staged.name)
+
+
+#: The set _promote_staged writes. A run that fails before promoting
+#: must clear these, or its metadata sits beside a previous run's.
+EXPORT_ARTIFACT_NAMES: tuple[str, ...] = (
+    "trace_toc.xml",
+    "trace_toc.json",
+    "trace_table.xml",
+)
+
+
+def _clear_stale_exports(output_dir: Path) -> None:
+    """Remove exported artifacts left by an earlier run."""
+    for name in EXPORT_ARTIFACT_NAMES:
+        with contextlib.suppress(FileNotFoundError, IsADirectoryError):
+            (output_dir / name).unlink()
 
 
 def _write_evidence(output_dir: Path, evidence: InstrumentsEvidence) -> None:
@@ -498,7 +547,14 @@ def _export_and_build(
             f"{trace_path.name}"
         )
 
-    toc = parse_table_of_contents(read_export_text(toc_path))
+    # xctrace wrote the raw TOC into the staging directory. Read it,
+    # then immediately replace it with a sanitized copy: the raw file
+    # names the machine's owner, its hardware UUID and the profiled
+    # command's full argument list, and only the sanitized version is
+    # ever promoted into the output directory.
+    raw_toc = read_export_text(toc_path)
+    toc = parse_table_of_contents(raw_toc)
+    atomic_write_text(toc_path, sanitize_table_of_contents(raw_toc))
     run = toc.runs[0]
 
     table: ExportedTable | None = None

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -489,6 +489,7 @@ def import_trace(
 
     if not resolved_capability.supported:
         evidence = unsupported_evidence(resolved_capability, template=template)
+        _clear_stale_exports(output_dir)
         _write_evidence(output_dir, evidence)
         return TraceCollection(
             capability=resolved_capability,

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -310,14 +310,33 @@ def _record_reserved(
             message=result.message,
         )
 
-    collection = import_trace(
-        runner=runner,
-        capability=capability,
-        trace_path=result.trace_path,
-        output_dir=output_dir,
-        template=template,
-        table_schema=table_schema,
-    )
+    try:
+        collection = import_trace(
+            runner=runner,
+            capability=capability,
+            trace_path=result.trace_path,
+            output_dir=output_dir,
+            template=template,
+            table_schema=table_schema,
+        )
+    except InstrumentsExportError as exc:
+        # The recording succeeded, so this run has already written its
+        # capability report and record metadata into output_dir. Letting
+        # the export failure propagate would leave those beside a
+        # previous run's evidence and GPU metrics, which is exactly the
+        # mixing the staging directory prevents on the export side.
+        # Writing this run's evidence replaces them.
+        reason = f"the trace was recorded but could not be exported: {exc}"
+        evidence = failed_recording_evidence(
+            capability, template=template, reason=reason
+        )
+        _write_evidence(output_dir, evidence)
+        return TraceCollection(
+            capability=capability,
+            record=result,
+            evidence=evidence,
+            message=reason,
+        )
     return TraceCollection(
         capability=capability,
         record=result,
@@ -357,7 +376,14 @@ def _promote_staged(staging: Path, output_dir: Path) -> None:
     strictly better than the alternative, because the promoted files all
     belong to this run, whereas exporting in place mixed two runs.
     """
-    for staged in sorted(staging.iterdir()):
+    for staged in sorted(
+        staging.iterdir(),
+        # instruments_evidence.json is the artifact a reader trusts, so
+        # it is promoted last. If a tear ever did happen mid-loop, the
+        # evidence left behind would be the stale one, rather than a new
+        # one pointing at a table that had not landed yet.
+        key=lambda path: (path.name == "instruments_evidence.json", path.name),
+    ):
         if staged.is_dir():
             raise InstrumentsExportError(
                 f"unexpected directory in the export staging set: " f"{staged.name}"

--- a/llmtracefx/optimizer/instruments/workflow.py
+++ b/llmtracefx/optimizer/instruments/workflow.py
@@ -610,6 +610,15 @@ def _export_and_build(
     atomic_write_text(
         staging / "trace_toc.json", json.dumps(toc.to_dict(), indent=2) + "\n"
     )
+    # Clear before promoting, not only on failure paths. The staged set
+    # is not always complete: trace_table.xml is staged only when a
+    # table was actually exported, so --no-export and a schema absent
+    # from the trace both promote a partial set. Without this, a
+    # successful run could leave a previous run's GPU table beside its
+    # own zero-metric evidence. Safe because every staged file is
+    # written before promotion begins, so this only removes artifacts
+    # this run is not about to replace.
+    _clear_stale_exports(output_dir)
     _promote_staged(staging, output_dir)
     return TraceCollection(
         capability=resolved_capability,

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -577,6 +577,24 @@ class PowerMetrics:
         )
 
 
+#: Substrings that must never appear in an ``InstrumentsEvidence``
+#: metric name. Instruments exposes tables whose names gesture at these
+#: quantities, but deriving them needs modelling assumptions this
+#: project has not validated, so the schema refuses to persist a metric
+#: that claims one. Enforced by ``ExperimentRecord.validate``, not only
+#: by convention.
+FORBIDDEN_INSTRUMENT_METRIC_MARKERS: tuple[str, ...] = (
+    "utilization",
+    "occupancy",
+    "bandwidth",
+    "busy_percent",
+    "kernel_time",
+    "gpu_power",
+    "gpu_energy",
+    "gpu_memory",
+)
+
+
 @dataclass(frozen=True)
 class InstrumentsEvidence:
     """Evidence sourced from an Apple Instruments ``.trace`` bundle.
@@ -842,6 +860,17 @@ class ExperimentRecord:
                 raise SchemaValidationError(
                     "instruments.metrics keys must be non-empty strings"
                 )
+            folded = name.casefold()
+            for marker in FORBIDDEN_INSTRUMENT_METRIC_MARKERS:
+                if marker in folded:
+                    raise SchemaValidationError(
+                        f"instruments.metrics.{name} claims a quantity this "
+                        f"project cannot derive from an Instruments export "
+                        f"(forbidden marker '{marker}'). GPU utilization, "
+                        "occupancy, bandwidth, kernel time, power and memory "
+                        "are not recoverable from the exported tables "
+                        "without unvalidated modelling assumptions."
+                    )
             if measurement.value < 0:
                 raise SchemaValidationError(
                     f"instruments.metrics.{name} must be >= 0, "

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -189,6 +189,30 @@ def _coerce_bool_with_default(
     return _validate_bool(data[key], context=context, key=key)
 
 
+def _coerce_str_tuple(
+    data: dict[str, Any], key: str, *, context: str
+) -> tuple[str, ...]:
+    """Read an optional list-of-strings field as a tuple.
+
+    A bare string is a ``Sequence[str]`` in Python, so ``tuple("abc")``
+    would silently become ``("a", "b", "c")``. Require a real list/tuple
+    of non-empty strings instead of quietly shredding a scalar.
+    """
+    value = data.get(key)
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise SchemaValidationError(
+            f"{context}.{key} must be a list of strings, got {value!r}"
+        )
+    items = tuple(value)
+    if not all(isinstance(item, str) and item for item in items):
+        raise SchemaValidationError(
+            f"{context}.{key} must contain only non-empty strings, got {value!r}"
+        )
+    return items
+
+
 @dataclass(frozen=True)
 class PlatformInfo:
     """Hardware/platform/OS context the run executed under."""
@@ -554,6 +578,92 @@ class PowerMetrics:
 
 
 @dataclass(frozen=True)
+class InstrumentsEvidence:
+    """Evidence sourced from an Apple Instruments ``.trace`` bundle.
+
+    Deliberately kept separate from ``MemoryMetrics``/``PowerMetrics``:
+    those carry runtime-allocator and host-side numbers (for example the
+    MLX allocator's active/cache/peak bytes), whereas everything here
+    came out of ``xctrace``. Mixing the two would make it impossible to
+    tell an allocator bookkeeping value apart from a profiler
+    measurement.
+
+    The common case for this dataclass is "a trace exists, and these are
+    the schemas it advertises". ``metrics`` stays empty unless a strict,
+    reproducible parser actually derived a value from an exported table,
+    so an absent GPU/bandwidth/occupancy/power number is always visibly
+    absent rather than silently zero.
+    """
+
+    tool: str = "xctrace"
+    tool_version: str | None = None
+    """Exact ``xctrace version`` output, when it could be read."""
+    capability: str | None = None
+    """Capability state at collection time, e.g. 'supported'."""
+    template: str | None = None
+    """Instruments template requested, e.g. 'Metal System Trace'."""
+    trace_bundle_name: str | None = None
+    """Basename of the ``.trace`` bundle. Never a full path: the bundle
+    lives beside the record, and absolute paths leak home directories."""
+    available_schemas: tuple[str, ...] = ()
+    """Table schemas the bundle's table of contents advertises."""
+    parsed_schemas: tuple[str, ...] = ()
+    """Schemas a strict parser in this project actually understood."""
+    unsupported_schemas: tuple[str, ...] = ()
+    """Schemas present in the bundle that this project cannot parse
+    reproducibly. Listed so the gap is explicit rather than invisible."""
+    metrics: dict[str, Measurement] = field(default_factory=dict)
+    """Only values a strict parser derived from an exported table."""
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "tool_version": self.tool_version,
+            "capability": self.capability,
+            "template": self.template,
+            "trace_bundle_name": self.trace_bundle_name,
+            "available_schemas": list(self.available_schemas),
+            "parsed_schemas": list(self.parsed_schemas),
+            "unsupported_schemas": list(self.unsupported_schemas),
+            "metrics": {
+                name: measurement.to_dict()
+                for name, measurement in sorted(self.metrics.items())
+            },
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InstrumentsEvidence:
+        metrics_data = data.get("metrics", {})
+        if not isinstance(metrics_data, dict):
+            raise SchemaValidationError(
+                f"InstrumentsEvidence.metrics must be an object, got {metrics_data!r}"
+            )
+        return cls(
+            tool=str(data.get("tool", "xctrace")),
+            tool_version=data.get("tool_version"),
+            capability=data.get("capability"),
+            template=data.get("template"),
+            trace_bundle_name=data.get("trace_bundle_name"),
+            available_schemas=_coerce_str_tuple(
+                data, "available_schemas", context="InstrumentsEvidence"
+            ),
+            parsed_schemas=_coerce_str_tuple(
+                data, "parsed_schemas", context="InstrumentsEvidence"
+            ),
+            unsupported_schemas=_coerce_str_tuple(
+                data, "unsupported_schemas", context="InstrumentsEvidence"
+            ),
+            metrics={
+                str(name): Measurement.from_dict(value)
+                for name, value in metrics_data.items()
+            },
+            notes=data.get("notes"),
+        )
+
+
+@dataclass(frozen=True)
 class OutcomeInfo:
     """Task outcome/quality fields."""
 
@@ -624,6 +734,12 @@ class ExperimentRecord:
     )
     memory: MemoryMetrics = field(default_factory=MemoryMetrics)
     power: PowerMetrics = field(default_factory=PowerMetrics)
+    instruments: InstrumentsEvidence | None = None
+    """Apple Instruments (``xctrace``) evidence, when a trace was taken.
+
+    Additive and optional: records written before this field existed
+    parse unchanged and leave it ``None``. ``None`` means "no trace was
+    taken", not "the trace measured zero"."""
     outcome: OutcomeInfo = field(default_factory=OutcomeInfo)
     error: ErrorInfo | None = None
 
@@ -695,6 +811,52 @@ class ExperimentRecord:
                 "outcome.success cannot be True when error is set"
             )
 
+        self._validate_instruments()
+
+    def _validate_instruments(self) -> None:
+        """Enforce that Instruments metrics cannot overclaim.
+
+        Two invariants, both aimed at the same failure mode (a plausible
+        looking GPU number that nothing actually measured):
+
+        1. A metric may only be labeled ``measured_native`` when at
+           least one table schema was genuinely parsed. Without a parsed
+           schema there is no exported table the value could have come
+           from, so the label would be a fabrication.
+        2. A schema cannot be simultaneously parsed and unsupported.
+        """
+        evidence = self.instruments
+        if evidence is None:
+            return
+
+        parsed = set(evidence.parsed_schemas)
+        overlap = parsed & set(evidence.unsupported_schemas)
+        if overlap:
+            raise SchemaValidationError(
+                "instruments schemas cannot be both parsed and unsupported: "
+                + ", ".join(sorted(overlap))
+            )
+
+        for name, measurement in sorted(evidence.metrics.items()):
+            if not name:
+                raise SchemaValidationError(
+                    "instruments.metrics keys must be non-empty strings"
+                )
+            if measurement.value < 0:
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} must be >= 0, "
+                    f"got {measurement.value}"
+                )
+            if (
+                measurement.provenance is MetricProvenance.MEASURED_NATIVE
+                and not parsed
+            ):
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} claims provenance "
+                    "'measured_native' but instruments.parsed_schemas is "
+                    "empty, so no exported table could have produced it"
+                )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": self.schema_version,
@@ -711,6 +873,9 @@ class ExperimentRecord:
             "speculative": self.speculative.to_dict(),
             "memory": self.memory.to_dict(),
             "power": self.power.to_dict(),
+            "instruments": (
+                None if self.instruments is None else self.instruments.to_dict()
+            ),
             "outcome": self.outcome.to_dict(),
             "error": None if self.error is None else self.error.to_dict(),
         }
@@ -738,6 +903,11 @@ class ExperimentRecord:
                 ),
                 memory=MemoryMetrics.from_dict(data.get("memory", {})),
                 power=PowerMetrics.from_dict(data.get("power", {})),
+                instruments=(
+                    None
+                    if data.get("instruments") is None
+                    else InstrumentsEvidence.from_dict(data["instruments"])
+                ),
                 outcome=OutcomeInfo.from_dict(data.get("outcome", {})),
                 error=(
                     None

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -577,12 +577,43 @@ class PowerMetrics:
         )
 
 
+#: The complete set of Instruments metrics this project is willing to
+#: persist, with the exact table each must come from, its exact unit and
+#: its exact provenance. An allowlist rather than a denylist: a denylist
+#: only blocks the overclaims somebody thought to enumerate, and
+#: ``metal_power_watts`` sailed straight through one.
+INSTRUMENT_METRIC_SPECS: dict[str, tuple[str, str, MetricProvenance]] = {
+    "metal_gpu_interval_count": (
+        "metal-gpu-intervals",
+        "intervals",
+        MetricProvenance.MEASURED_NATIVE,
+    ),
+    "metal_gpu_interval_duration_sum": (
+        "metal-gpu-intervals",
+        "ms",
+        MetricProvenance.MEASURED_NATIVE,
+    ),
+    "metal_gpu_interval_wall_span": (
+        "metal-gpu-intervals",
+        "ms",
+        MetricProvenance.MEASURED_NATIVE,
+    ),
+    "metal_gpu_interval_count_all_processes": (
+        "metal-gpu-intervals",
+        "intervals",
+        MetricProvenance.MEASURED_NATIVE,
+    ),
+}
+
+#: Table schemas this project has a validated parser for. Anything in
+#: ``parsed_schemas`` must appear here, so a record cannot claim to have
+#: parsed a table no parser exists for.
+INSTRUMENT_PARSABLE_SCHEMAS: frozenset[str] = frozenset({"metal-gpu-intervals"})
+
 #: Substrings that must never appear in an ``InstrumentsEvidence``
-#: metric name. Instruments exposes tables whose names gesture at these
-#: quantities, but deriving them needs modelling assumptions this
-#: project has not validated, so the schema refuses to persist a metric
-#: that claims one. Enforced by ``ExperimentRecord.validate``, not only
-#: by convention.
+#: metric name. Redundant with the allowlist above and kept anyway,
+#: because it produces a much more specific error for the exact mistake
+#: it describes.
 FORBIDDEN_INSTRUMENT_METRIC_MARKERS: tuple[str, ...] = (
     "utilization",
     "occupancy",
@@ -834,14 +865,20 @@ class ExperimentRecord:
     def _validate_instruments(self) -> None:
         """Enforce that Instruments metrics cannot overclaim.
 
-        Two invariants, both aimed at the same failure mode (a plausible
+        The rules, all aimed at the same failure mode (a plausible
         looking GPU number that nothing actually measured):
 
-        1. A metric may only be labeled ``measured_native`` when at
-           least one table schema was genuinely parsed. Without a parsed
-           schema there is no exported table the value could have come
-           from, so the label would be a fabrication.
-        2. A schema cannot be simultaneously parsed and unsupported.
+        1. Every metric name must be in
+           :data:`INSTRUMENT_METRIC_SPECS`, with exactly the unit and
+           provenance that entry declares. An allowlist, because a
+           denylist only blocks the overclaims somebody remembered to
+           enumerate.
+        2. The table a metric is derived from must actually appear in
+           ``parsed_schemas``.
+        3. ``parsed_schemas`` must name tables this project has a parser
+           for, and must be a subset of the schemas the trace itself
+           advertised, so a phantom schema cannot unlock a metric.
+        4. A schema cannot be simultaneously parsed and unsupported.
         """
         evidence = self.instruments
         if evidence is None:
@@ -853,6 +890,29 @@ class ExperimentRecord:
             raise SchemaValidationError(
                 "instruments schemas cannot be both parsed and unsupported: "
                 + ", ".join(sorted(overlap))
+            )
+
+        unparsable = parsed - INSTRUMENT_PARSABLE_SCHEMAS
+        if unparsable:
+            raise SchemaValidationError(
+                "instruments.parsed_schemas names tables this project has "
+                "no parser for: " + ", ".join(sorted(unparsable))
+            )
+
+        advertised = set(evidence.available_schemas)
+        if advertised:
+            phantom = parsed - advertised
+            if phantom:
+                raise SchemaValidationError(
+                    "instruments.parsed_schemas is not a subset of "
+                    "instruments.available_schemas; the trace never "
+                    "advertised: " + ", ".join(sorted(phantom))
+                )
+        elif parsed:
+            raise SchemaValidationError(
+                "instruments.parsed_schemas is non-empty while "
+                "instruments.available_schemas is empty; a table cannot be "
+                "parsed from a trace that advertised nothing"
             )
 
         for name, measurement in sorted(evidence.metrics.items()):
@@ -871,19 +931,38 @@ class ExperimentRecord:
                         "are not recoverable from the exported tables "
                         "without unvalidated modelling assumptions."
                     )
+
+            spec = INSTRUMENT_METRIC_SPECS.get(name)
+            if spec is None:
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} is not a metric this "
+                    "project derives. Allowed: "
+                    + ", ".join(sorted(INSTRUMENT_METRIC_SPECS))
+                )
+            source_schema, expected_unit, expected_provenance = spec
+
+            if measurement.unit != expected_unit:
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} must be in "
+                    f"{expected_unit!r}, got {measurement.unit!r}"
+                )
+            if measurement.provenance is not expected_provenance:
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} must have provenance "
+                    f"'{expected_provenance.value}', got "
+                    f"'{measurement.provenance.value}'"
+                )
             if measurement.value < 0:
                 raise SchemaValidationError(
                     f"instruments.metrics.{name} must be >= 0, "
                     f"got {measurement.value}"
                 )
-            if (
-                measurement.provenance is MetricProvenance.MEASURED_NATIVE
-                and not parsed
-            ):
+            if source_schema not in parsed:
                 raise SchemaValidationError(
-                    f"instruments.metrics.{name} claims provenance "
-                    "'measured_native' but instruments.parsed_schemas is "
-                    "empty, so no exported table could have produced it"
+                    f"instruments.metrics.{name} is derived from "
+                    f"{source_schema!r}, which is not in "
+                    "instruments.parsed_schemas, so no exported table "
+                    "could have produced it"
                 )
 
     def to_dict(self) -> dict[str, Any]:

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -16,6 +16,7 @@ existing field changes meaning, type, or requiredness.
 from __future__ import annotations
 
 import json
+import math
 import os
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
@@ -951,6 +952,13 @@ class ExperimentRecord:
                     f"instruments.metrics.{name} must have provenance "
                     f"'{expected_provenance.value}', got "
                     f"'{measurement.provenance.value}'"
+                )
+            if not math.isfinite(measurement.value):
+                raise SchemaValidationError(
+                    f"instruments.metrics.{name} must be a finite number, "
+                    f"got {measurement.value}. NaN and infinity pass a "
+                    "'>= 0' check silently and would propagate as though "
+                    "they were measurements."
                 )
             if measurement.value < 0:
                 raise SchemaValidationError(

--- a/tests/optimizer/_instruments_fakes.py
+++ b/tests/optimizer/_instruments_fakes.py
@@ -115,6 +115,15 @@ class FakeCommandRunner:
         result = self.exports.get(key)
         if result is None:
             return fail(argv, returncode=1, stderr=f"no such table: {key}")
+        if result.returncode != 0 or result.timed_out:
+            # A failing export writes no output file, like the real tool.
+            return CommandResult(
+                argv=argv,
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                timed_out=result.timed_out,
+            )
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(result.stdout, encoding="utf-8")
         self.written.append(output)

--- a/tests/optimizer/_instruments_fakes.py
+++ b/tests/optimizer/_instruments_fakes.py
@@ -1,0 +1,198 @@
+"""Injectable fakes so the Instruments tests never need Xcode.
+
+Every boundary the collector touches (short probe commands, long
+recording processes) is a protocol, so the whole capability, record,
+export and evidence path can be exercised on any platform.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from typing import IO
+
+from llmtracefx.optimizer.instruments.process import (
+    CommandResult,
+    InstrumentsProcessError,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "instruments"
+
+#: The real error macOS emits when only Command Line Tools are selected.
+#: Captured verbatim from a machine in that state.
+COMMAND_LINE_TOOLS_STDERR = (
+    "xcode-select: error: tool 'xctrace' requires Xcode, but active "
+    "developer directory '/Library/Developer/CommandLineTools' is a "
+    "command line tools instance\n"
+)
+
+#: The real first line of `xctrace version` output on Xcode 16.0.
+VERSION_STDOUT = "xctrace version 16.0 (17F113)\n"
+
+#: Shape of real `xctrace list templates` output, trimmed.
+TEMPLATES_STDOUT = (
+    "== Standard Templates ==\n"
+    "Activity Monitor\n"
+    "Allocations\n"
+    "CPU Counters\n"
+    "Game Performance\n"
+    "Metal System Trace\n"
+    "System Trace\n"
+    "Time Profiler\n"
+    "== Custom Templates ==\n"
+)
+
+
+def read_fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def ok(argv: Sequence[str], stdout: str = "") -> CommandResult:
+    return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="")
+
+
+def fail(
+    argv: Sequence[str], *, returncode: int = 1, stderr: str = ""
+) -> CommandResult:
+    return CommandResult(
+        argv=tuple(argv), returncode=returncode, stdout="", stderr=stderr
+    )
+
+
+class FakeCommandRunner:
+    """Answers probes from a table keyed by the argv tail.
+
+    Keying on the tail (``('version',)``, ``('list', 'templates')``)
+    keeps tests independent of where xctrace was found on PATH.
+    """
+
+    def __init__(
+        self,
+        *,
+        version: CommandResult | None = None,
+        templates: CommandResult | None = None,
+        exports: dict[str, CommandResult] | None = None,
+        raise_on: str | None = None,
+    ) -> None:
+        self.version = version
+        self.templates = templates
+        self.exports = exports or {}
+        self.raise_on = raise_on
+        self.calls: list[tuple[str, ...]] = []
+        self.written: list[Path] = []
+
+    def run(self, argv: Sequence[str], *, timeout_seconds: float) -> CommandResult:
+        argv_tuple = tuple(argv)
+        self.calls.append(argv_tuple)
+        if self.raise_on is not None and self.raise_on in argv_tuple:
+            raise InstrumentsProcessError(f"cannot execute {self.raise_on}")
+
+        if argv_tuple[1:] == ("version",):
+            if self.version is None:
+                return ok(argv_tuple, VERSION_STDOUT)
+            return self.version
+        if argv_tuple[1:] == ("list", "templates"):
+            if self.templates is None:
+                return ok(argv_tuple, TEMPLATES_STDOUT)
+            return self.templates
+        if len(argv_tuple) > 1 and argv_tuple[1] == "export":
+            return self._export(argv_tuple)
+        raise AssertionError(f"unexpected command: {argv_tuple}")
+
+    def _export(self, argv: tuple[str, ...]) -> CommandResult:
+        output = Path(argv[argv.index("--output") + 1])
+        if "--toc" in argv:
+            key = "toc"
+        else:
+            xpath = argv[argv.index("--xpath") + 1]
+            key = xpath.split('@schema="')[1].split('"')[0]
+        result = self.exports.get(key)
+        if result is None:
+            return fail(argv, returncode=1, stderr=f"no such table: {key}")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(result.stdout, encoding="utf-8")
+        self.written.append(output)
+        return ok(argv)
+
+
+class FakeProcess:
+    """A recording process whose exit behavior the test dictates."""
+
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        timeout_waits: int = 0,
+        pid: int = 4242,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        signal_error: Exception | None = None,
+    ) -> None:
+        self._returncode: int | None = returncode
+        self._final_returncode = returncode
+        self.timeout_waits = timeout_waits
+        self._pid = pid
+        self.stdout_text = stdout_text
+        self.stderr_text = stderr_text
+        self.signal_error = signal_error
+        self.signals: list[int] = []
+        self.wait_calls: list[float] = []
+
+    @property
+    def pid(self) -> int:
+        return self._pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self._returncode
+
+    def wait(self, timeout_seconds: float) -> int:
+        self.wait_calls.append(timeout_seconds)
+        if self.timeout_waits > 0:
+            self.timeout_waits -= 1
+            self._returncode = None
+            raise subprocess.TimeoutExpired(cmd="xctrace", timeout=timeout_seconds)
+        self._returncode = self._final_returncode
+        return self._final_returncode
+
+    def signal_group(self, signal_number: int) -> None:
+        self.signals.append(signal_number)
+        if self.signal_error is not None:
+            raise self.signal_error
+
+
+class FakeLauncher:
+    """Spawns :class:`FakeProcess` and optionally creates the bundle."""
+
+    def __init__(
+        self,
+        process: FakeProcess,
+        *,
+        creates_trace: Path | None = None,
+        spawn_error: Exception | None = None,
+    ) -> None:
+        self.process = process
+        self.creates_trace = creates_trace
+        self.spawn_error = spawn_error
+        self.spawned: list[tuple[str, ...]] = []
+
+    def spawn(
+        self,
+        argv: Sequence[str],
+        *,
+        stdout: IO[bytes],
+        stderr: IO[bytes],
+        cwd: Path | None,
+        env: dict[str, str] | None,
+    ) -> FakeProcess:
+        self.spawned.append(tuple(argv))
+        if self.spawn_error is not None:
+            raise self.spawn_error
+        stdout.write(self.process.stdout_text.encode("utf-8"))
+        stderr.write(self.process.stderr_text.encode("utf-8"))
+        stdout.flush()
+        stderr.flush()
+        if self.creates_trace is not None:
+            self.creates_trace.mkdir(parents=True, exist_ok=True)
+        return self.process

--- a/tests/optimizer/_instruments_fakes.py
+++ b/tests/optimizer/_instruments_fakes.py
@@ -7,15 +7,20 @@ export and evidence path can be exercised on any platform.
 
 from __future__ import annotations
 
+import signal
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
 from typing import IO
 
 from llmtracefx.optimizer.instruments.process import (
+    STOP_SIGNAL_ESCALATION,
     CommandResult,
     InstrumentsProcessError,
 )
+
+#: Escalation order, used by FakeProcess to decide when a group dies.
+_SIGNAL_ORDER = list(STOP_SIGNAL_ESCALATION)
 
 FIXTURES = Path(__file__).parent / "fixtures" / "instruments"
 
@@ -117,7 +122,13 @@ class FakeCommandRunner:
 
 
 class FakeProcess:
-    """A recording process whose exit behavior the test dictates."""
+    """A recording process whose exit behavior the test dictates.
+
+    Models the leader and its process group as two separate things,
+    because that distinction is the whole point of the teardown logic: a
+    leader can exit while the program it launched keeps running in the
+    same group.
+    """
 
     def __init__(
         self,
@@ -128,6 +139,7 @@ class FakeProcess:
         stdout_text: str = "",
         stderr_text: str = "",
         signal_error: Exception | None = None,
+        group_dies_on: int | None = signal.SIGINT,
     ) -> None:
         self._returncode: int | None = returncode
         self._final_returncode = returncode
@@ -136,11 +148,20 @@ class FakeProcess:
         self.stdout_text = stdout_text
         self.stderr_text = stderr_text
         self.signal_error = signal_error
+        #: Lowest-priority signal that actually empties the group. None
+        #: means nothing does, which exercises bounded escalation.
+        self.group_dies_on = group_dies_on
+        self._group_alive = True
         self.signals: list[int] = []
         self.wait_calls: list[float] = []
+        self.group_alive_calls = 0
 
     @property
     def pid(self) -> int:
+        return self._pid
+
+    @property
+    def pgid(self) -> int:
         return self._pid
 
     @property
@@ -160,6 +181,17 @@ class FakeProcess:
         self.signals.append(signal_number)
         if self.signal_error is not None:
             raise self.signal_error
+        # The leader always dies on the first signal; the group only
+        # empties once a signal it cannot ignore arrives.
+        self._returncode = self._final_returncode
+        if self.group_dies_on is not None and _SIGNAL_ORDER.index(
+            signal_number
+        ) >= _SIGNAL_ORDER.index(self.group_dies_on):
+            self._group_alive = False
+
+    def group_alive(self) -> bool:
+        self.group_alive_calls += 1
+        return self._group_alive
 
 
 class FakeLauncher:

--- a/tests/optimizer/fixtures/instruments/table_metal_gpu_intervals.xml
+++ b/tests/optimizer/fixtures/instruments/table_metal_gpu_intervals.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--
+Synthetic 'xctrace export' in XPath mode for the metal-gpu-intervals table
+output. Shrunk to 4 columns and 4 rows, but structurally faithful to real
+xctrace 16.0 output in the ways the parser depends on:
+
+  * <node> holds one <schema name="..."> whose ordered <col> entries each
+    declare a <mnemonic> and an <engineering-type>.
+  * Every <row> has exactly one child per column, in column order, and
+    each child's tag equals that column's <engineering-type>.
+  * Repeated values are emitted once with an id and then referenced by
+    <tag ref="id"/>. Row 2 references the process defined in row 1, and
+    row 4 uses a ref to a value that is itself only defined later in
+    document order, which is why the id index is built over the whole
+    document before rows are resolved.
+  * <process> is a composite value carrying a nested <pid> and an
+    fmt attribute of the form "name (pid)".
+
+Durations and start times are integer nanoseconds, as in real output.
+-->
+<trace-query-result>
+<node xpath='//trace-toc[1]/run[1]/data[1]/table[1]'>
+<schema name="metal-gpu-intervals" documentation="Denotes an interesting period of activity in the GPU.">
+<col><mnemonic>start</mnemonic><name>Creation</name><engineering-type>start-time</engineering-type></col>
+<col><mnemonic>duration</mnemonic><name>Duration</name><engineering-type>duration</engineering-type></col>
+<col><mnemonic>channel-name</mnemonic><name>Channel Name</name><engineering-type>gpu-channel-name</engineering-type></col>
+<col><mnemonic>process</mnemonic><name>Process</name><engineering-type>process</engineering-type></col>
+</schema>
+<row>
+<start-time id="1" fmt="00:00.000.100">100000</start-time>
+<duration id="2" fmt="10.00 µs">10000</duration>
+<gpu-channel-name id="3" fmt="Compute">Compute</gpu-channel-name>
+<process id="4" fmt="probe (4242)"><pid id="5" fmt="4242">4242</pid><device-session id="6" fmt="TODO">TODO</device-session></process>
+</row>
+<row>
+<start-time id="7" fmt="00:00.000.200">200000</start-time>
+<duration id="8" fmt="20.00 µs">20000</duration>
+<gpu-channel-name ref="3"/>
+<process ref="4"/>
+</row>
+<row>
+<start-time id="9" fmt="00:00.000.300">300000</start-time>
+<duration id="10" fmt="5.00 µs">5000</duration>
+<gpu-channel-name id="11" fmt="Vertex">Vertex</gpu-channel-name>
+<process id="12" fmt="WindowServer (77)"><pid id="13" fmt="77">77</pid><device-session ref="6"/></process>
+</row>
+<row>
+<start-time id="14" fmt="00:00.000.400">400000</start-time>
+<duration ref="15"/>
+<gpu-channel-name ref="11"/>
+<process ref="12"/>
+</row>
+<row>
+<start-time id="16" fmt="00:00.000.500">500000</start-time>
+<duration id="15" fmt="1.00 µs">1000</duration>
+<gpu-channel-name ref="3"/>
+<process ref="4"/>
+</row>
+</node>
+</trace-query-result>

--- a/tests/optimizer/fixtures/instruments/table_unsupported_schema.xml
+++ b/tests/optimizer/fixtures/instruments/table_unsupported_schema.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+Synthetic export of a schema this project has no strict summarizer for.
+Used to prove that an exportable but unsupported table is reported as
+present and unsupported, and yields no derived metric, rather than being
+interpreted speculatively.
+-->
+<trace-query-result>
+<node xpath='//trace-toc[1]/run[1]/data[1]/table[2]'>
+<schema name="displayed-surfaces-per-second" documentation="Frames shown on screen per second.">
+<col><mnemonic>start</mnemonic><name>Start</name><engineering-type>start-time</engineering-type></col>
+<col><mnemonic>fps</mnemonic><name>Surfaces Per Second</name><engineering-type>uint64</engineering-type></col>
+</schema>
+<row>
+<start-time id="1" fmt="00:00.000.100">100000</start-time>
+<uint64 id="2" fmt="60">60</uint64>
+</row>
+<row>
+<start-time id="3" fmt="00:00.100.100">100100000</start-time>
+<uint64 ref="2"/>
+</row>
+</node>
+</trace-query-result>

--- a/tests/optimizer/fixtures/instruments/toc_metal_system_trace.xml
+++ b/tests/optimizer/fixtures/instruments/toc_metal_system_trace.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+Synthetic 'xctrace export' in TOC mode output. Structure mirrors real output
+from xctrace 16.0 (17F113) on macOS, shrunk to a handful of schemas and
+with every identifying value replaced: no real device name, no real
+hardware UUID, no real user paths.
+
+Kept deliberately faithful in two respects the parser depends on:
+  * <run number="N"> with info/summary metadata and a data/table list.
+  * an info/target/process element carrying the launched process's pid,
+    which is what metric attribution keys off.
+-->
+<trace-toc>
+    <run number="1">
+        <info>
+            <target>
+                <device platform="macOS" model="MacBook Pro" name="Example Mac" os-version="26.6.2 (25G83)" uuid="00000000-0000-0000-0000-000000000000"/>
+                <process arguments="120" type="launched" return-exit-status="0" name="probe" pid="4242" termination-reason="exit(0)"/>
+            </target>
+            <summary>
+                <start-date>2026-01-01T00:00:00.000+00:00</start-date>
+                <end-date>2026-01-01T00:00:00.500+00:00</end-date>
+                <duration>0.500000</duration>
+                <end-reason>Target app exited</end-reason>
+                <instruments-version>16.0 (17F113)</instruments-version>
+                <template-name>Metal System Trace</template-name>
+                <recording-mode>Deferred</recording-mode>
+                <time-limit>30 seconds</time-limit>
+            </summary>
+        </info>
+        <data>
+            <table schema="metal-gpu-intervals"/>
+            <table schema="displayed-surfaces-per-second"/>
+            <table schema="metal-application-encoders-list"/>
+            <table schema="time-profile"/>
+        </data>
+    </run>
+</trace-toc>

--- a/tests/optimizer/test_instruments_capability.py
+++ b/tests/optimizer/test_instruments_capability.py
@@ -1,0 +1,318 @@
+"""Tests for xctrace capability detection.
+
+Every distinguishable reason a Metal trace cannot be taken gets its own
+test, because the whole point of the capability layer is that "it did
+not work" is never an acceptable answer on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _instruments_fakes import (
+    COMMAND_LINE_TOOLS_STDERR,
+    TEMPLATES_STDOUT,
+    VERSION_STDOUT,
+    FakeCommandRunner,
+    fail,
+    ok,
+)
+
+from llmtracefx.optimizer.instruments.capability import (
+    METAL_SYSTEM_TRACE_TEMPLATE,
+    InstrumentsCapabilityError,
+    XctraceCapability,
+    XctraceCapabilityReport,
+    classify_xctrace_failure,
+    detect_xctrace_capability,
+    parse_templates,
+    parse_version,
+)
+
+DARWIN = {
+    "os_name": "Darwin",
+    "architecture": "arm64",
+    "path_resolver": lambda: "/usr/bin/xctrace",
+}
+
+
+def detect(runner: FakeCommandRunner, **overrides):
+    kwargs = {**DARWIN, **overrides}
+    return detect_xctrace_capability(runner=runner, **kwargs)
+
+
+# --- Platform gating --------------------------------------------------
+
+
+@pytest.mark.parametrize("os_name", ["Linux", "Windows", "Java"])
+def test_non_darwin_is_unsupported_os(os_name):
+    report = detect(FakeCommandRunner(), os_name=os_name)
+    assert report.capability is XctraceCapability.UNSUPPORTED_OS
+    assert report.supported is False
+    assert os_name in report.reason
+
+
+def test_non_arm64_is_reported_separately_from_os():
+    report = detect(FakeCommandRunner(), architecture="x86_64")
+    assert report.capability is XctraceCapability.UNSUPPORTED_ARCHITECTURE
+    assert "x86_64" in report.reason
+
+
+def test_platform_checks_run_no_subprocess():
+    runner = FakeCommandRunner()
+    detect(runner, os_name="Linux")
+    assert runner.calls == []
+
+
+# --- Locating xctrace -------------------------------------------------
+
+
+def test_missing_xctrace_is_not_found():
+    report = detect(FakeCommandRunner(), path_resolver=lambda: None)
+    assert report.capability is XctraceCapability.XCTRACE_NOT_FOUND
+    assert "Install Xcode" in (report.remediation or "")
+
+
+def test_command_line_tools_shim_is_not_treated_as_available():
+    """The shim exists on PATH but refuses to run.
+
+    This is the trap the whole layer exists to avoid: a plain "is
+    xctrace on PATH" check passes on a Command Line Tools only machine.
+    """
+    runner = FakeCommandRunner(
+        version=fail(
+            ("/usr/bin/xctrace", "version"),
+            returncode=1,
+            stderr=COMMAND_LINE_TOOLS_STDERR,
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.COMMAND_LINE_TOOLS_ONLY
+    assert report.supported is False
+    assert "full Xcode" in (report.remediation or "")
+
+
+def test_license_not_accepted_is_distinguished():
+    runner = FakeCommandRunner(
+        version=fail(
+            ("/usr/bin/xctrace", "version"),
+            returncode=69,
+            stderr=(
+                "You have not agreed to the Xcode license agreements, "
+                "please run 'sudo xcodebuild -license'."
+            ),
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.LICENSE_NOT_ACCEPTED
+    assert "xcodebuild -license accept" in (report.remediation or "")
+
+
+def test_first_launch_required_is_distinguished():
+    runner = FakeCommandRunner(
+        version=fail(
+            ("/usr/bin/xctrace", "version"),
+            returncode=1,
+            stderr="Xcode needs to run runFirstLaunch before use.",
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.FIRST_LAUNCH_REQUIRED
+
+
+def test_remediation_never_tells_the_tool_to_run_sudo_itself():
+    runner = FakeCommandRunner(
+        version=fail(
+            ("/usr/bin/xctrace", "version"),
+            returncode=1,
+            stderr="Xcode needs to run runFirstLaunch before use.",
+        )
+    )
+    report = detect(runner)
+    assert "never invokes sudo on your behalf" in (report.remediation or "")
+
+
+# --- Undocumented `version` must not be load bearing ------------------
+
+
+def test_unclassifiable_version_failure_falls_through_to_list_templates():
+    """`version` is not a documented subcommand.
+
+    A failure there is inconclusive, so detection must continue to the
+    documented `list templates` probe rather than declaring failure.
+    """
+    runner = FakeCommandRunner(
+        version=fail(
+            ("/usr/bin/xctrace", "version"), returncode=64, stderr="unknown command"
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.SUPPORTED
+    assert report.xctrace_version is None
+    assert ("/usr/bin/xctrace", "list", "templates") in runner.calls
+
+
+def test_unclassifiable_list_templates_failure_is_probe_failed():
+    runner = FakeCommandRunner(
+        templates=fail(
+            ("/usr/bin/xctrace", "list", "templates"),
+            returncode=70,
+            stderr="something nobody has seen before",
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.PROBE_FAILED
+    assert "matched no known cause" in report.reason
+    assert "70" in report.reason
+
+
+def test_probe_failure_does_not_leak_tool_output_into_the_report():
+    secret = "/Users/someone/private/path-that-should-not-leak"
+    runner = FakeCommandRunner(
+        templates=fail(
+            ("/usr/bin/xctrace", "list", "templates"), returncode=70, stderr=secret
+        )
+    )
+    report = detect(runner)
+    serialized = report.to_json()
+    assert secret not in serialized
+
+
+def test_process_error_becomes_probe_failed():
+    runner = FakeCommandRunner(raise_on="version")
+    report = detect(runner)
+    assert report.capability is XctraceCapability.PROBE_FAILED
+
+
+def test_timeout_on_list_templates_is_not_reported_as_supported():
+    runner = FakeCommandRunner(
+        templates=fail(("/usr/bin/xctrace", "list", "templates"), returncode=-1)
+    )
+    runner.templates = runner.templates.__class__(
+        argv=("/usr/bin/xctrace", "list", "templates"),
+        returncode=-1,
+        stdout="",
+        stderr="",
+        timed_out=True,
+    )
+    report = detect(runner)
+    assert report.supported is False
+    assert "timed out" in report.reason
+
+
+# --- Templates --------------------------------------------------------
+
+
+def test_missing_template_is_distinguished_from_broken_xctrace():
+    runner = FakeCommandRunner(
+        templates=ok(
+            ("/usr/bin/xctrace", "list", "templates"),
+            "== Standard Templates ==\nTime Profiler\n",
+        )
+    )
+    report = detect(runner)
+    assert report.capability is XctraceCapability.TEMPLATE_UNAVAILABLE
+    assert METAL_SYSTEM_TRACE_TEMPLATE in report.reason
+    assert report.available_templates == ("Time Profiler",)
+
+
+def test_supported_when_template_present():
+    report = detect(FakeCommandRunner())
+    assert report.capability is XctraceCapability.SUPPORTED
+    assert report.supported is True
+    assert report.xctrace_version == "xctrace version 16.0 (17F113)"
+    assert METAL_SYSTEM_TRACE_TEMPLATE in report.available_templates
+
+
+def test_template_none_skips_the_template_requirement():
+    runner = FakeCommandRunner(
+        templates=ok(
+            ("/usr/bin/xctrace", "list", "templates"),
+            "== Standard Templates ==\nTime Profiler\n",
+        )
+    )
+    report = detect(runner, template=None)
+    assert report.capability is XctraceCapability.SUPPORTED
+
+
+# --- Output parsing ---------------------------------------------------
+
+
+def test_parse_templates_drops_headers_and_blank_lines():
+    assert parse_templates(TEMPLATES_STDOUT) == (
+        "Activity Monitor",
+        "Allocations",
+        "CPU Counters",
+        "Game Performance",
+        "Metal System Trace",
+        "System Trace",
+        "Time Profiler",
+    )
+
+
+def test_parse_templates_strips_indentation_and_deduplicates():
+    parsed = parse_templates(
+        "== Standard Templates ==\n  Blank\n\n== Custom Templates ==\n  Blank\n"
+    )
+    assert parsed == ("Blank",)
+
+
+def test_parse_templates_of_empty_output_is_empty():
+    assert parse_templates("") == ()
+
+
+def test_parse_version_returns_first_non_empty_line():
+    assert parse_version(VERSION_STDOUT) == "xctrace version 16.0 (17F113)"
+    assert parse_version("\n\n") is None
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (COMMAND_LINE_TOOLS_STDERR, XctraceCapability.COMMAND_LINE_TOOLS_ONLY),
+        ("Operation not permitted", XctraceCapability.PERMISSION_DENIED),
+        ("Failed to attach to process", XctraceCapability.PERMISSION_DENIED),
+        (
+            "requires the get-task-allow entitlement",
+            XctraceCapability.PERMISSION_DENIED,
+        ),
+        ("total nonsense", None),
+    ],
+)
+def test_classify_xctrace_failure(text, expected):
+    assert classify_xctrace_failure(text) is expected
+
+
+# --- Report serialization ---------------------------------------------
+
+
+def test_report_round_trips_through_dict():
+    report = detect(FakeCommandRunner())
+    restored = XctraceCapabilityReport.from_dict(report.to_dict())
+    assert restored == report
+
+
+def test_report_rejects_unknown_capability():
+    payload = detect(FakeCommandRunner()).to_dict()
+    payload["capability"] = "definitely_not_a_state"
+    with pytest.raises(InstrumentsCapabilityError, match="unknown capability"):
+        XctraceCapabilityReport.from_dict(payload)
+
+
+def test_report_rejects_missing_field():
+    payload = detect(FakeCommandRunner()).to_dict()
+    del payload["reason"]
+    with pytest.raises(InstrumentsCapabilityError, match="missing required field"):
+        XctraceCapabilityReport.from_dict(payload)
+
+
+def test_report_writes_json_atomically(tmp_path):
+    report = detect(FakeCommandRunner())
+    target = tmp_path / "nested" / "capability.json"
+    report.write_json(target)
+    assert (
+        XctraceCapabilityReport.from_dict(
+            __import__("json").loads(target.read_text(encoding="utf-8"))
+        )
+        == report
+    )
+    assert list(target.parent.glob(".*tmp*")) == []

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -645,7 +645,7 @@ def test_further_password_spellings_are_redacted(flag):
     assert SENTINEL not in " ".join(plan.to_redacted_argv())
 
 
-@pytest.mark.parametrize("flag", ["--user", "--proxy-user", "-u"])
+@pytest.mark.parametrize("flag", ["--user", "--proxy-user"])
 def test_user_password_pairs_are_redacted(flag):
     """curl's `--user alice:hunter2` carries the secret in the pair.
 
@@ -687,3 +687,35 @@ def test_netrc_file_paths_are_still_readable():
         target=LaunchTarget(argv=("curl", "--netrc-file", "/home/u/.netrc"))
     )
     assert plan.to_redacted_argv()[-1] == "/home/u/.netrc"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("python3", "-u", "infer.py", "--model", "llama3"),
+        ("python3", "-u", "-m", "llmtracefx.bench"),
+        ("sort", "-u", "results.txt"),
+        ("docker", "run", "-u", "1000:1000", "image"),
+    ],
+)
+def test_short_options_never_consume_the_next_argument(argv):
+    """`-u` is curl's credential flag and nothing else's.
+
+    In `python -u` it is the unbuffered switch, which is the likeliest
+    command this project will ever record. Hardcoding curl's grammar for
+    every program erased the script name from the run's own evidence.
+    Single-dash short options stay outside the classifier.
+    """
+    plan = make_plan(target=LaunchTarget(argv=argv))
+    redacted = plan.to_redacted_argv()
+    assert REDACTED not in redacted
+    assert redacted[-len(argv) :] == argv
+
+
+def test_long_user_options_are_still_redacted():
+    """Removing the short form must not lose the real coverage."""
+    for flag in ("--user", "--proxy-user"):
+        plan = make_plan(
+            target=LaunchTarget(argv=("curl", flag, f"alice:{SENTINEL}", "https://h"))
+        )
+        assert SENTINEL not in " ".join(plan.to_redacted_argv()), flag

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -533,3 +533,31 @@ def test_unrecognized_key_style_options_default_to_secret(flag):
 def test_lookup_keys_are_still_readable(flag):
     plan = make_plan(target=LaunchTarget(argv=("bench", flag, "user_id")))
     assert plan.to_redacted_argv()[-1] == "user_id"
+
+
+@pytest.mark.parametrize("flag", ["--totp", "--otp", "--one-time-password"])
+def test_one_time_passwords_are_redacted(flag):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag", ["--cert", "--certificate", "--keystore", "--keyfile", "--nonce"]
+)
+def test_public_or_location_values_are_documented_as_not_redacted(flag):
+    """Pins a deliberate boundary rather than an oversight.
+
+    A certificate is public by design, a nonce is not secret, and a
+    keystore or keyfile names where a secret lives rather than being
+    one. Redacting them would cost reproducibility for no privacy gain.
+    The secret-bearing companions (`--keystore-password`,
+    `--private-key`) are still caught.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, "/some/value")))
+    assert REDACTED not in plan.to_redacted_argv()
+
+
+def test_the_secret_bearing_companions_are_still_caught():
+    for flag in ("--keystore-password", "--private-key", "--jwt-secret"):
+        plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+        assert SENTINEL not in " ".join(plan.to_redacted_argv()), flag

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -637,3 +637,9 @@ def test_descriptors_about_a_secret_are_not_the_secret(flag, value):
     """
     plan = make_plan(target=LaunchTarget(argv=("bench", flag, value)))
     assert plan.to_redacted_argv()[-1] == value
+
+
+@pytest.mark.parametrize("flag", ["--pwd", "--pass-phrase", "--netrc"])
+def test_further_password_spellings_are_redacted(flag):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -639,7 +639,51 @@ def test_descriptors_about_a_secret_are_not_the_secret(flag, value):
     assert plan.to_redacted_argv()[-1] == value
 
 
-@pytest.mark.parametrize("flag", ["--pwd", "--pass-phrase", "--netrc"])
+@pytest.mark.parametrize("flag", ["--pwd", "--pass-phrase"])
 def test_further_password_spellings_are_redacted(flag):
     plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
     assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize("flag", ["--user", "--proxy-user", "-u"])
+def test_user_password_pairs_are_redacted(flag):
+    """curl's `--user alice:hunter2` carries the secret in the pair.
+
+    The username half is not a secret, but the pair cannot be split
+    without the target program's grammar, so the whole value goes.
+    """
+    plan = make_plan(
+        target=LaunchTarget(argv=("curl", flag, f"alice:{SENTINEL}", "https://h"))
+    )
+    redacted = plan.to_redacted_argv()
+    assert SENTINEL not in " ".join(redacted)
+    # The URL after it must survive.
+    assert redacted[-1] == "https://h"
+
+
+@pytest.mark.parametrize("flag", ["--netrc", "--netrc-optional"])
+def test_boolean_auth_flags_do_not_consume_the_next_argument(flag):
+    """`--netrc` takes no value; it names a file or is a switch.
+
+    Treating it as value-taking could never prevent a leak, and would
+    replace the next unrelated argument, so the persisted argv would
+    misstate the command that actually ran.
+    """
+    plan = make_plan(
+        target=LaunchTarget(argv=("curl", flag, "-o", "out.bin", "https://h"))
+    )
+    redacted = plan.to_redacted_argv()
+    assert REDACTED not in redacted
+    assert redacted[-3:] == ("-o", "out.bin", "https://h")
+
+
+def test_a_username_on_its_own_is_not_a_secret():
+    plan = make_plan(target=LaunchTarget(argv=("bench", "--username", "alice")))
+    assert plan.to_redacted_argv()[-1] == "alice"
+
+
+def test_netrc_file_paths_are_still_readable():
+    plan = make_plan(
+        target=LaunchTarget(argv=("curl", "--netrc-file", "/home/u/.netrc"))
+    )
+    assert plan.to_redacted_argv()[-1] == "/home/u/.netrc"

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -382,3 +382,90 @@ def test_output_trace_tilde_is_expanded_once(tmp_path, monkeypatch):
     assert "~" not in recorded
     assert recorded == str(plan.output_trace)
     assert Path(recorded).is_absolute()
+
+
+# --- Split and attached credential arguments --------------------------
+#
+# Redaction used to handle only NAME=value, so `--api-key sk-live` kept
+# the secret in every artifact this project writes.
+
+SENTINEL = "sk-live-DO-NOT-LEAK"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("bench", "--api-key", SENTINEL),
+        ("bench", "--api_key", SENTINEL),
+        ("bench", "--API-KEY", SENTINEL),
+        ("bench", f"--api-key={SENTINEL}"),
+        ("bench", f"API_KEY={SENTINEL}"),
+        ("bench", "--hf-token", SENTINEL),
+        ("bench", "--auth-token", SENTINEL),
+        ("bench", "--password", SENTINEL),
+        ("bench", "--secret", SENTINEL),
+        ("bench", "--private-key", SENTINEL),
+        ("bench", "--credential", SENTINEL),
+        ("bench", "--bearer", SENTINEL),
+        # A value that itself looks like an option must still go.
+        ("bench", "--api-key", f"-{SENTINEL}"),
+        ("bench", "--token", f"--{SENTINEL}"),
+    ],
+)
+def test_every_credential_shape_is_redacted(argv):
+    plan = make_plan(target=LaunchTarget(argv=argv))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+    # The real invocation is untouched, or the program would break.
+    assert SENTINEL in " ".join(plan.to_argv())
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("bench", "--tokens", "128"),
+        ("bench", "--max-tokens", "512"),
+        ("bench", "--num-tokens", "64"),
+        ("bench", "--token-count", "9"),
+        ("bench", "--max_new_tokens", "32"),
+        ("bench", "--input-tokens", "10"),
+        ("bench", "--sort-key", "name"),
+        ("bench", "--cache-key", "abc"),
+        ("bench", "--temperature", "0.7"),
+        ("bench", "--keyword", "value"),
+    ],
+)
+def test_legitimate_options_are_not_corrupted(argv):
+    """Redaction must not eat ordinary inference parameters.
+
+    An LLM command is full of `--max-tokens` and `--num-tokens`. A naive
+    substring match on "token" would redact all of them and destroy the
+    reproducibility the recorded argv exists to provide.
+    """
+    plan = make_plan(target=LaunchTarget(argv=argv))
+    redacted = plan.to_redacted_argv()
+    assert REDACTED not in redacted
+    assert redacted[-len(argv) :] == argv
+
+
+def test_a_credential_flag_at_the_end_does_not_crash():
+    plan = make_plan(target=LaunchTarget(argv=("bench", "--api-key")))
+    assert plan.to_redacted_argv()[-1] == "--api-key"
+
+
+def test_only_the_value_immediately_after_the_flag_is_redacted():
+    plan = make_plan(
+        target=LaunchTarget(argv=("bench", "--api-key", SENTINEL, "--tokens", "128"))
+    )
+    redacted = plan.to_redacted_argv()
+    assert redacted[-4:] == ("--api-key", REDACTED, "--tokens", "128")
+
+
+def test_single_dash_attached_values_are_a_documented_limit():
+    """`-ksk-live` cannot be told from a cluster of short flags.
+
+    Guessing would corrupt legitimate arguments, so the boundary is
+    documented rather than papered over. This pins it so a future change
+    is a deliberate one.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("bench", f"-k{SENTINEL}")))
+    assert SENTINEL in " ".join(plan.to_redacted_argv())

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -561,3 +561,32 @@ def test_the_secret_bearing_companions_are_still_caught():
     for flag in ("--keystore-password", "--private-key", "--jwt-secret"):
         plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
         assert SENTINEL not in " ".join(plan.to_redacted_argv()), flag
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--auth",
+        "--basic-auth",
+        "--proxy-auth",
+        "--client-auth",
+        "--digest-auth",
+        "--http-auth",
+    ],
+)
+def test_auth_compounds_are_redacted_not_only_the_bare_spelling(flag):
+    """`--basic-auth user:password` carries the credential inline.
+
+    Only the exact name `auth` used to match, so every compound spelling
+    passed through verbatim into the persisted argv.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("curl", flag, f"alice:{SENTINEL}")))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag", ["--auth-path", "--auth-url", "--auth-file", "--auth-name"]
+)
+def test_auth_locations_are_still_readable(flag):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, "/etc/auth.conf")))
+    assert plan.to_redacted_argv()[-1] == "/etc/auth.conf"

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -469,3 +469,46 @@ def test_single_dash_attached_values_are_a_documented_limit():
     """
     plan = make_plan(target=LaunchTarget(argv=("bench", f"-k{SENTINEL}")))
     assert SENTINEL in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--Authorization",
+        "--authorization",
+        "--auth",
+        "--client-secret",
+        "--refresh-token",
+        "--x-api-key",
+        "--aws-secret-access-key",
+        "--apiKey",
+        "-api-key",
+    ],
+)
+def test_further_credential_spellings_are_redacted(flag):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--auth-mode",
+        "--auth-type",
+        "--private-key-path",
+        "--api-key-file",
+        "--token-file",
+        "--credential-dir",
+        "--secret-name",
+        "--tokenizer-path",
+    ],
+)
+def test_location_names_are_not_secrets(flag):
+    """A name that points at where a secret lives is not the secret.
+
+    Redacting `--private-key-path /etc/k.pem` hides a filename, gains no
+    privacy, and loses the reproducibility the recorded argv exists for.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, "/some/value")))
+    assert REDACTED not in plan.to_redacted_argv()
+    assert plan.to_redacted_argv()[-1] == "/some/value"

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -326,3 +326,59 @@ def test_simple_argv_builders():
     assert build_version_argv("/usr/bin/xctrace") == ("/usr/bin/xctrace", "version")
     with pytest.raises(InstrumentsCommandError):
         build_version_argv("")
+
+
+# --- Regressions found in independent review --------------------------
+
+
+def test_secrets_in_the_profiled_command_are_redacted():
+    """The profiled command is user supplied and can carry a secret."""
+    plan = make_plan(
+        target=LaunchTarget(
+            argv=(
+                "/usr/bin/env",
+                "HF_TOKEN=hf_supersecret",
+                "python",
+                "bench.py",
+                "OPENAI_API_KEY=sk-live-123",
+            )
+        )
+    )
+    stored = " ".join(plan.to_redacted_argv())
+    assert "hf_supersecret" not in stored
+    assert "sk-live-123" not in stored
+    assert f"HF_TOKEN={REDACTED}" in plan.to_redacted_argv()
+    # The real invocation still receives the true values.
+    assert "HF_TOKEN=hf_supersecret" in plan.to_argv()
+    # Ordinary arguments survive so the run stays reproducible.
+    assert "bench.py" in plan.to_redacted_argv()
+
+
+def test_redaction_does_not_disturb_launch_being_last():
+    plan = make_plan(
+        target=LaunchTarget(argv=("/bin/infer", "TOKEN=abc", "--tokens", "8"))
+    )
+    argv = plan.to_redacted_argv()
+    separator = argv.index("--launch")
+    assert argv[separator + 1] == "--"
+    assert argv[separator + 2 :] == (
+        "/bin/infer",
+        f"TOKEN={REDACTED}",
+        "--tokens",
+        "8",
+    )
+
+
+def test_output_trace_tilde_is_expanded_once(tmp_path, monkeypatch):
+    """The checked path and the recorded path must be identical.
+
+    An unexpanded `~` would make the collision check and mkdir target
+    $HOME while xctrace created a literal './~' directory.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    plan = make_plan(output_trace=Path("~/traces/run.trace"))
+    argv = plan.to_argv()
+    recorded = argv[argv.index("--output") + 1]
+    assert "~" not in recorded
+    assert recorded == str(plan.output_trace)
+    assert Path(recorded).is_absolute()

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -512,3 +512,24 @@ def test_location_names_are_not_secrets(flag):
     plan = make_plan(target=LaunchTarget(argv=("bench", flag, "/some/value")))
     assert REDACTED not in plan.to_redacted_argv()
     assert plan.to_redacted_argv()[-1] == "/some/value"
+
+
+@pytest.mark.parametrize(
+    "flag", ["--jwt", "--ssh-key", "--deploy-key", "--session-key", "--signing-key"]
+)
+def test_unrecognized_key_style_options_default_to_secret(flag):
+    """An unfamiliar `*-key` option is treated as sensitive.
+
+    Redacting a lookup key costs a little reproducibility; persisting a
+    private one is unrecoverable, so the default leans the safe way.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag", ["--sort-key", "--cache-key", "--partition-key", "--primary-key"]
+)
+def test_lookup_keys_are_still_readable(flag):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, "user_id")))
+    assert plan.to_redacted_argv()[-1] == "user_id"

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -1,0 +1,328 @@
+"""Tests for shell-free xctrace argv construction and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.instruments.commands import (
+    REDACTED,
+    AttachTarget,
+    EnvironmentAssignment,
+    ExportPlan,
+    InstrumentsCommandError,
+    LaunchTarget,
+    RecordPlan,
+    build_list_templates_argv,
+    build_version_argv,
+    duration_to_seconds,
+    redact_argv,
+    table_xpath,
+    validate_schema_name,
+    validate_time_limit,
+    validate_window,
+)
+
+
+def make_plan(**overrides) -> RecordPlan:
+    values = {
+        "xctrace_path": "/usr/bin/xctrace",
+        "template": "Metal System Trace",
+        "output_trace": Path("/tmp/out/run.trace"),
+        "target": LaunchTarget(argv=("/bin/infer", "--tokens", "128")),
+        "time_limit": "30s",
+    }
+    values.update(overrides)
+    return RecordPlan(**values)
+
+
+# --- Durations --------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["500ms", "1s", "30s", "2m", "1h"])
+def test_valid_time_limits(value):
+    assert validate_time_limit(value) == value
+
+
+@pytest.mark.parametrize(
+    "value", ["30", "30 s", "s30", "-5s", "1.5s", "30sec", "", "30S", "1d"]
+)
+def test_invalid_time_limits_are_refused(value):
+    with pytest.raises(InstrumentsCommandError, match="invalid --time-limit"):
+        validate_time_limit(value)
+
+
+def test_window_rejects_hours_because_xctrace_does():
+    assert validate_window("5s") == "5s"
+    with pytest.raises(InstrumentsCommandError, match="not for --window"):
+        validate_window("1h")
+
+
+@pytest.mark.parametrize(
+    "value,seconds", [("500ms", 0.5), ("30s", 30.0), ("2m", 120.0), ("1h", 3600.0)]
+)
+def test_duration_to_seconds(value, seconds):
+    assert duration_to_seconds(value) == seconds
+
+
+# --- XPath construction and injection ---------------------------------
+
+
+def test_table_xpath_matches_the_documented_form():
+    assert table_xpath("metal-gpu-intervals") == (
+        '/trace-toc/run[@number="1"]/data/table[@schema="metal-gpu-intervals"]'
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        'a"] | //*[@x="',
+        "schema name",
+        "",
+        "-leading-dash",
+        "1starts-with-digit",
+        "has/slash",
+        "has'quote",
+        "has]bracket",
+    ],
+)
+def test_schema_names_that_could_break_out_of_an_xpath_are_refused(name):
+    with pytest.raises(InstrumentsCommandError, match="invalid trace table schema"):
+        validate_schema_name(name)
+
+
+@pytest.mark.parametrize("run_number", [0, -1, True])
+def test_invalid_run_numbers_are_refused(run_number):
+    with pytest.raises(InstrumentsCommandError, match="invalid trace run number"):
+        table_xpath("time-profile", run_number=run_number)
+
+
+# --- Record argv ------------------------------------------------------
+
+
+def test_record_argv_shape_and_launch_is_last():
+    argv = make_plan().to_argv()
+    assert argv[:2] == ("/usr/bin/xctrace", "record")
+    assert "--template" in argv and argv[argv.index("--template") + 1] == (
+        "Metal System Trace"
+    )
+    assert argv[argv.index("--time-limit") + 1] == "30s"
+    assert "--no-prompt" in argv
+    # --launch and everything after it must be the tail of the argv.
+    assert argv[-5:] == ("--launch", "--", "/bin/infer", "--tokens", "128")
+
+
+def test_record_argv_never_targets_another_device():
+    """Omitting --device is what makes the host the target."""
+    argv = make_plan().to_argv()
+    assert "--device" not in argv
+    assert "--device-name" not in argv
+
+
+def test_record_argv_never_appends_to_an_existing_trace():
+    assert "--append-run" not in make_plan().to_argv()
+
+
+def test_record_argv_never_redirects_target_streams():
+    """Prompt and completion text must not flow into captured logs."""
+    argv = make_plan().to_argv()
+    assert "--target-stdout" not in argv
+    assert "--target-stdin" not in argv
+
+
+def test_record_argv_never_records_all_processes():
+    assert "--all-processes" not in make_plan().to_argv()
+
+
+def test_record_argv_is_deterministic():
+    assert make_plan().to_argv() == make_plan().to_argv()
+
+
+def test_attach_target_uses_pid():
+    argv = make_plan(target=AttachTarget(pid=4242)).to_argv()
+    assert argv[argv.index("--attach") + 1] == "4242"
+    assert "--launch" not in argv
+
+
+@pytest.mark.parametrize("pid", [0, -1, True, "1234"])
+def test_attach_by_anything_other_than_a_positive_int_is_refused(pid):
+    with pytest.raises(InstrumentsCommandError, match="attach pid"):
+        AttachTarget(pid=pid)
+
+
+def test_launch_target_requires_a_non_empty_command():
+    with pytest.raises(InstrumentsCommandError, match="non-empty"):
+        LaunchTarget(argv=())
+    with pytest.raises(InstrumentsCommandError, match="non-empty"):
+        LaunchTarget(argv=("",))
+
+
+def test_output_must_be_a_trace_bundle():
+    with pytest.raises(InstrumentsCommandError, match="must end in '.trace'"):
+        make_plan(output_trace=Path("/tmp/out.txt"))
+
+
+def test_window_flag_is_emitted_when_requested():
+    argv = make_plan(window="5s").to_argv()
+    assert argv[argv.index("--window") + 1] == "5s"
+
+
+def test_run_name_flag_is_emitted_when_requested():
+    argv = make_plan(run_name="baseline").to_argv()
+    assert argv[argv.index("--run-name") + 1] == "baseline"
+
+
+# --- Timeout ----------------------------------------------------------
+
+
+def test_host_timeout_exceeds_the_recording_window():
+    """xctrace keeps writing after the window closes.
+
+    A host deadline equal to --time-limit would kill every recording
+    during finalization.
+    """
+    plan = make_plan(time_limit="30s", grace_seconds=90.0)
+    assert plan.timeout_seconds == 120.0
+    assert plan.timeout_seconds > duration_to_seconds(plan.time_limit)
+
+
+def test_grace_must_be_positive():
+    with pytest.raises(InstrumentsCommandError, match="grace_seconds"):
+        make_plan(grace_seconds=0)
+
+
+# --- Credential redaction ---------------------------------------------
+
+
+def test_env_values_that_look_like_credentials_are_redacted():
+    plan = make_plan(
+        environment=(
+            EnvironmentAssignment(name="HF_TOKEN", value="hf_secret_value"),
+            EnvironmentAssignment(name="BATCH_SIZE", value="8"),
+        )
+    )
+    real = plan.to_argv()
+    stored = plan.to_redacted_argv()
+
+    assert "HF_TOKEN=hf_secret_value" in real
+    assert "hf_secret_value" not in " ".join(stored)
+    assert f"HF_TOKEN={REDACTED}" in stored
+    # A non-credential variable stays readable, so reproduction works.
+    assert "BATCH_SIZE=8" in stored
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "OPENAI_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "MY_PASSWORD",
+        "db_credential",
+        "Service_Token",
+        "PRIVATE_KEY",
+    ],
+)
+def test_credential_marker_matching_is_case_insensitive(name):
+    plan = make_plan(environment=(EnvironmentAssignment(name=name, value="s3cr3t"),))
+    assert "s3cr3t" not in " ".join(plan.to_redacted_argv())
+
+
+def test_redacted_argv_is_deterministic():
+    plan = make_plan(environment=(EnvironmentAssignment(name="HF_TOKEN", value="a"),))
+    assert plan.to_redacted_argv() == plan.to_redacted_argv()
+
+
+def test_redact_argv_handles_loose_argv():
+    assert redact_argv(("run", "API_KEY=abc", "SIZE=4")) == (
+        "run",
+        f"API_KEY={REDACTED}",
+        "SIZE=4",
+    )
+
+
+def test_environment_name_must_not_contain_equals():
+    with pytest.raises(InstrumentsCommandError, match="must not contain"):
+        EnvironmentAssignment(name="A=B", value="c")
+
+
+def test_env_is_refused_when_attaching():
+    """xctrace documents --env as launch only."""
+    with pytest.raises(InstrumentsCommandError, match="only supported when launching"):
+        make_plan(
+            target=AttachTarget(pid=1),
+            environment=(EnvironmentAssignment(name="A", value="b"),),
+        )
+
+
+# --- Export argv ------------------------------------------------------
+
+
+def test_export_toc_argv():
+    plan = ExportPlan(
+        xctrace_path="/usr/bin/xctrace",
+        input_trace=Path("/tmp/run.trace"),
+        output_path=Path("/tmp/toc.xml"),
+        toc=True,
+    )
+    argv = plan.to_argv()
+    assert argv[:2] == ("/usr/bin/xctrace", "export")
+    assert "--toc" in argv
+    assert "--xpath" not in argv
+
+
+def test_export_table_argv_uses_xpath():
+    plan = ExportPlan(
+        xctrace_path="/usr/bin/xctrace",
+        input_trace=Path("/tmp/run.trace"),
+        output_path=Path("/tmp/t.xml"),
+        schema_name="metal-gpu-intervals",
+        run_number=2,
+    )
+    argv = plan.to_argv()
+    assert "--toc" not in argv
+    assert argv[argv.index("--xpath") + 1] == (
+        '/trace-toc/run[@number="2"]/data/table[@schema="metal-gpu-intervals"]'
+    )
+
+
+def test_export_refuses_to_combine_toc_and_xpath():
+    with pytest.raises(InstrumentsCommandError, match="cannot combine"):
+        ExportPlan(
+            xctrace_path="/usr/bin/xctrace",
+            input_trace=Path("/tmp/run.trace"),
+            output_path=Path("/tmp/t.xml"),
+            toc=True,
+            schema_name="time-profile",
+        )
+
+
+def test_export_requires_a_mode():
+    with pytest.raises(InstrumentsCommandError, match="needs either"):
+        ExportPlan(
+            xctrace_path="/usr/bin/xctrace",
+            input_trace=Path("/tmp/run.trace"),
+            output_path=Path("/tmp/t.xml"),
+        )
+
+
+def test_export_rejects_injected_schema_name():
+    with pytest.raises(InstrumentsCommandError, match="invalid trace table schema"):
+        ExportPlan(
+            xctrace_path="/usr/bin/xctrace",
+            input_trace=Path("/tmp/run.trace"),
+            output_path=Path("/tmp/t.xml"),
+            schema_name='x"] | //*[@a="',
+        )
+
+
+def test_simple_argv_builders():
+    assert build_list_templates_argv("/usr/bin/xctrace") == (
+        "/usr/bin/xctrace",
+        "list",
+        "templates",
+    )
+    assert build_version_argv("/usr/bin/xctrace") == ("/usr/bin/xctrace", "version")
+    with pytest.raises(InstrumentsCommandError):
+        build_version_argv("")

--- a/tests/optimizer/test_instruments_commands.py
+++ b/tests/optimizer/test_instruments_commands.py
@@ -590,3 +590,50 @@ def test_auth_compounds_are_redacted_not_only_the_bare_spelling(flag):
 def test_auth_locations_are_still_readable(flag):
     plan = make_plan(target=LaunchTarget(argv=("bench", flag, "/etc/auth.conf")))
     assert plan.to_redacted_argv()[-1] == "/etc/auth.conf"
+
+
+@pytest.mark.parametrize(
+    "flag", ["--pw", "--pass", "--db-pass", "--connection-string", "--dsn"]
+)
+def test_short_and_embedded_credential_spellings_are_redacted(flag):
+    """A DSN or connection string carries the password inline."""
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, SENTINEL)))
+    assert SENTINEL not in " ".join(plan.to_redacted_argv())
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--pass-count", "3"),
+        ("--passes", "2"),
+        ("--key-count", "8"),
+        ("--retry-limit", "5"),
+        ("--batch-size", "16"),
+    ],
+)
+def test_quantity_suffixes_are_not_treated_as_secrets(flag, value):
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, value)))
+    assert plan.to_redacted_argv()[-1] == value
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--secret-type", "vault"),
+        ("--password-mode", "interactive"),
+        ("--api-key-version", "v2"),
+        ("--token-format", "jwt"),
+        ("--auth-scheme", "bearer"),
+        ("--credential-method", "oauth"),
+    ],
+)
+def test_descriptors_about_a_secret_are_not_the_secret(flag, value):
+    """These name how a credential is configured, not its value.
+
+    `--secret-type vault` and `--auth-scheme bearer` are settings.
+    Redacting them would hide nothing and lose reproducibility. This
+    pins the reasoning so the suffix exemption is a decision rather
+    than an accident.
+    """
+    plan = make_plan(target=LaunchTarget(argv=("bench", flag, value)))
+    assert plan.to_redacted_argv()[-1] == value

--- a/tests/optimizer/test_instruments_export.py
+++ b/tests/optimizer/test_instruments_export.py
@@ -151,7 +151,7 @@ def test_references_are_resolved_including_forward_references():
     """
     table = parse_exported_table(read_fixture(TABLE))
     fourth = table.rows[3]
-    assert fourth.require("duration").as_int(field="duration") == 1000
+    assert fourth.require("duration").as_int(field_name="duration") == 1000
     assert fourth.require("channel-name").text == "Vertex"
     assert fourth.require("process").fmt == "WindowServer (77)"
 
@@ -254,7 +254,7 @@ def test_non_integer_cell_is_refused():
     )
     table = parse_exported_table(payload)
     with pytest.raises(InstrumentsExportError, match="is not an integer"):
-        table.rows[0].require("a").as_int(field="a")
+        table.rows[0].require("a").as_int(field_name="a")
 
 
 def test_requiring_an_absent_column_is_an_error():
@@ -404,3 +404,133 @@ def test_forbidden_metric_names_cover_the_usual_gpu_overclaims():
         "gpu_power",
     ):
         assert name in FORBIDDEN_METRIC_NAMES
+
+
+# --- Regressions found in independent review --------------------------
+
+
+def test_a_ref_pointing_at_the_wrong_engineering_type_is_refused():
+    """Almost every real cell is a ref.
+
+    Checking only the referencing element's tag would leave the
+    engineering-type contract enforced on a tiny minority of the data,
+    and let a duration column take its value from a start-time.
+    """
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t">'
+        "<col><mnemonic>a</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>b</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "</schema>"
+        '<row><start-time id="1">100</start-time>'
+        '<duration id="2">7</duration></row>'
+        '<row><start-time ref="1"/><duration ref="1"/></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="referenced value"):
+        parse_exported_table(payload)
+
+
+def test_duplicate_column_mnemonics_are_refused():
+    """A repeated mnemonic would let one column overwrite another."""
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t">'
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "</schema>"
+        '<row><duration id="1">100</duration>'
+        '<duration id="2">999999</duration></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="duplicate column mnemonics"):
+        parse_exported_table(payload)
+
+
+def test_multiple_nodes_are_refused_rather_than_silently_truncated():
+    node = (
+        "<node>"
+        '<schema name="t"><col><mnemonic>a</mnemonic>'
+        "<engineering-type>uint64</engineering-type></col></schema>"
+        '<row><uint64 id="{i}">1</uint64></row>'
+        "</node>"
+    )
+    payload = (
+        "<trace-query-result>"
+        + node.format(i=1)
+        + node.format(i=2)
+        + "</trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="2 <node> elements"):
+        parse_exported_table(payload)
+
+
+def _intervals_table(*rows: str) -> str:
+    return (
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        "</schema>" + "".join(rows) + "</node></trace-query-result>"
+    )
+
+
+def test_one_pid_under_two_labels_refuses_to_attribute():
+    """Pid reuse or an exec rename must not silently pick a winner."""
+    table = parse_exported_table(
+        _intervals_table(
+            '<row><start-time id="1">10</start-time>'
+            '<duration id="2">10</duration>'
+            '<process id="3" fmt="probe (4242)"><pid id="4">4242</pid>'
+            "</process></row>",
+            '<row><start-time id="5">20</start-time>'
+            '<duration id="6">30</duration>'
+            '<process id="7" fmt="WindowServer (4242)"><pid id="8">4242</pid>'
+            "</process></row>",
+        )
+    )
+    summary = summarize_metal_gpu_intervals(table)
+    assert len(summary.per_process) == 2
+    with pytest.raises(InstrumentsExportError, match="is ambiguous"):
+        summary.for_process(4242)
+
+
+def test_pid_comes_from_the_structured_child_not_the_label():
+    """The display label is only a fallback."""
+    table = parse_exported_table(
+        _intervals_table(
+            '<row><start-time id="1">10</start-time>'
+            '<duration id="2">10</duration>'
+            '<process id="3" fmt="misleading (999)"><pid id="4">4242</pid>'
+            "</process></row>"
+        )
+    )
+    summary = summarize_metal_gpu_intervals(table)
+    assert summary.per_process[0].pid == 4242
+    assert summary.for_process(999) is None
+
+
+def test_processes_without_a_label_are_kept_apart_by_pid():
+    """Two unlabelled processes must not merge into one bucket."""
+    table = parse_exported_table(
+        _intervals_table(
+            '<row><start-time id="1">10</start-time>'
+            '<duration id="2">10</duration>'
+            '<process id="3"><pid id="4">11</pid></process></row>',
+            '<row><start-time id="5">20</start-time>'
+            '<duration id="6">10</duration>'
+            '<process id="7"><pid id="8">22</pid></process></row>',
+        )
+    )
+    summary = summarize_metal_gpu_intervals(table)
+    assert len(summary.per_process) == 2
+    assert {entry.pid for entry in summary.per_process} == {11, 22}
+    assert summary.for_process(11).interval_count == 1

--- a/tests/optimizer/test_instruments_export.py
+++ b/tests/optimizer/test_instruments_export.py
@@ -19,6 +19,7 @@ from llmtracefx.optimizer.instruments.export import (
     parse_exported_table,
     parse_table_of_contents,
     read_export_text,
+    sanitize_table_of_contents,
     summarize_metal_gpu_intervals,
 )
 
@@ -550,3 +551,72 @@ def test_parsable_schema_lists_cannot_drift_apart():
     assert set(SUPPORTED_TABLE_SCHEMAS) == set(INSTRUMENT_PARSABLE_SCHEMAS)
     sources = {source for source, _, _ in INSTRUMENT_METRIC_SPECS.values()}
     assert sources <= set(SUPPORTED_TABLE_SCHEMAS)
+
+
+# --- Table of contents sanitization -----------------------------------
+
+
+def test_toc_sanitization_removes_identity_and_target_arguments():
+    """The parser never read these; the raw file still carried them.
+
+    A real macOS device name is routinely the owner's own name, and the
+    target argument list is the one place a credential passed on the
+    command line survives argv redaction.
+    """
+    raw = read_fixture(TOC)
+    assert "Example Mac" in raw and 'arguments="120"' in raw
+
+    clean = sanitize_table_of_contents(raw)
+    assert "Example Mac" not in clean
+    assert "00000000-0000-0000-0000-000000000000" not in clean
+    assert "arguments=" not in clean
+
+
+def test_toc_sanitization_keeps_everything_attribution_needs():
+    raw = read_fixture(TOC)
+    clean = sanitize_table_of_contents(raw)
+
+    parsed = parse_table_of_contents(clean)
+    run = parsed.runs[0]
+    assert run.template_name == "Metal System Trace"
+    assert run.instruments_version == "16.0 (17F113)"
+    assert run.target_pid == 4242
+    assert run.target_process_name == "probe"
+    assert run.schemas == parse_table_of_contents(raw).runs[0].schemas
+
+
+def test_toc_sanitization_says_what_it_did():
+    clean = sanitize_table_of_contents(read_fixture(TOC))
+    assert "Sanitized by llmtracefx" in clean
+    assert ".trace bundle" in clean
+
+
+def test_toc_sanitization_is_idempotent():
+    once = sanitize_table_of_contents(read_fixture(TOC))
+    assert sanitize_table_of_contents(once) == once
+
+
+def test_implausible_interval_values_are_refused_not_overflowed():
+    """Python ints are unbounded; floats are not.
+
+    A malformed cell used to raise OverflowError from deep inside
+    evidence building rather than being rejected as bad input.
+    """
+    huge = "9" * 400
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        "</schema><row>"
+        '<start-time id="1">5</start-time>'
+        f'<duration id="2">{huge}</duration>'
+        '<process id="3" fmt="p (1)"><pid id="4">1</pid></process>'
+        "</row></node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="implausible"):
+        summarize_metal_gpu_intervals(parse_exported_table(payload))

--- a/tests/optimizer/test_instruments_export.py
+++ b/tests/optimizer/test_instruments_export.py
@@ -1,0 +1,406 @@
+"""Tests for strict parsing of xctrace export output.
+
+The fixtures are synthetic but structurally faithful to real
+``xctrace 16.0 (17F113)`` output, including the two properties that make
+naive parsing wrong: rows map to columns positionally, and repeated
+values are emitted once and then referenced by id.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _instruments_fakes import read_fixture
+
+from llmtracefx.optimizer.instruments.export import (
+    FORBIDDEN_METRIC_NAMES,
+    MAX_EXPORT_BYTES,
+    SUPPORTED_TABLE_SCHEMAS,
+    InstrumentsExportError,
+    parse_exported_table,
+    parse_table_of_contents,
+    read_export_text,
+    summarize_metal_gpu_intervals,
+)
+
+TOC = "toc_metal_system_trace.xml"
+TABLE = "table_metal_gpu_intervals.xml"
+UNSUPPORTED = "table_unsupported_schema.xml"
+
+
+# --- Table of contents ------------------------------------------------
+
+
+def test_toc_reports_runs_and_schemas():
+    toc = parse_table_of_contents(read_fixture(TOC))
+    assert len(toc.runs) == 1
+    run = toc.runs[0]
+    assert run.number == 1
+    assert run.template_name == "Metal System Trace"
+    assert run.instruments_version == "16.0 (17F113)"
+    assert run.duration_seconds == pytest.approx(0.5)
+    assert run.end_reason == "Target app exited"
+    assert "metal-gpu-intervals" in run.schemas
+
+
+def test_toc_reads_the_launched_process_for_attribution():
+    run = parse_table_of_contents(read_fixture(TOC)).runs[0]
+    assert run.target_pid == 4242
+    assert run.target_process_name == "probe"
+
+
+def test_toc_does_not_ingest_device_identity_or_target_arguments():
+    """The TOC carries a device display name, a hardware UUID and the
+    target's argument list. None may reach a parsed artifact."""
+    raw = read_fixture(TOC)
+    assert "Example Mac" in raw and "00000000-0000-0000-0000-000000000000" in raw
+
+    serialized = str(parse_table_of_contents(raw).to_dict())
+    assert "Example Mac" not in serialized
+    assert "00000000-0000-0000-0000-000000000000" not in serialized
+    assert "MacBook Pro" not in serialized
+    assert "arguments" not in serialized
+
+
+def test_toc_schema_names_are_deduplicated_and_sorted():
+    toc = parse_table_of_contents(read_fixture(TOC))
+    names = toc.schema_names
+    assert names == tuple(sorted(set(names)))
+
+
+def test_run_lookup_by_number():
+    toc = parse_table_of_contents(read_fixture(TOC))
+    assert toc.run_by_number(1) is not None
+    assert toc.run_by_number(99) is None
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ("<not-a-toc/>", "expected a <trace-toc>"),
+        ("<trace-toc></trace-toc>", "no <run> elements"),
+        ("<trace-toc><run/></trace-toc>", "missing @number"),
+        ('<trace-toc><run number="x"/></trace-toc>', "not an integer"),
+        ("<trace-toc", "not valid XML"),
+    ],
+)
+def test_malformed_toc_is_refused(payload, match):
+    with pytest.raises(InstrumentsExportError, match=match):
+        parse_table_of_contents(payload)
+
+
+def test_toc_with_non_numeric_duration_is_refused():
+    payload = (
+        '<trace-toc><run number="1"><info><summary>'
+        "<duration>not-a-number</duration>"
+        "</summary></info></run></trace-toc>"
+    )
+    with pytest.raises(InstrumentsExportError, match="duration is not a number"):
+        parse_table_of_contents(payload)
+
+
+def test_toc_with_non_numeric_target_pid_is_refused():
+    payload = (
+        '<trace-toc><run number="1"><info><target>'
+        '<process name="probe" pid="not-a-pid"/>'
+        "</target></info></run></trace-toc>"
+    )
+    with pytest.raises(InstrumentsExportError, match="@pid is not an integer"):
+        parse_table_of_contents(payload)
+
+
+# --- Entity expansion -------------------------------------------------
+
+
+def test_doctype_is_refused_before_parsing():
+    """Guards against entity expansion denial of service.
+
+    Real xctrace output never declares a doctype, so refusing one costs
+    nothing.
+    """
+    bomb = (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE trace-toc [<!ENTITY a "aaaaaaaaaa">]>'
+        "<trace-toc></trace-toc>"
+    )
+    with pytest.raises(InstrumentsExportError, match="DOCTYPE or ENTITY"):
+        parse_table_of_contents(bomb)
+
+
+def test_entity_declaration_is_refused_in_table_exports_too():
+    with pytest.raises(InstrumentsExportError, match="DOCTYPE or ENTITY"):
+        parse_exported_table('<!ENTITY x "y"><trace-query-result/>')
+
+
+# --- Table data -------------------------------------------------------
+
+
+def test_table_parses_columns_and_rows():
+    table = parse_exported_table(
+        read_fixture(TABLE), expected_schema="metal-gpu-intervals"
+    )
+    assert table.schema_name == "metal-gpu-intervals"
+    assert table.column_mnemonics == ("start", "duration", "channel-name", "process")
+    assert table.row_count == 5
+
+
+def test_references_are_resolved_including_forward_references():
+    """Row 4 references a duration first defined in row 5.
+
+    Ids are indexed over the whole document before rows are resolved, so
+    document order does not matter.
+    """
+    table = parse_exported_table(read_fixture(TABLE))
+    fourth = table.rows[3]
+    assert fourth.require("duration").as_int(field="duration") == 1000
+    assert fourth.require("channel-name").text == "Vertex"
+    assert fourth.require("process").fmt == "WindowServer (77)"
+
+
+def test_back_references_resolve_to_the_original_value():
+    table = parse_exported_table(read_fixture(TABLE))
+    second = table.rows[1]
+    assert second.require("channel-name").text == "Compute"
+    assert second.require("process").fmt == "probe (4242)"
+
+
+def test_dangling_reference_is_refused():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t"><col><mnemonic>a</mnemonic>'
+        "<engineering-type>uint64</engineering-type></col></schema>"
+        '<row><uint64 ref="999"/></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="undefined id"):
+        parse_exported_table(payload)
+
+
+def test_cyclic_reference_is_refused():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t"><col><mnemonic>a</mnemonic>'
+        "<engineering-type>uint64</engineering-type></col></schema>"
+        '<row><uint64 ref="1"/></row>'
+        '<row><uint64 id="1" ref="2"/></row>'
+        '<row><uint64 id="2" ref="1"/></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="cyclic ref chain"):
+        parse_exported_table(payload)
+
+
+def test_column_count_mismatch_is_refused_rather_than_guessed():
+    """A short row must not be silently mapped onto the wrong columns."""
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t">'
+        "<col><mnemonic>a</mnemonic><engineering-type>uint64</engineering-type></col>"
+        "<col><mnemonic>b</mnemonic><engineering-type>uint64</engineering-type></col>"
+        "</schema>"
+        '<row><uint64 id="1">5</uint64></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="Refusing to map values"):
+        parse_exported_table(payload)
+
+
+def test_engineering_type_mismatch_is_refused():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t"><col><mnemonic>a</mnemonic>'
+        "<engineering-type>uint64</engineering-type></col></schema>"
+        '<row><duration id="1">5</duration></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="declares engineering type"):
+        parse_exported_table(payload)
+
+
+def test_requesting_a_different_schema_than_returned_is_refused():
+    with pytest.raises(
+        InstrumentsExportError, match="but 'time-profile' was requested"
+    ):
+        parse_exported_table(read_fixture(TABLE), expected_schema="time-profile")
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ("<wrong-root/>", "expected a <trace-query-result>"),
+        ("<trace-query-result/>", "contains no <node>"),
+        ("<trace-query-result><node/></trace-query-result>", "has no <schema>"),
+        (
+            "<trace-query-result><node><schema/></node></trace-query-result>",
+            "missing @name",
+        ),
+        (
+            '<trace-query-result><node><schema name="t"/></node></trace-query-result>',
+            "declares no <col>",
+        ),
+    ],
+)
+def test_malformed_table_exports_are_refused(payload, match):
+    with pytest.raises(InstrumentsExportError, match=match):
+        parse_exported_table(payload)
+
+
+def test_non_integer_cell_is_refused():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="t"><col><mnemonic>a</mnemonic>'
+        "<engineering-type>uint64</engineering-type></col></schema>"
+        '<row><uint64 id="1">not-a-number</uint64></row>'
+        "</node></trace-query-result>"
+    )
+    table = parse_exported_table(payload)
+    with pytest.raises(InstrumentsExportError, match="is not an integer"):
+        table.rows[0].require("a").as_int(field="a")
+
+
+def test_requiring_an_absent_column_is_an_error():
+    table = parse_exported_table(read_fixture(TABLE))
+    assert table.rows[0].get("nope") is None
+    with pytest.raises(InstrumentsExportError, match="no column 'nope'"):
+        table.rows[0].require("nope")
+
+
+# --- Reading files ----------------------------------------------------
+
+
+def test_read_export_text_refuses_missing_and_oversized(tmp_path):
+    with pytest.raises(InstrumentsExportError, match="does not exist"):
+        read_export_text(tmp_path / "absent.xml")
+
+    directory = tmp_path / "dir.xml"
+    directory.mkdir()
+    with pytest.raises(InstrumentsExportError, match="not a file"):
+        read_export_text(directory)
+
+
+def test_read_export_text_rejects_invalid_utf8(tmp_path):
+    target = tmp_path / "bad.xml"
+    target.write_bytes(b"\xff\xfe\x00invalid")
+    with pytest.raises(InstrumentsExportError, match="not valid UTF-8"):
+        read_export_text(target)
+
+
+def test_export_size_limit_is_bounded():
+    assert 0 < MAX_EXPORT_BYTES <= 1024 * 1024 * 1024
+
+
+# --- Summaries --------------------------------------------------------
+
+
+def test_summary_attributes_intervals_per_process():
+    """Metal System Trace records every process, not only the target.
+
+    The fixture deliberately mixes the launched process with
+    WindowServer, so a system-wide total would overstate the target's
+    GPU work by more than half.
+    """
+    table = parse_exported_table(read_fixture(TABLE))
+    summary = summarize_metal_gpu_intervals(table)
+
+    assert summary.total_interval_count == 5
+    probe = summary.for_process(4242)
+    assert probe is not None
+    assert probe.interval_count == 3
+    assert probe.duration_sum_ns == 10000 + 20000 + 1000
+    assert probe.wall_span_ns == (500000 + 1000) - 100000
+
+    window_server = summary.for_process(77)
+    assert window_server is not None
+    assert window_server.interval_count == 2
+
+
+def test_summary_orders_processes_by_interval_count():
+    summary = summarize_metal_gpu_intervals(parse_exported_table(read_fixture(TABLE)))
+    counts = [entry.interval_count for entry in summary.per_process]
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_summary_for_unknown_pid_is_none():
+    summary = summarize_metal_gpu_intervals(parse_exported_table(read_fixture(TABLE)))
+    assert summary.for_process(999999) is None
+
+
+def test_summary_refuses_a_table_of_the_wrong_schema():
+    table = parse_exported_table(read_fixture(UNSUPPORTED))
+    with pytest.raises(
+        InstrumentsExportError, match="expected a 'metal-gpu-intervals'"
+    ):
+        summarize_metal_gpu_intervals(table)
+
+
+def test_summary_refuses_a_table_missing_required_columns():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals"><col><mnemonic>start</mnemonic>'
+        "<engineering-type>start-time</engineering-type></col></schema>"
+        '<row><start-time id="1">5</start-time></row>'
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="missing required columns"):
+        summarize_metal_gpu_intervals(parse_exported_table(payload))
+
+
+def test_negative_duration_is_refused():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        "</schema>"
+        "<row>"
+        '<start-time id="1">5</start-time>'
+        '<duration id="2">-7</duration>'
+        '<process id="3" fmt="p (1)"/>'
+        "</row>"
+        "</node></trace-query-result>"
+    )
+    with pytest.raises(InstrumentsExportError, match="negative duration"):
+        summarize_metal_gpu_intervals(parse_exported_table(payload))
+
+
+def test_unparsable_process_label_yields_no_pid_rather_than_a_wrong_one():
+    payload = (
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        "</schema>"
+        "<row>"
+        '<start-time id="1">5</start-time>'
+        '<duration id="2">7</duration>'
+        '<process id="3" fmt="no pid here"/>'
+        "</row>"
+        "</node></trace-query-result>"
+    )
+    summary = summarize_metal_gpu_intervals(parse_exported_table(payload))
+    assert summary.per_process[0].pid is None
+
+
+# --- No overclaiming --------------------------------------------------
+
+
+def test_only_validated_schemas_are_declared_supported():
+    assert SUPPORTED_TABLE_SCHEMAS == ("metal-gpu-intervals",)
+
+
+def test_forbidden_metric_names_cover_the_usual_gpu_overclaims():
+    for name in (
+        "gpu_utilization",
+        "gpu_kernel_time",
+        "memory_bandwidth",
+        "occupancy",
+        "gpu_power",
+    ):
+        assert name in FORBIDDEN_METRIC_NAMES

--- a/tests/optimizer/test_instruments_export.py
+++ b/tests/optimizer/test_instruments_export.py
@@ -534,3 +534,19 @@ def test_processes_without_a_label_are_kept_apart_by_pid():
     assert len(summary.per_process) == 2
     assert {entry.pid for entry in summary.per_process} == {11, 22}
     assert summary.for_process(11).interval_count == 1
+
+
+def test_parsable_schema_lists_cannot_drift_apart():
+    """The parser's list and the schema's guard must stay in step.
+
+    If they diverge, either a real run stops validating or the guard
+    stops guarding.
+    """
+    from llmtracefx.optimizer.schema import (
+        INSTRUMENT_METRIC_SPECS,
+        INSTRUMENT_PARSABLE_SCHEMAS,
+    )
+
+    assert set(SUPPORTED_TABLE_SCHEMAS) == set(INSTRUMENT_PARSABLE_SCHEMAS)
+    sources = {source for source, _, _ in INSTRUMENT_METRIC_SPECS.values()}
+    assert sources <= set(SUPPORTED_TABLE_SCHEMAS)

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -639,3 +639,54 @@ def test_a_clean_exit_with_an_empty_group_signals_nothing(tmp_path):
     assert result.status is RecordStatus.COMPLETED
     assert process.signals == []
     assert "process group was stopped" not in result.message
+
+
+def test_message_does_not_claim_a_stop_that_did_not_happen(tmp_path):
+    """A group that survives SIGKILL must not be reported as stopped.
+
+    The truth was already computed and then discarded, so the persisted
+    artifact asserted a cleanup that demonstrably had not occurred.
+    """
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    process = FakeProcess(returncode=0, timeout_waits=1, group_dies_on=None)
+
+    result = run_record(
+        make_plan(trace),
+        launcher=FakeLauncher(process),
+        artifacts_dir=artifacts,
+    )
+
+    assert result.status is RecordStatus.TIMED_OUT
+    assert "could NOT be stopped" in result.message
+    assert str(process.pgid) in result.message
+    persisted = json.loads(
+        (artifacts / "xctrace_record.json").read_text(encoding="utf-8")
+    )
+    assert "could NOT be stopped" in persisted["message"]
+
+
+def test_message_reports_a_real_stop_as_a_stop(tmp_path):
+    trace = tmp_path / "run.trace"
+    result = run_record(
+        make_plan(trace),
+        launcher=FakeLauncher(FakeProcess(returncode=0, timeout_waits=1)),
+        artifacts_dir=tmp_path / "artifacts",
+    )
+    assert "the process group was stopped" in result.message
+    assert "could NOT" not in result.message
+
+
+def test_unsignalable_group_is_not_reported_as_stopped(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(
+        timeout_waits=5,
+        signal_error=InstrumentsProcessError("not permitted"),
+        group_dies_on=None,
+    )
+    result = run_record(
+        make_plan(trace),
+        launcher=FakeLauncher(process),
+        artifacts_dir=tmp_path / "artifacts",
+    )
+    assert "could NOT be stopped" in result.message

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -8,12 +8,15 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from _instruments_fakes import COMMAND_LINE_TOOLS_STDERR, FakeLauncher, FakeProcess
 
+from llmtracefx.optimizer.instruments import recorder as recorder_module
 from llmtracefx.optimizer.instruments.commands import LaunchTarget, RecordPlan
 from llmtracefx.optimizer.instruments.process import (
     InstrumentsProcessError,
@@ -23,6 +26,8 @@ from llmtracefx.optimizer.instruments.recorder import (
     InstrumentsRecordError,
     RecordStatus,
     check_output_collision,
+    reservation_path_for,
+    reserve_trace_path,
     run_record,
 )
 
@@ -690,3 +695,117 @@ def test_unsignalable_group_is_not_reported_as_stopped(tmp_path):
         artifacts_dir=tmp_path / "artifacts",
     )
     assert "could NOT be stopped" in result.message
+
+
+# --- Atomic reservation -----------------------------------------------
+#
+# Checking that a path is free and then recording into it is a
+# check-then-use race. These pin the atomic claim that closes it.
+
+
+def test_reservation_is_exclusive(tmp_path):
+    trace = tmp_path / "run.trace"
+    with reserve_trace_path(trace):
+        with pytest.raises(InstrumentsRecordError, match="already reserved"):
+            with reserve_trace_path(trace):
+                pass
+
+
+def test_reservation_is_released_on_success(tmp_path):
+    trace = tmp_path / "run.trace"
+    with reserve_trace_path(trace) as resolved:
+        marker = reservation_path_for(resolved)
+        assert marker.exists()
+    assert not marker.exists()
+
+
+def test_reservation_is_released_when_the_body_raises(tmp_path):
+    trace = tmp_path / "run.trace"
+    marker = reservation_path_for(trace.resolve())
+    with pytest.raises(ValueError):
+        with reserve_trace_path(trace):
+            raise ValueError("boom")
+    assert not marker.exists()
+
+
+def test_reservation_refuses_a_bundle_that_appears_mid_start(tmp_path):
+    """The window between checking and claiming is itself checked.
+
+    A writer can create the bundle after the initial check passes.
+    Winning the marker is what makes the recheck conclusive.
+    """
+    trace = tmp_path / "run.trace"
+    real_check = recorder_module.check_output_collision
+
+    def check_then_create(path):
+        resolved = real_check(path)
+        resolved.mkdir(parents=True)  # a concurrent writer wins the race
+        return resolved
+
+    with mock.patch.object(
+        recorder_module, "check_output_collision", check_then_create
+    ):
+        with pytest.raises(InstrumentsRecordError, match="appeared while"):
+            with reserve_trace_path(trace):
+                pass
+    assert not reservation_path_for(trace.resolve()).exists()
+
+
+def test_only_one_of_many_concurrent_reservations_wins(tmp_path):
+    """The claim is a single atomic O_CREAT|O_EXCL, so exactly one wins."""
+    trace = tmp_path / "run.trace"
+    barrier = threading.Barrier(8)
+    won: list[int] = []
+    refused: list[int] = []
+    lock = threading.Lock()
+
+    def attempt(index: int) -> None:
+        barrier.wait(timeout=30)
+        try:
+            with reserve_trace_path(trace):
+                with lock:
+                    won.append(index)
+                time.sleep(0.05)
+        except InstrumentsRecordError:
+            with lock:
+                refused.append(index)
+
+    threads = [threading.Thread(target=attempt, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert len(won) == 1, f"expected exactly one winner, got {won}"
+    assert len(refused) == 7
+    assert not reservation_path_for(trace.resolve()).exists()
+
+
+def test_a_concurrent_run_is_refused_and_writes_nothing(tmp_path):
+    """A second recorder must not touch the first one's artifacts."""
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+
+    with reserve_trace_path(trace):
+        launcher = FakeLauncher(FakeProcess(returncode=0))
+        result = run_record(
+            make_plan(trace), launcher=launcher, artifacts_dir=artifacts
+        )
+
+    assert result.status is RecordStatus.REFUSED
+    assert "already reserved" in result.message
+    assert launcher.spawned == []
+    assert not artifacts.exists()
+
+
+def test_a_held_reservation_is_not_reacquired(tmp_path):
+    """The caller's claim spans its artifact writes and the recording."""
+    trace = tmp_path / "run.trace"
+    with reserve_trace_path(trace) as resolved:
+        result = run_record(
+            make_plan(trace),
+            launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+            artifacts_dir=tmp_path / "artifacts",
+            reserved_trace=resolved,
+        )
+    assert result.status is RecordStatus.COMPLETED

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import signal
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
 from _instruments_fakes import COMMAND_LINE_TOOLS_STDERR, FakeLauncher, FakeProcess
 
 from llmtracefx.optimizer.instruments.commands import LaunchTarget, RecordPlan
-from llmtracefx.optimizer.instruments.process import InstrumentsProcessError
+from llmtracefx.optimizer.instruments.process import (
+    InstrumentsProcessError,
+    SubprocessProcessLauncher,
+)
 from llmtracefx.optimizer.instruments.recorder import (
     InstrumentsRecordError,
     RecordStatus,
@@ -28,6 +35,7 @@ def make_plan(trace: Path, **overrides) -> RecordPlan:
         "target": LaunchTarget(argv=("/bin/infer", "--tokens", "8")),
         "time_limit": "5s",
         "grace_seconds": 10.0,
+        "stop_grace_seconds": 0.25,
     }
     values.update(overrides)
     return RecordPlan(**values)
@@ -239,10 +247,15 @@ def test_timeout_stops_the_process_group_starting_with_sigint(tmp_path):
     assert len(process.signals) == 1
 
 
-def test_timeout_escalates_when_sigint_is_ignored(tmp_path):
+def test_timeout_escalates_when_the_group_survives_sigint(tmp_path):
+    """The leader exiting is not the stop condition.
+
+    xctrace can exit on SIGINT while the program it launched keeps
+    running in the same group. Escalation must continue until the group
+    is empty, not stop the moment the leader is reaped.
+    """
     trace = tmp_path / "run.trace"
-    # One timeout for the main wait, then one per ignored stop signal.
-    process = FakeProcess(returncode=0, timeout_waits=3)
+    process = FakeProcess(returncode=0, timeout_waits=1, group_dies_on=signal.SIGKILL)
     launcher = FakeLauncher(process)
 
     run_record(
@@ -250,6 +263,33 @@ def test_timeout_escalates_when_sigint_is_ignored(tmp_path):
     )
 
     assert process.signals == [signal.SIGINT, signal.SIGTERM, signal.SIGKILL]
+    assert process.group_alive() is False
+
+
+def test_teardown_stops_once_the_group_is_actually_empty(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0, timeout_waits=1, group_dies_on=signal.SIGTERM)
+    launcher = FakeLauncher(process)
+
+    run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert process.signals == [signal.SIGINT, signal.SIGTERM]
+
+
+def test_teardown_is_bounded_when_the_group_never_dies(tmp_path):
+    """A group that ignores everything must not hang the recorder."""
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0, timeout_waits=1, group_dies_on=None)
+    launcher = FakeLauncher(process)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert process.signals == [signal.SIGINT, signal.SIGTERM, signal.SIGKILL]
+    assert result.status is RecordStatus.TIMED_OUT
 
 
 def test_timeout_uses_the_plan_deadline_not_the_time_limit(tmp_path):
@@ -291,7 +331,9 @@ def test_timeout_preserves_artifacts(tmp_path):
 def test_unsignalable_group_does_not_loop_forever(tmp_path):
     trace = tmp_path / "run.trace"
     process = FakeProcess(
-        timeout_waits=5, signal_error=InstrumentsProcessError("not permitted")
+        timeout_waits=5,
+        signal_error=InstrumentsProcessError("not permitted"),
+        group_dies_on=None,
     )
     launcher = FakeLauncher(process)
 
@@ -347,3 +389,253 @@ def test_keyboard_interrupt_while_waiting_still_stops_the_recording(tmp_path):
         )
 
     assert process.signals[0] == signal.SIGINT
+
+
+# --- Real process group teardown --------------------------------------
+#
+# The fakes above model the group, but the property that matters is a
+# real one: after run_record returns, nothing it started may still be
+# running. These use actual processes.
+
+
+#: A stand-in for xctrace: it accepts the same argv shape (a `record`
+#: subcommand, flags, then `-- program args`), starts the program in its
+#: own process group exactly as xctrace does, and exits on SIGINT while
+#: leaving that program running. No shell is involved.
+FAKE_XCTRACE_SOURCE = """\
+import signal
+import subprocess
+import sys
+import time
+
+argv = sys.argv[1:]
+target = argv[argv.index("--") + 1 :]
+subprocess.Popen([sys.executable, *target])
+
+# Exit cleanly on SIGINT, leaving the launched program behind. This is
+# the exact shape that used to end teardown early.
+signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+time.sleep(600)
+"""
+
+#: A profiled program that refuses SIGINT and SIGTERM, like a wedged
+#: inference process still holding the GPU.
+STUBBORN_TARGET_SOURCE = """\
+import os
+import signal
+import sys
+import time
+
+signal.signal(signal.SIGINT, signal.SIG_IGN)
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    handle.write(str(os.getpid()))
+time.sleep(600)
+"""
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _await_pid_exit(pid: int, timeout_seconds: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.05)
+    return not _pid_alive(pid)
+
+
+def _await_file(path: Path, timeout_seconds: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if path.exists() and path.read_text(encoding="utf-8").strip():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_descendant_is_killed_when_the_leader_exits_on_sigint(tmp_path):
+    """The regression: leader exits on SIGINT, descendant survives it.
+
+    Teardown used to return as soon as the leader was reaped, leaving
+    the program xctrace launched running in a detached session with
+    nothing left that knew how to reach it. Escalation now continues
+    until the process group is actually empty.
+    """
+    fake_xctrace = tmp_path / "fake_xctrace.py"
+    fake_xctrace.write_text(
+        f"#!{sys.executable}\n" + FAKE_XCTRACE_SOURCE, encoding="utf-8"
+    )
+    fake_xctrace.chmod(0o755)
+
+    target = tmp_path / "stubborn.py"
+    target.write_text(STUBBORN_TARGET_SOURCE, encoding="utf-8")
+    pid_file = tmp_path / "child.pid"
+
+    plan = make_plan(
+        tmp_path / "run.trace",
+        xctrace_path=str(fake_xctrace),
+        target=LaunchTarget(argv=(str(target), str(pid_file))),
+        time_limit="1s",
+        grace_seconds=1.0,
+        stop_grace_seconds=3.0,
+    )
+
+    child_pid: int | None = None
+    try:
+        result = run_record(
+            plan,
+            launcher=SubprocessProcessLauncher(),
+            artifacts_dir=tmp_path / "artifacts",
+        )
+
+        assert result.status is RecordStatus.TIMED_OUT
+        assert _await_file(pid_file), "the profiled program never started"
+        child_pid = int(pid_file.read_text(encoding="utf-8"))
+        assert _await_pid_exit(child_pid), (
+            f"the profiled program (pid {child_pid}) survived teardown; "
+            "the process group was not cleaned up"
+        )
+    finally:
+        if child_pid is not None and _pid_alive(child_pid):
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.kill(child_pid, signal.SIGKILL)
+
+
+def test_pgid_is_captured_at_spawn_and_survives_leader_exit(tmp_path):
+    """`os.getpgid` stops working once the leader is reaped.
+
+    Capturing the group at spawn is what keeps the survivors reachable.
+    """
+    script = tmp_path / "quick.py"
+    script.write_text("import sys; sys.exit(0)\n", encoding="utf-8")
+
+    launcher = SubprocessProcessLauncher()
+    with (tmp_path / "o.txt").open("wb") as out, (tmp_path / "e.txt").open("wb") as err:
+        process = launcher.spawn(
+            (sys.executable, str(script)),
+            stdout=out,
+            stderr=err,
+            cwd=None,
+            env=None,
+        )
+        pgid = process.pgid
+        assert pgid == process.pid  # start_new_session makes them equal
+        process.wait(30.0)
+
+    # The leader is reaped, so a lazy lookup would now fail outright.
+    with pytest.raises(ProcessLookupError):
+        os.getpgid(process.pid)
+    # The captured group id is still usable, and reports the group empty.
+    assert process.pgid == pgid
+    assert process.group_alive() is False
+
+
+# --- Spawn failure metadata -------------------------------------------
+
+
+def test_spawn_failure_writes_metadata_like_every_other_failure(tmp_path):
+    """A failure to start is still a failure worth recording.
+
+    This path used to return before the metadata write, so the one
+    outcome with no exit status and no tool output was also the one with
+    no record of having happened.
+    """
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(
+        FakeProcess(), spawn_error=InstrumentsProcessError("no such file")
+    )
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.status is RecordStatus.FAILED
+    metadata_path = artifacts / "xctrace_record.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["status"] == "failed"
+    assert "could not start xctrace" in metadata["message"]
+    assert metadata["returncode"] is None
+    assert metadata["trace_exists"] is False
+    assert (artifacts / "xctrace_record_stdout.txt").exists()
+    assert (artifacts / "xctrace_record_stderr.txt").exists()
+
+
+def test_spawn_failure_replaces_stale_metadata_from_a_previous_run(tmp_path):
+    """No mixing a previous run's metadata with this run's output.
+
+    The stdout and stderr files are truncated on every attempt, so a
+    surviving xctrace_record.json from an earlier success would have sat
+    next to empty logs describing a run that did not happen.
+    """
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir(parents=True)
+    stale = artifacts / "xctrace_record.json"
+    stale.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "status": "completed",
+                "message": "recorded an earlier run",
+                "returncode": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run_record(
+        make_plan(trace),
+        launcher=FakeLauncher(
+            FakeProcess(), spawn_error=InstrumentsProcessError("boom")
+        ),
+        artifacts_dir=artifacts,
+    )
+
+    metadata = json.loads(stale.read_text(encoding="utf-8"))
+    assert metadata["status"] == "failed"
+    assert "recorded an earlier run" not in metadata["message"]
+    assert metadata["returncode"] is None
+
+
+def test_survivors_are_stopped_even_when_xctrace_exits_normally(tmp_path):
+    """Adjacent to the timeout case, and just as leaky.
+
+    xctrace can fail early while the program it launched keeps running.
+    The leader exiting is not the timeout path, so nothing used to look
+    at the group at all on that route.
+    """
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=1, group_dies_on=signal.SIGTERM)
+    launcher = FakeLauncher(process)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.FAILED
+    assert process.signals == [signal.SIGINT, signal.SIGTERM]
+    assert "that process group was stopped" in result.message
+
+
+def test_a_clean_exit_with_an_empty_group_signals_nothing(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0)
+    process._group_alive = False
+    launcher = FakeLauncher(process, creates_trace=trace)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.COMPLETED
+    assert process.signals == []
+    assert "process group was stopped" not in result.message

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -1,0 +1,321 @@
+"""Tests for recording safety: collisions, timeouts, cleanup, artifacts."""
+
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+from pathlib import Path
+
+import pytest
+from _instruments_fakes import COMMAND_LINE_TOOLS_STDERR, FakeLauncher, FakeProcess
+
+from llmtracefx.optimizer.instruments.commands import LaunchTarget, RecordPlan
+from llmtracefx.optimizer.instruments.process import InstrumentsProcessError
+from llmtracefx.optimizer.instruments.recorder import (
+    InstrumentsRecordError,
+    RecordStatus,
+    check_output_collision,
+    run_record,
+)
+
+
+def make_plan(trace: Path, **overrides) -> RecordPlan:
+    values = {
+        "xctrace_path": "/usr/bin/xctrace",
+        "template": "Metal System Trace",
+        "output_trace": trace,
+        "target": LaunchTarget(argv=("/bin/infer", "--tokens", "8")),
+        "time_limit": "5s",
+        "grace_seconds": 10.0,
+    }
+    values.update(overrides)
+    return RecordPlan(**values)
+
+
+# --- Collision refusal ------------------------------------------------
+
+
+def test_existing_bundle_directory_is_refused(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    with pytest.raises(InstrumentsRecordError, match="existing directory"):
+        check_output_collision(trace)
+
+
+def test_existing_file_is_refused(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.write_text("stale", encoding="utf-8")
+    with pytest.raises(InstrumentsRecordError, match="existing file"):
+        check_output_collision(trace)
+
+
+def test_path_aliases_resolve_to_the_same_destination(tmp_path):
+    """`a/../run.trace` must not be treated as a fresh destination."""
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    (tmp_path / "sub").mkdir()
+    with pytest.raises(InstrumentsRecordError, match="existing directory"):
+        check_output_collision(tmp_path / "sub" / ".." / "run.trace")
+
+
+def test_symlinked_path_resolves_to_its_target(tmp_path):
+    real = tmp_path / "real.trace"
+    real.mkdir()
+    link = tmp_path / "link.trace"
+    link.symlink_to(real, target_is_directory=True)
+    with pytest.raises(InstrumentsRecordError, match="existing directory"):
+        check_output_collision(link)
+
+
+def test_fresh_path_is_accepted_and_resolved(tmp_path):
+    resolved = check_output_collision(tmp_path / "new.trace")
+    assert resolved.name == "new.trace"
+    assert resolved.is_absolute()
+
+
+def test_collision_refusal_executes_nothing(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    launcher = FakeLauncher(FakeProcess())
+    artifacts = tmp_path / "artifacts"
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.status is RecordStatus.REFUSED
+    assert launcher.spawned == []
+    assert not artifacts.exists()
+    assert "never overwritten" in result.message
+
+
+# --- Success ----------------------------------------------------------
+
+
+def test_successful_recording_writes_metadata_and_artifacts(tmp_path):
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(
+        FakeProcess(returncode=0, stdout_text="Recording completed."),
+        creates_trace=trace,
+    )
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.status is RecordStatus.COMPLETED
+    assert result.succeeded is True
+    assert result.returncode == 0
+    assert result.trace_exists is True
+    assert (artifacts / "xctrace_record_stdout.txt").exists()
+    assert (artifacts / "xctrace_record_stderr.txt").exists()
+
+    metadata = json.loads(
+        (artifacts / "xctrace_record.json").read_text(encoding="utf-8")
+    )
+    assert metadata["status"] == "completed"
+    assert metadata["trace_name"] == "run.trace"
+
+
+def test_metadata_uses_basenames_for_derived_path_fields(tmp_path):
+    """Derived fields are basenames; only argv keeps full paths.
+
+    The argv has to record the exact command or the run is not
+    reproducible, and every path in it was supplied by the caller. The
+    derived name fields carry no directory, and the evidence that goes
+    into a shared ``ExperimentRecord`` carries a bundle basename only
+    (see ``test_instruments_workflow``).
+    """
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=trace)
+
+    run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    metadata = json.loads(
+        (artifacts / "xctrace_record.json").read_text(encoding="utf-8")
+    )
+    assert metadata["trace_name"] == "run.trace"
+    assert metadata["stdout_name"] == "xctrace_record_stdout.txt"
+    assert metadata["stderr_name"] == "xctrace_record_stderr.txt"
+    for key in ("trace_name", "stdout_name", "stderr_name"):
+        assert "/" not in metadata[key]
+
+
+def test_stored_argv_is_the_redacted_one(tmp_path):
+    from llmtracefx.optimizer.instruments.commands import EnvironmentAssignment
+
+    trace = tmp_path / "run.trace"
+    plan = make_plan(
+        trace,
+        environment=(EnvironmentAssignment(name="HF_TOKEN", value="hf_leak"),),
+    )
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=trace)
+
+    result = run_record(plan, launcher=launcher, artifacts_dir=tmp_path / "artifacts")
+
+    assert "hf_leak" not in " ".join(result.argv)
+    # The real invocation still carries the true value.
+    assert "HF_TOKEN=hf_leak" in launcher.spawned[0]
+
+
+# --- Failure ----------------------------------------------------------
+
+
+def test_nonzero_exit_is_failure_and_artifacts_are_kept(tmp_path):
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(
+        FakeProcess(returncode=3, stderr_text="something went wrong")
+    )
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.status is RecordStatus.FAILED
+    assert result.returncode == 3
+    assert (artifacts / "xctrace_record_stderr.txt").read_text(
+        encoding="utf-8"
+    ) == "something went wrong"
+    assert (artifacts / "xctrace_record.json").exists()
+
+
+def test_failure_output_is_classified_but_not_persisted(tmp_path):
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(
+        FakeProcess(returncode=1, stderr_text=COMMAND_LINE_TOOLS_STDERR)
+    )
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.failure_capability is not None
+    assert result.failure_capability.value == "command_line_tools_only"
+    # Classified, but the raw tool text stays out of the metadata file.
+    metadata = (artifacts / "xctrace_record.json").read_text(encoding="utf-8")
+    assert "CommandLineTools" not in metadata
+
+
+def test_exit_zero_without_a_bundle_is_a_failure(tmp_path):
+    """A clean exit that produced nothing must not read as success."""
+    trace = tmp_path / "run.trace"
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=None)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.FAILED
+    assert result.trace_exists is False
+    assert "exited 0 but no trace bundle" in result.message
+
+
+def test_spawn_failure_is_reported_without_raising(tmp_path):
+    trace = tmp_path / "run.trace"
+    launcher = FakeLauncher(
+        FakeProcess(), spawn_error=InstrumentsProcessError("no such file")
+    )
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.FAILED
+    assert "could not start xctrace" in result.message
+
+
+# --- Timeout and process group cleanup --------------------------------
+
+
+def test_timeout_stops_the_process_group_starting_with_sigint(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0, timeout_waits=1)
+    launcher = FakeLauncher(process, creates_trace=trace)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.TIMED_OUT
+    # SIGINT first: it is how a recording is stopped with a valid bundle.
+    assert process.signals[0] == signal.SIGINT
+    assert len(process.signals) == 1
+
+
+def test_timeout_escalates_when_sigint_is_ignored(tmp_path):
+    trace = tmp_path / "run.trace"
+    # One timeout for the main wait, then one per ignored stop signal.
+    process = FakeProcess(returncode=0, timeout_waits=3)
+    launcher = FakeLauncher(process)
+
+    run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert process.signals == [signal.SIGINT, signal.SIGTERM, signal.SIGKILL]
+
+
+def test_timeout_uses_the_plan_deadline_not_the_time_limit(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0)
+    launcher = FakeLauncher(process, creates_trace=trace)
+    plan = make_plan(trace, time_limit="5s", grace_seconds=10.0)
+
+    run_record(plan, launcher=launcher, artifacts_dir=tmp_path / "artifacts")
+
+    assert process.wait_calls[0] == 15.0
+
+
+def test_timeout_message_explains_the_budget(tmp_path):
+    trace = tmp_path / "run.trace"
+    launcher = FakeLauncher(FakeProcess(timeout_waits=1))
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert "host deadline" in result.message
+    assert "Artifacts are preserved" in result.message
+
+
+def test_timeout_preserves_artifacts(tmp_path):
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    launcher = FakeLauncher(FakeProcess(timeout_waits=1, stderr_text="partial"))
+
+    run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert (artifacts / "xctrace_record.json").exists()
+    assert (artifacts / "xctrace_record_stderr.txt").read_text(
+        encoding="utf-8"
+    ) == "partial"
+
+
+def test_unsignalable_group_does_not_loop_forever(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(
+        timeout_waits=5, signal_error=InstrumentsProcessError("not permitted")
+    )
+    launcher = FakeLauncher(process)
+
+    result = run_record(
+        make_plan(trace), launcher=launcher, artifacts_dir=tmp_path / "artifacts"
+    )
+
+    assert result.status is RecordStatus.TIMED_OUT
+    assert process.signals == [signal.SIGINT]
+
+
+def test_non_timeout_wait_errors_propagate(tmp_path):
+    """Only timeouts are handled; other failures must not be swallowed."""
+
+    class Exploding(FakeProcess):
+        def wait(self, timeout_seconds: float) -> int:
+            raise subprocess.SubprocessError("unexpected")
+
+    trace = tmp_path / "run.trace"
+    launcher = FakeLauncher(Exploding())
+
+    with pytest.raises(subprocess.SubprocessError, match="unexpected"):
+        run_record(
+            make_plan(trace),
+            launcher=launcher,
+            artifacts_dir=tmp_path / "artifacts",
+        )

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -408,6 +408,7 @@ def test_keyboard_interrupt_while_waiting_still_stops_the_recording(tmp_path):
 #: own process group exactly as xctrace does, and exits on SIGINT while
 #: leaving that program running. No shell is involved.
 FAKE_XCTRACE_SOURCE = """\
+import os
 import signal
 import subprocess
 import sys
@@ -415,11 +416,22 @@ import time
 
 argv = sys.argv[1:]
 target = argv[argv.index("--") + 1 :]
-subprocess.Popen([sys.executable, *target])
 
 # Exit cleanly on SIGINT, leaving the launched program behind. This is
-# the exact shape that used to end teardown early.
+# the exact shape that used to end teardown early. Installed before the
+# child is started so no signal can arrive while it is still launching.
 signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+subprocess.Popen([sys.executable, *target])
+
+# Do not start the clock until the child has confirmed it is running and
+# has its own signal handlers installed. Without this the test could
+# tear the group down before the child existed, and then find nothing to
+# clean up, which would pass for the wrong reason.
+ready = target[0] + ".ready"
+while not os.path.exists(ready):
+    time.sleep(0.01)
+
 time.sleep(600)
 """
 
@@ -435,6 +447,13 @@ signal.signal(signal.SIGINT, signal.SIG_IGN)
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
     handle.write(str(os.getpid()))
+
+# Announce readiness only after the handlers are installed, so the
+# recording cannot be torn down while this process would still die to a
+# signal it is supposed to be ignoring.
+with open(sys.argv[0] + ".ready", "w", encoding="utf-8") as handle:
+    handle.write("ready")
+
 time.sleep(600)
 """
 
@@ -449,7 +468,7 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
-def _await_pid_exit(pid: int, timeout_seconds: float = 20.0) -> bool:
+def _await_pid_exit(pid: int, timeout_seconds: float = 60.0) -> bool:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if not _pid_alive(pid):
@@ -458,7 +477,7 @@ def _await_pid_exit(pid: int, timeout_seconds: float = 20.0) -> bool:
     return not _pid_alive(pid)
 
 
-def _await_file(path: Path, timeout_seconds: float = 20.0) -> bool:
+def _await_file(path: Path, timeout_seconds: float = 60.0) -> bool:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if path.exists() and path.read_text(encoding="utf-8").strip():
@@ -490,8 +509,12 @@ def test_descendant_is_killed_when_the_leader_exits_on_sigint(tmp_path):
         xctrace_path=str(fake_xctrace),
         target=LaunchTarget(argv=(str(target), str(pid_file))),
         time_limit="1s",
-        grace_seconds=1.0,
-        stop_grace_seconds=3.0,
+        # Generous, because this test races real processes against wall
+        # clock grace periods and a loaded CI runner can be slow to
+        # schedule them. Correctness does not depend on these being
+        # tight; only how long a genuine failure takes to surface does.
+        grace_seconds=2.0,
+        stop_grace_seconds=4.0,
     )
 
     child_pid: int | None = None
@@ -809,3 +832,38 @@ def test_a_held_reservation_is_not_reacquired(tmp_path):
             reserved_trace=resolved,
         )
     assert result.status is RecordStatus.COMPLETED
+
+
+def test_survivor_cleanup_failure_is_reported_on_a_completed_run(tmp_path):
+    """The leader-exit branch had the same false claim as the timeout one.
+
+    This is the more dangerous of the two, because it fires on a run
+    whose status is COMPLETED, where a reader trusts the message.
+    """
+    trace = tmp_path / "run.trace"
+    artifacts = tmp_path / "artifacts"
+    process = FakeProcess(returncode=0, group_dies_on=None)
+    launcher = FakeLauncher(process, creates_trace=trace)
+
+    result = run_record(make_plan(trace), launcher=launcher, artifacts_dir=artifacts)
+
+    assert result.status is RecordStatus.COMPLETED
+    assert process.signals == [signal.SIGINT, signal.SIGTERM, signal.SIGKILL]
+    assert process.group_alive() is True
+    assert "could NOT be stopped" in result.message
+    persisted = json.loads(
+        (artifacts / "xctrace_record.json").read_text(encoding="utf-8")
+    )
+    assert "could NOT be stopped" in persisted["message"]
+
+
+def test_survivor_cleanup_success_is_reported_as_success(tmp_path):
+    trace = tmp_path / "run.trace"
+    process = FakeProcess(returncode=0, group_dies_on=signal.SIGTERM)
+    result = run_record(
+        make_plan(trace),
+        launcher=FakeLauncher(process, creates_trace=trace),
+        artifacts_dir=tmp_path / "artifacts",
+    )
+    assert "that process group was stopped" in result.message
+    assert "could NOT" not in result.message

--- a/tests/optimizer/test_instruments_recorder.py
+++ b/tests/optimizer/test_instruments_recorder.py
@@ -308,10 +308,12 @@ def test_non_timeout_wait_errors_propagate(tmp_path):
 
     class Exploding(FakeProcess):
         def wait(self, timeout_seconds: float) -> int:
+            self.wait_calls.append(timeout_seconds)
             raise subprocess.SubprocessError("unexpected")
 
     trace = tmp_path / "run.trace"
-    launcher = FakeLauncher(Exploding())
+    process = Exploding()
+    launcher = FakeLauncher(process)
 
     with pytest.raises(subprocess.SubprocessError, match="unexpected"):
         run_record(
@@ -319,3 +321,29 @@ def test_non_timeout_wait_errors_propagate(tmp_path):
             launcher=launcher,
             artifacts_dir=tmp_path / "artifacts",
         )
+
+    # The recording lives in its own session, so nothing else would reap
+    # it. It must be stopped even on an unexpected error.
+    assert process.signals[0] == signal.SIGINT
+
+
+def test_keyboard_interrupt_while_waiting_still_stops_the_recording(tmp_path):
+    """KeyboardInterrupt is a BaseException, not an Exception."""
+
+    class Interrupted(FakeProcess):
+        def wait(self, timeout_seconds: float) -> int:
+            self.wait_calls.append(timeout_seconds)
+            raise KeyboardInterrupt
+
+    trace = tmp_path / "run.trace"
+    process = Interrupted()
+    launcher = FakeLauncher(process)
+
+    with pytest.raises(KeyboardInterrupt):
+        run_record(
+            make_plan(trace),
+            launcher=launcher,
+            artifacts_dir=tmp_path / "artifacts",
+        )
+
+    assert process.signals[0] == signal.SIGINT

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1156,3 +1156,25 @@ def test_the_four_real_metrics_pass_every_rule(tmp_path):
 
     assert set(collection.evidence.metrics) == set(INSTRUMENT_METRIC_SPECS)
     base_record(instruments=collection.evidence).validate()
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_metrics_are_rejected(bad):
+    """NaN and infinity both pass a `>= 0` check silently.
+
+    A NaN interval count is not a measurement, and would propagate into
+    every downstream comparison as though it were one.
+    """
+    from llmtracefx.optimizer.schema import Measurement, MetricProvenance
+
+    evidence = _evidence(
+        metrics={
+            "metal_gpu_interval_count": Measurement(
+                value=bad,
+                provenance=MetricProvenance.MEASURED_NATIVE,
+                unit="intervals",
+            )
+        }
+    )
+    with pytest.raises(SchemaValidationError, match="finite number|must be >= 0"):
+        base_record(instruments=evidence).validate()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -598,3 +598,128 @@ def test_cli_exposes_the_four_documented_subcommands():
     )[1]
     names = set(instruments._subparsers._group_actions[0].choices)
     assert names == {"capability", "plan", "record", "import"}
+
+
+# --- Regressions found in independent review --------------------------
+
+
+def test_failed_recording_evidence_does_not_claim_success(tmp_path):
+    """Capability succeeded, but no trace was produced.
+
+    Reusing the capability reason here would persist a note saying
+    xctrace provides the template, on an artifact that represents a
+    failed recording.
+    """
+    trace = tmp_path / "run.trace"
+    out = tmp_path / "artifacts"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=5)),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+
+    payload = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
+    assert payload["metrics"] == {}
+    assert payload["trace_bundle_name"] is None
+    notes = payload["notes"]
+    assert notes.startswith("no trace was produced:")
+    assert "provides the template" not in notes
+
+
+def test_timed_out_recording_evidence_says_so(tmp_path):
+    trace = tmp_path / "run.trace"
+    out = tmp_path / "artifacts"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(timeout_waits=1)),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+    notes = json.loads((out / "instruments_evidence.json").read_text("utf-8"))["notes"]
+    assert "host deadline" in notes
+
+
+def test_ambiguous_target_pid_yields_no_metric():
+    """A pid under two labels must not get one of them attributed."""
+    table = parse_exported_table(
+        "<trace-query-result><node>"
+        '<schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        "</schema>"
+        '<row><start-time id="1">10</start-time>'
+        '<duration id="2">10</duration>'
+        '<process id="3" fmt="probe (7)"><pid id="4">7</pid></process></row>'
+        '<row><start-time id="5">20</start-time>'
+        '<duration id="6">50</duration>'
+        '<process id="7" fmt="other (7)"><pid id="8">7</pid></process></row>'
+        "</node></trace-query-result>"
+    )
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals",),
+            table=table,
+            target_pid=7,
+        )
+    )
+    assert evidence.metrics == {}
+    assert "is ambiguous" in (evidence.notes or "")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gpu_utilization",
+        "metal_gpu_occupancy",
+        "memory_bandwidth",
+        "gpu_busy_percent",
+        "metal_kernel_time",
+        "gpu_power_watts",
+        "gpu_memory_bytes",
+    ],
+)
+def test_schema_structurally_rejects_overclaiming_metric_names(name):
+    """The rule is enforced by validate(), not only by convention."""
+    from llmtracefx.optimizer.schema import (
+        InstrumentsEvidence,
+        Measurement,
+        MetricProvenance,
+    )
+
+    evidence = InstrumentsEvidence(
+        parsed_schemas=("metal-gpu-intervals",),
+        metrics={
+            name: Measurement(
+                value=1.0, provenance=MetricProvenance.MEASURED_NATIVE, unit="x"
+            )
+        },
+    )
+    with pytest.raises(SchemaValidationError, match="forbidden marker"):
+        base_record(instruments=evidence).validate()
+
+
+def test_the_metrics_this_project_emits_survive_that_rule():
+    """The guard must not be so broad that real metrics are rejected."""
+    table = parse_exported_table(read_fixture(TABLE))
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals",),
+            table=table,
+            target_pid=4242,
+        )
+    )
+    assert evidence.metrics
+    base_record(instruments=evidence).validate()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1296,3 +1296,49 @@ def test_cli_still_announces_evidence_on_a_real_run(
     )
     assert code == 0
     assert "instruments_evidence.json" in capsys.readouterr().out
+
+
+def test_a_concurrent_record_is_refused_before_touching_artifacts(tmp_path):
+    """The reservation is held across the artifact writes, not just the
+    recording.
+
+    A second run must not overwrite the first run's capability report
+    and evidence on its way to discovering the conflict.
+    """
+    from llmtracefx.optimizer.instruments.recorder import reserve_trace_path
+
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    seeded = out / "capability_report.json"
+    seeded.write_bytes(b"FIRST RUN")
+    trace = tmp_path / "run.trace"
+
+    with reserve_trace_path(trace):
+        launcher = FakeLauncher(FakeProcess(returncode=0))
+        collection = record_trace(
+            runner=exporting_runner(),
+            launcher=launcher,
+            command=("/bin/infer",),
+            output_trace=trace,
+            output_dir=out,
+        )
+
+    assert collection.succeeded is False
+    assert collection.wrote_artifacts is False
+    assert "already reserved" in collection.message
+    assert launcher.spawned == []
+    assert seeded.read_bytes() == b"FIRST RUN"
+
+
+def test_a_normal_record_still_works_with_the_reservation(tmp_path):
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+    assert collection.succeeded is True
+    # The marker must not survive the run.
+    assert not list(tmp_path.glob(".*reservation"))

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -39,6 +39,8 @@ from llmtracefx.optimizer.instruments.export import (
     InstrumentsExportError,
     parse_exported_table,
 )
+from llmtracefx.optimizer.instruments.process import InstrumentsProcessError
+from llmtracefx.optimizer.instruments.recorder import RecordStatus
 from llmtracefx.optimizer.instruments.workflow import (
     import_trace,
     plan_trace,
@@ -130,6 +132,19 @@ def pinned_host_identity(monkeypatch):
     # module's own namespace, which is a separate binding. Pinning only
     # the workflow one would leave that subcommand reading the real host.
     monkeypatch.setattr(cli_module, "detect_xctrace_capability", pinned)
+
+
+@pytest.fixture
+def cli_launcher(monkeypatch, tmp_path):
+    """Give the CLI a fake process launcher.
+
+    `instruments record` spawns for real, so without this a CLI test
+    would depend on the profiled command existing on the machine.
+    """
+    created = tmp_path / "run.trace"
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=created)
+    monkeypatch.setattr(cli_module, "SubprocessProcessLauncher", lambda: launcher)
+    return launcher
 
 
 @pytest.fixture
@@ -1409,11 +1424,19 @@ def test_a_failed_export_after_a_good_recording_replaces_stale_evidence(tmp_path
         output_dir=out,
     )
 
-    assert collection.succeeded is True
+    # The recording completed, but the run measured nothing, so it is
+    # not a success and must not exit 0.
+    assert collection.succeeded is False
+    assert collection.export_failed is True
+    assert collection.record.status is RecordStatus.COMPLETED
+
     fresh = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
-    assert fresh["trace_bundle_name"] is None
+    # The bundle exists and is re-exportable, so its name is kept.
+    assert fresh["trace_bundle_name"] == "run2.trace"
     assert fresh["metrics"] == {}
     assert "could not be exported" in fresh["notes"]
+    assert "instruments import" in fresh["notes"]
+    assert "no trace was produced" not in fresh["notes"]
     record_meta = json.loads((out / "xctrace_record.json").read_text("utf-8"))
     assert record_meta["trace_name"] == "run2.trace"
 
@@ -1442,3 +1465,104 @@ def test_evidence_is_promoted_last_so_a_tear_leaves_it_stale(tmp_path):
         workflow_module._promote_staged(staging, out)
 
     assert promoted[-1] == "instruments_evidence.json"
+
+
+def test_cli_exits_nonzero_when_the_export_failed(
+    tmp_path, capsys, cli_command_runner, cli_launcher
+):
+    """A run that measured nothing must not report success.
+
+    `record.status` is COMPLETED, which is true of the recording, but
+    letting that stand in for the run would let a CI job record a green,
+    "measured" run whose evidence has zero GPU metrics.
+    """
+    cli_command_runner.exports["toc"] = fail((), returncode=1)
+    out = tmp_path / "artifacts"
+
+    code = run_cli(
+        [
+            "instruments",
+            "record",
+            "--output-trace",
+            str(tmp_path / "run.trace"),
+            "--output-dir",
+            str(out),
+            "--",
+            "/bin/infer",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "Recorded, but the export failed" in captured.err
+    assert "instruments import" in captured.err
+    assert "Recording did not complete" not in captured.err
+
+
+def test_cli_exits_zero_on_a_fully_successful_record(
+    tmp_path, capsys, cli_command_runner, cli_launcher
+):
+    """The nonzero path must not swallow real successes."""
+    out = tmp_path / "artifacts"
+    code = run_cli(
+        [
+            "instruments",
+            "record",
+            "--output-trace",
+            str(tmp_path / "run.trace"),
+            "--output-dir",
+            str(out),
+            "--",
+            "/bin/infer",
+        ]
+    )
+    assert code == 0
+    assert "evidence written to" in capsys.readouterr().out.casefold()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        InstrumentsProcessError("could not execute xctrace"),
+        OSError("disk full"),
+    ],
+)
+def test_any_export_failure_replaces_stale_evidence(tmp_path, error):
+    """Not only InstrumentsExportError reaches this path.
+
+    xctrace can become unexecutable between the capability probe and the
+    export, and the staging or evidence writes can fail. Each used to
+    propagate past the handler and leave the previous run's GPU metrics
+    attributed to this run's command.
+    """
+    out = tmp_path / "artifacts"
+    first = tmp_path / "run1.trace"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=first),
+        command=("/bin/infer",),
+        output_trace=first,
+        output_dir=out,
+    )
+    assert json.loads((out / "instruments_evidence.json").read_text("utf-8"))["metrics"]
+
+    class ExplodingRunner(FakeCommandRunner):
+        def run(self, argv, *, timeout_seconds):
+            if len(argv) > 1 and argv[1] == "export":
+                raise error
+            return super().run(argv, timeout_seconds=timeout_seconds)
+
+    second = tmp_path / "run2.trace"
+    collection = record_trace(
+        runner=ExplodingRunner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=second),
+        command=("/bin/infer",),
+        output_trace=second,
+        output_dir=out,
+    )
+
+    assert collection.export_failed is True
+    assert collection.succeeded is False
+    evidence = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
+    assert evidence["metrics"] == {}
+    assert evidence["trace_bundle_name"] == "run2.trace"

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import platform
+import shutil
+import tempfile
+from pathlib import Path
 
 import pytest
 from _instruments_fakes import (
@@ -15,8 +19,14 @@ from _instruments_fakes import (
     read_fixture,
 )
 
+from llmtracefx.optimizer import cli as cli_module
 from llmtracefx.optimizer.cli import main
-from llmtracefx.optimizer.instruments.capability import detect_xctrace_capability
+from llmtracefx.optimizer.instruments import workflow as workflow_module
+from llmtracefx.optimizer.instruments.capability import (
+    METAL_SYSTEM_TRACE_TEMPLATE,
+    XctraceCapability,
+    detect_xctrace_capability,
+)
 from llmtracefx.optimizer.instruments.evidence import (
     TraceEvidenceInputs,
     build_instruments_evidence,
@@ -64,6 +74,60 @@ def capability(runner: FakeCommandRunner):
         architecture="arm64",
         path_resolver=lambda: "/usr/bin/xctrace",
     )
+
+
+#: Host identity the workflow tests pin themselves to. Chosen because
+#: the Metal path only claims support on Apple Silicon, so this is the
+#: identity under which the interesting branches exist at all.
+PINNED_OS = "Darwin"
+PINNED_ARCHITECTURE = "arm64"
+PINNED_XCTRACE_PATH = "/usr/bin/xctrace"
+
+
+@pytest.fixture(autouse=True)
+def pinned_host_identity(monkeypatch):
+    """Pin the host identity that the workflow layer detects against.
+
+    ``plan_trace``/``record_trace``/``import_trace`` call
+    ``detect_xctrace_capability`` with no platform overrides, so it reads
+    the *real* host. That made these tests host-dependent in both
+    directions: on a Linux runner every one of them short-circuited to
+    ``unsupported_os`` before the injected fake was ever consulted, and
+    on a macOS runner they silently depended on whether Xcode happened
+    to be installed.
+
+    Only host identity and path discovery are overridden. The real
+    detector still runs, and still runs against whatever
+    ``FakeCommandRunner`` the individual test supplied, so the Command
+    Line Tools, license, template-missing and probe-failure branches are
+    all still genuinely exercised rather than stubbed out. A test that
+    wants to assert the platform gating itself passes its own
+    ``os_name``/``architecture``, which this wrapper preserves.
+    """
+    real_detector = workflow_module.detect_xctrace_capability
+
+    def pinned(*, runner, template=METAL_SYSTEM_TRACE_TEMPLATE, **overrides):
+        overrides.setdefault("os_name", PINNED_OS)
+        overrides.setdefault("architecture", PINNED_ARCHITECTURE)
+        overrides.setdefault("path_resolver", lambda: PINNED_XCTRACE_PATH)
+        return real_detector(runner=runner, template=template, **overrides)
+
+    monkeypatch.setattr(workflow_module, "detect_xctrace_capability", pinned)
+
+
+@pytest.fixture
+def cli_command_runner(monkeypatch):
+    """Give the CLI a fake xctrace instead of the real subprocess one.
+
+    The CLI constructs its own ``SubprocessCommandRunner``, so pinning
+    the host identity alone is not enough: on a machine without xctrace
+    the probe would still fail for real. Replacing the constructor keeps
+    the whole cli -> workflow -> capability -> export path under test
+    while making it independent of what is installed.
+    """
+    runner = exporting_runner()
+    monkeypatch.setattr(cli_module, "SubprocessCommandRunner", lambda: runner)
+    return runner
 
 
 # --- Dry-run plan -----------------------------------------------------
@@ -553,7 +617,9 @@ def test_cli_plan_requires_a_target_command(tmp_path, capsys):
     assert "no program to profile" in capsys.readouterr().err
 
 
-def test_cli_rejects_an_output_path_that_is_not_a_trace(tmp_path, capsys):
+def test_cli_rejects_an_output_path_that_is_not_a_trace(
+    tmp_path, capsys, cli_command_runner
+):
     code = run_cli(
         [
             "instruments",
@@ -572,7 +638,7 @@ def test_cli_rejects_an_output_path_that_is_not_a_trace(tmp_path, capsys):
     assert ".trace" in (combined.out + combined.err)
 
 
-def test_cli_import_of_a_missing_trace_exits_one(tmp_path, capsys):
+def test_cli_import_of_a_missing_trace_exits_one(tmp_path, capsys, cli_command_runner):
     code = run_cli(
         [
             "instruments",
@@ -723,3 +789,85 @@ def test_the_metrics_this_project_emits_survive_that_rule():
     )
     assert evidence.metrics
     base_record(instruments=evidence).validate()
+
+
+# --- Host independence of this test module ----------------------------
+#
+# These tests exist because every workflow test above once passed only
+# because the machine running them happened to be an Apple Silicon Mac
+# with Xcode installed. On the Linux CI runners the same tests failed,
+# since plan/record/import detect against the real host and correctly
+# short-circuit to unsupported_os there.
+
+
+def test_platform_gating_still_rejects_linux_when_linux_is_declared():
+    """The fixture pins identity; it does not disable the gate.
+
+    Run inside this module, so the autouse fixture is active. Supplying
+    an explicit non-Darwin identity must still produce ``unsupported_os``
+    through the very same call path the workflows use. If the fixture
+    had stubbed detection out, or the implementation had stopped gating,
+    this would come back supported.
+    """
+    report = workflow_module.detect_xctrace_capability(
+        runner=exporting_runner(), os_name="Linux"
+    )
+    assert report.capability is XctraceCapability.UNSUPPORTED_OS
+    assert report.supported is False
+
+
+def test_platform_gating_still_rejects_non_arm64_when_declared():
+    report = workflow_module.detect_xctrace_capability(
+        runner=exporting_runner(), architecture="x86_64"
+    )
+    assert report.capability is XctraceCapability.UNSUPPORTED_ARCHITECTURE
+
+
+def test_workflows_do_not_read_the_real_host(monkeypatch):
+    """Simulate the Linux CI runner and re-run a full workflow.
+
+    ``platform.system``/``platform.machine`` are forced to the values a
+    Linux runner reports, and ``shutil.which`` is made to deny xctrace.
+    The workflow still succeeds, because this module supplies the
+    platform identity explicitly rather than inheriting the host's.
+    """
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda command, *args, **kwargs: None,
+    )
+
+    trace = Path(tempfile.mkdtemp()) / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=trace.parent / "artifacts",
+    )
+
+    assert collection.succeeded is True
+    assert collection.evidence.parsed_schemas == ("metal-gpu-intervals",)
+    assert collection.evidence.metrics["metal_gpu_interval_count"].value == 3.0
+
+
+def test_the_real_detector_would_have_failed_under_that_simulation(monkeypatch):
+    """Confirms the simulation above is a real one.
+
+    Without the pinned identity, the same simulated Linux process makes
+    the production detector report ``unsupported_os``. That is what
+    proves the previous test passes because identity is injected, and
+    not because the simulation was ineffective.
+    """
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+
+    report = detect_xctrace_capability(runner=exporting_runner())
+    assert report.capability is XctraceCapability.UNSUPPORTED_OS
+
+
+def test_cli_tests_do_not_depend_on_a_real_xctrace(cli_command_runner):
+    """The CLI builds its own runner, so it has to be replaced."""
+    assert cli_module.SubprocessCommandRunner() is cli_command_runner

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -34,6 +34,7 @@ from llmtracefx.optimizer.instruments.evidence import (
 )
 from llmtracefx.optimizer.instruments.export import (
     FORBIDDEN_METRIC_NAMES,
+    InstrumentsExportError,
     parse_exported_table,
 )
 from llmtracefx.optimizer.instruments.workflow import (
@@ -1178,3 +1179,120 @@ def test_non_finite_metrics_are_rejected(bad):
     )
     with pytest.raises(SchemaValidationError, match="finite number|must be >= 0"):
         base_record(instruments=evidence).validate()
+
+
+# --- Failures must not leave two runs' artifacts mixed ----------------
+
+
+def test_a_failed_import_leaves_every_previous_artifact_intact(tmp_path):
+    """xctrace writes the TOC and the table itself, mid-flight.
+
+    Exporting straight into the output directory meant a failure between
+    the two left this run's trace_toc.xml sitting beside a previous
+    run's evidence, table and toc json.
+    """
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    out.mkdir()
+
+    seeded = {
+        out / "trace_toc.xml": b"PREVIOUS toc xml",
+        out / "trace_toc.json": b"PREVIOUS toc json",
+        out / "trace_table.xml": b"PREVIOUS table",
+        out / "instruments_evidence.json": b"PREVIOUS evidence",
+    }
+    for path, payload in seeded.items():
+        path.write_bytes(payload)
+
+    # The TOC export succeeds; the table export fails.
+    runner = exporting_runner(**{"metal-gpu-intervals": fail((), returncode=1)})
+    with pytest.raises(InstrumentsExportError, match="failed"):
+        import_trace(runner=runner, trace_path=trace, output_dir=out)
+
+    for path, payload in seeded.items():
+        assert path.read_bytes() == payload, f"{path.name} was overwritten"
+
+
+def test_a_successful_import_replaces_every_artifact_together(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    for name in ("trace_toc.xml", "trace_toc.json", "instruments_evidence.json"):
+        (out / name).write_bytes(b"PREVIOUS")
+
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+
+    for name in ("trace_toc.xml", "trace_toc.json", "instruments_evidence.json"):
+        assert (out / name).read_bytes() != b"PREVIOUS", name
+    assert not (out / ".import-staging").exists()
+
+
+def test_import_staging_is_cleaned_up_on_success(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+    assert sorted(p.name for p in out.iterdir()) == [
+        "instruments_evidence.json",
+        "trace_table.xml",
+        "trace_toc.json",
+        "trace_toc.xml",
+    ]
+
+
+def test_cli_does_not_announce_evidence_it_did_not_write(
+    tmp_path, capsys, cli_command_runner
+):
+    """A refusal must not point the reader at an earlier run's metrics.
+
+    The filesystem was already correct, but the CLI still printed
+    "Instruments evidence written to ...", naming a file that either did
+    not exist or belonged to a different run.
+    """
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    stale = out / "instruments_evidence.json"
+    stale.write_bytes(b"EVIDENCE FROM AN EARLIER RUN")
+    trace = out / "run.trace"
+    trace.mkdir()
+
+    code = run_cli(
+        [
+            "instruments",
+            "record",
+            "--output-trace",
+            str(trace),
+            "--output-dir",
+            str(out),
+            "--",
+            "/bin/infer",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "evidence written to" not in captured.out.casefold()
+    assert "Nothing was written" in captured.err
+    assert stale.read_bytes() == b"EVIDENCE FROM AN EARLIER RUN"
+
+
+def test_cli_still_announces_evidence_on_a_real_run(
+    tmp_path, capsys, cli_command_runner
+):
+    out = tmp_path / "artifacts"
+    code = run_cli(
+        [
+            "instruments",
+            "plan",
+            "--output-trace",
+            str(tmp_path / "run.trace"),
+            "--output-dir",
+            str(out),
+            "--",
+            "/bin/infer",
+        ]
+    )
+    assert code == 0
+    assert "instruments_evidence.json" in capsys.readouterr().out

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1724,3 +1724,21 @@ def test_a_bad_run_number_in_the_toc_does_not_mix_runs(tmp_path):
     evidence = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
     assert evidence["metrics"] == {}
     assert evidence["trace_bundle_name"] == "run2.trace"
+
+
+def test_derived_artifacts_never_name_another_process(tmp_path):
+    """Only the raw export lists other processes, and it is documented.
+
+    Metal System Trace records every process on the system, so the raw
+    table names them. The artifacts a reader actually consumes must not:
+    they carry this run's pid and counts only.
+    """
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+
+    for name in ("instruments_evidence.json", "trace_toc.json", "trace_toc.xml"):
+        assert "WindowServer" not in (out / name).read_text("utf-8"), name
+    # The raw export does, by nature. Pinned so the boundary is explicit.
+    assert "WindowServer" in (out / "trace_table.xml").read_text("utf-8")

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -107,12 +107,26 @@ def pinned_host_identity(monkeypatch):
     real_detector = workflow_module.detect_xctrace_capability
 
     def pinned(*, runner, template=METAL_SYSTEM_TRACE_TEMPLATE, **overrides):
-        overrides.setdefault("os_name", PINNED_OS)
-        overrides.setdefault("architecture", PINNED_ARCHITECTURE)
-        overrides.setdefault("path_resolver", lambda: PINNED_XCTRACE_PATH)
+        # Filled when the key is absent *or* explicitly None, because
+        # None is the real API's "resolve this from the host" sentinel.
+        # A plain setdefault would let `os_name=None` reach the detector
+        # unchanged and quietly reintroduce the host dependence this
+        # fixture exists to remove, in the same shape as before: green
+        # on macOS with Xcode, red on Linux.
+        for key, value in (
+            ("os_name", PINNED_OS),
+            ("architecture", PINNED_ARCHITECTURE),
+            ("path_resolver", lambda: PINNED_XCTRACE_PATH),
+        ):
+            if overrides.get(key) is None:
+                overrides[key] = value
         return real_detector(runner=runner, template=template, **overrides)
 
     monkeypatch.setattr(workflow_module, "detect_xctrace_capability", pinned)
+    # `instruments capability` resolves the detector from the CLI
+    # module's own namespace, which is a separate binding. Pinning only
+    # the workflow one would leave that subcommand reading the real host.
+    monkeypatch.setattr(cli_module, "detect_xctrace_capability", pinned)
 
 
 @pytest.fixture
@@ -868,6 +882,59 @@ def test_the_real_detector_would_have_failed_under_that_simulation(monkeypatch):
     assert report.capability is XctraceCapability.UNSUPPORTED_OS
 
 
-def test_cli_tests_do_not_depend_on_a_real_xctrace(cli_command_runner):
-    """The CLI builds its own runner, so it has to be replaced."""
-    assert cli_module.SubprocessCommandRunner() is cli_command_runner
+def test_cli_uses_the_injected_runner_rather_than_a_real_xctrace(
+    tmp_path, cli_command_runner
+):
+    """Asserts the CLI observably went through the fake.
+
+    An earlier version of this test asserted that the patched factory
+    returned the fixture's object, which is true by construction one
+    frame after the fixture sets it and stays true even when the CLI
+    obtains its runner some other way. This drives `main` instead and
+    checks the fake was actually consulted.
+    """
+    run_cli(
+        [
+            "instruments",
+            "import",
+            "--trace",
+            str(tmp_path / "absent.trace"),
+            "--output-dir",
+            str(tmp_path / "a"),
+        ]
+    )
+    assert cli_command_runner.calls, "the CLI never consulted the injected runner"
+    assert all(argv[0] == PINNED_XCTRACE_PATH for argv in cli_command_runner.calls)
+
+
+def test_cli_capability_subcommand_is_host_independent(capsys, cli_command_runner):
+    """`instruments capability` resolves the detector from cli.py.
+
+    That is a different binding from the workflow one, so it needs its
+    own pinning. Without it this subcommand would report unsupported_os
+    on a Linux runner and depend on a local Xcode on a macOS one.
+    """
+    code = run_cli(["instruments", "capability"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert payload["capability"] == "supported"
+    assert payload["os_name"] == PINNED_OS
+    assert payload["architecture"] == PINNED_ARCHITECTURE
+    assert METAL_SYSTEM_TRACE_TEMPLATE in payload["available_templates"]
+
+
+def test_pinning_survives_an_explicit_none_identity():
+    """None is the real API's "read the host" sentinel.
+
+    Passing it must not defeat the pinning, or the host dependence comes
+    straight back in its original shape.
+    """
+    report = workflow_module.detect_xctrace_capability(
+        runner=exporting_runner(),
+        os_name=None,
+        architecture=None,
+        path_resolver=None,
+    )
+    assert report.capability is XctraceCapability.SUPPORTED
+    assert report.os_name == PINNED_OS

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import platform
 import shutil
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from _instruments_fakes import (
@@ -1372,3 +1374,71 @@ def test_a_successful_import_leaves_no_staging_directory_behind(tmp_path):
     out = tmp_path / "artifacts"
     import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
     assert not (out / STAGING_DIR_NAME).exists()
+
+
+def test_a_failed_export_after_a_good_recording_replaces_stale_evidence(tmp_path):
+    """`record` writes its metadata before exporting.
+
+    An export failure used to propagate out of record_trace, leaving
+    this run's capability report and record metadata sitting beside a
+    previous run's evidence and GPU metrics. --output-trace and
+    --output-dir are independent flags, so a fixed artifacts directory
+    with a per-run trace name is the natural invocation and the trace
+    collision check does not catch it.
+    """
+    out = tmp_path / "artifacts"
+
+    first = tmp_path / "run1.trace"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=first),
+        command=("/bin/infer",),
+        output_trace=first,
+        output_dir=out,
+    )
+    stale = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
+    assert stale["trace_bundle_name"] == "run1.trace"
+    assert stale["metrics"]
+
+    second = tmp_path / "run2.trace"
+    collection = record_trace(
+        runner=exporting_runner(**{"toc": fail((), returncode=1)}),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=second),
+        command=("/bin/infer",),
+        output_trace=second,
+        output_dir=out,
+    )
+
+    assert collection.succeeded is True
+    fresh = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
+    assert fresh["trace_bundle_name"] is None
+    assert fresh["metrics"] == {}
+    assert "could not be exported" in fresh["notes"]
+    record_meta = json.loads((out / "xctrace_record.json").read_text("utf-8"))
+    assert record_meta["trace_name"] == "run2.trace"
+
+
+def test_evidence_is_promoted_last_so_a_tear_leaves_it_stale(tmp_path):
+    """Promotion order matters if the loop is ever interrupted."""
+    from llmtracefx.optimizer.instruments.workflow import STAGING_DIR_NAME
+
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    (out / STAGING_DIR_NAME).mkdir()
+    staging = out / STAGING_DIR_NAME
+    for name in ("trace_toc.xml", "instruments_evidence.json", "trace_table.xml"):
+        (staging / name).write_text(name, encoding="utf-8")
+
+    promoted: list[str] = []
+    real_replace = os.replace
+
+    def recording_replace(src, dst):
+        promoted.append(Path(dst).name)
+        real_replace(src, dst)
+
+    with mock.patch.object(workflow_module.os, "replace", recording_replace):
+        workflow_module._promote_staged(staging, out)
+
+    assert promoted[-1] == "instruments_evidence.json"

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -556,7 +556,9 @@ def test_native_provenance_without_a_parsed_schema_is_rejected():
             )
         },
     )
-    with pytest.raises(SchemaValidationError, match="parsed_schemas is"):
+    with pytest.raises(
+        SchemaValidationError, match="not in instruments.parsed_schemas"
+    ):
         base_record(instruments=evidence).validate()
 
 
@@ -579,6 +581,7 @@ def test_negative_instrument_metric_is_rejected():
     )
 
     evidence = InstrumentsEvidence(
+        available_schemas=("metal-gpu-intervals",),
         parsed_schemas=("metal-gpu-intervals",),
         metrics={
             "metal_gpu_interval_count": Measurement(
@@ -777,6 +780,7 @@ def test_schema_structurally_rejects_overclaiming_metric_names(name):
     )
 
     evidence = InstrumentsEvidence(
+        available_schemas=("metal-gpu-intervals",),
         parsed_schemas=("metal-gpu-intervals",),
         metrics={
             name: Measurement(
@@ -938,3 +942,217 @@ def test_pinning_survives_an_explicit_none_identity():
     )
     assert report.capability is XctraceCapability.SUPPORTED
     assert report.os_name == PINNED_OS
+
+
+# --- Collisions are resolved before anything is written ---------------
+
+
+def test_rerun_into_an_occupied_directory_touches_no_existing_byte(tmp_path):
+    """A refused rerun must not leave one run's trace beside another's
+    metadata.
+
+    record_trace used to write capability_report.json immediately, and
+    only then reach the trace collision check inside run_record. The
+    trace was correctly refused, but the metadata beside it had already
+    been replaced.
+    """
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    trace = out / "run.trace"
+    trace.mkdir()
+
+    existing = {
+        out / "capability_report.json": b'{"from": "the first run"}',
+        out / "instruments_evidence.json": b'{"from": "the first run"}',
+        out / "xctrace_record.json": b'{"from": "the first run"}',
+        out / "trace_toc.xml": b"<trace-toc/>",
+    }
+    for path, payload in existing.items():
+        path.write_bytes(payload)
+    before = {path: path.read_bytes() for path in existing}
+
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=trace)
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=launcher,
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+
+    assert collection.succeeded is False
+    assert collection.wrote_artifacts is False
+    assert launcher.spawned == []
+    assert "never overwritten" in collection.message
+    for path, payload in before.items():
+        assert path.read_bytes() == payload, f"{path.name} was rewritten"
+
+
+def test_refused_rerun_creates_no_new_files(tmp_path):
+    out = tmp_path / "artifacts"
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0)),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+
+    assert not out.exists()
+
+
+def test_a_clean_run_still_writes_every_artifact(tmp_path):
+    """The ordering fix must not stop a normal run from writing."""
+    out = tmp_path / "artifacts"
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+
+    assert collection.succeeded is True
+    assert collection.wrote_artifacts is True
+    for name in (
+        "capability_report.json",
+        "instruments_evidence.json",
+        "xctrace_record.json",
+        "trace_toc.xml",
+        "trace_toc.json",
+    ):
+        assert (out / name).exists(), name
+
+
+# --- Metric allowlist -------------------------------------------------
+
+
+def _evidence(**overrides):
+    from llmtracefx.optimizer.schema import InstrumentsEvidence
+
+    values = {
+        "available_schemas": ("metal-gpu-intervals",),
+        "parsed_schemas": ("metal-gpu-intervals",),
+    }
+    values.update(overrides)
+    return InstrumentsEvidence(**values)
+
+
+def _native(value=1.0, unit="intervals"):
+    from llmtracefx.optimizer.schema import Measurement, MetricProvenance
+
+    return Measurement(
+        value=value, provenance=MetricProvenance.MEASURED_NATIVE, unit=unit
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "metal_power_watts",
+        "metal_energy_joules",
+        "metal_memory_footprint",
+        "gpu_temperature",
+        "metal_gpu_interval_count_v2",
+        "interval_count",
+        "anything_at_all",
+    ],
+)
+def test_metrics_outside_the_allowlist_are_rejected(name):
+    """A denylist only blocks what somebody enumerated.
+
+    `metal_power_watts` passed the substring denylist cleanly, because
+    the entry was `gpu_power`. An allowlist has no such gap.
+    """
+    evidence = _evidence(metrics={name: _native()})
+    with pytest.raises(SchemaValidationError, match="not a metric this project"):
+        base_record(instruments=evidence).validate()
+
+
+@pytest.mark.parametrize(
+    "name,wrong_unit",
+    [
+        ("metal_gpu_interval_count", "ms"),
+        ("metal_gpu_interval_duration_sum", "intervals"),
+        ("metal_gpu_interval_wall_span", "ns"),
+        ("metal_gpu_interval_count_all_processes", ""),
+    ],
+)
+def test_allowlisted_metrics_must_carry_their_declared_unit(name, wrong_unit):
+    evidence = _evidence(metrics={name: _native(unit=wrong_unit)})
+    with pytest.raises(SchemaValidationError, match="must be in"):
+        base_record(instruments=evidence).validate()
+
+
+@pytest.mark.parametrize(
+    "provenance_name", ["MEASURED_WALL_CLOCK", "DERIVED", "ESTIMATED"]
+)
+def test_allowlisted_metrics_must_carry_native_provenance(provenance_name):
+    from llmtracefx.optimizer.schema import Measurement, MetricProvenance
+
+    evidence = _evidence(
+        metrics={
+            "metal_gpu_interval_count": Measurement(
+                value=1.0,
+                provenance=getattr(MetricProvenance, provenance_name),
+                unit="intervals",
+            )
+        }
+    )
+    with pytest.raises(SchemaValidationError, match="must have provenance"):
+        base_record(instruments=evidence).validate()
+
+
+def test_a_metric_requires_its_own_source_table_to_have_been_parsed():
+    evidence = _evidence(
+        parsed_schemas=(), metrics={"metal_gpu_interval_count": _native()}
+    )
+    with pytest.raises(
+        SchemaValidationError, match="not in instruments.parsed_schemas"
+    ):
+        base_record(instruments=evidence).validate()
+
+
+def test_a_phantom_parsed_schema_cannot_unlock_a_metric():
+    """parsed_schemas must be a subset of what the trace advertised."""
+    evidence = _evidence(
+        available_schemas=("time-profile",),
+        parsed_schemas=("metal-gpu-intervals",),
+        metrics={"metal_gpu_interval_count": _native()},
+    )
+    with pytest.raises(SchemaValidationError, match="never advertised"):
+        base_record(instruments=evidence).validate()
+
+
+def test_parsing_cannot_be_claimed_when_the_trace_advertised_nothing():
+    evidence = _evidence(available_schemas=())
+    with pytest.raises(SchemaValidationError, match="advertised nothing"):
+        base_record(instruments=evidence).validate()
+
+
+def test_parsed_schemas_must_name_a_table_this_project_can_parse():
+    evidence = _evidence(
+        available_schemas=("os-signpost",), parsed_schemas=("os-signpost",)
+    )
+    with pytest.raises(SchemaValidationError, match="no parser for"):
+        base_record(instruments=evidence).validate()
+
+
+def test_the_four_real_metrics_pass_every_rule(tmp_path):
+    """The guard must not be so strict that a real run is rejected."""
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+    from llmtracefx.optimizer.schema import INSTRUMENT_METRIC_SPECS
+
+    assert set(collection.evidence.metrics) == set(INSTRUMENT_METRIC_SPECS)
+    base_record(instruments=collection.evidence).validate()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1742,3 +1742,67 @@ def test_derived_artifacts_never_name_another_process(tmp_path):
         assert "WindowServer" not in (out / name).read_text("utf-8"), name
     # The raw export does, by nature. Pinned so the boundary is explicit.
     assert "WindowServer" in (out / "trace_table.xml").read_text("utf-8")
+
+
+def test_an_ambiguous_pid_note_does_not_name_other_processes(tmp_path):
+    """The refusal must stay actionable without leaking a name.
+
+    An operator needs the conflicting labels on stderr; a persisted
+    artifact must not carry another process's name, which is what the
+    README promises of instruments_evidence.json.
+    """
+    rows = "".join(
+        f'<row><start-time id="{i * 4 + 1}">{i * 10}</start-time>'
+        f'<duration id="{i * 4 + 2}">5</duration>'
+        f'<process id="{i * 4 + 3}" fmt="{name} (4242)">'
+        f'<pid id="{i * 4 + 4}">4242</pid></process></row>'
+        for i, name in enumerate(["Signal", "probe"])
+    )
+    table = (
+        '<trace-query-result><node><schema name="metal-gpu-intervals">'
+        "<col><mnemonic>start</mnemonic>"
+        "<engineering-type>start-time</engineering-type></col>"
+        "<col><mnemonic>duration</mnemonic>"
+        "<engineering-type>duration</engineering-type></col>"
+        "<col><mnemonic>process</mnemonic>"
+        "<engineering-type>process</engineering-type></col>"
+        f"</schema>{rows}</node></trace-query-result>"
+    )
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(
+        runner=exporting_runner(**{"metal-gpu-intervals": ok((), table)}),
+        trace_path=trace,
+        output_dir=out,
+    )
+
+    notes = json.loads((out / "instruments_evidence.json").read_text("utf-8"))["notes"]
+    assert "is ambiguous" in notes
+    assert "2 different process labels" in notes
+    assert "Signal" not in notes
+
+
+def test_import_clears_stale_exports_when_xctrace_is_unavailable(tmp_path):
+    """The one evidence-writing path that was missed.
+
+    `instruments import` is reachable directly, so an unavailable
+    xctrace wrote fresh no-metrics evidence on top of a previous run's
+    exported GPU table and left it in place.
+    """
+    out = tmp_path / "artifacts"
+    out.mkdir()
+    for name in ("trace_toc.xml", "trace_toc.json", "trace_table.xml"):
+        (out / name).write_text("PREVIOUS RUN", encoding="utf-8")
+
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    runner = FakeCommandRunner(
+        version=fail((), returncode=1, stderr=COMMAND_LINE_TOOLS_STDERR)
+    )
+    collection = import_trace(runner=runner, trace_path=trace, output_dir=out)
+
+    assert collection.capability.supported is False
+    for name in ("trace_toc.xml", "trace_toc.json", "trace_table.xml"):
+        assert not (out / name).exists(), f"{name} survived from the earlier run"
+    assert (out / "instruments_evidence.json").exists()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1342,3 +1342,33 @@ def test_a_normal_record_still_works_with_the_reservation(tmp_path):
     assert collection.succeeded is True
     # The marker must not survive the run.
     assert not list(tmp_path.glob(".*reservation"))
+
+
+def test_a_failed_import_leaves_no_staging_directory_behind(tmp_path):
+    """Scratch state must not outlive the call that created it.
+
+    Without guaranteed cleanup the partial staging set sat in the user's
+    output directory until some later run happened to clear it.
+    """
+    from llmtracefx.optimizer.instruments.workflow import STAGING_DIR_NAME
+
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+
+    runner = exporting_runner(**{"metal-gpu-intervals": fail((), returncode=1)})
+    with pytest.raises(InstrumentsExportError):
+        import_trace(runner=runner, trace_path=trace, output_dir=out)
+
+    assert not (out / STAGING_DIR_NAME).exists()
+    assert list(out.iterdir()) == []
+
+
+def test_a_successful_import_leaves_no_staging_directory_behind(tmp_path):
+    from llmtracefx.optimizer.instruments.workflow import STAGING_DIR_NAME
+
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+    assert not (out / STAGING_DIR_NAME).exists()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1806,3 +1806,59 @@ def test_import_clears_stale_exports_when_xctrace_is_unavailable(tmp_path):
     for name in ("trace_toc.xml", "trace_toc.json", "trace_table.xml"):
         assert not (out / name).exists(), f"{name} survived from the earlier run"
     assert (out / "instruments_evidence.json").exists()
+
+
+def test_a_successful_no_export_run_clears_a_previous_gpu_table(tmp_path):
+    """The staged set is not always complete.
+
+    trace_table.xml is staged only when a table was actually exported,
+    so --no-export promotes three files and a fourth survives from an
+    earlier run. The run succeeds and exits 0, leaving this run's
+    zero-metric evidence beside another run's GPU intervals.
+    """
+    out = tmp_path / "artifacts"
+    first = tmp_path / "run1.trace"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=first),
+        command=("/bin/infer",),
+        output_trace=first,
+        output_dir=out,
+    )
+    assert (out / "trace_table.xml").exists()
+
+    second = tmp_path / "run2.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=second),
+        command=("/bin/infer",),
+        output_trace=second,
+        output_dir=out,
+        table_schema=None,
+    )
+
+    assert collection.succeeded is True
+    assert collection.evidence.metrics == {}
+    assert not (out / "trace_table.xml").exists()
+    # The artifacts this run did produce are still there.
+    assert (out / "trace_toc.xml").exists()
+    assert (out / "trace_toc.json").exists()
+
+
+def test_an_import_for_an_absent_schema_clears_a_previous_gpu_table(tmp_path):
+    """Same hole, reached by importing a trace without the table."""
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+    assert (out / "trace_table.xml").exists()
+
+    import_trace(
+        runner=exporting_runner(),
+        trace_path=trace,
+        output_dir=out,
+        table_schema="os-signpost",
+    )
+
+    assert not (out / "trace_table.xml").exists()
+    assert (out / "trace_toc.json").exists()

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -1,0 +1,600 @@
+"""Tests for the plan / record / import workflows and their CLI surfaces."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from _instruments_fakes import (
+    COMMAND_LINE_TOOLS_STDERR,
+    FakeCommandRunner,
+    FakeLauncher,
+    FakeProcess,
+    fail,
+    ok,
+    read_fixture,
+)
+
+from llmtracefx.optimizer.cli import main
+from llmtracefx.optimizer.instruments.capability import detect_xctrace_capability
+from llmtracefx.optimizer.instruments.evidence import (
+    TraceEvidenceInputs,
+    build_instruments_evidence,
+    unsupported_evidence,
+)
+from llmtracefx.optimizer.instruments.export import (
+    FORBIDDEN_METRIC_NAMES,
+    parse_exported_table,
+)
+from llmtracefx.optimizer.instruments.workflow import (
+    import_trace,
+    plan_trace,
+    record_trace,
+)
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ExperimentRecord,
+    ModelInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SchemaValidationError,
+    utc_now_iso,
+)
+
+TOC = "toc_metal_system_trace.xml"
+TABLE = "table_metal_gpu_intervals.xml"
+UNSUPPORTED = "table_unsupported_schema.xml"
+
+
+def exporting_runner(**overrides) -> FakeCommandRunner:
+    exports = {
+        "toc": ok((), read_fixture(TOC)),
+        "metal-gpu-intervals": ok((), read_fixture(TABLE)),
+        "displayed-surfaces-per-second": ok((), read_fixture(UNSUPPORTED)),
+    }
+    exports.update(overrides)
+    return FakeCommandRunner(exports=exports)
+
+
+def capability(runner: FakeCommandRunner):
+    return detect_xctrace_capability(
+        runner=runner,
+        os_name="Darwin",
+        architecture="arm64",
+        path_resolver=lambda: "/usr/bin/xctrace",
+    )
+
+
+# --- Dry-run plan -----------------------------------------------------
+
+
+def test_plan_executes_nothing_and_creates_nothing(tmp_path):
+    runner = exporting_runner()
+    trace = tmp_path / "run.trace"
+    out = tmp_path / "artifacts"
+
+    plan = plan_trace(
+        runner=runner,
+        command=("/bin/infer", "--tokens", "8"),
+        output_trace=trace,
+        output_dir=out,
+    )
+
+    assert plan.ready is True
+    assert not trace.exists()
+    assert not out.exists()
+    # Only read-only capability probes ran.
+    assert all(
+        argv[1:] in (("version",), ("list", "templates")) for argv in runner.calls
+    )
+
+
+def test_plan_lists_exact_output_paths(tmp_path):
+    plan = plan_trace(
+        runner=exporting_runner(),
+        command=("/bin/infer",),
+        output_trace=tmp_path / "run.trace",
+        output_dir=tmp_path / "artifacts",
+    )
+    paths = plan.output_paths
+    assert paths["trace_bundle"] == str(tmp_path / "run.trace")
+    assert paths["evidence"].endswith("instruments_evidence.json")
+    assert paths["capability_report"].endswith("capability_report.json")
+
+
+def test_plan_reports_the_exact_argv_it_would_run(tmp_path):
+    plan = plan_trace(
+        runner=exporting_runner(),
+        command=("/bin/infer", "--tokens", "8"),
+        output_trace=tmp_path / "run.trace",
+        output_dir=tmp_path / "artifacts",
+        time_limit="45s",
+    )
+    argv = plan.record_plan.to_redacted_argv()
+    assert argv[-4:] == ("--launch", "--", "/bin/infer", "--tokens", "8")[-4:]
+    assert "45s" in argv
+
+
+def test_plan_surfaces_unmet_capability_as_a_prerequisite(tmp_path):
+    runner = FakeCommandRunner(
+        version=fail((), returncode=1, stderr=COMMAND_LINE_TOOLS_STDERR)
+    )
+    plan = plan_trace(
+        runner=runner,
+        command=("/bin/infer",),
+        output_trace=tmp_path / "run.trace",
+        output_dir=tmp_path / "artifacts",
+    )
+    assert plan.ready is False
+    assert any("full Xcode" in item for item in plan.prerequisites)
+
+
+def test_plan_surfaces_a_collision_as_a_prerequisite(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    plan = plan_trace(
+        runner=exporting_runner(),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+    assert plan.ready is False
+    assert any("never overwritten" in item for item in plan.prerequisites)
+
+
+def test_plan_serializes_to_json(tmp_path):
+    plan = plan_trace(
+        runner=exporting_runner(),
+        command=("/bin/infer",),
+        output_trace=tmp_path / "run.trace",
+        output_dir=tmp_path / "artifacts",
+    )
+    payload = json.loads(plan.to_json())
+    assert payload["ready"] is True
+    assert payload["capability"] == "supported"
+
+
+# --- Record -----------------------------------------------------------
+
+
+def test_record_writes_evidence_with_attributed_metrics(tmp_path):
+    trace = tmp_path / "run.trace"
+    runner = exporting_runner()
+    launcher = FakeLauncher(FakeProcess(returncode=0), creates_trace=trace)
+
+    collection = record_trace(
+        runner=runner,
+        launcher=launcher,
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+
+    assert collection.succeeded is True
+    evidence = collection.evidence
+    assert evidence.parsed_schemas == ("metal-gpu-intervals",)
+    # The fixture's launched process is pid 4242 with 3 of 5 intervals.
+    assert evidence.metrics["metal_gpu_interval_count"].value == 3.0
+    assert evidence.metrics["metal_gpu_interval_count_all_processes"].value == 5.0
+
+
+def test_record_notes_explain_the_attribution(tmp_path):
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+    notes = collection.evidence.notes or ""
+    assert "pid 4242 only" in notes
+    assert "not GPU busy time or utilization" in notes
+
+
+def test_record_on_unsupported_capability_does_not_launch_anything(tmp_path):
+    runner = FakeCommandRunner(
+        version=fail((), returncode=1, stderr=COMMAND_LINE_TOOLS_STDERR)
+    )
+    launcher = FakeLauncher(FakeProcess())
+
+    collection = record_trace(
+        runner=runner,
+        launcher=launcher,
+        command=("/bin/infer",),
+        output_trace=tmp_path / "run.trace",
+        output_dir=tmp_path / "artifacts",
+    )
+
+    assert launcher.spawned == []
+    assert collection.succeeded is False
+    assert collection.evidence.capability == "command_line_tools_only"
+    assert collection.evidence.metrics == {}
+
+
+def test_record_failure_still_writes_evidence(tmp_path):
+    trace = tmp_path / "run.trace"
+    out = tmp_path / "artifacts"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=2)),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=out,
+    )
+    assert collection.succeeded is False
+    assert (out / "instruments_evidence.json").exists()
+    assert collection.evidence.metrics == {}
+
+
+# --- Import -----------------------------------------------------------
+
+
+def test_import_of_an_existing_bundle(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+
+    collection = import_trace(
+        runner=exporting_runner(), trace_path=trace, output_dir=out
+    )
+
+    assert collection.evidence.parsed_schemas == ("metal-gpu-intervals",)
+    assert (out / "trace_toc.json").exists()
+    assert (out / "instruments_evidence.json").exists()
+
+
+def test_import_records_unsupported_schemas_explicitly(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    collection = import_trace(
+        runner=exporting_runner(), trace_path=trace, output_dir=tmp_path / "a"
+    )
+    evidence = collection.evidence
+    assert "displayed-surfaces-per-second" in evidence.unsupported_schemas
+    assert "time-profile" in evidence.unsupported_schemas
+    assert set(evidence.parsed_schemas).isdisjoint(evidence.unsupported_schemas)
+
+
+def test_import_of_a_schema_without_a_summarizer_derives_no_metric(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    collection = import_trace(
+        runner=exporting_runner(),
+        trace_path=trace,
+        output_dir=tmp_path / "a",
+        table_schema="displayed-surfaces-per-second",
+    )
+    assert collection.evidence.metrics == {}
+    assert "no strict summarizer" in (collection.message or "")
+
+
+def test_import_of_a_schema_absent_from_the_toc_is_reported(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    collection = import_trace(
+        runner=exporting_runner(),
+        trace_path=trace,
+        output_dir=tmp_path / "a",
+        table_schema="os-signpost",
+    )
+    assert collection.evidence.metrics == {}
+    assert "not present in this trace" in (collection.message or "")
+
+
+def test_import_with_no_export_reads_only_the_toc(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    collection = import_trace(
+        runner=exporting_runner(),
+        trace_path=trace,
+        output_dir=tmp_path / "a",
+        table_schema=None,
+    )
+    assert collection.table is None
+    assert collection.evidence.metrics == {}
+    assert collection.evidence.available_schemas
+
+
+def test_import_of_a_missing_bundle_raises(tmp_path):
+    from llmtracefx.optimizer.instruments.export import InstrumentsExportError
+
+    with pytest.raises(InstrumentsExportError, match="does not exist"):
+        import_trace(
+            runner=exporting_runner(),
+            trace_path=tmp_path / "absent.trace",
+            output_dir=tmp_path / "a",
+        )
+
+
+def test_import_evidence_carries_no_absolute_path(tmp_path):
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+
+    raw = (out / "instruments_evidence.json").read_text(encoding="utf-8")
+    assert str(tmp_path) not in raw
+    assert json.loads(raw)["trace_bundle_name"] == "run.trace"
+
+
+# --- Evidence and no overclaiming -------------------------------------
+
+
+def test_evidence_without_a_target_pid_emits_no_metric(tmp_path):
+    table = parse_exported_table(read_fixture(TABLE))
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals",),
+            table=table,
+            target_pid=None,
+        )
+    )
+    assert evidence.metrics == {}
+    assert "would misattribute" in (evidence.notes or "")
+
+
+def test_evidence_for_a_pid_with_no_intervals_emits_no_metric():
+    table = parse_exported_table(read_fixture(TABLE))
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals",),
+            table=table,
+            target_pid=999999,
+        )
+    )
+    assert evidence.metrics == {}
+    assert "contributed no GPU intervals" in (evidence.notes or "")
+
+
+def test_no_emitted_metric_name_is_an_overclaim():
+    table = parse_exported_table(read_fixture(TABLE))
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals",),
+            table=table,
+            target_pid=4242,
+        )
+    )
+    assert evidence.metrics
+    for name in evidence.metrics:
+        assert name not in FORBIDDEN_METRIC_NAMES
+    joined = " ".join(evidence.metrics)
+    for forbidden in ("utilization", "occupancy", "bandwidth", "power"):
+        assert forbidden not in joined
+
+
+def test_unsupported_evidence_keeps_the_reason(tmp_path):
+    runner = FakeCommandRunner(
+        version=fail((), returncode=1, stderr=COMMAND_LINE_TOOLS_STDERR)
+    )
+    report = capability(runner)
+    evidence = unsupported_evidence(report, template="Metal System Trace")
+    assert evidence.capability == "command_line_tools_only"
+    assert evidence.metrics == {}
+    assert evidence.notes == report.reason
+
+
+# --- Canonical schema integration -------------------------------------
+
+
+def base_record(**overrides) -> ExperimentRecord:
+    values = {
+        "run_id": "r1",
+        "started_at": utc_now_iso(),
+        "platform": PlatformInfo(
+            os_name="Darwin", os_version="26.6.2", architecture="arm64"
+        ),
+        "model": ModelInfo(model_id="m"),
+        "runtime": RuntimeInfo(name="mlx"),
+        "command": CommandInfo(argv=("infer",)),
+        "repetition": RepetitionInfo(
+            warmup_repetitions=0, measured_repetitions=1, repetition_index=0
+        ),
+    }
+    values.update(overrides)
+    return ExperimentRecord(**values)
+
+
+def test_instruments_evidence_round_trips_in_an_experiment_record():
+    table = parse_exported_table(read_fixture(TABLE))
+    evidence = build_instruments_evidence(
+        TraceEvidenceInputs(
+            capability=capability(exporting_runner()),
+            trace_bundle_name="run.trace",
+            template="Metal System Trace",
+            available_schemas=("metal-gpu-intervals", "time-profile"),
+            table=table,
+            target_pid=4242,
+        )
+    )
+    record = base_record(instruments=evidence)
+    record.validate()
+    restored = ExperimentRecord.from_dict(record.to_dict())
+    assert restored.instruments == evidence
+
+
+def test_records_without_instruments_still_parse():
+    """The field is additive: older records must load unchanged."""
+    payload = base_record().to_dict()
+    del payload["instruments"]
+    assert ExperimentRecord.from_dict(payload).instruments is None
+
+
+def test_instruments_memory_stays_separate_from_allocator_memory():
+    """MLX allocator bytes and Instruments values must not merge."""
+    from llmtracefx.optimizer.schema import Measurement, MemoryMetrics, MetricProvenance
+
+    record = base_record(
+        memory=MemoryMetrics(
+            active=Measurement(
+                value=1024.0,
+                provenance=MetricProvenance.MEASURED_NATIVE,
+                unit="bytes",
+            )
+        ),
+        instruments=build_instruments_evidence(
+            TraceEvidenceInputs(
+                capability=capability(exporting_runner()),
+                trace_bundle_name="run.trace",
+                template="Metal System Trace",
+                available_schemas=("metal-gpu-intervals",),
+                table=parse_exported_table(read_fixture(TABLE)),
+                target_pid=4242,
+            )
+        ),
+    )
+    record.validate()
+    payload = record.to_dict()
+    assert payload["memory"]["active"]["value"] == 1024.0
+    assert "active" not in payload["instruments"]["metrics"]
+
+
+def test_native_provenance_without_a_parsed_schema_is_rejected():
+    """Structurally prevents a fabricated hardware measurement."""
+    from llmtracefx.optimizer.schema import (
+        InstrumentsEvidence,
+        Measurement,
+        MetricProvenance,
+    )
+
+    evidence = InstrumentsEvidence(
+        parsed_schemas=(),
+        metrics={
+            "metal_gpu_interval_count": Measurement(
+                value=1.0,
+                provenance=MetricProvenance.MEASURED_NATIVE,
+                unit="intervals",
+            )
+        },
+    )
+    with pytest.raises(SchemaValidationError, match="parsed_schemas is"):
+        base_record(instruments=evidence).validate()
+
+
+def test_a_schema_cannot_be_both_parsed_and_unsupported():
+    from llmtracefx.optimizer.schema import InstrumentsEvidence
+
+    evidence = InstrumentsEvidence(
+        parsed_schemas=("metal-gpu-intervals",),
+        unsupported_schemas=("metal-gpu-intervals",),
+    )
+    with pytest.raises(SchemaValidationError, match="both parsed and unsupported"):
+        base_record(instruments=evidence).validate()
+
+
+def test_negative_instrument_metric_is_rejected():
+    from llmtracefx.optimizer.schema import (
+        InstrumentsEvidence,
+        Measurement,
+        MetricProvenance,
+    )
+
+    evidence = InstrumentsEvidence(
+        parsed_schemas=("metal-gpu-intervals",),
+        metrics={
+            "metal_gpu_interval_count": Measurement(
+                value=-1.0,
+                provenance=MetricProvenance.MEASURED_NATIVE,
+                unit="intervals",
+            )
+        },
+    )
+    with pytest.raises(SchemaValidationError, match="must be >= 0"):
+        base_record(instruments=evidence).validate()
+
+
+def test_instruments_evidence_rejects_a_non_object_metrics_field():
+    from llmtracefx.optimizer.schema import InstrumentsEvidence
+
+    with pytest.raises(SchemaValidationError, match="must be an object"):
+        InstrumentsEvidence.from_dict({"metrics": ["not", "an", "object"]})
+
+
+def test_instruments_evidence_rejects_a_bare_string_schema_list():
+    """A bare string is a Sequence, so tuple() would shred it."""
+    from llmtracefx.optimizer.schema import InstrumentsEvidence
+
+    with pytest.raises(SchemaValidationError, match="must be a list of strings"):
+        InstrumentsEvidence.from_dict({"parsed_schemas": "metal-gpu-intervals"})
+
+
+# --- CLI --------------------------------------------------------------
+
+
+def run_cli(argv: list[str]) -> int:
+    with pytest.raises(SystemExit) as excinfo:
+        main(argv)
+    return excinfo.value.code
+
+
+def test_cli_plan_requires_a_target_command(tmp_path, capsys):
+    code = run_cli(
+        [
+            "instruments",
+            "plan",
+            "--output-trace",
+            str(tmp_path / "run.trace"),
+            "--output-dir",
+            str(tmp_path / "a"),
+        ]
+    )
+    assert code == 1
+    assert "no program to profile" in capsys.readouterr().err
+
+
+def test_cli_rejects_an_output_path_that_is_not_a_trace(tmp_path, capsys):
+    code = run_cli(
+        [
+            "instruments",
+            "plan",
+            "--output-trace",
+            str(tmp_path / "run.txt"),
+            "--output-dir",
+            str(tmp_path / "a"),
+            "--",
+            "/bin/echo",
+            "hi",
+        ]
+    )
+    assert code in (1, 3)
+    combined = capsys.readouterr()
+    assert ".trace" in (combined.out + combined.err)
+
+
+def test_cli_import_of_a_missing_trace_exits_one(tmp_path, capsys):
+    code = run_cli(
+        [
+            "instruments",
+            "import",
+            "--trace",
+            str(tmp_path / "absent.trace"),
+            "--output-dir",
+            str(tmp_path / "a"),
+        ]
+    )
+    assert code == 1
+    assert "Failed to import the trace" in capsys.readouterr().err
+
+
+def test_cli_exposes_the_four_documented_subcommands():
+    from llmtracefx.optimizer.cli import build_parser
+
+    parser = build_parser()
+    instruments = next(
+        action
+        for action in parser._subparsers._group_actions[0].choices.items()
+        if action[0] == "instruments"
+    )[1]
+    names = set(instruments._subparsers._group_actions[0].choices)
+    assert names == {"capability", "plan", "record", "import"}

--- a/tests/optimizer/test_instruments_workflow.py
+++ b/tests/optimizer/test_instruments_workflow.py
@@ -29,6 +29,7 @@ from llmtracefx.optimizer.instruments.capability import (
     XctraceCapability,
     detect_xctrace_capability,
 )
+from llmtracefx.optimizer.instruments.commands import InstrumentsCommandError
 from llmtracefx.optimizer.instruments.evidence import (
     TraceEvidenceInputs,
     build_instruments_evidence,
@@ -1563,6 +1564,163 @@ def test_any_export_failure_replaces_stale_evidence(tmp_path, error):
 
     assert collection.export_failed is True
     assert collection.succeeded is False
+    evidence = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
+    assert evidence["metrics"] == {}
+    assert evidence["trace_bundle_name"] == "run2.trace"
+
+
+def test_the_promoted_toc_carries_no_identity(tmp_path):
+    """The file written to disk, not just the parsed object."""
+    trace = tmp_path / "run.trace"
+    trace.mkdir()
+    out = tmp_path / "artifacts"
+    import_trace(runner=exporting_runner(), trace_path=trace, output_dir=out)
+
+    promoted = (out / "trace_toc.xml").read_text("utf-8")
+    assert "Example Mac" not in promoted
+    assert "00000000-0000-0000-0000-000000000000" not in promoted
+    assert "arguments=" not in promoted
+    assert "Metal System Trace" in promoted
+
+
+def test_a_failed_run_clears_a_previous_run_exported_tables(tmp_path):
+    """Replacing only the evidence still leaves a stale GPU table.
+
+    A directory holding run 2's metadata beside run 1's exported
+    intervals invites exactly the misattribution this project exists to
+    prevent.
+    """
+    out = tmp_path / "artifacts"
+    first = tmp_path / "run1.trace"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=first),
+        command=("/bin/infer",),
+        output_trace=first,
+        output_dir=out,
+    )
+    for name in ("trace_toc.xml", "trace_toc.json", "trace_table.xml"):
+        assert (out / name).exists(), name
+
+    second = tmp_path / "run2.trace"
+    record_trace(
+        runner=exporting_runner(**{"toc": fail((), returncode=1)}),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=second),
+        command=("/bin/infer",),
+        output_trace=second,
+        output_dir=out,
+    )
+
+    for name in ("trace_toc.xml", "trace_toc.json", "trace_table.xml"):
+        assert not (out / name).exists(), f"{name} survived from the earlier run"
+
+
+def test_an_invalid_request_writes_nothing(tmp_path):
+    """Validation must precede the first byte written.
+
+    capability_report.json used to land before the plan was built, so a
+    bad time limit left an artifact describing a run that never started.
+    """
+    out = tmp_path / "artifacts"
+    with pytest.raises(InstrumentsCommandError, match="time-limit"):
+        record_trace(
+            runner=exporting_runner(),
+            launcher=FakeLauncher(FakeProcess(returncode=0)),
+            command=("/bin/infer",),
+            output_trace=tmp_path / "run.trace",
+            output_dir=out,
+            time_limit="not-a-duration",
+        )
+    assert not out.exists() or list(out.iterdir()) == []
+
+
+def test_two_runs_cannot_share_an_artifact_directory(tmp_path):
+    """Different traces, same --output-dir, still race on the metadata."""
+    from llmtracefx.optimizer.instruments.recorder import reserve_output_dir
+
+    out = tmp_path / "artifacts"
+    with reserve_output_dir(out):
+        launcher = FakeLauncher(FakeProcess(returncode=0))
+        collection = record_trace(
+            runner=exporting_runner(),
+            launcher=launcher,
+            command=("/bin/infer",),
+            output_trace=tmp_path / "other.trace",
+            output_dir=out,
+        )
+
+    assert collection.succeeded is False
+    assert collection.wrote_artifacts is False
+    assert "already reserved the artifact directory" in collection.message
+    assert launcher.spawned == []
+
+
+def test_a_leaked_descendant_makes_the_run_unsuccessful(tmp_path):
+    """A run that left processes running did not fully succeed.
+
+    The trace is valid and the recording completed, both of which stay
+    true in the metadata, but the exit code must not say success.
+    """
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(
+            FakeProcess(returncode=0, group_dies_on=None), creates_trace=trace
+        ),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+        # The group never dies, so this bounds the full escalation.
+        stop_grace_seconds=0.05,
+    )
+
+    assert collection.record.status is RecordStatus.COMPLETED
+    assert collection.record.cleanup_failed is True
+    assert collection.succeeded is False
+    assert "could NOT be stopped" in collection.record.message
+
+
+def test_a_clean_run_is_not_marked_as_leaking(tmp_path):
+    trace = tmp_path / "run.trace"
+    collection = record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=trace),
+        command=("/bin/infer",),
+        output_trace=trace,
+        output_dir=tmp_path / "artifacts",
+    )
+    assert collection.record.cleanup_failed is False
+    assert collection.succeeded is True
+
+
+def test_a_bad_run_number_in_the_toc_does_not_mix_runs(tmp_path):
+    """Trace-derived input is validated, and that raises a command error.
+
+    It escaped the handler, leaving this run's metadata beside the
+    previous run's live GPU metrics.
+    """
+    out = tmp_path / "artifacts"
+    first = tmp_path / "run1.trace"
+    record_trace(
+        runner=exporting_runner(),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=first),
+        command=("/bin/infer",),
+        output_trace=first,
+        output_dir=out,
+    )
+    assert json.loads((out / "instruments_evidence.json").read_text("utf-8"))["metrics"]
+
+    bad_toc = read_fixture(TOC).replace('<run number="1">', '<run number="0">')
+    second = tmp_path / "run2.trace"
+    collection = record_trace(
+        runner=exporting_runner(**{"toc": ok((), bad_toc)}),
+        launcher=FakeLauncher(FakeProcess(returncode=0), creates_trace=second),
+        command=("/bin/infer",),
+        output_trace=second,
+        output_dir=out,
+    )
+
+    assert collection.export_failed is True
     evidence = json.loads((out / "instruments_evidence.json").read_text("utf-8"))
     assert evidence["metrics"] == {}
     assert evidence["trace_bundle_name"] == "run2.trace"


### PR DESCRIPTION
Wraps Apple's Instruments CLI (`xctrace`) to record a **Metal System Trace** around a local inference command and turn the resulting `.trace` bundle into canonical `ExperimentRecord` evidence, without inventing GPU numbers.

Independent of #12. Opened against `main`, left unmerged.

## Live validation

Xcode was still downloading at kickoff, so the foundation was built offline first and then validated against a real capture once it landed:

| | |
| --- | --- |
| Tool | `xctrace version 16.0 (17F113)` |
| Host | macOS 26.6.2 (25G83), Apple M5 Pro, arm64 |
| Template | `Metal System Trace` (present in 25 templates) |
| Schemas advertised by one capture | 82 |
| Table parsed | `metal-gpu-intervals` |

Flag spellings and semantics came from the local `xctrace help record` / `xctrace help export`, not from secondary sources. The workload was a ~40 line local Metal compute program compiled with `swiftc`: no model downloads, no network, no user data.

**Parser cross-validation.** The probe issues a known number of GPU dispatches. 400, 250, 120, 77 and 133 dispatches produced exactly 400, 250, 120, 77 and 133 attributed intervals.

## Two findings from the real trace that shaped the design

1. **Exports are reference-deduplicated.** One capture used 43,818 `ref` attributes across 44,280 cells. A parser that ignored them would silently discard the overwhelming majority of every row.
2. **Metal System Trace captures every process, not just yours.** A capture of a trivial local Metal program also contained `WindowServer` and `com.apple.WebKit.GPU` intervals; in one capture **81% of all intervals were WindowServer's**. A naive total would have overclaimed the target's GPU work by roughly 6x.

So metrics are always attributed per pid, read from the `<process>` cell's structured `pid` child. Without a target pid, or when one pid appears under two labels, no scalar metric is emitted at all.

## What is claimed, and what is not

Four metrics, all `measured_native`, all scoped to one pid: `metal_gpu_interval_count`, `metal_gpu_interval_duration_sum` (ms), `metal_gpu_interval_wall_span` (ms), and `metal_gpu_interval_count_all_processes` so the attributed share is visible rather than implied.

**No** GPU utilization, busy percentage, kernel time, memory bandwidth, occupancy, power, energy or memory footprint is derived. `duration_sum` is explicitly not GPU busy time: Metal runs Vertex, Fragment and Compute concurrently, so overlapping intervals are counted more than once. No benchmark claims anywhere.

This is enforced structurally, not by convention. `ExperimentRecord.validate` rejects a metric carrying `measured_native` provenance when no schema was parsed, and rejects any metric name containing `utilization`, `occupancy`, `bandwidth`, `busy_percent`, `kernel_time`, `gpu_power`, `gpu_energy` or `gpu_memory`.

## Capability detection

Nine distinguishable states, each with its own remediation, rather than one "unavailable": not macOS, not arm64, xctrace absent, Command Line Tools only, license not accepted, first launch incomplete, template unavailable, permission denied, and an explicit `probe_failed` for anything unrecognized. No broad excepts, no silent fallbacks.

Presence on `PATH` is never treated as support. On a Command Line Tools machine `/usr/bin/xctrace` exists and is executable but fails on every call, so the probe always invokes the tool. This was observed directly on this machine before Xcode finished installing.

## Safety and privacy

- Traces are never overwritten: the output path is resolved (symlinks, `..`, and case-insensitively on macOS) and refused if anything exists. `--append-run` is never passed.
- No shell. Argv lists only. Schema names are validated before entering an XPath so they cannot break out of the query.
- Host deadline strictly greater than `--time-limit` to leave room for bundle finalization. Own process group, teardown escalating SIGINT, SIGTERM, SIGKILL, because `--launch` starts the profiled program itself.
- Failures preserved: stdout, stderr, metadata and any partial bundle stay on disk.
- No prompt or completion capture: `--target-stdin`/`--target-stdout` are never constructed. `--all-processes` is never used; attach is by numeric pid only.
- Credential-looking values are redacted from stored/printed argv, in both `--env` and the profiled command's own arguments.
- The TOC's device display name (routinely a person's name), hardware UUID and target argument list are never read. Only the launched process's own pid and name are, because attribution is impossible without them.

## Independent review

A read-only reviewer found seven issues, all fixed in the second commit with regression tests. The two high-severity ones were genuine bugs:

- **Engineering-type validation was bypassed for referenced cells.** The tag check ran on the un-resolved child, so for `<tag ref="N"/>` the resolved value's type was never verified. Given ~99% of real cells are refs, the parser's core safety property was enforced on roughly 1% of the data, and a duration column could take its value from a start-time.
- **Attribution could name the wrong process.** Grouping by display label meant one pid under two labels silently returned whichever had more intervals, published as `measured_native` under a note claiming it described that pid alone.

Also fixed: evidence after a failed recording carried a misleading success note; the profiled command's argv was never redacted; duplicate column mnemonics let one column overwrite another; multi-node exports parsed only the first node; an unexpanded `~` made the collision check and the executed path diverge. Separately self-caught: an unexpected `wait()` error left the recording orphaned in its own session.

The hardened parser was re-run against the original real 2460-row export and still reads it correctly, confirming the stricter invariants hold on genuine output rather than only on fixtures.

## CLI

```bash
llmtracefx-optimizer instruments capability   # 0 supported, 3 blocked, 1 error
llmtracefx-optimizer instruments plan   ...   # dry run: executes nothing, writes nothing
llmtracefx-optimizer instruments record ...   # record, then export and parse
llmtracefx-optimizer instruments import ...   # export and parse an existing bundle
```

`plan` is a true dry run: it prints the exact argv and exact artifact paths, and creates no files.

## Schema change

`ExperimentRecord.instruments` is a new optional field. `SCHEMA_VERSION` stays `"1"` deliberately: the field is purely additive, and since `validate()` requires an exact version match, bumping it would make every existing record unreadable. Records written before this change parse unchanged. Instruments evidence is kept separate from `memory`/`power`, which carry MLX allocator and host-side values.

## Host independence

The first CI run failed 16 tests on every Ubuntu job while passing on macOS. `plan_trace`, `record_trace` and `import_trace` detect capability against the real host, so on Linux they correctly short-circuited to `unsupported_os` before the injected fake was ever consulted, and on macOS they silently depended on a locally installed Xcode. They were not testing what they claimed on either platform.

Fixed at the boundary the workflows actually use: an autouse fixture pins host identity and xctrace path discovery for that module only, and still calls the real detector against each test's own fake, so the Command Line Tools, license, template-missing and probe-failure branches stay genuinely exercised. The CLI builds its own runner, so that is replaced too. The capability tests are untouched; they already supply identity explicitly.

A second review round then caught three gaps, each fixed and confirmed by reverting the fix and watching the matching test fail: a tautological CLI test that passed even when the CLI bypassed the injected runner, a `setdefault` that missed `None` (the detector's own "read the host" sentinel), and the `instruments capability` subcommand resolving the detector from a second, unpinned binding.

The suite is now audited against five host shapes, 949 passing under each: Linux x86_64, Apple Silicon without Xcode, Intel macOS without Xcode, the Command Line Tools shim where xctrace is on PATH but every call fails, and the real macOS host. The three no-Xcode simulations also raise if any test tries to execute a real xctrace, and none does.

## Verification

- **2514 tests pass**, 400+ new for this feature. All run without Xcode, by injecting the subprocess and process-launch boundaries and parsing small synthetic fixtures derived from real output.
- Audited under simulated hosts as well as the real one: Linux x86_64, Apple Silicon without Xcode, Intel macOS without Xcode, and the Command Line Tools shim where xctrace is on PATH but every call fails. The no-Xcode simulations hard-fail if any test tries to execute a real xctrace, and none does.
- All 10 CI checks green: 4 Ubuntu (3.10 to 3.13), 2 macOS, CodeQL, analyze, wheel, quality ratchet.
- Rebased onto current `main`; the diff is purely additive (9106 insertions, 0 deletions).
- README documents setup, the exact supported evidence, the explicit unsupported claims, the limits of credential redaction, and which artifacts disclose what.

## Review history

Six rounds of independent exact-head review, each finding fixed with a regression verified load-bearing by reverting the fix and watching the named test fail. Notable catches, several of them my own regressions:

- Engineering-type validation was bypassed for referenced cells, so the parser's core safety property covered ~1% of real data.
- Interval attribution could return the wrong process when one pid appeared under two labels.
- A run whose export failed exited 0 with zero metrics in its evidence.
- The raw table of contents was promoted with the device owner's name, hardware UUID and the target's argument list intact.
- `-u` was briefly treated as a credential flag, which erased the script name from `python3 -u infer.py` in the run's own evidence.
