### PR TITLE
Harden API collector verification and framing

### DIFF
--- a/llmtracefx/optimizer/collectors/openai_api.py
+++ b/llmtracefx/optimizer/collectors/openai_api.py
@@ -184,7 +184,7 @@ _EVENT_KIND_DONE = "done"
 
 _MAX_ERROR_BODY_BYTES = 64 * 1024
 _MAX_STREAM_BODY_BYTES = 64 * 1024 * 1024
-_MAX_RESPONSE_CONTENT_CHARACTERS = 16 * 1024 * 1024
+_MAX_RESPONSE_CONTENT_CHARACTERS = _MAX_VERIFIED_ARTIFACT_BYTES // 16
 _MAX_CONTENT_DELTA_TIMINGS = 100_000
 _MAX_PERSISTED_MESSAGE_CHARS = 600
 _MAX_PERSISTED_HEADER_CHARS = 128
@@ -4042,7 +4042,7 @@ def _publish_artifacts(
 def _read_bounded_regular_file(path: Path, limit: int) -> bytes | None:
     if path.is_symlink():
         return None
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
     except OSError:
@@ -4071,7 +4071,7 @@ def _read_bounded_regular_file(path: Path, limit: int) -> bytes | None:
 def _hash_bounded_regular_file(path: Path, limit: int) -> str | None:
     if path.is_symlink():
         return None
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
     except OSError:

--- a/llmtracefx/optimizer/collectors/sse.py
+++ b/llmtracefx/optimizer/collectors/sse.py
@@ -86,6 +86,12 @@ class SSEDecoder:
                 prefix = self._decoder.decode(chunk[:prefix_length], False)
                 self._buffer += self._strip_leading_bom(prefix)
                 yield from self._drain_complete_lines()
+                if self._buffer.endswith("\r"):
+                    # The following byte is malformed, so the deferred CR
+                    # cannot be the first half of CRLF. Resolve it as the
+                    # legal lone-CR terminator before reporting the suffix.
+                    self._buffer = f"{self._buffer[:-1]}\n"
+                    yield from self._drain_complete_lines()
             raise SSEDecodeError(f"stream is not valid UTF-8: {exc}") from exc
         self._buffer += self._strip_leading_bom(decoded)
         yield from self._drain_complete_lines()

--- a/llmtracefx/optimizer/collectors/sse.py
+++ b/llmtracefx/optimizer/collectors/sse.py
@@ -86,12 +86,12 @@ class SSEDecoder:
                 prefix = self._decoder.decode(chunk[:prefix_length], False)
                 self._buffer += self._strip_leading_bom(prefix)
                 yield from self._drain_complete_lines()
-                if self._buffer.endswith("\r"):
-                    # The following byte is malformed, so the deferred CR
-                    # cannot be the first half of CRLF. Resolve it as the
-                    # legal lone-CR terminator before reporting the suffix.
-                    self._buffer = f"{self._buffer[:-1]}\n"
-                    yield from self._drain_complete_lines()
+            if self._buffer.endswith("\r"):
+                # The following byte is malformed, so the deferred CR
+                # cannot be the first half of CRLF. Resolve it as the
+                # legal lone-CR terminator before reporting the suffix.
+                self._buffer = f"{self._buffer[:-1]}\n"
+                yield from self._drain_complete_lines()
             raise SSEDecodeError(f"stream is not valid UTF-8: {exc}") from exc
         self._buffer += self._strip_leading_bom(decoded)
         yield from self._drain_complete_lines()

--- a/tests/optimizer/test_openai_api_collector.py
+++ b/tests/optimizer/test_openai_api_collector.py
@@ -31,6 +31,8 @@ from llmtracefx.optimizer.collectors.openai_api import (
     _MAX_CREDENTIAL_WORD,
     _MAX_EXACT_TOKEN_COUNT,
     _MAX_PERSISTED_HEADER_CHARS,
+    _MAX_RESPONSE_CONTENT_CHARACTERS,
+    _MAX_VERIFIED_ARTIFACT_BYTES,
     _MAX_WHITESPACE_RUN,
     _REDACTED,
     ARTIFACT_MANIFEST_NAME,
@@ -1995,6 +1997,19 @@ def test_a_symlinked_manifest_is_not_trusted(tmp_path: Path) -> None:
     marker_path.symlink_to(target)
 
     assert artifact_set_is_complete(config.output_dir) is False
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+def test_a_fifo_manifest_is_rejected_without_blocking(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    output_dir.mkdir()
+    os.mkfifo(output_dir / ARTIFACT_MANIFEST_NAME)
+
+    started = time.monotonic()
+    complete = artifact_set_is_complete(output_dir)
+
+    assert complete is False
+    assert time.monotonic() - started < 0.5
 
 
 def test_precreated_legacy_temp_symlink_cannot_overwrite_another_file(
@@ -5860,6 +5875,18 @@ def test_stream_body_bytes_are_bounded(
     assert result.evidence.failure.category == FAILURE_STREAM_DECODE
     assert "bounded response size" in result.evidence.failure.message
     assert_failure_artifacts(config, FAILURE_STREAM_DECODE)
+
+
+def test_redaction_expansion_stays_within_artifact_verifier_limit() -> None:
+    worst_case_bytes_per_character = max(
+        len(_REDACTED.encode("utf-8")),
+        4,
+    )
+
+    assert (
+        _MAX_RESPONSE_CONTENT_CHARACTERS * worst_case_bytes_per_character
+        <= _MAX_VERIFIED_ARTIFACT_BYTES
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/optimizer/test_openai_api_transport.py
+++ b/tests/optimizer/test_openai_api_transport.py
@@ -706,6 +706,11 @@ class _FakeSocket:
         self.timeouts.append(value)
 
 
+class _ClosedSocket:
+    def settimeout(self, _value: float) -> None:
+        raise OSError("socket closed")
+
+
 class _FakeRaw:
     """An ``HTTPResponse`` stub exposing the documented ``fp.raw._sock`` chain."""
 
@@ -759,6 +764,19 @@ def test_a_read_that_starts_past_the_deadline_is_a_timeout() -> None:
     with pytest.raises(TransportTimeout):
         for _ in response.iter_bytes():
             now[0] += 6.0
+
+
+def test_socket_timeout_race_is_a_typed_transport_failure() -> None:
+    response = _UrllibResponse(
+        _FakeRaw([b"a"], _ClosedSocket()),
+        200,
+        {},
+        deadline=10.0,
+        clock=lambda: 0.0,
+    )
+
+    with pytest.raises(TransportConnectionError, match="timeout adjustment failed"):
+        list(response.iter_bytes())
 
 
 def test_a_response_without_a_deadline_is_unchanged() -> None:

--- a/tests/optimizer/test_sse_parser.py
+++ b/tests/optimizer/test_sse_parser.py
@@ -167,6 +167,16 @@ def test_invalid_utf8_preserves_a_lone_cr_framed_prefix() -> None:
         next(events)
 
 
+def test_invalid_utf8_preserves_a_lone_cr_prefix_across_chunks() -> None:
+    decoder = SSEDecoder()
+    assert list(decoder.feed(b"data: [DONE]\r\r")) == []
+
+    events = decoder.feed(b"\xff")
+    assert next(events).data == "[DONE]"
+    with pytest.raises(SSEDecodeError, match="not valid UTF-8"):
+        next(events)
+
+
 def test_stream_ending_mid_character_raises_a_decode_error() -> None:
     decoder = SSEDecoder()
     list(decoder.feed(b"data: \xcf"))

--- a/tests/optimizer/test_sse_parser.py
+++ b/tests/optimizer/test_sse_parser.py
@@ -158,6 +158,15 @@ def test_invalid_utf8_raises_a_decode_error() -> None:
         list(decoder.feed(b"data: \xff\xfe\n\n"))
 
 
+def test_invalid_utf8_preserves_a_lone_cr_framed_prefix() -> None:
+    decoder = SSEDecoder()
+    events = decoder.feed(b"data: [DONE]\r\r\xff")
+
+    assert next(events).data == "[DONE]"
+    with pytest.raises(SSEDecodeError, match="not valid UTF-8"):
+        next(events)
+
+
 def test_stream_ending_mid_character_raises_a_decode_error() -> None:
     decoder = SSEDecoder()
     list(decoder.feed(b"data: \xcf"))


### PR DESCRIPTION
## Summary

- prevent artifact verification from blocking on FIFO paths
- bound response content so redaction expansion stays within verifier limits
- preserve complete lone-CR SSE prefixes before invalid UTF-8, including split chunks
- cover socket timeout adjustment races as typed transport failures

## Validation

- targeted collector tests: 642 passed
- full pytest suite: 1601 passed
- quality ratchet: passed
- ratchet tests: 44 passed
- wheel build and clean import: passed
- independent review: no remaining findings