### PR TITLE
fix(optimizer): harden persisted evidence parsing

### DIFF
--- a/llmtracefx/optimizer/_artifact_io.py
+++ b/llmtracefx/optimizer/_artifact_io.py
@@ -53,7 +53,10 @@ def read_bounded_regular_bytes(path: str | Path, max_bytes: int) -> bytes:
         raise ArtifactReadError(f"{artifact_path} must not be a symlink")
 
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-    descriptor = os.open(artifact_path, flags)
+    try:
+        descriptor = os.open(artifact_path, flags)
+    except (ValueError, UnicodeError) as exc:
+        raise ArtifactReadError(f"{artifact_path!s} is not a valid file path") from exc
 
     try:
         metadata = os.fstat(descriptor)

--- a/llmtracefx/optimizer/_artifact_io.py
+++ b/llmtracefx/optimizer/_artifact_io.py
@@ -14,8 +14,8 @@ class ArtifactReadError(ValueError):
     """Raised when an artifact is not a bounded, regular UTF-8 file."""
 
 
-def read_bounded_regular_text(path: str | Path, max_bytes: int) -> str:
-    """Read a regular UTF-8 file without following symlinks or exceeding a limit.
+def read_bounded_regular_bytes(path: str | Path, max_bytes: int) -> bytes:
+    """Read a regular file without following symlinks or exceeding a limit.
 
     Filesystem failures remain ``OSError`` so callers can distinguish a missing
     artifact from one that exists but is structurally unsafe.
@@ -51,7 +51,13 @@ def read_bounded_regular_text(path: str | Path, max_bytes: int) -> str:
     finally:
         os.close(descriptor)
 
+    return b"".join(chunks)
+
+
+def read_bounded_regular_text(path: str | Path, max_bytes: int) -> str:
+    """Read a bounded regular file and require strict UTF-8."""
+    raw = read_bounded_regular_bytes(path, max_bytes)
     try:
-        return b"".join(chunks).decode("utf-8")
+        return raw.decode("utf-8")
     except UnicodeDecodeError as exc:
-        raise ArtifactReadError(f"{artifact_path} is not valid UTF-8") from exc
+        raise ArtifactReadError(f"{path} is not valid UTF-8") from exc

--- a/llmtracefx/optimizer/_artifact_io.py
+++ b/llmtracefx/optimizer/_artifact_io.py
@@ -3,16 +3,38 @@
 from __future__ import annotations
 
 import os
+import re
 import stat
 from pathlib import Path
 from typing import NoReturn
 
 MAX_METADATA_ARTIFACT_BYTES = 64 * 1024
 MAX_EVIDENCE_ARTIFACT_BYTES = 64 * 1024 * 1024
+_SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 class ArtifactReadError(ValueError):
     """Raised when an artifact is not a bounded, regular UTF-8 file."""
+
+
+def unsafe_run_id_reason(run_id: str) -> str | None:
+    """Return why a run ID is unsafe as a path component, if applicable."""
+    if not run_id:
+        return "run_id is empty"
+    if run_id in (".", ".."):
+        return "run_id is a relative directory reference"
+    if os.path.isabs(run_id) or os.path.splitdrive(run_id)[0]:
+        return "run_id is an absolute path"
+    if "/" in run_id or "\\" in run_id or os.sep in run_id:
+        return "run_id contains a path separator"
+    if "\x00" in run_id:
+        return "run_id contains a null byte"
+    if not _SAFE_RUN_ID.fullmatch(run_id):
+        return (
+            "run_id is not a single safe path component matching "
+            "[A-Za-z0-9][A-Za-z0-9._-]{0,127}"
+        )
+    return None
 
 
 def reject_non_finite_json_constant(value: str) -> NoReturn:

--- a/llmtracefx/optimizer/_artifact_io.py
+++ b/llmtracefx/optimizer/_artifact_io.py
@@ -1,0 +1,57 @@
+"""Bounded reads for persisted optimizer artifacts."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+MAX_METADATA_ARTIFACT_BYTES = 64 * 1024
+MAX_EVIDENCE_ARTIFACT_BYTES = 64 * 1024 * 1024
+
+
+class ArtifactReadError(ValueError):
+    """Raised when an artifact is not a bounded, regular UTF-8 file."""
+
+
+def read_bounded_regular_text(path: str | Path, max_bytes: int) -> str:
+    """Read a regular UTF-8 file without following symlinks or exceeding a limit.
+
+    Filesystem failures remain ``OSError`` so callers can distinguish a missing
+    artifact from one that exists but is structurally unsafe.
+    """
+    artifact_path = Path(path)
+    if artifact_path.is_symlink():
+        raise ArtifactReadError(f"{artifact_path} must not be a symlink")
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    descriptor = os.open(artifact_path, flags)
+
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ArtifactReadError(f"{artifact_path} must be a regular file")
+        if metadata.st_size > max_bytes:
+            raise ArtifactReadError(
+                f"{artifact_path} exceeds the {max_bytes}-byte size limit"
+            )
+
+        chunks: list[bytes] = []
+        bytes_read = 0
+        while True:
+            chunk = os.read(descriptor, min(64 * 1024, max_bytes - bytes_read + 1))
+            if not chunk:
+                break
+            bytes_read += len(chunk)
+            if bytes_read > max_bytes:
+                raise ArtifactReadError(
+                    f"{artifact_path} exceeds the {max_bytes}-byte size limit"
+                )
+            chunks.append(chunk)
+    finally:
+        os.close(descriptor)
+
+    try:
+        return b"".join(chunks).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ArtifactReadError(f"{artifact_path} is not valid UTF-8") from exc

--- a/llmtracefx/optimizer/_artifact_io.py
+++ b/llmtracefx/optimizer/_artifact_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
+from typing import NoReturn
 
 MAX_METADATA_ARTIFACT_BYTES = 64 * 1024
 MAX_EVIDENCE_ARTIFACT_BYTES = 64 * 1024 * 1024
@@ -12,6 +13,11 @@ MAX_EVIDENCE_ARTIFACT_BYTES = 64 * 1024 * 1024
 
 class ArtifactReadError(ValueError):
     """Raised when an artifact is not a bounded, regular UTF-8 file."""
+
+
+def reject_non_finite_json_constant(value: str) -> NoReturn:
+    """Reject Python's non-standard JSON NaN and infinity extensions."""
+    raise ValueError(f"non-finite JSON number {value}")
 
 
 def read_bounded_regular_bytes(path: str | Path, max_bytes: int) -> bytes:

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -762,17 +762,30 @@ class InstrumentsEvidence:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> InstrumentsEvidence:
+        data = _require_object(data, context="InstrumentsEvidence")
         metrics_data = data.get("metrics", {})
         if not isinstance(metrics_data, dict):
             raise SchemaValidationError(
                 f"InstrumentsEvidence.metrics must be an object, got {metrics_data!r}"
             )
+        if not all(isinstance(name, str) for name in metrics_data):
+            raise SchemaValidationError(
+                "InstrumentsEvidence.metrics keys must be strings"
+            )
         return cls(
-            tool=str(data.get("tool", "xctrace")),
-            tool_version=data.get("tool_version"),
-            capability=data.get("capability"),
-            template=data.get("template"),
-            trace_bundle_name=data.get("trace_bundle_name"),
+            tool=_string_with_default(
+                data, "tool", context="InstrumentsEvidence", default="xctrace"
+            ),
+            tool_version=_optional_string(
+                data, "tool_version", context="InstrumentsEvidence"
+            ),
+            capability=_optional_string(
+                data, "capability", context="InstrumentsEvidence"
+            ),
+            template=_optional_string(data, "template", context="InstrumentsEvidence"),
+            trace_bundle_name=_optional_string(
+                data, "trace_bundle_name", context="InstrumentsEvidence"
+            ),
             available_schemas=_coerce_str_tuple(
                 data, "available_schemas", context="InstrumentsEvidence"
             ),
@@ -783,10 +796,10 @@ class InstrumentsEvidence:
                 data, "unsupported_schemas", context="InstrumentsEvidence"
             ),
             metrics={
-                str(name): Measurement.from_dict(value)
+                name: Measurement.from_dict(value)
                 for name, value in metrics_data.items()
             },
-            notes=data.get("notes"),
+            notes=_optional_string(data, "notes", context="InstrumentsEvidence"),
         )
 
 

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -25,11 +25,25 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from ._artifact_io import (
+    MAX_EVIDENCE_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+)
+
 SCHEMA_VERSION = "1"
 
 
 class SchemaValidationError(ValueError):
     """Raised when an ``ExperimentRecord`` (or a part of it) is invalid."""
+
+
+def _require_object(value: Any, *, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SchemaValidationError(
+            f"{context} must be an object, got {type(value).__name__}"
+        )
+    return value
 
 
 def utc_now_iso() -> str:
@@ -90,9 +104,12 @@ class Measurement:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Measurement:
+        data = _require_object(data, context="Measurement")
         try:
             return cls(
-                value=float(data["value"]),
+                value=_validate_float(
+                    data["value"], context="Measurement", key="value"
+                ),
                 provenance=MetricProvenance(data["provenance"]),
                 unit=str(data.get("unit", "")),
             )
@@ -100,7 +117,7 @@ class Measurement:
             raise SchemaValidationError(
                 f"Measurement is missing required field: {exc}"
             ) from exc
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             raise SchemaValidationError(
                 f"Measurement has an invalid value: {exc}"
             ) from exc
@@ -232,6 +249,7 @@ class PlatformInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PlatformInfo:
+        data = _require_object(data, context="PlatformInfo")
         try:
             return cls(
                 os_name=data["os_name"],
@@ -272,6 +290,7 @@ class ModelInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ModelInfo:
+        data = _require_object(data, context="ModelInfo")
         try:
             return cls(
                 model_id=data["model_id"],
@@ -308,6 +327,7 @@ class RuntimeInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInfo:
+        data = _require_object(data, context="RuntimeInfo")
         try:
             return cls(
                 name=data["name"],
@@ -339,6 +359,7 @@ class CommandInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CommandInfo:
+        data = _require_object(data, context="CommandInfo")
         if "argv" not in data:
             raise SchemaValidationError("CommandInfo is missing required field: 'argv'")
         argv = data["argv"]
@@ -380,6 +401,7 @@ class RepetitionInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RepetitionInfo:
+        data = _require_object(data, context="RepetitionInfo")
         return cls(
             warmup_repetitions=_coerce_required_int(
                 data, "warmup_repetitions", context="RepetitionInfo"
@@ -420,6 +442,7 @@ class TokenCounts:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TokenCounts:
+        data = _require_object(data, context="TokenCounts")
         provenance = data.get("provenance")
         if provenance is not None:
             try:
@@ -464,6 +487,7 @@ class TimingMetrics:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TimingMetrics:
+        data = _require_object(data, context="TimingMetrics")
         return cls(
             model_load=_measurement_from_optional(data.get("model_load")),
             tokenize=_measurement_from_optional(data.get("tokenize")),
@@ -512,6 +536,7 @@ class SpeculativeDecodingInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SpeculativeDecodingInfo:
+        data = _require_object(data, context="SpeculativeDecodingInfo")
         return cls(
             enabled=_coerce_bool_with_default(
                 data, "enabled", context="SpeculativeDecodingInfo", default=False
@@ -549,6 +574,7 @@ class MemoryMetrics:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MemoryMetrics:
+        data = _require_object(data, context="MemoryMetrics")
         return cls(
             active=_measurement_from_optional(data.get("active")),
             cache=_measurement_from_optional(data.get("cache")),
@@ -572,6 +598,7 @@ class PowerMetrics:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PowerMetrics:
+        data = _require_object(data, context="PowerMetrics")
         return cls(
             average_power=_measurement_from_optional(data.get("average_power")),
             energy=_measurement_from_optional(data.get("energy")),
@@ -728,6 +755,7 @@ class OutcomeInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> OutcomeInfo:
+        data = _require_object(data, context="OutcomeInfo")
         return cls(
             success=_coerce_bool_with_default(
                 data, "success", context="OutcomeInfo", default=True
@@ -752,6 +780,7 @@ class ErrorInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ErrorInfo:
+        data = _require_object(data, context="ErrorInfo")
         try:
             return cls(category=data["category"], message=data["message"])
         except KeyError as exc:
@@ -1001,6 +1030,7 @@ class ExperimentRecord:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExperimentRecord:
+        data = _require_object(data, context="ExperimentRecord")
         try:
             record = cls(
                 schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
@@ -1042,7 +1072,7 @@ class ExperimentRecord:
     def from_json(cls, payload: str) -> ExperimentRecord:
         try:
             data = json.loads(payload)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, RecursionError) as exc:
             raise SchemaValidationError(
                 f"Invalid JSON for ExperimentRecord: {exc}"
             ) from exc
@@ -1068,4 +1098,10 @@ class ExperimentRecord:
 
     @classmethod
     def read_json(cls, path: str | Path) -> ExperimentRecord:
-        return cls.from_json(Path(path).read_text(encoding="utf-8"))
+        try:
+            payload = read_bounded_regular_text(path, MAX_EVIDENCE_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise SchemaValidationError(
+                f"Invalid ExperimentRecord file: {exc}"
+            ) from exc
+        return cls.from_json(payload)

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -46,6 +46,32 @@ def _require_object(value: Any, *, context: str) -> dict[str, Any]:
     return value
 
 
+def _required_string(data: dict[str, Any], key: str, *, context: str) -> str:
+    if key not in data:
+        raise SchemaValidationError(f"{context} is missing required field: '{key}'")
+    value = data[key]
+    if not isinstance(value, str):
+        raise SchemaValidationError(f"{context}.{key} must be a string, got {value!r}")
+    return value
+
+
+def _optional_string(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, str):
+        raise SchemaValidationError(
+            f"{context}.{key} must be a string or null, got {value!r}"
+        )
+    return value
+
+
+def _string_with_default(
+    data: dict[str, Any], key: str, *, context: str, default: str
+) -> str:
+    if key not in data:
+        return default
+    return _required_string(data, key, context=context)
+
+
 def utc_now_iso() -> str:
     """Return the current UTC time as an ISO-8601 string ending in ``Z``."""
     return (
@@ -111,7 +137,9 @@ class Measurement:
                     data["value"], context="Measurement", key="value"
                 ),
                 provenance=MetricProvenance(data["provenance"]),
-                unit=str(data.get("unit", "")),
+                unit=_string_with_default(
+                    data, "unit", context="Measurement", default=""
+                ),
             )
         except KeyError as exc:
             raise SchemaValidationError(
@@ -257,17 +285,21 @@ class PlatformInfo:
         data = _require_object(data, context="PlatformInfo")
         try:
             return cls(
-                os_name=data["os_name"],
-                os_version=data["os_version"],
-                architecture=data["architecture"],
-                cpu_model=data.get("cpu_model"),
+                os_name=_required_string(data, "os_name", context="PlatformInfo"),
+                os_version=_required_string(data, "os_version", context="PlatformInfo"),
+                architecture=_required_string(
+                    data, "architecture", context="PlatformInfo"
+                ),
+                cpu_model=_optional_string(data, "cpu_model", context="PlatformInfo"),
                 cpu_cores=_coerce_optional_int(
                     data, "cpu_cores", context="PlatformInfo"
                 ),
                 total_memory_gb=_coerce_optional_float(
                     data, "total_memory_gb", context="PlatformInfo"
                 ),
-                accelerator=data.get("accelerator"),
+                accelerator=_optional_string(
+                    data, "accelerator", context="PlatformInfo"
+                ),
             )
         except KeyError as exc:
             raise SchemaValidationError(
@@ -298,11 +330,19 @@ class ModelInfo:
         data = _require_object(data, context="ModelInfo")
         try:
             return cls(
-                model_id=data["model_id"],
-                model_revision=data.get("model_revision"),
-                tokenizer_revision=data.get("tokenizer_revision"),
-                quantization=data.get("quantization"),
-                model_family=data.get("model_family"),
+                model_id=_required_string(data, "model_id", context="ModelInfo"),
+                model_revision=_optional_string(
+                    data, "model_revision", context="ModelInfo"
+                ),
+                tokenizer_revision=_optional_string(
+                    data, "tokenizer_revision", context="ModelInfo"
+                ),
+                quantization=_optional_string(
+                    data, "quantization", context="ModelInfo"
+                ),
+                model_family=_optional_string(
+                    data, "model_family", context="ModelInfo"
+                ),
             )
         except KeyError as exc:
             raise SchemaValidationError(
@@ -335,11 +375,13 @@ class RuntimeInfo:
         data = _require_object(data, context="RuntimeInfo")
         try:
             return cls(
-                name=data["name"],
-                version=data.get("version"),
-                backend=data.get("backend"),
-                git_revision=data.get("git_revision"),
-                provider=data.get("provider"),
+                name=_required_string(data, "name", context="RuntimeInfo"),
+                version=_optional_string(data, "version", context="RuntimeInfo"),
+                backend=_optional_string(data, "backend", context="RuntimeInfo"),
+                git_revision=_optional_string(
+                    data, "git_revision", context="RuntimeInfo"
+                ),
+                provider=_optional_string(data, "provider", context="RuntimeInfo"),
             )
         except KeyError as exc:
             raise SchemaValidationError(
@@ -386,8 +428,10 @@ class CommandInfo:
             )
         return cls(
             argv=argv_tuple,
-            config_hash=data.get("config_hash"),
-            workload_hash=data.get("workload_hash"),
+            config_hash=_optional_string(data, "config_hash", context="CommandInfo"),
+            workload_hash=_optional_string(
+                data, "workload_hash", context="CommandInfo"
+            ),
         )
 
 
@@ -546,7 +590,7 @@ class SpeculativeDecodingInfo:
             enabled=_coerce_bool_with_default(
                 data, "enabled", context="SpeculativeDecodingInfo", default=False
             ),
-            method=data.get("method"),
+            method=_optional_string(data, "method", context="SpeculativeDecodingInfo"),
             configured_depth=_coerce_optional_int(
                 data, "configured_depth", context="SpeculativeDecodingInfo"
             ),
@@ -768,8 +812,10 @@ class OutcomeInfo:
             quality_score=_coerce_optional_float(
                 data, "quality_score", context="OutcomeInfo"
             ),
-            quality_metric=data.get("quality_metric"),
-            notes=data.get("notes"),
+            quality_metric=_optional_string(
+                data, "quality_metric", context="OutcomeInfo"
+            ),
+            notes=_optional_string(data, "notes", context="OutcomeInfo"),
         )
 
 
@@ -787,7 +833,10 @@ class ErrorInfo:
     def from_dict(cls, data: dict[str, Any]) -> ErrorInfo:
         data = _require_object(data, context="ErrorInfo")
         try:
-            return cls(category=data["category"], message=data["message"])
+            return cls(
+                category=_required_string(data, "category", context="ErrorInfo"),
+                message=_required_string(data, "message", context="ErrorInfo"),
+            )
         except KeyError as exc:
             raise SchemaValidationError(
                 f"ErrorInfo is missing required field: {exc}"
@@ -1038,10 +1087,17 @@ class ExperimentRecord:
         data = _require_object(data, context="ExperimentRecord")
         try:
             record = cls(
-                schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
-                run_id=data["run_id"],
-                started_at=data["started_at"],
-                ended_at=data.get("ended_at"),
+                schema_version=_string_with_default(
+                    data,
+                    "schema_version",
+                    context="ExperimentRecord",
+                    default=SCHEMA_VERSION,
+                ),
+                run_id=_required_string(data, "run_id", context="ExperimentRecord"),
+                started_at=_required_string(
+                    data, "started_at", context="ExperimentRecord"
+                ),
+                ended_at=_optional_string(data, "ended_at", context="ExperimentRecord"),
                 platform=PlatformInfo.from_dict(data["platform"]),
                 model=ModelInfo.from_dict(data["model"]),
                 runtime=RuntimeInfo.from_dict(data["runtime"]),

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -29,6 +29,7 @@ from ._artifact_io import (
     MAX_EVIDENCE_ARTIFACT_BYTES,
     ArtifactReadError,
     read_bounded_regular_text,
+    reject_non_finite_json_constant,
 )
 
 SCHEMA_VERSION = "1"
@@ -1083,7 +1084,9 @@ class ExperimentRecord:
         return json.dumps(self.to_dict(), indent=indent, sort_keys=False)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ExperimentRecord:
+    def from_dict(
+        cls, data: dict[str, Any], *, allow_non_finite: bool = False
+    ) -> ExperimentRecord:
         data = _require_object(data, context="ExperimentRecord")
         try:
             record = cls(
@@ -1127,12 +1130,26 @@ class ExperimentRecord:
                 f"ExperimentRecord is missing required field: {exc}"
             ) from exc
         record.validate()
+        if not allow_non_finite:
+            try:
+                json.dumps(record.to_dict(), allow_nan=False)
+            except ValueError as exc:
+                raise SchemaValidationError(
+                    "ExperimentRecord numeric fields must be finite"
+                ) from exc
         return record
 
     @classmethod
-    def from_json(cls, payload: str) -> ExperimentRecord:
+    def from_json(
+        cls, payload: str, *, allow_non_finite: bool = False
+    ) -> ExperimentRecord:
         try:
-            data = json.loads(payload)
+            data = json.loads(
+                payload,
+                parse_constant=(
+                    None if allow_non_finite else reject_non_finite_json_constant
+                ),
+            )
         except (ValueError, RecursionError) as exc:
             raise SchemaValidationError(
                 f"Invalid JSON for ExperimentRecord: {exc}"
@@ -1146,7 +1163,7 @@ class ExperimentRecord:
             raise SchemaValidationError(
                 f"ExperimentRecord JSON must be an object, got {type(data).__name__}"
             )
-        return cls.from_dict(data)
+        return cls.from_dict(data, allow_non_finite=allow_non_finite)
 
     def write_json(self, path: str | Path) -> None:
         """Atomically write this record as pretty JSON to ``path``."""
@@ -1158,11 +1175,13 @@ class ExperimentRecord:
         os.replace(tmp_path, target)
 
     @classmethod
-    def read_json(cls, path: str | Path) -> ExperimentRecord:
+    def read_json(
+        cls, path: str | Path, *, allow_non_finite: bool = False
+    ) -> ExperimentRecord:
         try:
             payload = read_bounded_regular_text(path, MAX_EVIDENCE_ARTIFACT_BYTES)
         except ArtifactReadError as exc:
             raise SchemaValidationError(
                 f"Invalid ExperimentRecord file: {exc}"
             ) from exc
-        return cls.from_json(payload)
+        return cls.from_json(payload, allow_non_finite=allow_non_finite)

--- a/llmtracefx/optimizer/schema.py
+++ b/llmtracefx/optimizer/schema.py
@@ -172,7 +172,12 @@ def _validate_float(value: Any, *, context: str, key: str) -> float:
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise SchemaValidationError(f"{context}.{key} must be a number, got {value!r}")
-    return float(value)
+    try:
+        return float(value)
+    except OverflowError as exc:
+        raise SchemaValidationError(
+            f"{context}.{key} must be a finite number, got an overflowing integer"
+        ) from exc
 
 
 def _coerce_optional_float(
@@ -1072,7 +1077,7 @@ class ExperimentRecord:
     def from_json(cls, payload: str) -> ExperimentRecord:
         try:
             data = json.loads(payload)
-        except (json.JSONDecodeError, RecursionError) as exc:
+        except (ValueError, RecursionError) as exc:
             raise SchemaValidationError(
                 f"Invalid JSON for ExperimentRecord: {exc}"
             ) from exc

--- a/llmtracefx/optimizer/tune/loader.py
+++ b/llmtracefx/optimizer/tune/loader.py
@@ -4,8 +4,7 @@ Consumes exactly the artifacts PR #6's verification pipeline produces:
 ``<results_dir>/runs/<run_id>/verification.json`` and the
 ``final_record.json`` it references. Never trusts a ``verification.json``
 summary at face value -- the referenced ``final_record.json`` is always
-re-read and re-validated (``ExperimentRecord.from_json`` already enforces
-the canonical schema), and run/workload/hash identity between the two
+re-read and structurally validated, and run/workload/hash identity between the two
 artifacts is re-checked here. A row whose identity does not check out is
 excluded entirely (not merely rejected as a candidate) because nothing
 about it can be trusted enough to even place it in a comparable group.
@@ -172,7 +171,9 @@ def _load_one_run(
         verification.final_record_path, results_dir=results_dir, run_id=run_id
     )
     try:
-        record = ExperimentRecord.read_json(final_record_path)
+        # Preserve legacy tune diagnostics: the tuner classifies non-finite
+        # measurements with field-specific rejection reasons.
+        record = ExperimentRecord.read_json(final_record_path, allow_non_finite=True)
     except OSError as exc:
         return None, ExcludedRun(
             run_id=verification.run_id,

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -26,6 +26,7 @@ side by side.
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -61,7 +62,15 @@ def _load_verifications(results_dir: Path) -> tuple[RowVerification, ...]:
     verifications: list[RowVerification] = []
     for verification_path in sorted(runs_dir.glob("*/verification.json")):
         try:
-            verifications.append(RowVerification.read_json(verification_path))
+            verification = RowVerification.read_json(verification_path)
+            if any(
+                value is not None and not math.isfinite(value)
+                for value in (verification.quality_score, verification.total_ms)
+            ):
+                raise VerifyError(
+                    "verification.json numeric summary fields must be finite"
+                )
+            verifications.append(verification)
         except (OSError, VerifyError):
             # A corrupt/partial artifact must not silently skew aggregates;
             # it is simply excluded rather than crashing the whole summary.

--- a/llmtracefx/optimizer/workloads/aggregate.py
+++ b/llmtracefx/optimizer/workloads/aggregate.py
@@ -62,7 +62,7 @@ def _load_verifications(results_dir: Path) -> tuple[RowVerification, ...]:
     for verification_path in sorted(runs_dir.glob("*/verification.json")):
         try:
             verifications.append(RowVerification.read_json(verification_path))
-        except (OSError, json.JSONDecodeError, VerifyError):
+        except (OSError, VerifyError):
             # A corrupt/partial artifact must not silently skew aggregates;
             # it is simply excluded rather than crashing the whole summary.
             continue

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -94,6 +94,7 @@ from .._artifact_io import (
     ArtifactReadError,
     read_bounded_regular_bytes,
     read_bounded_regular_text,
+    reject_non_finite_json_constant,
 )
 from ..collectors._shared import (
     atomic_write_text,
@@ -229,8 +230,8 @@ def run_artifacts_are_complete(run_dir: Path, *, expected_run_id: str) -> bool:
         marker_text = read_bounded_regular_text(
             run_dir / RUN_MANIFEST_NAME, MAX_METADATA_ARTIFACT_BYTES
         )
-        marker = json.loads(marker_text)
-    except (OSError, ArtifactReadError, json.JSONDecodeError, RecursionError):
+        marker = json.loads(marker_text, parse_constant=reject_non_finite_json_constant)
+    except (OSError, ArtifactReadError, ValueError, RecursionError):
         return False
     if not isinstance(marker, dict):
         return False

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -88,6 +88,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .._artifact_io import (
+    MAX_EVIDENCE_ARTIFACT_BYTES,
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_bytes,
+    read_bounded_regular_text,
+)
 from ..collectors._shared import (
     atomic_write_text,
     config_hash,
@@ -160,6 +167,11 @@ _SEALED_COLLECTION_MARKER = f"collection/{ARTIFACT_MANIFEST_NAME}"
 _SEALED_ARTIFACT_NAMES = frozenset(
     {_SEALED_COLLECTION_MARKER, "final_record.json", "verification.json"}
 )
+_SEALED_ARTIFACT_LIMITS = {
+    _SEALED_COLLECTION_MARKER: MAX_METADATA_ARTIFACT_BYTES,
+    "final_record.json": MAX_EVIDENCE_ARTIFACT_BYTES,
+    "verification.json": MAX_METADATA_ARTIFACT_BYTES,
+}
 
 
 def _run_marker_payload(
@@ -186,7 +198,12 @@ def _run_marker_payload(
         "schema_version": RUN_MANIFEST_SCHEMA_VERSION,
         "run_id": run_id,
         "artifacts": [
-            {"name": name, "sha256": sha256_bytes(path.read_bytes())}
+            {
+                "name": name,
+                "sha256": sha256_bytes(
+                    read_bounded_regular_bytes(path, _SEALED_ARTIFACT_LIMITS[name])
+                ),
+            }
             for name, path in (
                 (_SEALED_COLLECTION_MARKER, collection_dir / ARTIFACT_MANIFEST_NAME),
                 ("final_record.json", final_record_path),
@@ -209,8 +226,11 @@ def run_artifacts_are_complete(run_dir: Path, *, expected_run_id: str) -> bool:
     made without regenerating the marker.
     """
     try:
-        marker = json.loads((run_dir / RUN_MANIFEST_NAME).read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
+        marker_text = read_bounded_regular_text(
+            run_dir / RUN_MANIFEST_NAME, MAX_METADATA_ARTIFACT_BYTES
+        )
+        marker = json.loads(marker_text)
+    except (OSError, ArtifactReadError, json.JSONDecodeError, RecursionError):
         return False
     if not isinstance(marker, dict):
         return False
@@ -250,8 +270,10 @@ def run_artifacts_are_complete(run_dir: Path, *, expected_run_id: str) -> bool:
 
     for name, digest in sealed.items():
         try:
-            raw = (run_dir / name).read_bytes()
-        except OSError:
+            raw = read_bounded_regular_bytes(
+                run_dir / name, _SEALED_ARTIFACT_LIMITS[name]
+            )
+        except (OSError, ArtifactReadError):
             return False
         if sha256_bytes(raw) != digest:
             return False

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -134,6 +134,7 @@ from .verify import (
     RowStatus,
     RowVerification,
     VerifyError,
+    _record_is_safe_to_resume,
     select_entries,
 )
 
@@ -1323,9 +1324,11 @@ def execute_api_row(
                 trusted_record = ExperimentRecord.read_json(final_record_path)
             except (OSError, UnicodeError, SchemaValidationError):
                 trusted_record = None
-            # The record carries its own run_id, and a copied directory
-            # is exactly the case where it disagrees with this row.
-            if trusted_record is not None and trusted_record.run_id != entry.run_id:
+            if trusted_record is not None and not _record_is_safe_to_resume(
+                trusted_record,
+                expected_run_id=entry.run_id,
+                expected_model_id=binding.model_id,
+            ):
                 trusted_record = None
             if trusted_record is not None:
                 return _finish(

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -82,7 +82,6 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
-import re
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -95,6 +94,7 @@ from .._artifact_io import (
     read_bounded_regular_bytes,
     read_bounded_regular_text,
     reject_non_finite_json_constant,
+    unsafe_run_id_reason,
 )
 from ..collectors._shared import (
     atomic_write_text,
@@ -631,46 +631,6 @@ class APIBinding:
 # --- Planning ----------------------------------------------------------------
 
 
-#: A run_id becomes a directory name, so it has to be one path component
-#: and nothing more. The generated ids are ``<workload>-<tier>-<mode>``
-#: with an optional ``-depth<n>``, so this is the shape they already have.
-_SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-
-
-def _unsafe_run_id_reason(run_id: str) -> str | None:
-    """Why ``run_id`` cannot be used as a directory name, or ``None``.
-
-    A run_id is read straight out of the matrix manifest, which is a file
-    on disk, and is then joined onto the output directory. An absolute
-    value replaces the output directory outright; ``..`` climbs out of it;
-    a separator plants artifacts somewhere nobody asked for. None of that
-    needs an attacker, either: a hand-edited manifest is enough to have a
-    run quietly write outside the directory the caller named.
-
-    The value is not echoed. It failed this check, which is exactly the
-    circumstance in which repeating it is a bad idea.
-    """
-    if not isinstance(run_id, str) or not run_id:
-        return "run_id is empty"
-    if run_id in (".", ".."):
-        return "run_id is a relative directory reference"
-    if os.path.isabs(run_id) or os.path.splitdrive(run_id)[0]:
-        return "run_id is an absolute path"
-    if "/" in run_id or "\\" in run_id or os.sep in run_id:
-        return "run_id contains a path separator"
-    if "\x00" in run_id:
-        return "run_id contains a null byte"
-    # ``fullmatch`` rather than ``match``: ``$`` also matches just
-    # before a trailing newline, so ``match`` would accept "row\\n" and
-    # create a directory whose name the refusal text says is impossible.
-    if not _SAFE_RUN_ID.fullmatch(run_id):
-        return (
-            "run_id is not a single safe path component matching "
-            "[A-Za-z0-9][A-Za-z0-9._-]{0,127}"
-        )
-    return None
-
-
 def _run_dir(entry: MatrixEntry, *, output_dir: Path) -> Path:
     return output_dir / "runs" / entry.run_id
 
@@ -813,7 +773,7 @@ def plan_api_row(
     # what a real run would do rather than printing a plan for a row that
     # would then be rejected. The path is not echoed either way: it is
     # rejected precisely because of what it may contain.
-    refusal = _unsafe_run_id_reason(entry.run_id)
+    refusal = unsafe_run_id_reason(entry.run_id)
     if (
         refusal is None
         and credential
@@ -865,8 +825,10 @@ def plan_api_row(
         blockers.append(f"prompt file missing: {prompt_path}")
     else:
         try:
-            prompt_text = prompt_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError) as exc:
+            prompt_text = read_bounded_regular_text(
+                prompt_path, MAX_EVIDENCE_ARTIFACT_BYTES
+            )
+        except (OSError, ArtifactReadError) as exc:
             blockers.append(f"prompt file unreadable: {exc}")
         else:
             verified_hash = sha256_text(prompt_text)
@@ -1076,7 +1038,7 @@ def execute_api_row(
     # the rejection paths, so an unsafe id would have its refusal written
     # to the very place it should not reach. Nothing is written here for
     # the same reason: there is no directory this row may safely touch.
-    refusal = _unsafe_run_id_reason(entry.run_id)
+    refusal = unsafe_run_id_reason(entry.run_id)
     if refusal is None and credential is not None:
         candidate = _run_dir(entry, output_dir=output_dir)
         if _contains_credential(str(candidate), credential):
@@ -1225,8 +1187,10 @@ def execute_api_row(
         return _finish(RowStatus.FAILED, f"prompt file missing: {prompt_path}")
 
     try:
-        prompt_text = prompt_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError) as exc:
+        prompt_text = read_bounded_regular_text(
+            prompt_path, MAX_EVIDENCE_ARTIFACT_BYTES
+        )
+    except (OSError, ArtifactReadError) as exc:
         return _finish(RowStatus.FAILED, f"prompt file unreadable: {exc}")
 
     verified_hash = sha256_text(prompt_text)

--- a/llmtracefx/optimizer/workloads/api_verify.py
+++ b/llmtracefx/optimizer/workloads/api_verify.py
@@ -1163,7 +1163,7 @@ def execute_api_row(
                     )
                     + "\n",
                 )
-            except OSError:
+            except (OSError, ArtifactReadError):
                 # A marker that cannot be written simply is not written.
                 # The row's evidence still stands on its own; only resume
                 # declines to trust it, which is the safe direction.

--- a/llmtracefx/optimizer/workloads/materialize.py
+++ b/llmtracefx/optimizer/workloads/materialize.py
@@ -78,6 +78,10 @@ class MaterializedPrompt:
         prompt-integrity check the verification pipeline performs before
         executing any row.
         """
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"MaterializedPrompt must be an object, got {type(data).__name__}"
+            )
         try:
             return cls(
                 workload_id=data["workload_id"],
@@ -89,10 +93,8 @@ class MaterializedPrompt:
                 text="",
                 prompt_hash=data["prompt_hash"],
             )
-        except KeyError as exc:
-            raise ValueError(
-                f"MaterializedPrompt is missing required field: {exc}"
-            ) from exc
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"invalid MaterializedPrompt: {exc}") from exc
 
 
 def _build_filler(remaining_chars: int) -> tuple[str, int]:

--- a/llmtracefx/optimizer/workloads/materialize.py
+++ b/llmtracefx/optimizer/workloads/materialize.py
@@ -39,6 +39,24 @@ from .schema import (
 APPROX_CHARS_PER_TOKEN = 4
 
 
+def _required_string(data: dict[str, Any], key: str) -> str:
+    if key not in data:
+        raise ValueError(f"missing required field: '{key}'")
+    value = data[key]
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def _required_integer(data: dict[str, Any], key: str) -> int:
+    if key not in data:
+        raise ValueError(f"missing required field: '{key}'")
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
 @dataclass(frozen=True)
 class MaterializedPrompt:
     """The fully materialized prompt text plus its planning metadata."""
@@ -84,16 +102,18 @@ class MaterializedPrompt:
             )
         try:
             return cls(
-                workload_id=data["workload_id"],
-                workload_version=data["workload_version"],
-                context_tier=ContextTier(data["context_tier"]),
-                target_context_tokens=int(data["target_context_tokens"]),
-                approx_chars_per_token=int(data["approx_chars_per_token"]),
-                filler_segments_used=int(data["filler_segments_used"]),
+                workload_id=_required_string(data, "workload_id"),
+                workload_version=_required_string(data, "workload_version"),
+                context_tier=ContextTier(_required_string(data, "context_tier")),
+                target_context_tokens=_required_integer(data, "target_context_tokens"),
+                approx_chars_per_token=_required_integer(
+                    data, "approx_chars_per_token"
+                ),
+                filler_segments_used=_required_integer(data, "filler_segments_used"),
                 text="",
-                prompt_hash=data["prompt_hash"],
+                prompt_hash=_required_string(data, "prompt_hash"),
             )
-        except (KeyError, TypeError, ValueError) as exc:
+        except (KeyError, TypeError, ValueError, OverflowError) as exc:
             raise ValueError(f"invalid MaterializedPrompt: {exc}") from exc
 
 

--- a/llmtracefx/optimizer/workloads/matrix.py
+++ b/llmtracefx/optimizer/workloads/matrix.py
@@ -24,6 +24,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .._artifact_io import (
+    MAX_EVIDENCE_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+)
 from ..collectors._shared import atomic_write_text
 from ..collectors.native_mtp import detect_native_mtp_capability
 from .catalog import WORKLOADS
@@ -46,6 +51,32 @@ DEFAULT_MAX_TOKENS = 128
 
 class MatrixSchemaError(ValueError):
     """Raised when a persisted matrix manifest is malformed."""
+
+
+def _required_string(data: dict[str, Any], key: str, *, context: str) -> str:
+    try:
+        value = data[key]
+    except KeyError as exc:
+        raise MatrixSchemaError(
+            f"{context} is missing required field: '{key}'"
+        ) from exc
+    if not isinstance(value, str):
+        raise MatrixSchemaError(f"{context}.{key} must be a string")
+    return value
+
+
+def _optional_string(data: dict[str, Any], key: str, *, context: str) -> str | None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, str):
+        raise MatrixSchemaError(f"{context}.{key} must be a string or null")
+    return value
+
+
+def _integer(data: dict[str, Any], key: str, *, context: str, default: int) -> int:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MatrixSchemaError(f"{context}.{key} must be an integer")
+    return value
 
 
 @dataclass(frozen=True)
@@ -89,6 +120,10 @@ class MatrixEntry:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MatrixEntry:
+        if not isinstance(data, dict):
+            raise MatrixSchemaError(
+                f"MatrixEntry must be an object, got {type(data).__name__}"
+            )
         try:
             command_argv = data["command_argv"]
             if isinstance(command_argv, (str, bytes)) or not isinstance(
@@ -98,27 +133,67 @@ class MatrixEntry:
                     f"MatrixEntry.command_argv must be a list of strings, "
                     f"got {command_argv!r}"
                 )
+            if not all(isinstance(item, str) and item for item in command_argv):
+                raise MatrixSchemaError(
+                    "MatrixEntry.command_argv must contain non-empty strings"
+                )
+            configured_depth = data.get("configured_depth")
+            if configured_depth is not None and (
+                isinstance(configured_depth, bool)
+                or not isinstance(configured_depth, int)
+            ):
+                raise MatrixSchemaError(
+                    "MatrixEntry.configured_depth must be an integer or null"
+                )
+            runnable = data["runnable"]
+            if not isinstance(runnable, bool):
+                raise MatrixSchemaError("MatrixEntry.runnable must be a boolean")
             return cls(
-                run_id=data["run_id"],
-                workload_id=data["workload_id"],
-                workload_version=data["workload_version"],
-                category=data["category"],
-                context_tier=data["context_tier"],
-                decode_mode=data["decode_mode"],
-                configured_depth=data.get("configured_depth"),
+                run_id=_required_string(data, "run_id", context="MatrixEntry"),
+                workload_id=_required_string(
+                    data, "workload_id", context="MatrixEntry"
+                ),
+                workload_version=_required_string(
+                    data, "workload_version", context="MatrixEntry"
+                ),
+                category=_required_string(data, "category", context="MatrixEntry"),
+                context_tier=_required_string(
+                    data, "context_tier", context="MatrixEntry"
+                ),
+                decode_mode=_required_string(
+                    data, "decode_mode", context="MatrixEntry"
+                ),
+                configured_depth=configured_depth,
                 prompt=MaterializedPrompt.from_dict(data["prompt"]),
-                prompt_path=data["prompt_path"],
-                runner_results_dir=data["runner_results_dir"],
-                collector_output_dir=data["collector_output_dir"],
-                runnable=bool(data["runnable"]),
-                unsupported_reason=data.get("unsupported_reason"),
+                prompt_path=_required_string(
+                    data, "prompt_path", context="MatrixEntry"
+                ),
+                runner_results_dir=_required_string(
+                    data, "runner_results_dir", context="MatrixEntry"
+                ),
+                collector_output_dir=_required_string(
+                    data, "collector_output_dir", context="MatrixEntry"
+                ),
+                runnable=runnable,
+                unsupported_reason=_optional_string(
+                    data, "unsupported_reason", context="MatrixEntry"
+                ),
                 command_argv=tuple(command_argv),
-                max_tokens=int(data.get("max_tokens", DEFAULT_MAX_TOKENS)),
+                max_tokens=_integer(
+                    data,
+                    "max_tokens",
+                    context="MatrixEntry",
+                    default=DEFAULT_MAX_TOKENS,
+                ),
             )
         except KeyError as exc:
             raise MatrixSchemaError(
                 f"MatrixEntry is missing required field: {exc}"
             ) from exc
+        except (TypeError, ValueError) as exc:
+            if isinstance(exc, MatrixSchemaError):
+                raise
+            raise MatrixSchemaError(f"invalid MatrixEntry: {exc}") from exc
 
 
 @dataclass(frozen=True)
@@ -145,15 +220,31 @@ class MatrixManifest:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MatrixManifest:
+        if not isinstance(data, dict):
+            raise MatrixSchemaError(
+                f"MatrixManifest must be an object, got {type(data).__name__}"
+            )
         try:
             entries_raw = data["entries"]
             if not isinstance(entries_raw, list):
                 raise MatrixSchemaError("MatrixManifest.entries must be a list")
             return cls(
-                schema_version=str(data.get("schema_version", MATRIX_SCHEMA_VERSION)),
-                model_id=data["model_id"],
-                model_family=data["model_family"],
-                output_dir=data["output_dir"],
+                schema_version=_required_string(
+                    {
+                        "schema_version": data.get(
+                            "schema_version", MATRIX_SCHEMA_VERSION
+                        )
+                    },
+                    "schema_version",
+                    context="MatrixManifest",
+                ),
+                model_id=_required_string(data, "model_id", context="MatrixManifest"),
+                model_family=_required_string(
+                    data, "model_family", context="MatrixManifest"
+                ),
+                output_dir=_required_string(
+                    data, "output_dir", context="MatrixManifest"
+                ),
                 entries=tuple(MatrixEntry.from_dict(entry) for entry in entries_raw),
             )
         except KeyError as exc:
@@ -165,7 +256,7 @@ class MatrixManifest:
     def from_json(cls, payload: str) -> MatrixManifest:
         try:
             data = json.loads(payload)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, RecursionError) as exc:
             raise MatrixSchemaError(f"Invalid JSON for MatrixManifest: {exc}") from exc
         if not isinstance(data, dict):
             raise MatrixSchemaError("MatrixManifest JSON must be an object")
@@ -173,7 +264,11 @@ class MatrixManifest:
 
     @classmethod
     def read_json(cls, path: str | Path) -> MatrixManifest:
-        return cls.from_json(Path(path).read_text(encoding="utf-8"))
+        try:
+            payload = read_bounded_regular_text(path, MAX_EVIDENCE_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise MatrixSchemaError(f"Invalid MatrixManifest file: {exc}") from exc
+        return cls.from_json(payload)
 
 
 def _collect_mlx_argv(

--- a/llmtracefx/optimizer/workloads/matrix.py
+++ b/llmtracefx/optimizer/workloads/matrix.py
@@ -28,6 +28,7 @@ from .._artifact_io import (
     MAX_EVIDENCE_ARTIFACT_BYTES,
     ArtifactReadError,
     read_bounded_regular_text,
+    reject_non_finite_json_constant,
 )
 from ..collectors._shared import atomic_write_text
 from ..collectors.native_mtp import detect_native_mtp_capability
@@ -255,8 +256,8 @@ class MatrixManifest:
     @classmethod
     def from_json(cls, payload: str) -> MatrixManifest:
         try:
-            data = json.loads(payload)
-        except (json.JSONDecodeError, RecursionError) as exc:
+            data = json.loads(payload, parse_constant=reject_non_finite_json_constant)
+        except (ValueError, RecursionError) as exc:
             raise MatrixSchemaError(f"Invalid JSON for MatrixManifest: {exc}") from exc
         if not isinstance(data, dict):
             raise MatrixSchemaError("MatrixManifest JSON must be an object")

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -711,10 +711,13 @@ def execute_row(
             and prior.verified_prompt_hash == verified_hash
             and prior.run_binding_hash == binding_hash
             and prior.workload_version == workload.version
+            and prior.run_id == entry.run_id
         ):
             try:
                 trusted_record = ExperimentRecord.read_json(final_record_path)
             except (OSError, SchemaValidationError):
+                trusted_record = None
+            if trusted_record is not None and trusted_record.run_id != entry.run_id:
                 trusted_record = None
             if trusted_record is not None:
                 return _finish(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -717,7 +717,10 @@ def execute_row(
                 trusted_record = ExperimentRecord.read_json(final_record_path)
             except (OSError, SchemaValidationError):
                 trusted_record = None
-            if trusted_record is not None and trusted_record.run_id != entry.run_id:
+            if trusted_record is not None and (
+                trusted_record.run_id != entry.run_id
+                or trusted_record.model.model_id != model_id
+            ):
                 trusted_record = None
             if trusted_record is not None:
                 return _finish(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -145,7 +145,12 @@ def _optional_number(data: dict[str, Any], key: str) -> float | None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise VerifyError(f"verification.json field '{key}' must be a number or null")
-    return float(value)
+    try:
+        return float(value)
+    except OverflowError as exc:
+        raise VerifyError(
+            f"verification.json field '{key}' must be a finite number"
+        ) from exc
 
 
 class RowStatus(str, Enum):
@@ -412,7 +417,7 @@ class RowVerification:
         try:
             payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
             data = json.loads(payload)
-        except (ArtifactReadError, json.JSONDecodeError, RecursionError) as exc:
+        except (ArtifactReadError, ValueError, RecursionError) as exc:
             raise VerifyError(f"invalid verification.json: {exc}") from exc
         return cls.from_dict(data)
 

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -72,9 +72,11 @@ from pathlib import Path
 from typing import Any
 
 from .._artifact_io import (
+    MAX_EVIDENCE_ARTIFACT_BYTES,
     MAX_METADATA_ARTIFACT_BYTES,
     ArtifactReadError,
     read_bounded_regular_text,
+    unsafe_run_id_reason,
 )
 from ..collectors._shared import atomic_write_text, config_hash, sha256_text
 from ..collectors.mlx import (
@@ -487,8 +489,22 @@ def plan_row(
     binding: RunBinding | None,
 ) -> RowPlan:
     """Describe what running ``entry`` would do, without loading a model."""
-    run_dir = _run_dir(entry, output_dir=output_dir)
     prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
+    refusal = unsafe_run_id_reason(entry.run_id)
+    if refusal is not None:
+        placeholder = output_dir / "runs" / "__rejected__"
+        return RowPlan(
+            entry=entry,
+            unsupported=False,
+            unsupported_reason=None,
+            ready=False,
+            blockers=(f"unsafe artifact path: {refusal}",),
+            prompt_path=prompt_path,
+            collection_dir=placeholder,
+            final_record_path=placeholder,
+            verification_path=placeholder,
+        )
+    run_dir = _run_dir(entry, output_dir=output_dir)
 
     if entry.decode_mode == DECODE_MODE_NATIVE_MTP or not entry.runnable:
         reason = entry.unsupported_reason or (
@@ -511,10 +527,14 @@ def plan_row(
     if binding is None:
         blockers.append("no --model-path binding was provided")
 
-    if not prompt_path.exists():
-        blockers.append(f"prompt file missing: {prompt_path}")
+    try:
+        prompt_text = read_bounded_regular_text(
+            prompt_path, MAX_EVIDENCE_ARTIFACT_BYTES
+        )
+    except (OSError, ArtifactReadError) as exc:
+        blockers.append(f"prompt file unreadable: {exc}")
     else:
-        verified_hash = sha256_text(prompt_path.read_text(encoding="utf-8"))
+        verified_hash = sha256_text(prompt_text)
         if verified_hash != entry.prompt.prompt_hash:
             blockers.append(
                 "prompt hash mismatch: matrix metadata records "
@@ -613,6 +633,32 @@ def execute_row(
     therefore never imports or platform-checks) an MLX runtime.
     """
     started_at = utc_now_iso()
+    refusal = unsafe_run_id_reason(entry.run_id)
+    if refusal is not None:
+        verification = RowVerification(
+            schema_version=VERIFICATION_SCHEMA_VERSION,
+            run_id=entry.run_id,
+            workload_id=entry.workload_id,
+            workload_version=entry.workload_version,
+            category=entry.category,
+            context_tier=entry.context_tier,
+            decode_mode=entry.decode_mode,
+            status=RowStatus.FAILED,
+            reason=f"unsafe artifact path: {refusal}",
+            recorded_prompt_hash=entry.prompt.prompt_hash,
+            verified_prompt_hash=None,
+            run_binding_hash=None,
+            resumed=False,
+            outcome_success=None,
+            quality_score=None,
+            total_ms=None,
+            started_at=started_at,
+            ended_at=utc_now_iso(),
+            final_record_path=None,
+            collection_dir=None,
+        )
+        return RowResult(entry=entry, verification=verification, final_record=None)
+
     run_dir = _run_dir(entry, output_dir=output_dir)
     verification_path = run_dir / "verification.json"
     collection_dir = run_dir / "collection"
@@ -678,10 +724,12 @@ def execute_row(
 
     # 2. Verify the fully materialized prompt against the matrix metadata.
     prompt_path = _resolve_path(entry.prompt_path, base_dir=manifest_dir)
-    if not prompt_path.exists():
-        return _finish(RowStatus.FAILED, f"prompt file missing: {prompt_path}")
-
-    prompt_text = prompt_path.read_text(encoding="utf-8")
+    try:
+        prompt_text = read_bounded_regular_text(
+            prompt_path, MAX_EVIDENCE_ARTIFACT_BYTES
+        )
+    except (OSError, ArtifactReadError) as exc:
+        return _finish(RowStatus.FAILED, f"prompt file unreadable: {exc}")
     verified_hash = sha256_text(prompt_text)
     if verified_hash != entry.prompt.prompt_hash:
         return _finish(

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -71,6 +71,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from .._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+)
 from ..collectors._shared import atomic_write_text, config_hash, sha256_text
 from ..collectors.mlx import (
     MLXCollectionConfig,
@@ -106,6 +111,41 @@ BACKEND_OPENAI_API = "openai-api"
 
 class VerifyError(ValueError):
     """Raised for invalid verify-pipeline configuration (not row outcomes)."""
+
+
+def _required_identity(data: dict[str, Any], key: str) -> str:
+    try:
+        value = data[key]
+    except KeyError as exc:
+        raise VerifyError(
+            f"verification.json is missing required field: '{key}'"
+        ) from exc
+    if not isinstance(value, str) or not value:
+        raise VerifyError(f"verification.json field '{key}' must be a non-empty string")
+    return value
+
+
+def _optional_string(data: dict[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, str):
+        raise VerifyError(f"verification.json field '{key}' must be a string or null")
+    return value
+
+
+def _optional_bool(data: dict[str, Any], key: str) -> bool | None:
+    value = data.get(key)
+    if value is not None and not isinstance(value, bool):
+        raise VerifyError(f"verification.json field '{key}' must be a boolean or null")
+    return value
+
+
+def _optional_number(data: dict[str, Any], key: str) -> float | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise VerifyError(f"verification.json field '{key}' must be a number or null")
+    return float(value)
 
 
 class RowStatus(str, Enum):
@@ -322,42 +362,59 @@ class RowVerification:
                 f"verification.json must be a JSON object, got {type(data).__name__}"
             )
         try:
+            resumed = data.get("resumed", False)
+            if not isinstance(resumed, bool):
+                raise VerifyError("verification.json field 'resumed' must be a boolean")
             return cls(
-                schema_version=str(
-                    data.get("schema_version", VERIFICATION_SCHEMA_VERSION)
+                schema_version=_required_identity(
+                    {
+                        "schema_version": data.get(
+                            "schema_version", VERIFICATION_SCHEMA_VERSION
+                        )
+                    },
+                    "schema_version",
                 ),
-                run_id=data["run_id"],
-                workload_id=data["workload_id"],
-                workload_version=data["workload_version"],
-                category=data["category"],
-                context_tier=data["context_tier"],
-                decode_mode=data["decode_mode"],
+                run_id=_required_identity(data, "run_id"),
+                workload_id=_required_identity(data, "workload_id"),
+                workload_version=_required_identity(data, "workload_version"),
+                category=_required_identity(data, "category"),
+                context_tier=_required_identity(data, "context_tier"),
+                decode_mode=_required_identity(data, "decode_mode"),
                 status=RowStatus(data["status"]),
-                reason=data.get("reason"),
-                recorded_prompt_hash=data.get("recorded_prompt_hash"),
-                verified_prompt_hash=data.get("verified_prompt_hash"),
-                run_binding_hash=data.get("run_binding_hash"),
-                resumed=bool(data.get("resumed", False)),
-                outcome_success=data.get("outcome_success"),
-                quality_score=data.get("quality_score"),
-                total_ms=data.get("total_ms"),
-                started_at=data["started_at"],
-                ended_at=data["ended_at"],
-                final_record_path=data.get("final_record_path"),
-                collection_dir=data.get("collection_dir"),
+                reason=_optional_string(data, "reason"),
+                recorded_prompt_hash=_optional_string(data, "recorded_prompt_hash"),
+                verified_prompt_hash=_optional_string(data, "verified_prompt_hash"),
+                run_binding_hash=_optional_string(data, "run_binding_hash"),
+                resumed=resumed,
+                outcome_success=_optional_bool(data, "outcome_success"),
+                quality_score=_optional_number(data, "quality_score"),
+                total_ms=_optional_number(data, "total_ms"),
+                started_at=_required_identity(data, "started_at"),
+                ended_at=_required_identity(data, "ended_at"),
+                final_record_path=_optional_string(data, "final_record_path"),
+                collection_dir=_optional_string(data, "collection_dir"),
                 # Additive v2 fields. A v1 artifact predates any backend
                 # other than local MLX, so its absence is not ambiguous.
-                backend=str(data.get("backend", BACKEND_MLX)),
-                provider=data.get("provider"),
-                api_model_id=data.get("api_model_id"),
-                artifacts_verified=data.get("artifacts_verified"),
+                backend=_required_identity(
+                    {"backend": data.get("backend", BACKEND_MLX)}, "backend"
+                ),
+                provider=_optional_string(data, "provider"),
+                api_model_id=_optional_string(data, "api_model_id"),
+                artifacts_verified=_optional_bool(data, "artifacts_verified"),
             )
-        except (KeyError, ValueError) as exc:
+        except (KeyError, TypeError, ValueError) as exc:
+            if isinstance(exc, VerifyError):
+                raise
             raise VerifyError(f"invalid verification.json: {exc}") from exc
 
     @classmethod
     def read_json(cls, path: Path) -> RowVerification:
-        return cls.from_dict(json.loads(path.read_text(encoding="utf-8")))
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+            data = json.loads(payload)
+        except (ArtifactReadError, json.JSONDecodeError, RecursionError) as exc:
+            raise VerifyError(f"invalid verification.json: {exc}") from exc
+        return cls.from_dict(data)
 
 
 def _load_prior_verification(path: Path) -> RowVerification | None:
@@ -365,7 +422,7 @@ def _load_prior_verification(path: Path) -> RowVerification | None:
         return None
     try:
         return RowVerification.read_json(path)
-    except (OSError, json.JSONDecodeError, VerifyError):
+    except (OSError, VerifyError):
         # A corrupt/partial artifact from an interrupted previous run must
         # never be mistaken for a trustworthy completed result.
         return None

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -113,6 +113,18 @@ class VerifyError(ValueError):
     """Raised for invalid verify-pipeline configuration (not row outcomes)."""
 
 
+def _record_is_safe_to_resume(
+    record: ExperimentRecord, *, expected_run_id: str, expected_model_id: str
+) -> bool:
+    if record.run_id != expected_run_id or record.model.model_id != expected_model_id:
+        return False
+    try:
+        json.dumps(record.to_dict(), allow_nan=False)
+    except ValueError:
+        return False
+    return True
+
+
 def _required_identity(data: dict[str, Any], key: str) -> str:
     try:
         value = data[key]
@@ -717,9 +729,10 @@ def execute_row(
                 trusted_record = ExperimentRecord.read_json(final_record_path)
             except (OSError, SchemaValidationError):
                 trusted_record = None
-            if trusted_record is not None and (
-                trusted_record.run_id != entry.run_id
-                or trusted_record.model.model_id != model_id
+            if trusted_record is not None and not _record_is_safe_to_resume(
+                trusted_record,
+                expected_run_id=entry.run_id,
+                expected_model_id=model_id,
             ):
                 trusted_record = None
             if trusted_record is not None:

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -146,6 +146,19 @@ def test_experiment_record_wraps_truncation_and_recursion(
         ExperimentRecord.from_json(payload)
 
 
+def test_experiment_record_wraps_overflowing_numbers() -> None:
+    payload = _record_payload()
+    payload["timing"] = {
+        "total": {
+            "value": 10**4_000,
+            "provenance": "measured_wall_clock",
+            "unit": "ms",
+        }
+    }
+    with pytest.raises(SchemaValidationError, match="finite number"):
+        ExperimentRecord.from_dict(payload)
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [
@@ -164,6 +177,23 @@ def test_matrix_manifest_wraps_truncation_and_recursion(
 def test_matrix_manifest_rejects_non_object_roots(root: object) -> None:
     with pytest.raises(MatrixSchemaError, match="JSON must be an object"):
         MatrixManifest.from_json(json.dumps(root))
+
+
+def test_all_json_parsers_wrap_oversized_integer_errors(tmp_path: Path) -> None:
+    huge_integer = "9" * 5_000
+    verification_path = tmp_path / "verification.json"
+    verification_path.write_text(f'{{"total_ms": {huge_integer}}}', encoding="utf-8")
+    with pytest.raises(VerifyError):
+        RowVerification.read_json(verification_path)
+    with pytest.raises(MatrixSchemaError):
+        MatrixManifest.from_json(f'{{"value": {huge_integer}}}')
+    with pytest.raises(SchemaValidationError):
+        ExperimentRecord.from_json(f'{{"value": {huge_integer}}}')
+
+
+def test_row_verification_wraps_overflowing_numbers() -> None:
+    with pytest.raises(VerifyError, match="finite number"):
+        RowVerification.from_dict(_verification_payload(total_ms=10**4_000))
 
 
 def test_matrix_manifest_rejects_malformed_nested_entry_and_prompt() -> None:
@@ -274,3 +304,19 @@ def test_summary_excludes_invalid_grouping_identity_without_crashing(
     assert [group.key for group in summary.by_provider] == ["openrouter"]
     assert [group.key for group in summary.by_backend] == [BACKEND_OPENAI_API]
     assert summary.overall.completed == 1
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_summary_excludes_non_finite_numeric_evidence(
+    tmp_path: Path, value: float
+) -> None:
+    run_dir = tmp_path / "runs" / "non-finite"
+    run_dir.mkdir(parents=True)
+    (run_dir / "verification.json").write_text(
+        json.dumps(_verification_payload(total_ms=value)), encoding="utf-8"
+    )
+
+    summary = summarize_results(tmp_path)
+
+    assert summary.overall.total == 0
+    assert summary.overall.correct_cases_per_minute is None

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -116,6 +116,7 @@ def test_row_verification_rejects_container_identity_fields(
         "speculative",
         "memory",
         "power",
+        "instruments",
         "outcome",
         "error",
     ],
@@ -137,12 +138,20 @@ def test_experiment_record_rejects_non_object_nested_values(field: str) -> None:
         ("runtime", "backend", []),
         ("command", "config_hash", {}),
         ("speculative", "method", []),
+        ("instruments", "tool", []),
+        ("instruments", "tool_version", {}),
+        ("instruments", "capability", []),
+        ("instruments", "template", {}),
+        ("instruments", "trace_bundle_name", []),
+        ("instruments", "notes", {}),
     ],
 )
 def test_experiment_record_rejects_container_identity_fields(
     section: str, field: str, value: object
 ) -> None:
     payload = _record_payload()
+    if section == "instruments":
+        payload[section] = {}
     payload[section][field] = value  # type: ignore[index]
     with pytest.raises(SchemaValidationError, match=field):
         ExperimentRecord.from_dict(payload)

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -20,6 +20,7 @@ from llmtracefx.optimizer.schema import (
     SchemaValidationError,
     utc_now_iso,
 )
+from llmtracefx.optimizer.tune.loader import load_evidence
 from llmtracefx.optimizer.workloads.aggregate import summarize_results
 from llmtracefx.optimizer.workloads.matrix import MatrixManifest, MatrixSchemaError
 from llmtracefx.optimizer.workloads.verify import (
@@ -123,6 +124,27 @@ def test_experiment_record_rejects_non_object_nested_values(field: str) -> None:
     payload = _record_payload()
     payload[field] = []
     with pytest.raises(SchemaValidationError, match="object"):
+        ExperimentRecord.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("model", "model_id", []),
+        ("model", "model_family", {}),
+        ("platform", "accelerator", []),
+        ("runtime", "name", {}),
+        ("runtime", "backend", []),
+        ("command", "config_hash", {}),
+        ("speculative", "method", []),
+    ],
+)
+def test_experiment_record_rejects_container_identity_fields(
+    section: str, field: str, value: object
+) -> None:
+    payload = _record_payload()
+    payload[section][field] = value  # type: ignore[index]
+    with pytest.raises(SchemaValidationError, match=field):
         ExperimentRecord.from_dict(payload)
 
 
@@ -320,3 +342,26 @@ def test_summary_excludes_non_finite_numeric_evidence(
 
     assert summary.overall.total == 0
     assert summary.overall.correct_cases_per_minute is None
+
+
+def test_tune_loader_excludes_unhashable_record_identity(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    final_record_path = run_dir / "final_record.json"
+    verification = _verification_payload(
+        backend="mlx",
+        provider=None,
+        final_record_path=str(final_record_path),
+    )
+    (run_dir / "verification.json").write_text(
+        json.dumps(verification), encoding="utf-8"
+    )
+    record = _record_payload()
+    record["model"]["model_id"] = []  # type: ignore[index]
+    final_record_path.write_text(json.dumps(record), encoding="utf-8")
+
+    loaded = load_evidence((tmp_path,))
+
+    assert loaded.usable == ()
+    assert len(loaded.excluded) == 1
+    assert "model_id" in loaded.excluded[0].reason

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import pytest
 
-import llmtracefx.optimizer.schema as schema_module
-import llmtracefx.optimizer.workloads.matrix as matrix_module
-import llmtracefx.optimizer.workloads.verify as verify_module
 from llmtracefx.optimizer.schema import (
     CommandInfo,
     ExperimentRecord,
@@ -369,25 +366,22 @@ def test_matrix_manifest_wraps_exponent_overflow_in_prompt_integer() -> None:
 
 
 @pytest.mark.parametrize(
-    ("reader", "error_type", "limit_owner", "limit_name"),
+    ("reader", "error_type", "limit_target"),
     [
         (
             RowVerification.read_json,
             VerifyError,
-            verify_module,
-            "MAX_METADATA_ARTIFACT_BYTES",
+            "llmtracefx.optimizer.workloads.verify.MAX_METADATA_ARTIFACT_BYTES",
         ),
         (
             MatrixManifest.read_json,
             MatrixSchemaError,
-            matrix_module,
-            "MAX_EVIDENCE_ARTIFACT_BYTES",
+            "llmtracefx.optimizer.workloads.matrix.MAX_EVIDENCE_ARTIFACT_BYTES",
         ),
         (
             ExperimentRecord.read_json,
             SchemaValidationError,
-            schema_module,
-            "MAX_EVIDENCE_ARTIFACT_BYTES",
+            "llmtracefx.optimizer.schema.MAX_EVIDENCE_ARTIFACT_BYTES",
         ),
     ],
 )
@@ -396,15 +390,14 @@ def test_artifact_readers_reject_invalid_utf8_oversize_and_symlinks(
     monkeypatch: pytest.MonkeyPatch,
     reader: object,
     error_type: type[ValueError],
-    limit_owner: object,
-    limit_name: str,
+    limit_target: str,
 ) -> None:
     path = tmp_path / "artifact.json"
     path.write_bytes(b"\xff")
     with pytest.raises(error_type, match="valid UTF-8"):
         reader(path)  # type: ignore[operator]
 
-    monkeypatch.setattr(limit_owner, limit_name, 16)
+    monkeypatch.setattr(limit_target, 16)
     path.write_bytes(b"x" * 17)
     with pytest.raises(error_type, match="size limit"):
         reader(path)  # type: ignore[operator]

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -1,0 +1,276 @@
+"""Adversarial coverage for persisted optimizer artifact boundaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import llmtracefx.optimizer.schema as schema_module
+import llmtracefx.optimizer.workloads.matrix as matrix_module
+import llmtracefx.optimizer.workloads.verify as verify_module
+from llmtracefx.optimizer.schema import (
+    CommandInfo,
+    ExperimentRecord,
+    ModelInfo,
+    PlatformInfo,
+    RepetitionInfo,
+    RuntimeInfo,
+    SchemaValidationError,
+    utc_now_iso,
+)
+from llmtracefx.optimizer.workloads.aggregate import summarize_results
+from llmtracefx.optimizer.workloads.matrix import MatrixManifest, MatrixSchemaError
+from llmtracefx.optimizer.workloads.verify import (
+    BACKEND_OPENAI_API,
+    RowVerification,
+    VerifyError,
+)
+
+
+def _verification_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "2",
+        "run_id": "run-1",
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "category": "structured_json",
+        "context_tier": "2k",
+        "decode_mode": "autoregressive",
+        "status": "completed",
+        "reason": None,
+        "recorded_prompt_hash": "sha256:abc",
+        "verified_prompt_hash": "sha256:abc",
+        "run_binding_hash": "sha256:def",
+        "resumed": False,
+        "outcome_success": True,
+        "quality_score": 1.0,
+        "total_ms": 100.0,
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T00:00:01Z",
+        "final_record_path": "final_record.json",
+        "collection_dir": "collection",
+        "backend": BACKEND_OPENAI_API,
+        "provider": "openrouter",
+        "api_model_id": "model-1",
+        "artifacts_verified": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _record_payload() -> dict[str, object]:
+    return ExperimentRecord(
+        run_id="run-1",
+        started_at=utc_now_iso(),
+        platform=PlatformInfo(
+            os_name="Darwin", os_version="24.0", architecture="arm64"
+        ),
+        model=ModelInfo(model_id="model-1"),
+        runtime=RuntimeInfo(name="runtime-1"),
+        command=CommandInfo(argv=("runner",)),
+        repetition=RepetitionInfo(
+            warmup_repetitions=0,
+            measured_repetitions=1,
+            repetition_index=0,
+        ),
+    ).to_dict()
+
+
+@pytest.mark.parametrize("root", [None, [], "verification", 1])
+def test_row_verification_rejects_non_object_roots(root: object) -> None:
+    with pytest.raises(VerifyError, match="JSON object"):
+        RowVerification.from_dict(root)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("run_id", []),
+        ("context_tier", {}),
+        ("decode_mode", []),
+        ("backend", {}),
+        ("provider", []),
+        ("provider", {}),
+    ],
+)
+def test_row_verification_rejects_container_identity_fields(
+    field: str, value: object
+) -> None:
+    with pytest.raises(VerifyError, match=field):
+        RowVerification.from_dict(_verification_payload(**{field: value}))
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "platform",
+        "model",
+        "runtime",
+        "command",
+        "repetition",
+        "tokens",
+        "timing",
+        "speculative",
+        "memory",
+        "power",
+        "outcome",
+        "error",
+    ],
+)
+def test_experiment_record_rejects_non_object_nested_values(field: str) -> None:
+    payload = _record_payload()
+    payload[field] = []
+    with pytest.raises(SchemaValidationError, match="object"):
+        ExperimentRecord.from_dict(payload)
+
+
+@pytest.mark.parametrize("root", [None, [], "record", 1])
+def test_experiment_record_rejects_non_object_roots(root: object) -> None:
+    with pytest.raises(SchemaValidationError, match="object"):
+        ExperimentRecord.from_dict(root)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("{", "Invalid JSON"),
+        ("[" * 10_000 + "0" + "]" * 10_000, "Invalid JSON"),
+    ],
+)
+def test_experiment_record_wraps_truncation_and_recursion(
+    payload: str, message: str
+) -> None:
+    with pytest.raises(SchemaValidationError, match=message):
+        ExperimentRecord.from_json(payload)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("{", "Invalid JSON"),
+        ("[" * 10_000 + "0" + "]" * 10_000, "Invalid JSON"),
+    ],
+)
+def test_matrix_manifest_wraps_truncation_and_recursion(
+    payload: str, message: str
+) -> None:
+    with pytest.raises(MatrixSchemaError, match=message):
+        MatrixManifest.from_json(payload)
+
+
+@pytest.mark.parametrize("root", [None, [], "manifest", 1])
+def test_matrix_manifest_rejects_non_object_roots(root: object) -> None:
+    with pytest.raises(MatrixSchemaError, match="JSON must be an object"):
+        MatrixManifest.from_json(json.dumps(root))
+
+
+def test_matrix_manifest_rejects_malformed_nested_entry_and_prompt() -> None:
+    base = {
+        "schema_version": "1",
+        "model_id": "model-1",
+        "model_family": "family-1",
+        "output_dir": "matrix",
+    }
+    with pytest.raises(MatrixSchemaError, match="MatrixEntry must be an object"):
+        MatrixManifest.from_dict({**base, "entries": [[]]})
+
+    entry = {
+        "run_id": "run-1",
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "category": "structured_json",
+        "context_tier": "2k",
+        "decode_mode": "autoregressive",
+        "configured_depth": None,
+        "prompt": [],
+        "prompt_path": "prompt.txt",
+        "runner_results_dir": "runner",
+        "collector_output_dir": "collector",
+        "runnable": True,
+        "unsupported_reason": None,
+        "command_argv": ["runner"],
+        "max_tokens": 1,
+    }
+    with pytest.raises(MatrixSchemaError, match="MaterializedPrompt"):
+        MatrixManifest.from_dict({**base, "entries": [entry]})
+
+
+@pytest.mark.parametrize(
+    ("reader", "error_type", "limit_owner", "limit_name"),
+    [
+        (
+            RowVerification.read_json,
+            VerifyError,
+            verify_module,
+            "MAX_METADATA_ARTIFACT_BYTES",
+        ),
+        (
+            MatrixManifest.read_json,
+            MatrixSchemaError,
+            matrix_module,
+            "MAX_EVIDENCE_ARTIFACT_BYTES",
+        ),
+        (
+            ExperimentRecord.read_json,
+            SchemaValidationError,
+            schema_module,
+            "MAX_EVIDENCE_ARTIFACT_BYTES",
+        ),
+    ],
+)
+def test_artifact_readers_reject_invalid_utf8_oversize_and_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reader: object,
+    error_type: type[ValueError],
+    limit_owner: object,
+    limit_name: str,
+) -> None:
+    path = tmp_path / "artifact.json"
+    path.write_bytes(b"\xff")
+    with pytest.raises(error_type, match="valid UTF-8"):
+        reader(path)  # type: ignore[operator]
+
+    monkeypatch.setattr(limit_owner, limit_name, 16)
+    path.write_bytes(b"x" * 17)
+    with pytest.raises(error_type, match="size limit"):
+        reader(path)  # type: ignore[operator]
+
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+    path.unlink()
+    path.symlink_to(target)
+    with pytest.raises(error_type, match="symlink"):
+        reader(path)  # type: ignore[operator]
+
+
+def test_summary_excludes_invalid_grouping_identity_without_crashing(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    good_dir = runs_dir / "good"
+    bad_provider_dir = runs_dir / "bad-provider"
+    bad_backend_dir = runs_dir / "bad-backend"
+    for run_dir in (good_dir, bad_provider_dir, bad_backend_dir):
+        run_dir.mkdir(parents=True)
+
+    (good_dir / "verification.json").write_text(
+        json.dumps(_verification_payload()), encoding="utf-8"
+    )
+    (bad_provider_dir / "verification.json").write_text(
+        json.dumps(_verification_payload(run_id="bad-provider", provider=[])),
+        encoding="utf-8",
+    )
+    (bad_backend_dir / "verification.json").write_text(
+        json.dumps(_verification_payload(run_id="bad-backend", backend={})),
+        encoding="utf-8",
+    )
+
+    summary = summarize_results(tmp_path)
+
+    assert summary.overall.total == 1
+    assert [group.key for group in summary.by_provider] == ["openrouter"]
+    assert [group.key for group in summary.by_backend] == [BACKEND_OPENAI_API]
+    assert summary.overall.completed == 1

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -181,6 +181,22 @@ def test_experiment_record_wraps_overflowing_numbers() -> None:
         ExperimentRecord.from_dict(payload)
 
 
+@pytest.mark.parametrize("token", ["1e400", "NaN", "Infinity", "-Infinity"])
+def test_experiment_record_rejects_non_finite_json_numbers(token: str) -> None:
+    payload = _record_payload()
+    payload["timing"] = {
+        "total": {
+            "value": "NON_FINITE",
+            "provenance": "measured_wall_clock",
+            "unit": "ms",
+        }
+    }
+    serialized = json.dumps(payload).replace('"NON_FINITE"', token)
+
+    with pytest.raises(SchemaValidationError, match="finite|non-finite"):
+        ExperimentRecord.from_json(serialized)
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [

--- a/tests/optimizer/test_artifact_parser_robustness.py
+++ b/tests/optimizer/test_artifact_parser_robustness.py
@@ -250,6 +250,100 @@ def test_matrix_manifest_rejects_malformed_nested_entry_and_prompt() -> None:
 
 
 @pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("workload_id", []),
+        ("workload_version", {}),
+        ("context_tier", []),
+        ("target_context_tokens", 1.5),
+        ("approx_chars_per_token", "4"),
+        ("filler_segments_used", True),
+        ("prompt_hash", []),
+    ],
+)
+def test_matrix_manifest_rejects_malformed_prompt_fields(
+    field: str, value: object
+) -> None:
+    prompt = {
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "context_tier": "2k",
+        "target_context_tokens": 2_048,
+        "approx_chars_per_token": 4,
+        "filler_segments_used": 1,
+        "prompt_hash": "sha256:abc",
+    }
+    prompt[field] = value
+    entry = {
+        "run_id": "run-1",
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "category": "structured_json",
+        "context_tier": "2k",
+        "decode_mode": "autoregressive",
+        "configured_depth": None,
+        "prompt": prompt,
+        "prompt_path": "prompt.txt",
+        "runner_results_dir": "runner",
+        "collector_output_dir": "collector",
+        "runnable": True,
+        "unsupported_reason": None,
+        "command_argv": ["runner"],
+        "max_tokens": 1,
+    }
+    manifest = {
+        "schema_version": "1",
+        "model_id": "model-1",
+        "model_family": "family-1",
+        "output_dir": "matrix",
+        "entries": [entry],
+    }
+
+    with pytest.raises(MatrixSchemaError, match=field):
+        MatrixManifest.from_dict(manifest)
+
+
+def test_matrix_manifest_wraps_exponent_overflow_in_prompt_integer() -> None:
+    prompt = {
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "context_tier": "2k",
+        "target_context_tokens": "NON_FINITE",
+        "approx_chars_per_token": 4,
+        "filler_segments_used": 1,
+        "prompt_hash": "sha256:abc",
+    }
+    entry = {
+        "run_id": "run-1",
+        "workload_id": "workload-1",
+        "workload_version": "1",
+        "category": "structured_json",
+        "context_tier": "2k",
+        "decode_mode": "autoregressive",
+        "configured_depth": None,
+        "prompt": prompt,
+        "prompt_path": "prompt.txt",
+        "runner_results_dir": "runner",
+        "collector_output_dir": "collector",
+        "runnable": True,
+        "unsupported_reason": None,
+        "command_argv": ["runner"],
+        "max_tokens": 1,
+    }
+    manifest = {
+        "schema_version": "1",
+        "model_id": "model-1",
+        "model_family": "family-1",
+        "output_dir": "matrix",
+        "entries": [entry],
+    }
+    payload = json.dumps(manifest).replace('"NON_FINITE"', "1e400")
+
+    with pytest.raises(MatrixSchemaError, match="target_context_tokens"):
+        MatrixManifest.from_json(payload)
+
+
+@pytest.mark.parametrize(
     ("reader", "error_type", "limit_owner", "limit_name"),
     [
         (

--- a/tests/optimizer/test_optimize_cli.py
+++ b/tests/optimizer/test_optimize_cli.py
@@ -832,6 +832,25 @@ def test_optimize_invalid_matrix_manifest_exits_1(tmp_path):
     assert exit_code == 1
 
 
+def test_optimize_non_utf8_matrix_manifest_exits_1(tmp_path, capsys):
+    matrix_path = tmp_path / "manifest.json"
+    matrix_path.write_bytes(b"\xff\xfe not utf-8")
+    policy_path = _write_policy(tmp_path, {"objective": "min_mean_total_latency_ms"})
+
+    exit_code = _run_optimize(
+        _base_argv(
+            matrix_path=matrix_path,
+            results_dir=tmp_path / "results",
+            policy_path=policy_path,
+            report_json=tmp_path / "report.json",
+            model_path=tmp_path,
+        )
+    )
+
+    assert exit_code == 1
+    assert "Failed to load matrix manifest" in capsys.readouterr().err
+
+
 def test_optimize_no_rows_selected_exits_1(tmp_path):
     matrix_path = _build_matrix(tmp_path, (STRUCTURED_JSON_PROFILE_EXTRACTION,))
     model_path = tmp_path / "model"

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1713,6 +1713,50 @@ def test_a_credential_in_the_effective_row_path_is_refused(tmp_path):
 # --- Resume binds the row's identity ------------------------------------------
 
 
+@pytest.mark.parametrize("corruption", ["oversized", "symlink"])
+def test_api_prompt_must_be_a_bounded_regular_file(tmp_path, monkeypatch, corruption):
+    bundle = build_manifest(tmp_path)
+    manifest, manifest_dir, matrix_path = bundle
+    entry = autoregressive_entry(manifest)
+    prompt_path = Path(entry.prompt_path)
+    if corruption == "oversized":
+        monkeypatch.setattr(api_verify, "MAX_EVIDENCE_ARTIFACT_BYTES", 8)
+    else:
+        target_path = tmp_path / "prompt-target.txt"
+        target_path.write_text(
+            prompt_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        prompt_path.unlink()
+        prompt_path.symlink_to(target_path)
+    binding = make_binding()
+
+    plan = plan_api_row(
+        entry,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=binding,
+        environ=ENVIRON,
+    )
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    result = execute_api_row(
+        entry,
+        manifest_dir=manifest_dir,
+        matrix_path=matrix_path,
+        output_dir=tmp_path / "results",
+        binding=binding,
+        resume=True,
+        transport_factory=lambda: transport,
+        environ=ENVIRON,
+    )
+
+    assert not plan.ready
+    assert "prompt file unreadable" in plan.blockers[0]
+    assert result.verification.status is RowStatus.FAILED
+    assert "prompt file unreadable" in (result.verification.reason or "")
+    assert transport.requests == []
+
+
 def test_a_run_directory_copied_from_another_row_is_never_trusted(tmp_path):
     """Every hash checks out; the evidence still describes another row.
 

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1420,6 +1420,23 @@ def test_a_completed_row_writes_a_run_level_marker(tmp_path):
     assert "verification.json" in sealed
 
 
+def test_an_unsafe_artifact_during_marker_creation_does_not_crash(
+    tmp_path, monkeypatch
+):
+    def refuse_marker(**_kwargs):
+        raise api_verify.ArtifactReadError("unsafe sealed artifact")
+
+    monkeypatch.setattr(api_verify, "_run_marker_payload", refuse_marker)
+
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+
+    assert result.verification.status is RowStatus.COMPLETED
+    assert not (run_dir / RUN_MANIFEST_NAME).exists()
+
+
 @pytest.mark.parametrize("victim", ["final_record.json", "verification.json"])
 def test_editing_a_file_outside_the_collection_marker_forces_a_rerun(tmp_path, victim):
     """These two sit outside the collector's marker and were trusted blind."""

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1868,6 +1868,31 @@ def test_a_malformed_final_record_behind_a_valid_marker_reruns(tmp_path, payload
     assert second.verification.status is RowStatus.COMPLETED
 
 
+def test_a_non_finite_final_record_behind_a_valid_marker_reruns(tmp_path):
+    bundle = build_manifest(tmp_path)
+    first = run_one(
+        tmp_path,
+        transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER))),
+        manifest_bundle=bundle,
+    )
+    run_dir = Path(first.verification.collection_dir or "").parent
+    record_path = run_dir / "final_record.json"
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    payload["timing"]["total"]["value"] = "NON_FINITE"
+    record_path.write_text(
+        json.dumps(payload).replace('"NON_FINITE"', "1e400"), encoding="utf-8"
+    )
+    _reseal(run_dir)
+
+    assert run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+
+    transport = FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    second = run_one(tmp_path, transport=transport, manifest_bundle=bundle)
+
+    assert transport.requests
+    assert second.verification.status is RowStatus.COMPLETED
+
+
 @pytest.mark.parametrize("payload_label", sorted(_MALFORMED_ROOTS))
 def test_a_malformed_run_marker_is_rejected_not_raised(tmp_path, payload_label):
     """The marker reader is the one gate that must never raise."""

--- a/tests/optimizer/test_workloads_api_verify.py
+++ b/tests/optimizer/test_workloads_api_verify.py
@@ -1878,3 +1878,45 @@ def test_a_malformed_run_marker_is_rejected_not_raised(tmp_path, payload_label):
     (run_dir / RUN_MANIFEST_NAME).write_bytes(_MALFORMED_ROOTS[payload_label])
 
     assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+
+
+@pytest.mark.parametrize("corruption", ["recursion", "oversized", "symlink"])
+def test_an_unsafe_run_marker_is_rejected_not_raised(tmp_path, corruption, monkeypatch):
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+    marker_path = run_dir / RUN_MANIFEST_NAME
+    if corruption == "recursion":
+        marker_path.write_text("[" * 10_000 + "0" + "]" * 10_000, encoding="utf-8")
+    elif corruption == "oversized":
+        monkeypatch.setattr(api_verify, "MAX_METADATA_ARTIFACT_BYTES", 16)
+        marker_path.write_bytes(b"x" * 17)
+    else:
+        target = marker_path.with_name("run-target.json")
+        target.write_bytes(marker_path.read_bytes())
+        marker_path.unlink()
+        marker_path.symlink_to(target)
+
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)
+
+
+@pytest.mark.parametrize("corruption", ["oversized", "symlink"])
+def test_an_unsafe_sealed_artifact_is_rejected_not_raised(
+    tmp_path, corruption, monkeypatch
+):
+    result = run_one(
+        tmp_path, transport=FakeTransport(FakeResponse(answer_stream(GOOD_JSON_ANSWER)))
+    )
+    run_dir = Path(result.verification.collection_dir or "").parent
+    artifact_path = run_dir / "verification.json"
+    if corruption == "oversized":
+        monkeypatch.setitem(api_verify._SEALED_ARTIFACT_LIMITS, "verification.json", 16)
+        artifact_path.write_bytes(b"x" * 17)
+    else:
+        target = artifact_path.with_name("verification-target.json")
+        target.write_bytes(artifact_path.read_bytes())
+        artifact_path.unlink()
+        artifact_path.symlink_to(target)
+
+    assert not run_artifacts_are_complete(run_dir, expected_run_id=run_dir.name)

--- a/tests/optimizer/test_workloads_cli.py
+++ b/tests/optimizer/test_workloads_cli.py
@@ -436,6 +436,25 @@ def test_workloads_run_cli_unknown_matrix_manifest_fails(tmp_path, capsys):
     assert "Failed to load matrix manifest" in capsys.readouterr().err
 
 
+def test_workloads_run_cli_non_utf8_matrix_manifest_fails_cleanly(tmp_path, capsys):
+    matrix_path = tmp_path / "manifest.json"
+    matrix_path.write_bytes(b"\xff\xfe not utf-8")
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "workloads",
+            "run",
+            "--matrix",
+            str(matrix_path),
+            "--output-dir",
+            str(tmp_path / "results"),
+        ]
+    )
+
+    assert args.func(args) == 1
+    assert "Failed to load matrix manifest" in capsys.readouterr().err
+
+
 def test_workloads_summarize_cli_reports_pass_rate(tmp_path, monkeypatch):
     matrix_path = _build_small_matrix(tmp_path)
     model_path = tmp_path / "model"

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 
-import llmtracefx.optimizer.workloads.verify as verify_module
 from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
 from llmtracefx.optimizer.schema import ExperimentRecord
 from llmtracefx.optimizer.workloads.catalog import (
@@ -355,7 +354,9 @@ def test_local_prompt_must_be_a_bounded_regular_file(tmp_path, monkeypatch, corr
         payload["prompt_path"] = "\0"
         entry = MatrixEntry.from_dict(payload)
     elif corruption == "oversized":
-        monkeypatch.setattr(verify_module, "MAX_EVIDENCE_ARTIFACT_BYTES", 8)
+        monkeypatch.setattr(
+            "llmtracefx.optimizer.workloads.verify.MAX_EVIDENCE_ARTIFACT_BYTES", 8
+        )
     else:
         target_path = tmp_path / "prompt-target.txt"
         target_path.write_text(
@@ -537,12 +538,12 @@ def test_evaluator_error_produces_inconclusive_status(tmp_path, monkeypatch):
     )
     runtime = FakeMLXRuntime(GOOD_RESPONSE)
 
-    import llmtracefx.optimizer.workloads.verify as verify_module
-
     def _boom(workload, response_text):
         raise OSError("evaluator subprocess could not start")
 
-    monkeypatch.setattr(verify_module, "evaluate_workload", _boom)
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.workloads.verify.evaluate_workload", _boom
+    )
 
     result = execute_row(
         entry,

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import llmtracefx.optimizer.workloads.verify as verify_module
 from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
 from llmtracefx.optimizer.schema import ExperimentRecord
 from llmtracefx.optimizer.workloads.catalog import (
@@ -16,6 +17,7 @@ from llmtracefx.optimizer.workloads.catalog import (
 from llmtracefx.optimizer.workloads.matrix import (
     DECODE_MODE_AUTOREGRESSIVE,
     DECODE_MODE_NATIVE_MTP,
+    MatrixEntry,
     MatrixManifest,
     generate_matrix,
     write_matrix,
@@ -27,6 +29,7 @@ from llmtracefx.optimizer.workloads.verify import (
     RunBinding,
     VerifyError,
     execute_row,
+    plan_row,
     plan_selected_rows,
     run_selected_rows,
     select_entries,
@@ -299,6 +302,87 @@ def test_native_mtp_rows_not_downgraded_even_with_draft_model_path(tmp_path):
 
 
 # --- Prompt hash verification -------------------------------------------------
+
+
+def test_local_run_id_cannot_escape_output_directory(tmp_path):
+    manifest, manifest_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    original = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    payload = original.to_dict()
+    payload["run_id"] = "../escaped"
+    entry = MatrixEntry.from_dict(payload)
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+
+    plan = plan_row(
+        entry,
+        manifest_dir=manifest_dir,
+        output_dir=results_dir,
+        binding=binding,
+    )
+    runtime = FakeMLXRuntime()
+    result = execute_row(
+        entry,
+        manifest_dir=manifest_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert not plan.ready
+    assert "unsafe artifact path" in plan.blockers[0]
+    assert result.verification.status is RowStatus.FAILED
+    assert "unsafe artifact path" in (result.verification.reason or "")
+    assert not results_dir.exists()
+    assert not (tmp_path / "escaped").exists()
+    assert runtime.load_calls == []
+
+
+@pytest.mark.parametrize("corruption", ["oversized", "symlink"])
+def test_local_prompt_must_be_a_bounded_regular_file(tmp_path, monkeypatch, corruption):
+    manifest, manifest_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    prompt_path = Path(entry.prompt_path)
+    if corruption == "oversized":
+        monkeypatch.setattr(verify_module, "MAX_EVIDENCE_ARTIFACT_BYTES", 8)
+    else:
+        target_path = tmp_path / "prompt-target.txt"
+        target_path.write_text(
+            prompt_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        prompt_path.unlink()
+        prompt_path.symlink_to(target_path)
+    binding = RunBinding(target_model_path=target)
+
+    plan = plan_row(
+        entry,
+        manifest_dir=manifest_dir,
+        output_dir=tmp_path / "results",
+        binding=binding,
+    )
+    runtime = FakeMLXRuntime()
+    result = execute_row(
+        entry,
+        manifest_dir=manifest_dir,
+        output_dir=tmp_path / "results",
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert not plan.ready
+    assert "prompt file unreadable" in plan.blockers[0]
+    assert result.verification.status is RowStatus.FAILED
+    assert "prompt file unreadable" in (result.verification.reason or "")
+    assert runtime.load_calls == []
 
 
 def test_prompt_hash_mismatch_fails_the_row_without_executing(tmp_path):

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -744,6 +744,45 @@ def test_resume_reruns_when_final_record_has_another_model_id(tmp_path):
     assert runtime.load_calls == [target]
 
 
+def test_resume_reruns_when_final_record_has_non_finite_metric(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+    first = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+    path = Path(first.verification.final_record_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["timing"]["total"]["value"] = "NON_FINITE"
+    path.write_text(
+        json.dumps(payload).replace('"NON_FINITE"', "1e400"), encoding="utf-8"
+    )
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
 def test_resume_reruns_when_prompt_content_changes(tmp_path):
     """A stale hash-mismatched artifact must be re-run, not blindly trusted."""
     manifest, output_dir = build_manifest(tmp_path)

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -666,6 +666,47 @@ def test_resume_reruns_when_final_record_is_unreadable(
     assert runtime.load_calls == [target]
 
 
+@pytest.mark.parametrize("artifact", ["verification", "final-record"])
+def test_resume_reruns_when_prior_artifact_has_another_run_id(tmp_path, artifact):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+    first = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+    if artifact == "verification":
+        path = results_dir / "runs" / entry.run_id / "verification.json"
+    else:
+        path = Path(first.verification.final_record_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["run_id"] = "copied-from-another-row"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
 def test_resume_reruns_when_prompt_content_changes(tmp_path):
     """A stale hash-mismatched artifact must be re-run, not blindly trusted."""
     manifest, output_dir = build_manifest(tmp_path)

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -342,7 +342,7 @@ def test_local_run_id_cannot_escape_output_directory(tmp_path):
     assert runtime.load_calls == []
 
 
-@pytest.mark.parametrize("corruption", ["oversized", "symlink"])
+@pytest.mark.parametrize("corruption", ["invalid-path", "oversized", "symlink"])
 def test_local_prompt_must_be_a_bounded_regular_file(tmp_path, monkeypatch, corruption):
     manifest, manifest_dir = build_manifest(tmp_path)
     target = make_target_model(tmp_path)
@@ -350,7 +350,11 @@ def test_local_prompt_must_be_a_bounded_regular_file(tmp_path, monkeypatch, corr
         e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
     )
     prompt_path = Path(entry.prompt_path)
-    if corruption == "oversized":
+    if corruption == "invalid-path":
+        payload = entry.to_dict()
+        payload["prompt_path"] = "\0"
+        entry = MatrixEntry.from_dict(payload)
+    elif corruption == "oversized":
         monkeypatch.setattr(verify_module, "MAX_EVIDENCE_ARTIFACT_BYTES", 8)
     else:
         target_path = tmp_path / "prompt-target.txt"

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -550,6 +550,122 @@ def test_resume_trusts_hash_matching_completed_artifact(tmp_path):
     assert result.final_record.outcome.success is True
 
 
+@pytest.mark.parametrize(
+    "corruption",
+    ["invalid-utf8", "truncated", "recursion", "oversized", "symlink"],
+)
+def test_resume_reruns_when_prior_verification_is_unreadable(
+    tmp_path, corruption, monkeypatch
+):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+    execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+    verification_path = results_dir / "runs" / entry.run_id / "verification.json"
+    if corruption == "invalid-utf8":
+        verification_path.write_bytes(b"\xff")
+    elif corruption == "truncated":
+        verification_path.write_text("{", encoding="utf-8")
+    elif corruption == "recursion":
+        verification_path.write_text(
+            "[" * 10_000 + "0" + "]" * 10_000, encoding="utf-8"
+        )
+    elif corruption == "oversized":
+        monkeypatch.setattr(
+            "llmtracefx.optimizer.workloads.verify.MAX_METADATA_ARTIFACT_BYTES", 16
+        )
+        verification_path.write_bytes(b"x" * 17)
+    else:
+        target_path = verification_path.with_name("verification-target.json")
+        target_path.write_text("{}", encoding="utf-8")
+        verification_path.unlink()
+        verification_path.symlink_to(target_path)
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    ["invalid-utf8", "truncated", "recursion", "oversized", "symlink"],
+)
+def test_resume_reruns_when_final_record_is_unreadable(
+    tmp_path, corruption, monkeypatch
+):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+    first = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+    final_record_path = Path(first.verification.final_record_path)
+    if corruption == "invalid-utf8":
+        final_record_path.write_bytes(b"\xff")
+    elif corruption == "truncated":
+        final_record_path.write_text("{", encoding="utf-8")
+    elif corruption == "recursion":
+        final_record_path.write_text(
+            "[" * 10_000 + "0" + "]" * 10_000, encoding="utf-8"
+        )
+    elif corruption == "oversized":
+        monkeypatch.setattr(
+            "llmtracefx.optimizer.schema.MAX_EVIDENCE_ARTIFACT_BYTES", 16
+        )
+        final_record_path.write_bytes(b"x" * 17)
+    else:
+        target_path = final_record_path.with_name("record-target.json")
+        target_path.write_text("{}", encoding="utf-8")
+        final_record_path.unlink()
+        final_record_path.symlink_to(target_path)
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
 def test_resume_reruns_when_prompt_content_changes(tmp_path):
     """A stale hash-mismatched artifact must be re-run, not blindly trusted."""
     manifest, output_dir = build_manifest(tmp_path)

--- a/tests/optimizer/test_workloads_verify.py
+++ b/tests/optimizer/test_workloads_verify.py
@@ -707,6 +707,43 @@ def test_resume_reruns_when_prior_artifact_has_another_run_id(tmp_path, artifact
     assert runtime.load_calls == [target]
 
 
+def test_resume_reruns_when_final_record_has_another_model_id(tmp_path):
+    manifest, output_dir = build_manifest(tmp_path)
+    target = make_target_model(tmp_path)
+    entry = next(
+        e for e in manifest.entries if e.decode_mode == DECODE_MODE_AUTOREGRESSIVE
+    )
+    results_dir = tmp_path / "results"
+    binding = RunBinding(target_model_path=target)
+    first = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: FakeMLXRuntime(GOOD_RESPONSE),
+    )
+    path = Path(first.verification.final_record_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["model"]["model_id"] = "copied-from-another-model"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    runtime = FakeMLXRuntime(GOOD_RESPONSE)
+    result = execute_row(
+        entry,
+        manifest_dir=output_dir,
+        output_dir=results_dir,
+        model_id=manifest.model_id,
+        binding=binding,
+        resume=True,
+        runtime_factory=lambda: runtime,
+    )
+
+    assert result.verification.status == RowStatus.COMPLETED
+    assert runtime.load_calls == [target]
+
+
 def test_resume_reruns_when_prompt_content_changes(tmp_path):
     """A stale hash-mismatched artifact must be re-run, not blindly trusted."""
     manifest, output_dir = build_manifest(tmp_path)


### PR DESCRIPTION
## Summary

- validate artifact roots, nested objects, identity fields, numeric values, and Instruments evidence before construction or grouping
- use bounded regular-file reads with UTF-8, size, symlink, recursion, and unsafe-path handling across local and API resume paths
- exclude corrupt evidence from summaries and force safe reruns instead of allowing parser failures to escape
- add adversarial regression matrices for malformed JSON, invalid UTF-8, excessive nesting, oversized files, unsafe identities, and resume behavior

Fixes #40
Fixes #41

## Validation

- `uv run pytest -q` (2617 passed)
- `./scripts/lint-changed.sh origin/main`
- independent exact-head review approved `8cefbc4224337438557f4810fe134f10233d8280`