### PR TITLE
fix(optimizer): harden tune report provenance parsing

### DIFF
--- a/llmtracefx/optimizer/tune/report.py
+++ b/llmtracefx/optimizer/tune/report.py
@@ -557,7 +557,13 @@ class TuneReport:
     def from_json(cls, payload: str) -> TuneReport:
         try:
             data = json.loads(payload)
-        except json.JSONDecodeError as exc:
+        # ``json`` raises past its own limits with exceptions that are not
+        # ``JSONDecodeError``: an integer literal over the interpreter's
+        # digit cap raises a plain ``ValueError``, and deep nesting raises
+        # ``RecursionError``. Neither is caught by any caller, so both
+        # escaped as a traceback from a merely malformed file.
+        # ``CompareReport.from_json`` already handles both this way.
+        except (ValueError, RecursionError) as exc:
             raise TuneReportValidationError(
                 f"invalid JSON for tune report: {exc}"
             ) from exc

--- a/tests/optimizer/test_compare_cli.py
+++ b/tests/optimizer/test_compare_cli.py
@@ -430,3 +430,46 @@ def test_compare_report_reports_a_missing_input(
     )
     assert code == 1
     assert "Could not read compare report input" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("integer past the digit cap", '{"x": ' + "9" * 4400 + "}"),
+        ("array nested past the recursion limit", "[" * 200_000 + "]" * 200_000),
+    ],
+)
+def test_compare_refuses_a_tune_report_json_past_the_parser_limits(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    label: str,
+    payload: str,
+) -> None:
+    """``json`` exceeds its own limits with exceptions that are not decode errors.
+
+    An integer literal over the interpreter's digit cap raises a plain
+    ``ValueError`` and deep nesting raises ``RecursionError``. Neither is a
+    ``JSONDecodeError``, so both escaped as a stack trace from a merely
+    malformed provenance file -- on the one input that had not been hardened
+    the way the compare report, the policy and the pricing manifest already
+    were.
+    """
+    results = tmp_path / "results"
+    _three_systems(results)
+    policy = write_json(tmp_path / "policy.json", COMPARE_POLICY)
+    bad = tmp_path / "bad.json"
+    bad.write_text(payload, encoding="utf-8")
+
+    code = _run(
+        [
+            "compare",
+            "--results",
+            str(results),
+            "--policy",
+            str(policy),
+            "--tune-report",
+            str(bad),
+        ]
+    )
+    assert code == 1, label
+    assert "Invalid tune report" in capsys.readouterr().err

--- a/tests/optimizer/test_compare_hardening.py
+++ b/tests/optimizer/test_compare_hardening.py
@@ -2396,13 +2396,10 @@ def test_a_non_finite_quality_score_is_rejected(tmp_path: Path) -> None:
         results_dirs=(tmp_path,), policy=ComparePolicy.from_dict(COMPARE_POLICY)
     )
     stratum = report.strata[0]
-    assert (
-        any(
-            "non-finite" in reason
-            for entry in stratum.rejected
-            for reason in entry.reasons
-        )
-        or not stratum.ranked
+    assert any(
+        "outcome.quality_score is non-finite" in reason
+        for entry in stratum.rejected
+        for reason in entry.reasons
     )
 
 


### PR DESCRIPTION
Follow-up to #36, found by an exact-head review that finished after that PR merged.

## The bug

`compare --tune-report` publishes each path under **"Corroborating tune reports"** in the provenance section, and validates it so the claim is true rather than merely asserted. That validation goes through `TuneReport.from_json`, which caught only `json.JSONDecodeError`.

`json` exceeds its own limits with exceptions that are *not* decode errors:

- an integer literal past the interpreter's 4300-digit cap raises a plain `ValueError`
- deeply nested arrays raise `RecursionError`

Neither was caught anywhere up the stack, so a merely malformed provenance file ended the whole comparison with a traceback instead of a stated reason. The comparison itself had already succeeded at that point, so all of that work was lost behind a stack trace.

Reproduced against the real CLI entry point on a healthy results tree:

```
$ llmtracefx-optimizer compare --results <tree> --policy p.json --tune-report big_int.json
Traceback (most recent call last):
  ...
ValueError: Exceeds the limit (4300 digits) for integer string conversion

$ llmtracefx-optimizer compare --results <tree> --policy p.json --tune-report deep.json
RecursionError: maximum recursion depth exceeded while decoding a JSON array
```

## The fix

`CompareReport.from_json` already handles both cases exactly this way, and so do the compare policy and pricing manifest loaders. `--tune-report` was the one input left out, so this brings it in line rather than inventing a new rule.

Fixed at the source in `TuneReport.from_json`, which means `tune-report --input` is covered too, not just `compare --tune-report`. Both now exit 1 with a stated reason:

```
Invalid tune report in big_int.json: invalid JSON for tune report: Exceeds the limit (4300 digits) ...
```

## Also included

Tightens the non-finite quality score regression. Its assertion carried an `or not stratum.ranked` arm, which meant a regression that stopped the system being ranked for some unrelated reason would still pass. The rejection reason is exact (`run <id>: outcome.quality_score is non-finite and unusable`), so the test now pins that string and drops the slack.

## Validation

- Both changes are mutation tested: revert the fix and a test fails. Reverting `except (ValueError, RecursionError)` back to `except json.JSONDecodeError` fails the new parametrised CLI test; disabling the `math.isfinite(score)` check fails the tightened regression.
- Full suite: 3033 passed.
- Quality ratchet on changed files: ruff, black, isort, mypy all clean.
- Rebased onto current `main`, 0 behind.

No production behaviour changes for well-formed input, and the tune report is still only recorded as provenance, never merged into the comparison.
