### PR TITLE
feat: add reproducible M5 Pro inference lab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,17 @@ jobs:
           print('imported llmtracefx from', llmtracefx.__file__)
           print('version', md.version('llmtracefx'))
           "
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" --help
+          set +e
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" plan > m5-plan.json
+          plan_status="$?"
+          set -e
+          test "$plan_status" -eq 2
+          "$GITHUB_WORKSPACE/.wheel-check/bin/python" -c "
+          import json
+          from pathlib import Path
+          plan = json.loads(Path('m5-plan.json').read_text())
+          assert plan['manifest'].startswith('package:')
+          assert plan['model']['repository_id'] == 'mlx-community/Qwen3.8-27B-4bit'
+          assert plan['downloads_performed'] is False
+          "

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence
+.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence m5-lab m5-lab-acquire m5-lab-run m5-lab-verify m5-lab-report
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - evidence-first inference toolkit"
@@ -101,6 +101,27 @@ glm-plan:  ## Adjudicate a deployment plan (make glm-plan ARGS="--max-usd 10 ...
 
 test-deploy:  ## Run the offline deployment harness tests
 	uv run pytest tests/deploy
+
+# Pinned M5 Pro / Qwen3.8-27B local evidence lab. The default target is an
+# offline, no-download plan. Acquisition and inference are explicit.
+M5_LAB_MANIFEST ?= llmtracefx/optimizer/lab/data/lab-manifest-v1.json
+M5_LAB_WORKSPACE ?= .cache/llmtracefx/m5-pro-qwen3.8-27b-v1
+MAX_TIER ?= 2k
+
+m5-lab:  ## Plan the M5 lab without downloading or loading a model
+	uv run --offline --no-sync --extra mlx llmtracefx-m5-lab plan --manifest $(M5_LAB_MANIFEST) --workspace $(M5_LAB_WORKSPACE)
+
+m5-lab-acquire:  ## Download and SHA-256 verify the pinned public MLX model
+	uv run --extra mlx llmtracefx-m5-lab acquire --manifest $(M5_LAB_MANIFEST) --workspace $(M5_LAB_WORKSPACE)
+
+m5-lab-run:  ## Acquire if absent, then resume the safety-gated local lab
+	uv run --extra mlx llmtracefx-m5-lab run --acquire --max-tier $(MAX_TIER) --manifest $(M5_LAB_MANIFEST) --workspace $(M5_LAB_WORKSPACE)
+
+m5-lab-verify:  ## Verify pinned model files and evidence bindings
+	uv run --extra mlx llmtracefx-m5-lab verify --manifest $(M5_LAB_MANIFEST) --workspace $(M5_LAB_WORKSPACE)
+
+m5-lab-report:  ## Rebuild self-contained local lab/tune/compare reports
+	uv run --extra mlx llmtracefx-m5-lab report --manifest $(M5_LAB_MANIFEST) --workspace $(M5_LAB_WORKSPACE)
 
 metal-evidence:  ## Capture privacy-safe Metal evidence (requires OUTPUT_DIR)
 	@test -n "$(OUTPUT_DIR)" || { echo "OUTPUT_DIR is required" >&2; exit 2; }

--- a/examples/optimizer/m5-pro-qwen3.8-27b/README.md
+++ b/examples/optimizer/m5-pro-qwen3.8-27b/README.md
@@ -1,0 +1,90 @@
+# M5 Pro local inference lab
+
+This lab measures useful, deterministic work on one pinned local system:
+`mlx-community/Qwen3.8-27B-4bit` at
+`3e6447f082e89cc7f0bc6e5441afd38dfce760ff`, using `mlx-vlm==0.6.8`.
+The official upstream is `Qwen/Qwen3.8-27B` at
+`1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`; both repositories declare
+Apache-2.0.
+
+The conversion is affine 4-bit with group size 64. The 15 pinned files total
+16,081,490,933 bytes (14.98 GiB). That leaves limited but plausible runtime
+headroom on a 24 GB M5 Pro at 2K-16K because only 16 of the language model's 64
+layers use full attention. Fit is verified by measurement, not assumed:
+execution starts at 2K and stops before 8K or 16K if the previous tier fails,
+MLX peak memory exceeds 20 GiB, free-memory pressure drops below 25%, or swap
+use exceeds 12 GiB.
+
+## Commands
+
+```bash
+# Default: offline plan only. No model load or download.
+make m5-lab
+
+# Explicitly acquire and SHA-256 verify the public pinned snapshot.
+make m5-lab-acquire
+
+# Resume the bounded experiment, starting at 2K.
+make m5-lab-run MAX_TIER=2k
+
+# Request gated escalation through 8K and 16K.
+make m5-lab-run MAX_TIER=16k
+
+# Re-verify model/evidence bindings and render reports.
+make m5-lab-verify
+make m5-lab-report
+```
+
+Local weights, prompts, raw responses, and absolute-path-bearing artifacts live
+under `.cache/llmtracefx/` and are ignored by Git. Only sanitized aggregate
+evidence and the self-contained report are suitable to copy into this example
+directory.
+
+## What is measured
+
+- host wall-clock total, prefill/time-to-first-token, and decode duration;
+- tokenizer-reported input and generated token counts;
+- decode tokens/second derived from measured tokens and decode time;
+- MLX allocator peak memory when exposed by the runtime;
+- deterministic structured-extraction and reasoning evaluator results;
+- pass rate and correct cases per minute.
+
+Missing measurements remain `null`. The lab does not infer GPU utilization,
+bandwidth, power, energy, or kernel timing. The report applies only to the
+pinned model, runtime, workloads, context tier, output cap, sampling settings,
+and safety constraints; it does not claim a universally fastest setup.
+The configured 1,800-second timeout is cooperative: it is checked after model
+load, tokenization, and each streamed generation response, so it cannot
+preempt a blocked native model load or prefill call.
+
+## Recorded result on this machine
+
+The pinned checkpoint passed file verification and loaded with
+`mlx-vlm==0.6.8`, `mlx==0.32.2`, `mlx-lm==0.31.3`, and
+`transformers==5.16.1`. A direct lazy reload of the exact checkpoint also
+constructed `Qwen3VLProcessor` successfully. The 2K warmup prompt tokenized to
+1,657 tokens. Metal then stopped during prefill after 22.731 seconds with:
+
+```text
+[METAL] Command buffer execution failed: Insufficient Memory
+(00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory).
+```
+
+No output token or evaluator result was produced, so prefill latency, decode
+latency, token rate, allocator peak memory, pass rate, quality, and correct
+cases per minute remain `null`. The safety gate did not run measured
+repetitions and did not attempt 8K or 16K. This is evidence that this exact
+27B/4-bit checkpoint and runtime did not fit the observed 24 GB environment,
+not a claim that every 24 GB M5 Pro will always fail.
+
+The safest next attempt is the same pinned experiment after a clean boot with
+other GPU/memory-heavy applications closed. Any smaller model or different
+quantization must use a separate, independently researched manifest and must
+not be blended into this result.
+
+## Provenance caveat
+
+The MLX conversion card publishes the upstream model ID and converter version,
+but not the exact source-model commit. The manifest therefore pins the produced
+MLX snapshot and official upstream revision independently; it does not claim a
+cryptographic link between them.

--- a/examples/optimizer/m5-pro-qwen3.8-27b/evidence-summary.json
+++ b/examples/optimizer/m5-pro-qwen3.8-27b/evidence-summary.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "1",
+  "lab_id": "m5-pro-qwen3.8-27b-v1",
+  "generated_at": "2026-08-31T14:57:58.660151Z",
+  "model": {
+    "official_id": "Qwen/Qwen3.8-27B",
+    "official_revision": "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+    "repository_id": "mlx-community/Qwen3.8-27B-4bit",
+    "revision": "3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+    "license": "Apache-2.0",
+    "quantization": "MLX affine 4-bit, group size 64",
+    "converter": "mlx-vlm 0.6.8",
+    "converter_revision": "61990c9054f2bc7bb8f32541e3238b4a58fe64e5",
+    "download_bytes": 16081490933,
+    "sources": [
+      "https://huggingface.co/Qwen/Qwen3.8-27B/tree/1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+      "https://huggingface.co/mlx-community/Qwen3.8-27B-4bit/tree/3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+      "https://github.com/Blaizzy/mlx-vlm/tree/61990c9054f2bc7bb8f32541e3238b4a58fe64e5"
+    ]
+  },
+  "environment": {
+    "os_name": "Darwin",
+    "os_release": "25.6.0",
+    "architecture": "arm64",
+    "python_implementation": "CPython",
+    "python_version": "3.13.15",
+    "cpu_count": 18,
+    "total_memory_gb": 24.0,
+    "accelerator": "Apple M5 Pro",
+    "package_versions": {
+      "aiohttp": "3.14.3",
+      "fastapi": "0.141.1",
+      "huggingface-hub": "1.13.0",
+      "llmtracefx": "1.0.0",
+      "mlx": "0.32.2",
+      "mlx-lm": "0.31.3",
+      "mlx-vlm": "0.6.8",
+      "numpy": "2.2.6",
+      "pandas": "2.3.3",
+      "plotly": "6.2.0",
+      "streamlit": "1.62.0",
+      "transformers": "5.16.1",
+      "uvicorn": "0.35.0"
+    }
+  },
+  "runtime_contract": {
+    "name": "mlx-vlm",
+    "version": "0.6.8",
+    "mlx_version": "0.32.2",
+    "mlx_lm_version": "0.31.3",
+    "transformers_version": "5.16.1",
+    "prefill_step_size": 2048
+  },
+  "generation": {
+    "max_output_tokens": 96,
+    "seed": 20260831,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "enable_thinking": false
+  },
+  "repetitions": {
+    "warmup_per_tier": 1,
+    "measured_per_workload": 2
+  },
+  "cooperative_timeout_seconds": 1800.0,
+  "safety": {
+    "required_chip": "Apple M5 Pro",
+    "required_total_memory_bytes": 25769803776,
+    "minimum_free_disk_after_download_bytes": 107374182400,
+    "minimum_memory_free_percent": 25.0,
+    "maximum_peak_memory_bytes": 21474836480,
+    "maximum_swap_used_bytes": 12884901888,
+    "stop_on_any_failed_row": true
+  },
+  "safety_observations": {
+    "provenance": "macOS memory_pressure and sysctl",
+    "preflight_memory_free_percent": 36.0,
+    "preflight_swap_used_bytes": 8472494080,
+    "postflight_memory_free_percent": 4.0,
+    "postflight_swap_used_bytes": 20151795712
+  },
+  "tiers": [],
+  "failed_attempts": [
+    {
+      "run_id": "structured-json-profile-extraction-2k-warmup-01",
+      "tier": "2k",
+      "phase": "warmup",
+      "status": "failed",
+      "reason": "[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory).",
+      "input_tokens": 1657,
+      "total_ms": 22730.868291997467,
+      "prefill_ms": null,
+      "decode_ms": null,
+      "peak_memory_bytes": null
+    }
+  ],
+  "stopped_before_tier": null,
+  "stopped_during": {
+    "tier": "2k",
+    "phase": "warmup"
+  },
+  "requested_max_tier": "2k",
+  "unattempted_tiers": [],
+  "not_executed_tiers": [
+    "8k",
+    "16k"
+  ],
+  "stop_reasons": [
+    "[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)."
+  ],
+  "limitations": [
+    "Results apply only to the pinned model, runtime, workloads, context tiers, and this 24 GB M5 Pro configuration.",
+    "Total, prefill, and decode durations are host wall-clock boundaries; they are not kernel timings.",
+    "Peak memory is MLX allocator peak memory when available, not whole-system resident memory.",
+    "Decode token rate is derived from measured generated tokens and decode wall time.",
+    "The configured timeout is cooperative and cannot preempt a blocked native model-load or prefill call.",
+    "No GPU utilization, bandwidth, power, energy, or kernel timing is measured or inferred.",
+    "The 4-bit conversion card names the upstream model but does not cryptographically bind its source revision."
+  ]
+}

--- a/examples/optimizer/m5-pro-qwen3.8-27b/report.html
+++ b/examples/optimizer/m5-pro-qwen3.8-27b/report.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>M5 Pro Qwen3.8 local inference lab</title>
+<style>
+:root{--ink:#17202a;--muted:#5d6670;--paper:#f7f3ea;--panel:#fffdf8;--accent:#f05d23;}
+*{box-sizing:border-box} body{margin:0;background:var(--paper);color:var(--ink);
+font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace} main{max-width:1120px;
+margin:auto;padding:40px 24px} h1{font-size:clamp(28px,5vw,54px);line-height:1.02}
+.stamp{color:var(--muted)} .card,.chart{background:var(--panel);border:1px solid #d9d1c3;
+padding:20px;margin:20px 0;overflow:auto} table{width:100%;border-collapse:collapse;
+min-width:900px} th,td{text-align:right;padding:10px;border-bottom:1px solid #ddd5c8}
+th:first-child,td:first-child{text-align:left} svg{width:100%;min-width:560px}
+.bar{fill:var(--accent)} .axis,.value{font:14px ui-monospace,SFMono-Regular,Menlo,monospace;
+fill:var(--ink)} code{overflow-wrap:anywhere} .warning{border-left:5px solid var(--accent)}
+</style>
+</head>
+<body><main>
+<p class="stamp">LLMTraceFX / local evidence / no external references</p>
+<h1>M5 Pro × Qwen3.8-27B</h1>
+<p>Measured evidence for <code>mlx-community/Qwen3.8-27B-4bit@3e6447f082e89cc7f0bc6e5441afd38dfce760ff</code>,
+MLX affine 4-bit, group size 64, under the pinned workloads and constraints below. This
+is not a universal fastest-model claim.</p>
+<section class="card"><h2>Run contract</h2>
+<p>Official model: <code>Qwen/Qwen3.8-27B@1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0</code><br>
+License: Apache-2.0<br>Converter: mlx-vlm 0.6.8 at
+<code>61990c9054f2bc7bb8f32541e3238b4a58fe64e5</code><br>Generated:
+2026-08-31T14:57:58.660151Z</p></section>
+<section class="card"><h2>Environment</h2><p>
+Accelerator: Apple M5 Pro<br>
+Memory: 24.0 GiB<br>
+OS: Darwin
+25.6.0 / arm64<br>
+Python: 3.13.15<br>
+Runtime: mlx-vlm 0.6.8,
+MLX 0.32.2
+</p></section>
+<section class="card"><h2>Safety observations</h2><p>
+Preflight free memory: 36.0%,
+swap used: 8472494080 bytes.<br>
+Postflight free memory: 4.0%,
+swap used: 20151795712 bytes.<br>
+Provenance: macOS memory_pressure and sysctl.
+</p></section>
+<section class="card"><h2>Measured outcomes</h2><table><thead><tr>
+<th>Tier</th><th>Runs</th><th>Pass rate</th><th>Mean quality</th>
+<th>Total ms</th><th>Prefill ms</th><th>Decode ms</th><th>Decode tok/s</th>
+<th>Correct/min</th></tr></thead><tbody></tbody></table></section>
+<section class="card warning"><h2>Stopped attempts</h2><table><thead><tr>
+<th>Tier</th><th>Phase</th><th>Status</th><th>Input tokens</th><th>Reason</th>
+</tr></thead><tbody><tr><td>2k</td><td>warmup</td><td>failed</td><td>1657</td><td>[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory).</td></tr></tbody></table></section>
+<section class="chart"><h2>Mean total latency by safe context tier</h2><svg viewBox="0 0 620 64" role="img" aria-label="Mean total latency by safe context tier"></svg></section><section class="chart"><h2>Deterministic evaluator pass rate</h2><svg viewBox="0 0 620 64" role="img" aria-label="Deterministic evaluator pass rate"></svg></section><section class="chart"><h2>Correct cases per minute</h2><svg viewBox="0 0 620 64" role="img" aria-label="Correct cases per minute"></svg></section><section class="chart"><h2>Observed MLX peak memory</h2><svg viewBox="0 0 620 64" role="img" aria-label="Observed MLX peak memory"></svg></section>
+<section class="card warning"><h2>Limits and provenance</h2><ul><li>Results apply only to the pinned model, runtime, workloads, context tiers, and this 24 GB M5 Pro configuration.</li><li>Total, prefill, and decode durations are host wall-clock boundaries; they are not kernel timings.</li><li>Peak memory is MLX allocator peak memory when available, not whole-system resident memory.</li><li>Decode token rate is derived from measured generated tokens and decode wall time.</li><li>The configured timeout is cooperative and cannot preempt a blocked native model-load or prefill call.</li><li>No GPU utilization, bandwidth, power, energy, or kernel timing is measured or inferred.</li><li>The 4-bit conversion card names the upstream model but does not cryptographically bind its source revision.</li></ul>
+<p>Stop point: 2k / warmup. Requested maximum:
+2k. Not executed:
+8k, 16k.</p></section>
+</main></body></html>

--- a/llmtracefx/optimizer/cli.py
+++ b/llmtracefx/optimizer/cli.py
@@ -229,6 +229,10 @@ def _collect_mlx_argv(args: argparse.Namespace) -> tuple[str, ...]:
         str(args.max_tokens),
         "--seed",
         str(args.seed),
+        "--temperature",
+        str(args.temperature),
+        "--top-p",
+        str(args.top_p),
         "--num-draft-tokens",
         str(args.num_draft_tokens),
     ]
@@ -256,6 +260,8 @@ def _cmd_collect_mlx(args: argparse.Namespace) -> int:
             command_argv=_collect_mlx_argv(args),
             max_tokens=args.max_tokens,
             seed=args.seed,
+            temperature=args.temperature,
+            top_p=args.top_p,
             model_revision=args.model_revision,
             tokenizer_revision=args.tokenizer_revision,
             quantization=args.quantization,
@@ -265,7 +271,18 @@ def _cmd_collect_mlx(args: argparse.Namespace) -> int:
             ),
             num_draft_tokens=args.num_draft_tokens,
         )
-        result = collect_mlx(config, runtime=MLXLMRuntime())
+        runtime = MLXLMRuntime()
+        configure_sampling = getattr(runtime, "configure_sampling", None)
+        if configure_sampling is not None:
+            configure_sampling(
+                temperature=args.temperature,
+                top_p=args.top_p,
+            )
+        elif args.temperature != 0.0 or args.top_p != 1.0:
+            raise MLXCollectorError(
+                "the selected MLX runtime cannot apply non-default sampling"
+            )
+        result = collect_mlx(config, runtime=runtime)
     except (OSError, UnicodeError, MLXCollectorError) as exc:
         print(f"Failed to collect MLX evidence: {exc}", file=sys.stderr)
         return 1
@@ -2482,6 +2499,8 @@ def build_parser() -> argparse.ArgumentParser:
     collect_mlx_parser.add_argument("--output-dir", required=True)
     collect_mlx_parser.add_argument("--max-tokens", type=int, default=128)
     collect_mlx_parser.add_argument("--seed", type=int, default=0)
+    collect_mlx_parser.add_argument("--temperature", type=float, default=0.0)
+    collect_mlx_parser.add_argument("--top-p", type=float, default=1.0)
     collect_mlx_parser.add_argument(
         "--accelerator",
         default=None,

--- a/llmtracefx/optimizer/collectors/mlx.py
+++ b/llmtracefx/optimizer/collectors/mlx.py
@@ -8,13 +8,14 @@ collector's scope.
 
 from __future__ import annotations
 
+import math
 import platform
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from ...profiler.mlx_tracer import mlx_memory_snapshot
 from ..manifest import collect_environment_manifest
@@ -74,6 +75,12 @@ class MLXRuntime(Protocol):
     @property
     def mlx_lm_version(self) -> str | None: ...
 
+    @property
+    def runtime_name(self) -> str: ...
+
+    @property
+    def runtime_version(self) -> str | None: ...
+
     def load_model(self, path: Path) -> tuple[Any, Any]: ...
 
     def encode(self, tokenizer: Any, prompt: str) -> list[int]: ...
@@ -110,14 +117,15 @@ def _installed_version(distribution: str) -> str | None:
 class MLXLMRuntime:
     """Production adapter for MLX-LM on Apple Silicon."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, temperature: float = 0.0, top_p: float = 1.0) -> None:
         if platform.system() != "Darwin" or platform.machine() != "arm64":
             raise MLXCollectorError(
                 "MLX collection requires Apple Silicon running macOS"
             )
         try:
-            import mlx.core as mx  # type: ignore[import-not-found]
+            import mlx.core as mx
             from mlx_lm import load, stream_generate
+            from mlx_lm.sample_utils import make_sampler
         except ImportError as exc:
             raise MLXCollectorError(
                 "MLX collection requires the optional runtime dependencies. "
@@ -128,6 +136,11 @@ class MLXLMRuntime:
         self._mx = mx
         self._load = load
         self._stream_generate = stream_generate
+        self._make_sampler = make_sampler
+        self.configure_sampling(temperature=temperature, top_p=top_p)
+
+    def configure_sampling(self, *, temperature: float, top_p: float) -> None:
+        self._sampler = self._make_sampler(temp=temperature, top_p=top_p)
 
     @property
     def mlx_version(self) -> str | None:
@@ -136,6 +149,14 @@ class MLXLMRuntime:
     @property
     def mlx_lm_version(self) -> str | None:
         return _installed_version("mlx-lm")
+
+    @property
+    def runtime_name(self) -> str:
+        return "mlx-lm"
+
+    @property
+    def runtime_version(self) -> str | None:
+        return self.mlx_lm_version
 
     def load_model(self, path: Path) -> tuple[Any, Any]:
         loaded = self._load(str(path), lazy=False, return_config=False)
@@ -202,11 +223,192 @@ class MLXLMRuntime:
         draft_model: Any | None,
         num_draft_tokens: int,
     ) -> Iterator[MLXGenerationResponse]:
-        kwargs: dict[str, Any] = {"max_tokens": max_tokens}
+        kwargs: dict[str, Any] = {
+            "max_tokens": max_tokens,
+            "sampler": self._sampler,
+        }
         if draft_model is not None:
             kwargs["draft_model"] = draft_model
             kwargs["num_draft_tokens"] = num_draft_tokens
-        return self._stream_generate(model, tokenizer, prompt_tokens, **kwargs)
+        return cast(
+            Iterator[MLXGenerationResponse],
+            self._stream_generate(model, tokenizer, prompt_tokens, **kwargs),
+        )
+
+
+@dataclass
+class _MLXVLMGenerationResponse:
+    text: str
+    from_draft: bool
+    prompt_tokens: int
+    generation_tokens: int
+    finish_reason: str | None
+
+
+class MLXVLMRuntime:
+    """Text-only adapter for MLX-VLM checkpoints such as Qwen3.8.
+
+    The adapter deliberately requires an existing local checkpoint path. It
+    applies the checkpoint's chat template with no image/audio/video inputs,
+    tokenizes before the collector's generation phase, and passes those exact
+    token IDs to ``mlx_vlm.stream_generate``. This keeps prompt-token counts
+    measured by the model's own processor and avoids an implicit second
+    tokenization inside the timed prefill boundary.
+    """
+
+    def __init__(
+        self,
+        *,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        enable_thinking: bool = False,
+        prefill_step_size: int = 2048,
+    ) -> None:
+        if temperature < 0:
+            raise MLXCollectorError("temperature must be non-negative")
+        if not 0 < top_p <= 1:
+            raise MLXCollectorError("top_p must be within (0, 1]")
+        if prefill_step_size < 1:
+            raise MLXCollectorError("prefill_step_size must be positive")
+        if platform.system() != "Darwin" or platform.machine() != "arm64":
+            raise MLXCollectorError(
+                "MLX-VLM collection requires Apple Silicon running macOS"
+            )
+        try:
+            import mlx.core as mx
+            from mlx_vlm import load, stream_generate
+            from mlx_vlm.prompt_utils import apply_chat_template
+        except ImportError as exc:
+            raise MLXCollectorError(
+                "MLX-VLM collection requires the optional runtime dependencies. "
+                "Install them with `uv sync --extra mlx`."
+            ) from exc
+
+        self._mx = mx
+        self._load = load
+        self._stream_generate = stream_generate
+        self._apply_chat_template = apply_chat_template
+        self._temperature = temperature
+        self._top_p = top_p
+        self._enable_thinking = enable_thinking
+        self._prefill_step_size = prefill_step_size
+        self._loaded: dict[Path, tuple[Any, Any]] = {}
+        self._active_config: Any | None = None
+
+    @property
+    def mlx_version(self) -> str | None:
+        return _installed_version("mlx")
+
+    @property
+    def mlx_lm_version(self) -> str | None:
+        return _installed_version("mlx-vlm")
+
+    @property
+    def runtime_name(self) -> str:
+        return "mlx-vlm"
+
+    @property
+    def runtime_version(self) -> str | None:
+        return _installed_version("mlx-vlm")
+
+    def load_model(self, path: Path) -> tuple[Any, Any]:
+        resolved = path.resolve()
+        loaded = self._loaded.get(resolved)
+        if loaded is None:
+            loaded = self._load(str(resolved), lazy=False)
+            if len(loaded) != 2:
+                raise MLXCollectorError(
+                    "mlx_vlm.load returned an unexpected result shape"
+                )
+            self._loaded[resolved] = (loaded[0], loaded[1])
+        model, processor = self._loaded[resolved]
+        self._active_config = model.config
+        return model, processor
+
+    def encode(self, processor: Any, prompt: str) -> list[int]:
+        if self._active_config is None:
+            raise MLXCollectorError("MLX-VLM model must be loaded before tokenization")
+        formatted = self._apply_chat_template(
+            processor,
+            self._active_config,
+            prompt,
+            num_images=0,
+            num_audios=0,
+            enable_thinking=self._enable_thinking,
+        )
+        if not isinstance(formatted, str):
+            raise MLXCollectorError(
+                "MLX-VLM chat template returned a non-text prompt for a text-only run"
+            )
+        tokenizer = (
+            processor.tokenizer if hasattr(processor, "tokenizer") else processor
+        )
+        encoded = tokenizer.encode(formatted, add_special_tokens=True)
+        return [int(token) for token in encoded]
+
+    def seed(self, seed: int) -> None:
+        self._mx.random.seed(seed)
+
+    def synchronize(self) -> None:
+        self._mx.synchronize()
+
+    def reset_peak_memory(self) -> None:
+        reset = getattr(self._mx, "reset_peak_memory", None)
+        if reset is not None:
+            reset()
+
+    def memory_snapshot(self) -> MLXMemorySnapshot:
+        snapshot = mlx_memory_snapshot(self._mx)
+        return MLXMemorySnapshot(
+            active_bytes=snapshot.get("active_memory_bytes"),
+            cache_bytes=snapshot.get("cache_memory_bytes"),
+            peak_bytes=snapshot.get("peak_memory_bytes"),
+        )
+
+    def accelerator_name(self) -> str | None:
+        device_info = cast(Any, self._mx.device_info())
+        if not isinstance(device_info, dict):
+            return None
+        for key in ("device_name", "architecture"):
+            value = device_info.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def stream_generate(
+        self,
+        model: Any,
+        processor: Any,
+        prompt_tokens: list[int],
+        *,
+        max_tokens: int,
+        draft_model: Any | None,
+        num_draft_tokens: int,
+    ) -> Iterator[MLXGenerationResponse]:
+        if draft_model is not None:
+            raise MLXCollectorError(
+                "generic MLX-LM draft models are not accepted by MLX-VLM runs"
+            )
+        input_ids = self._mx.array([prompt_tokens])
+        for response in self._stream_generate(
+            model,
+            processor,
+            "",
+            input_ids=input_ids,
+            max_tokens=max_tokens,
+            temperature=self._temperature,
+            top_p=self._top_p,
+            enable_thinking=self._enable_thinking,
+            prefill_step_size=self._prefill_step_size,
+            verbose=False,
+        ):
+            yield _MLXVLMGenerationResponse(
+                text=response.text,
+                from_draft=bool(getattr(response, "is_draft", False)),
+                prompt_tokens=int(response.prompt_tokens),
+                generation_tokens=int(response.generation_tokens),
+                finish_reason=response.finish_reason,
+            )
 
 
 @dataclass(frozen=True)
@@ -221,12 +423,21 @@ class MLXCollectionConfig:
     command_argv: tuple[str, ...]
     max_tokens: int = 128
     seed: int = 0
+    temperature: float = 0.0
+    top_p: float = 1.0
+    enable_thinking: bool = False
+    prefill_step_size: int | None = None
     model_revision: str | None = None
     tokenizer_revision: str | None = None
     quantization: str | None = None
+    model_family: str | None = None
     accelerator: str | None = None
     draft_model_path: Path | None = None
     num_draft_tokens: int = 2
+    timeout_seconds: float | None = None
+    warmup_repetitions: int = 0
+    measured_repetitions: int = 1
+    repetition_index: int = 0
 
     def __post_init__(self) -> None:
         if not self.run_id:
@@ -255,11 +466,60 @@ class MLXCollectionConfig:
         if isinstance(self.seed, bool) or not isinstance(self.seed, int):
             raise MLXCollectorError("seed must be an integer")
         if (
+            isinstance(self.temperature, bool)
+            or not isinstance(self.temperature, (int, float))
+            or not math.isfinite(self.temperature)
+            or not 0 <= self.temperature
+        ):
+            raise MLXCollectorError("temperature must be non-negative")
+        if (
+            isinstance(self.top_p, bool)
+            or not isinstance(self.top_p, (int, float))
+            or not math.isfinite(self.top_p)
+            or not 0 < self.top_p <= 1
+        ):
+            raise MLXCollectorError("top_p must be within (0, 1]")
+        if not isinstance(self.enable_thinking, bool):
+            raise MLXCollectorError("enable_thinking must be a boolean")
+        if self.prefill_step_size is not None and (
+            isinstance(self.prefill_step_size, bool)
+            or not isinstance(self.prefill_step_size, int)
+            or self.prefill_step_size < 1
+        ):
+            raise MLXCollectorError("prefill_step_size must be positive when set")
+        if (
             isinstance(self.num_draft_tokens, bool)
             or not isinstance(self.num_draft_tokens, int)
             or self.num_draft_tokens < 1
         ):
             raise MLXCollectorError("num_draft_tokens must be a positive integer")
+        if self.timeout_seconds is not None and (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or self.timeout_seconds <= 0
+        ):
+            raise MLXCollectorError("timeout_seconds must be positive when set")
+        if (
+            isinstance(self.warmup_repetitions, bool)
+            or not isinstance(self.warmup_repetitions, int)
+            or self.warmup_repetitions < 0
+        ):
+            raise MLXCollectorError("warmup_repetitions must be a non-negative integer")
+        if (
+            isinstance(self.measured_repetitions, bool)
+            or not isinstance(self.measured_repetitions, int)
+            or self.measured_repetitions < 1
+        ):
+            raise MLXCollectorError("measured_repetitions must be a positive integer")
+        if (
+            isinstance(self.repetition_index, bool)
+            or not isinstance(self.repetition_index, int)
+            or self.repetition_index < 0
+            or self.repetition_index >= self.measured_repetitions
+        ):
+            raise MLXCollectorError(
+                "repetition_index must identify a measured repetition"
+            )
 
 
 @dataclass(frozen=True)
@@ -270,18 +530,60 @@ class MLXCollectionResult:
     response_text: str
 
 
-def _config_hash(config: MLXCollectionConfig) -> str:
+def mlx_collection_contract_hash(
+    *,
+    model_id: str,
+    model_revision: str | None,
+    tokenizer_revision: str | None,
+    quantization: str | None,
+    model_family: str | None,
+    max_tokens: int,
+    seed: int,
+    temperature: float,
+    top_p: float,
+    enable_thinking: bool,
+    prefill_step_size: int | None,
+    draft_enabled: bool,
+    num_draft_tokens: int,
+    timeout_seconds: float | None,
+) -> str:
+    """Hash every semantic collector setting, excluding paths and repetition."""
     payload = {
-        "model_id": config.model_id,
-        "model_revision": config.model_revision,
-        "tokenizer_revision": config.tokenizer_revision,
-        "quantization": config.quantization,
-        "max_tokens": config.max_tokens,
-        "seed": config.seed,
-        "draft_enabled": config.draft_model_path is not None,
-        "num_draft_tokens": config.num_draft_tokens,
+        "model_id": model_id,
+        "model_revision": model_revision,
+        "tokenizer_revision": tokenizer_revision,
+        "quantization": quantization,
+        "model_family": model_family,
+        "max_tokens": max_tokens,
+        "seed": seed,
+        "temperature": temperature,
+        "top_p": top_p,
+        "enable_thinking": enable_thinking,
+        "prefill_step_size": prefill_step_size,
+        "draft_enabled": draft_enabled,
+        "num_draft_tokens": num_draft_tokens,
+        "timeout_seconds": timeout_seconds,
     }
     return config_hash(payload)
+
+
+def _config_hash(config: MLXCollectionConfig) -> str:
+    return mlx_collection_contract_hash(
+        model_id=config.model_id,
+        model_revision=config.model_revision,
+        tokenizer_revision=config.tokenizer_revision,
+        quantization=config.quantization,
+        model_family=config.model_family,
+        max_tokens=config.max_tokens,
+        seed=config.seed,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        enable_thinking=config.enable_thinking,
+        prefill_step_size=config.prefill_step_size,
+        draft_enabled=config.draft_model_path is not None,
+        num_draft_tokens=config.num_draft_tokens,
+        timeout_seconds=config.timeout_seconds,
+    )
 
 
 def collect_mlx(
@@ -313,6 +615,16 @@ def collect_mlx(
     memory = MLXMemorySnapshot()
     error: ErrorInfo | None = None
 
+    def check_timeout(stage: str) -> None:
+        if (
+            config.timeout_seconds is not None
+            and clock() - total_started > config.timeout_seconds
+        ):
+            raise TimeoutError(
+                f"MLX collection exceeded {config.timeout_seconds:g}s "
+                f"timeout during {stage}"
+            )
+
     try:
         load_started = clock()
         model, tokenizer = runtime.load_model(config.model_path)
@@ -323,11 +635,13 @@ def collect_mlx(
         )
         runtime.synchronize()
         load_ended = clock()
+        check_timeout("model load")
 
         runtime.reset_peak_memory()
         tokenize_started = clock()
         prompt_tokens = runtime.encode(tokenizer, config.prompt)
         tokenize_ended = clock()
+        check_timeout("tokenization")
         runtime.seed(config.seed)
         runtime.synchronize()
 
@@ -342,6 +656,7 @@ def collect_mlx(
             num_draft_tokens=config.num_draft_tokens,
         ):
             observed_at = clock()
+            check_timeout("generation")
             if first_token_at is None:
                 first_token_at = observed_at
             response_parts.append(response.text)
@@ -358,7 +673,14 @@ def collect_mlx(
         runtime.synchronize()
         generation_ended = clock()
         memory = runtime.memory_snapshot()
-    except (KeyError, RuntimeError, ValueError, OSError, MemoryError) as exc:
+    except (
+        KeyError,
+        RuntimeError,
+        ValueError,
+        OSError,
+        MemoryError,
+        TimeoutError,
+    ) as exc:
         generation_ended = clock()
         error = ErrorInfo(category=type(exc).__name__, message=str(exc))
 
@@ -375,10 +697,11 @@ def collect_mlx(
             model_revision=config.model_revision,
             tokenizer_revision=config.tokenizer_revision,
             quantization=config.quantization,
+            model_family=config.model_family,
         ),
         runtime=RuntimeInfo(
-            name="mlx-lm",
-            version=runtime.mlx_lm_version,
+            name=getattr(runtime, "runtime_name", "mlx-lm"),
+            version=getattr(runtime, "runtime_version", runtime.mlx_lm_version),
             backend="Metal",
             git_revision=None,
         ),
@@ -388,9 +711,9 @@ def collect_mlx(
             workload_hash=sha256_text(config.prompt),
         ),
         repetition=RepetitionInfo(
-            warmup_repetitions=0,
-            measured_repetitions=1,
-            repetition_index=0,
+            warmup_repetitions=config.warmup_repetitions,
+            measured_repetitions=config.measured_repetitions,
+            repetition_index=config.repetition_index,
             seed=config.seed,
         ),
         tokens=TokenCounts(
@@ -432,6 +755,14 @@ def collect_mlx(
     config.output_dir.mkdir(parents=True, exist_ok=True)
     record.write_json(config.output_dir / "record.json")
     atomic_write_text(config.output_dir / "response.txt", response_text)
-    manifest = collect_environment_manifest(extra_packages=("mlx", "mlx-lm"))
+    manifest = collect_environment_manifest(
+        extra_packages=(
+            "mlx",
+            "mlx-lm",
+            "mlx-vlm",
+            "transformers",
+            "huggingface-hub",
+        )
+    )
     atomic_write_text(config.output_dir / "environment.json", manifest.to_json() + "\n")
     return MLXCollectionResult(record=record, response_text=response_text)

--- a/llmtracefx/optimizer/lab/__init__.py
+++ b/llmtracefx/optimizer/lab/__init__.py
@@ -1,0 +1,5 @@
+"""Reproducible local inference lab orchestration."""
+
+from .manifest import LabManifest, LabManifestError
+
+__all__ = ["LabManifest", "LabManifestError"]

--- a/llmtracefx/optimizer/lab/cli.py
+++ b/llmtracefx/optimizer/lab/cli.py
@@ -1,0 +1,223 @@
+"""Command line entrypoint for the pinned local inference lab."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+
+from .core import (
+    LabError,
+    acquire_model,
+    assess_safety,
+    model_files_present,
+    run_lab,
+    verify_catalog,
+    verify_evidence,
+    verify_model,
+    write_reports,
+)
+from .manifest import LabManifest, LabManifestError
+
+DEFAULT_MANIFEST_RESOURCE = "data/lab-manifest-v1.json"
+
+
+def _load(args: argparse.Namespace) -> tuple[LabManifest, str, Path, Path]:
+    if args.manifest is None:
+        resource = resources.files("llmtracefx.optimizer.lab").joinpath(
+            DEFAULT_MANIFEST_RESOURCE
+        )
+        manifest = LabManifest.from_json(resource.read_text(encoding="utf-8"))
+        manifest_source = (
+            f"package:llmtracefx.optimizer.lab/{DEFAULT_MANIFEST_RESOURCE}"
+        )
+    else:
+        manifest_path = Path(args.manifest)
+        manifest = LabManifest.read_json(manifest_path)
+        manifest_source = str(manifest_path)
+    workspace = (
+        Path(args.workspace)
+        if args.workspace is not None
+        else Path(manifest.artifacts.workspace)
+    )
+    model_path = (
+        Path(args.model_path)
+        if args.model_path is not None
+        else Path(manifest.artifacts.model_cache)
+    )
+    verify_catalog(manifest)
+    return manifest, manifest_source, workspace, model_path
+
+
+def _cmd_plan(args: argparse.Namespace) -> int:
+    manifest, manifest_source, workspace, model_path = _load(args)
+    present = model_files_present(manifest, model_path)
+    workspace_decision = assess_safety(manifest, workspace, include_download=False)
+    model_decision = assess_safety(
+        manifest,
+        model_path.parent,
+        include_download=not present,
+    )
+    payload = {
+        "action": "plan",
+        "no_spend": True,
+        "downloads_performed": False,
+        "model_present_by_size": present,
+        "manifest": manifest_source,
+        "workspace": str(workspace),
+        "model_path": str(model_path),
+        "model": {
+            "official_id": manifest.model.official_id,
+            "official_revision": manifest.model.official_revision,
+            "repository_id": manifest.model.repository_id,
+            "revision": manifest.model.revision,
+            "license": manifest.model.license,
+            "quantization": manifest.model.quantization,
+            "expected_download_bytes": manifest.model.expected_download_bytes,
+        },
+        "tiers": [tier.name for tier in manifest.context_tiers],
+        "safety": model_decision.to_dict(),
+        "workspace_safety": workspace_decision.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=False))
+    return 0 if model_decision.safe and workspace_decision.safe else 2
+
+
+def _cmd_acquire(args: argparse.Namespace) -> int:
+    manifest, _, workspace, model_path = _load(args)
+    result = acquire_model(manifest, model_path=model_path, workspace=workspace)
+    print(json.dumps(result, indent=2, sort_keys=False))
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    manifest, _, workspace, model_path = _load(args)
+    if not model_files_present(manifest, model_path):
+        if not args.acquire:
+            raise LabError(
+                "pinned model is not present; rerun with --acquire after "
+                "reviewing the no-spend plan"
+            )
+        acquire_model(manifest, model_path=model_path, workspace=workspace)
+    else:
+        verify_model(manifest, model_path)
+    state = run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier=args.max_tier,
+        resume=not args.no_resume,
+    )
+    report = write_reports(
+        manifest,
+        workspace=workspace,
+        shareable_dir=(
+            Path(args.shareable_dir)
+            if args.shareable_dir
+            else Path(manifest.artifacts.shareable_example_dir)
+        ),
+    )
+    print(
+        json.dumps(
+            {
+                "state": state,
+                "report": report,
+            },
+            indent=2,
+            sort_keys=False,
+        )
+    )
+    return 0 if not state["stop_reasons"] else 2
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    manifest, _, workspace, _ = _load(args)
+    report = write_reports(
+        manifest,
+        workspace=workspace,
+        shareable_dir=(
+            Path(args.shareable_dir)
+            if args.shareable_dir
+            else Path(manifest.artifacts.shareable_example_dir)
+        ),
+    )
+    print(json.dumps(report, indent=2, sort_keys=False))
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    manifest, _, workspace, model_path = _load(args)
+    verify_model(manifest, model_path)
+    result = verify_evidence(manifest, workspace=workspace)
+    print(json.dumps(result, indent=2, sort_keys=False))
+    return 0 if result["verified"] else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="llmtracefx-m5-lab",
+        description=(
+            "Pinned, safety-gated Qwen3.8-27B MLX-VLM evidence lab. "
+            "The default action is an offline/no-download plan."
+        ),
+    )
+    parser.add_argument(
+        "action",
+        nargs="?",
+        default="plan",
+        choices=("plan", "acquire", "run", "report", "verify"),
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help=(
+            "Optional lab manifest path; defaults to the versioned manifest "
+            "packaged with llmtracefx"
+        ),
+    )
+    parser.add_argument("--workspace", default=None)
+    parser.add_argument("--model-path", default=None)
+    parser.add_argument(
+        "--max-tier",
+        choices=("2k", "8k", "16k"),
+        default="2k",
+        help="Highest requested tier; every prior tier must pass its safety gate",
+    )
+    parser.add_argument(
+        "--acquire",
+        action="store_true",
+        help="Allow `run` to download the pinned public model when absent",
+    )
+    parser.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Ignore hash-matching completed row artifacts",
+    )
+    parser.add_argument(
+        "--shareable-dir",
+        default=None,
+        help="Optional destination for sanitized JSON and self-contained HTML",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    commands = {
+        "plan": _cmd_plan,
+        "acquire": _cmd_acquire,
+        "run": _cmd_run,
+        "report": _cmd_report,
+        "verify": _cmd_verify,
+    }
+    try:
+        return commands[args.action](args)
+    except (OSError, UnicodeError, LabManifestError, LabError) as exc:
+        print(f"M5 lab failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llmtracefx/optimizer/lab/core.py
+++ b/llmtracefx/optimizer/lab/core.py
@@ -1,0 +1,1721 @@
+"""Safety-gated orchestration for the pinned M5 Pro Qwen3.8 lab."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import platform
+import re
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, replace
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+from ..collectors._shared import atomic_write_text, config_hash
+from ..collectors.mlx import MLXVLMRuntime, mlx_collection_contract_hash
+from ..compare.compare import compare
+from ..compare.policy import CompareConstraints, CompareObjective, ComparePolicy
+from ..compare.report_html import render_compare_report_html
+from ..schema import ExperimentRecord, MetricProvenance, utc_now_iso
+from ..tune.policy import TuneConstraints, TuneObjective, TunePolicy
+from ..tune.report_html import render_tune_report_html
+from ..tune.tuner import tune
+from ..workloads.aggregate import correct_cases_per_minute
+from ..workloads.catalog import workload_by_id
+from ..workloads.materialize import MaterializedPrompt, materialize_prompt
+from ..workloads.matrix import (
+    DECODE_MODE_AUTOREGRESSIVE,
+    MatrixEntry,
+)
+from ..workloads.schema import CONTEXT_TIER_TARGET_TOKENS, ContextTier
+from ..workloads.verify import (
+    RowResult,
+    RowStatus,
+    RowVerification,
+    RunBinding,
+    execute_row,
+)
+from .manifest import LabManifest, LabManifestError
+
+LAB_REPORT_SCHEMA_VERSION = "1"
+MODEL_VERIFICATION_SCHEMA_VERSION = "1"
+LAB_STATE_SCHEMA_VERSION = "1"
+
+_PRIVATE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"/Users/[^/\s]+"),
+    re.compile(r"/home/[^/\s]+"),
+    re.compile(r"[A-Za-z]:\\Users\\[^\\\s]+"),
+    re.compile(r"\b(?:hf[_-]|sk-)[A-Za-z0-9_-]{12,}\b"),
+    re.compile(r"(?<![:/\w])(?:/|\.{1,2}/|[A-Za-z]:\\)[^\s'\"<>]+"),
+)
+
+
+class LabError(RuntimeError):
+    """Raised when a lab action cannot proceed safely."""
+
+
+@dataclass(frozen=True)
+class HostSnapshot:
+    collected_at: str
+    os_name: str
+    os_release: str
+    architecture: str
+    python_implementation: str
+    python_version: str
+    cpu_count: int | None
+    chip: str | None
+    total_memory_bytes: int | None
+    memory_free_percent: float | None
+    swap_used_bytes: int | None
+    disk_free_bytes: int
+    package_versions: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SafetyDecision:
+    safe: bool
+    blockers: tuple[str, ...]
+    snapshot: HostSnapshot
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "safe": self.safe,
+            "blockers": list(self.blockers),
+            "snapshot": self.snapshot.to_dict(),
+        }
+
+
+def _run_text(argv: list[str]) -> str | None:
+    try:
+        return subprocess.run(
+            argv,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            shell=False,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _parse_byte_quantity(value: str) -> int | None:
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)([KMG])", value)
+    if match is None:
+        return None
+    factors = {"K": 1024, "M": 1024**2, "G": 1024**3}
+    return int(float(match.group(1)) * factors[match.group(2)])
+
+
+def collect_host_snapshot(path: Path) -> HostSnapshot:
+    disk_probe = path
+    while not disk_probe.exists() and disk_probe != disk_probe.parent:
+        disk_probe = disk_probe.parent
+    memory_raw = _run_text(["sysctl", "-n", "hw.memsize"])
+    chip = _run_text(["sysctl", "-n", "machdep.cpu.brand_string"])
+    pressure = _run_text(["memory_pressure"])
+    swap = _run_text(["sysctl", "-n", "vm.swapusage"])
+    free_match = (
+        re.search(r"System-wide memory free percentage:\s*([0-9.]+)%", pressure)
+        if pressure
+        else None
+    )
+    swap_match = re.search(r"\bused\s*=\s*([0-9.]+[KMG])", swap) if swap else None
+    versions: dict[str, str] = {}
+    for package in (
+        "llmtracefx",
+        "mlx",
+        "mlx-lm",
+        "mlx-vlm",
+        "transformers",
+        "huggingface-hub",
+    ):
+        try:
+            versions[package] = importlib_metadata.version(package)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return HostSnapshot(
+        collected_at=utc_now_iso(),
+        os_name=platform.system(),
+        os_release=platform.release(),
+        architecture=platform.machine(),
+        python_implementation=platform.python_implementation(),
+        python_version=platform.python_version(),
+        cpu_count=(
+            None
+            if (cpu_count := _run_text(["sysctl", "-n", "hw.ncpu"])) is None
+            else int(cpu_count)
+        ),
+        chip=chip,
+        total_memory_bytes=(
+            int(memory_raw) if memory_raw and memory_raw.isdigit() else None
+        ),
+        memory_free_percent=(
+            float(free_match.group(1)) if free_match is not None else None
+        ),
+        swap_used_bytes=(
+            _parse_byte_quantity(swap_match.group(1))
+            if swap_match is not None
+            else None
+        ),
+        disk_free_bytes=shutil.disk_usage(disk_probe).free,
+        package_versions=dict(sorted(versions.items())),
+    )
+
+
+def assess_safety(
+    manifest: LabManifest,
+    path: Path,
+    *,
+    include_download: bool,
+) -> SafetyDecision:
+    snapshot = collect_host_snapshot(path)
+    blockers: list[str] = []
+    required_free = manifest.safety.minimum_free_disk_after_download_bytes
+    if include_download:
+        required_free += manifest.model.expected_download_bytes
+    if snapshot.disk_free_bytes < required_free:
+        blockers.append(
+            f"disk free {snapshot.disk_free_bytes} bytes is below required "
+            f"{required_free} bytes"
+        )
+    if snapshot.os_name != "Darwin" or snapshot.architecture != "arm64":
+        blockers.append("the selected MLX lab requires Apple Silicon macOS")
+    if snapshot.chip != manifest.safety.required_chip:
+        blockers.append(
+            f"chip is {snapshot.chip or 'unavailable'}, expected "
+            f"{manifest.safety.required_chip}"
+        )
+    if snapshot.total_memory_bytes is None:
+        blockers.append("total physical memory could not be measured")
+    elif snapshot.total_memory_bytes != manifest.safety.required_total_memory_bytes:
+        blockers.append(
+            f"physical memory is {snapshot.total_memory_bytes} bytes, expected "
+            f"{manifest.safety.required_total_memory_bytes} bytes"
+        )
+    if snapshot.memory_free_percent is None:
+        blockers.append("current memory headroom could not be measured")
+    elif snapshot.memory_free_percent < manifest.safety.minimum_memory_free_percent:
+        blockers.append(
+            f"memory free {snapshot.memory_free_percent:g}% is below "
+            f"{manifest.safety.minimum_memory_free_percent:g}%"
+        )
+    if snapshot.swap_used_bytes is None:
+        blockers.append("current swap usage could not be measured")
+    elif snapshot.swap_used_bytes > manifest.safety.maximum_swap_used_bytes:
+        blockers.append(
+            f"swap used {snapshot.swap_used_bytes} bytes exceeds "
+            f"{manifest.safety.maximum_swap_used_bytes} bytes"
+        )
+    expected_versions = {
+        "mlx": manifest.runtime.mlx_version,
+        "mlx-lm": manifest.runtime.mlx_lm_version,
+        manifest.runtime.name: manifest.runtime.version,
+        "transformers": manifest.runtime.transformers_version,
+    }
+    for package, expected in expected_versions.items():
+        observed = snapshot.package_versions.get(package)
+        if observed != expected:
+            blockers.append(
+                f"{package} version is {observed or 'not installed'}, expected {expected}"
+            )
+    return SafetyDecision(
+        safe=not blockers, blockers=tuple(blockers), snapshot=snapshot
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_model(manifest: LabManifest, model_path: Path) -> dict[str, Any]:
+    failures: list[str] = []
+    files: list[dict[str, Any]] = []
+    expected_paths = {pin.path for pin in manifest.model.files}
+    if model_path.is_dir():
+        unexpected = sorted(
+            path.name
+            for path in model_path.iterdir()
+            if path.name != ".cache" and path.name not in expected_paths
+        )
+        failures.extend(f"unpinned model-root entry: {name}" for name in unexpected)
+    for pin in manifest.model.files:
+        path = model_path / pin.path
+        if not path.is_file() or path.is_symlink():
+            failures.append(f"missing regular model file: {pin.path}")
+            continue
+        size = path.stat().st_size
+        if size != pin.size_bytes:
+            failures.append(f"{pin.path} size {size} does not match {pin.size_bytes}")
+            continue
+        digest = _sha256_file(path)
+        if digest != pin.sha256:
+            failures.append(f"{pin.path} sha256 {digest} does not match {pin.sha256}")
+            continue
+        files.append({"path": pin.path, "size_bytes": size, "sha256": digest})
+    result = {
+        "schema_version": MODEL_VERIFICATION_SCHEMA_VERSION,
+        "repository_id": manifest.model.repository_id,
+        "revision": manifest.model.revision,
+        "verified": not failures,
+        "failures": failures,
+        "files": files,
+    }
+    if failures:
+        raise LabError("model verification failed: " + "; ".join(failures))
+    return result
+
+
+def acquire_model(
+    manifest: LabManifest, *, model_path: Path, workspace: Path
+) -> dict[str, Any]:
+    workspace_decision = assess_safety(manifest, workspace, include_download=False)
+    model_decision = assess_safety(manifest, model_path.parent, include_download=True)
+    blockers = tuple(
+        dict.fromkeys(workspace_decision.blockers + model_decision.blockers)
+    )
+    if blockers:
+        raise LabError("download blocked by safety preflight: " + "; ".join(blockers))
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise LabError("huggingface-hub is required; install the `mlx` extra") from exc
+    downloaded = Path(
+        snapshot_download(
+            repo_id=manifest.model.repository_id,
+            revision=manifest.model.revision,
+            local_dir=model_path,
+            allow_patterns=[pin.path for pin in manifest.model.files],
+        )
+    )
+    result = verify_model(manifest, downloaded)
+    workspace.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        workspace / "model-verification.json",
+        json.dumps(result, indent=2, sort_keys=False) + "\n",
+    )
+    return result
+
+
+def model_files_present(manifest: LabManifest, model_path: Path) -> bool:
+    return all(
+        (model_path / pin.path).is_file()
+        and not (model_path / pin.path).is_symlink()
+        and (model_path / pin.path).stat().st_size == pin.size_bytes
+        for pin in manifest.model.files
+    )
+
+
+def verify_catalog(manifest: LabManifest) -> None:
+    expected_tiers = {tier.value: tier for tier in ContextTier}
+    for tier in manifest.context_tiers:
+        enum_tier = expected_tiers.get(tier.name)
+        if enum_tier is None:
+            raise LabManifestError(
+                f"context tier {tier.name!r} is not supported by the workload catalog"
+            )
+        if CONTEXT_TIER_TARGET_TOKENS[enum_tier] != tier.target_tokens:
+            raise LabManifestError(
+                f"context tier {tier.name!r} target changed from pinned "
+                f"{tier.target_tokens} to {CONTEXT_TIER_TARGET_TOKENS[enum_tier]}"
+            )
+    for pin in manifest.workloads:
+        try:
+            workload = workload_by_id(pin.workload_id)
+        except KeyError as exc:
+            raise LabManifestError(
+                f"pinned workload {pin.workload_id!r} is not in the catalog"
+            ) from exc
+        if workload.version != pin.version:
+            raise LabManifestError(
+                f"workload {pin.workload_id!r} version changed from "
+                f"{pin.version} to {workload.version}"
+            )
+        for tier_name, expected_hash in pin.prompt_hashes.items():
+            materialized = materialize_prompt(workload, expected_tiers[tier_name])
+            if materialized.prompt_hash != expected_hash:
+                raise LabManifestError(
+                    f"workload {pin.workload_id!r} {tier_name} prompt hash "
+                    f"changed from {expected_hash} to {materialized.prompt_hash}"
+                )
+
+
+def _entry(
+    manifest: LabManifest,
+    *,
+    workload_id: str,
+    tier: ContextTier,
+    repetition_index: int,
+    prompt: MaterializedPrompt,
+    prompt_path: Path,
+    output_dir: Path,
+    warmup: bool,
+) -> MatrixEntry:
+    label = "warmup" if warmup else "rep"
+    run_id = f"{workload_id}-{tier.value}-{label}-{repetition_index + 1:02d}"
+    return MatrixEntry(
+        run_id=run_id,
+        workload_id=workload_id,
+        workload_version=workload_by_id(workload_id).version,
+        category=workload_by_id(workload_id).category.value,
+        context_tier=tier.value,
+        decode_mode=DECODE_MODE_AUTOREGRESSIVE,
+        configured_depth=None,
+        prompt=prompt,
+        prompt_path=str(prompt_path.resolve()),
+        runner_results_dir=str((output_dir / "runner" / run_id).resolve()),
+        collector_output_dir=str(
+            (output_dir / "runs" / run_id / "collection").resolve()
+        ),
+        runnable=True,
+        unsupported_reason=None,
+        command_argv=("llmtracefx-m5-lab", "run"),
+        max_tokens=manifest.generation.max_output_tokens,
+    )
+
+
+def _binding(
+    manifest: LabManifest,
+    model_path: Path,
+    *,
+    repetition_index: int,
+    hardware_fingerprint: str,
+    measured_repetitions: int | None = None,
+) -> RunBinding:
+    return RunBinding(
+        target_model_path=model_path,
+        seed=manifest.generation.seed,
+        temperature=manifest.generation.temperature,
+        top_p=manifest.generation.top_p,
+        enable_thinking=manifest.generation.enable_thinking,
+        prefill_step_size=manifest.runtime.prefill_step_size,
+        model_revision=manifest.model.revision,
+        tokenizer_revision=manifest.model.revision,
+        quantization=manifest.model.quantization,
+        model_family="qwen3_5",
+        timeout_seconds=manifest.cooperative_timeout_seconds,
+        warmup_repetitions=manifest.repetitions.warmup_per_tier,
+        measured_repetitions=(
+            measured_repetitions
+            if measured_repetitions is not None
+            else manifest.repetitions.measured_per_workload
+        ),
+        repetition_index=repetition_index,
+        hardware_fingerprint=hardware_fingerprint,
+    )
+
+
+def _write_prompt(path: Path, prompt: MaterializedPrompt) -> None:
+    atomic_write_text(path, prompt.text)
+
+
+def _peak_bytes(result: RowResult) -> float | None:
+    if result.final_record is None or result.final_record.memory.peak is None:
+        return None
+    return result.final_record.memory.peak.value
+
+
+def _tier_is_safe(
+    manifest: LabManifest,
+    results: tuple[RowResult, ...],
+    postflight: SafetyDecision,
+) -> tuple[bool, tuple[str, ...]]:
+    blockers = list(postflight.blockers)
+    for result in results:
+        if (
+            manifest.safety.stop_on_any_failed_row
+            and result.verification.status
+            not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+        ):
+            blockers.append(
+                f"{result.entry.run_id} ended as " f"{result.verification.status.value}"
+            )
+        peak = _peak_bytes(result)
+        if peak is None:
+            blockers.append(f"{result.entry.run_id} has no observed MLX peak memory")
+        elif peak > manifest.safety.maximum_peak_memory_bytes:
+            blockers.append(
+                f"{result.entry.run_id} peak memory {peak:.0f} exceeds "
+                f"{manifest.safety.maximum_peak_memory_bytes} bytes"
+            )
+    return not blockers, tuple(blockers)
+
+
+def run_lab(
+    manifest: LabManifest,
+    *,
+    workspace: Path,
+    model_path: Path,
+    max_tier: str,
+    resume: bool,
+) -> dict[str, Any]:
+    verify_catalog(manifest)
+    verify_model(manifest, model_path)
+    preflight = assess_safety(manifest, workspace, include_download=False)
+    if not preflight.safe:
+        raise LabError(
+            "run blocked by safety preflight: " + "; ".join(preflight.blockers)
+        )
+
+    selected_max = manifest.tier(max_tier)
+    tiers = tuple(
+        tier for tier in manifest.context_tiers if tier.order <= selected_max.order
+    )
+    hardware_fingerprint = config_hash(
+        {
+            "os_name": preflight.snapshot.os_name,
+            "os_release": preflight.snapshot.os_release,
+            "architecture": preflight.snapshot.architecture,
+            "python_implementation": preflight.snapshot.python_implementation,
+            "python_version": preflight.snapshot.python_version,
+            "cpu_count": preflight.snapshot.cpu_count,
+            "chip": preflight.snapshot.chip,
+            "total_memory_bytes": preflight.snapshot.total_memory_bytes,
+            "package_versions": preflight.snapshot.package_versions,
+        }
+    )
+
+    state: dict[str, Any] = {
+        "schema_version": LAB_STATE_SCHEMA_VERSION,
+        "lab_id": manifest.lab_id,
+        "started_at": utc_now_iso(),
+        "status": "running",
+        "requested_max_tier": max_tier,
+        "preflight": preflight.to_dict(),
+        "tiers": [],
+        "stopped_before_tier": None,
+        "stopped_during": None,
+        "unattempted_tiers": [],
+        "stop_reasons": [],
+    }
+    state["execution_id"] = config_hash(
+        {
+            "lab_id": manifest.lab_id,
+            "started_at": state["started_at"],
+            "hardware_fingerprint": hardware_fingerprint,
+        }
+    )
+    workspace.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        workspace / "state.json",
+        json.dumps(state, indent=2, sort_keys=False) + "\n",
+    )
+
+    runtime = MLXVLMRuntime(
+        temperature=manifest.generation.temperature,
+        top_p=manifest.generation.top_p,
+        enable_thinking=manifest.generation.enable_thinking,
+        prefill_step_size=manifest.runtime.prefill_step_size,
+    )
+
+    def runtime_factory() -> MLXVLMRuntime:
+        return runtime
+
+    results_root = workspace / "results"
+
+    for tier_pin in tiers:
+        tier = ContextTier(tier_pin.name)
+        tier_preflight = assess_safety(manifest, workspace, include_download=False)
+        if not tier_preflight.safe:
+            state["stopped_before_tier"] = tier.value
+            state["unattempted_tiers"] = [
+                candidate.name
+                for candidate in manifest.context_tiers
+                if tier_pin.order <= candidate.order <= selected_max.order
+            ]
+            state["stop_reasons"] = list(tier_preflight.blockers)
+            break
+
+        warmup_results: list[RowResult] = []
+        if manifest.repetitions.warmup_per_tier:
+            warmup_pin = manifest.workloads[0]
+            warmup_workload = workload_by_id(warmup_pin.workload_id)
+            prompt = materialize_prompt(warmup_workload, tier)
+            prompt_path = (
+                workspace
+                / "prompts"
+                / (f"{warmup_workload.workload_id}-{tier.value}.txt")
+            )
+            _write_prompt(prompt_path, prompt)
+            for index in range(manifest.repetitions.warmup_per_tier):
+                warmup_entry = _entry(
+                    manifest,
+                    workload_id=warmup_workload.workload_id,
+                    tier=tier,
+                    repetition_index=index,
+                    prompt=prompt,
+                    prompt_path=prompt_path,
+                    output_dir=workspace / "warmups" / tier.value,
+                    warmup=True,
+                )
+                warmup_binding = _binding(
+                    manifest,
+                    model_path,
+                    repetition_index=index,
+                    hardware_fingerprint=hardware_fingerprint,
+                    measured_repetitions=max(manifest.repetitions.warmup_per_tier, 1),
+                )
+                result = execute_row(
+                    warmup_entry,
+                    manifest_dir=workspace,
+                    output_dir=workspace / "warmups" / tier.value,
+                    model_id=manifest.model.repository_id,
+                    binding=warmup_binding,
+                    resume=False,
+                    runtime_factory=runtime_factory,
+                )
+                warmup_results.append(result)
+                if (
+                    manifest.safety.stop_on_any_failed_row
+                    and result.verification.status
+                    not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+                ):
+                    break
+        if any(
+            result.verification.status not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+            for result in warmup_results
+        ):
+            reasons = [
+                result.verification.reason
+                or f"{result.entry.run_id} ended as {result.verification.status.value}"
+                for result in warmup_results
+                if result.verification.status
+                not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+            ]
+            state["tiers"].append(
+                {
+                    "tier": tier.value,
+                    "status": "failed_warmup",
+                    "run_ids": [result.entry.run_id for result in warmup_results],
+                    "maximum_observed_peak_memory_bytes": max(
+                        (
+                            peak
+                            for result in warmup_results
+                            if (peak := _peak_bytes(result)) is not None
+                        ),
+                        default=None,
+                    ),
+                    "postflight": assess_safety(
+                        manifest, workspace, include_download=False
+                    ).to_dict(),
+                    "blockers": reasons,
+                }
+            )
+            state["stopped_during"] = {
+                "tier": tier.value,
+                "phase": "warmup",
+            }
+            state["stopped_before_tier"] = None
+            state["unattempted_tiers"] = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stop_reasons"] = reasons
+            break
+        warmup_postflight = assess_safety(manifest, workspace, include_download=False)
+        warmup_safe, warmup_blockers = _tier_is_safe(
+            manifest, tuple(warmup_results), warmup_postflight
+        )
+        if not warmup_safe:
+            state["tiers"].append(
+                {
+                    "tier": tier.value,
+                    "status": "failed_warmup_safety",
+                    "run_ids": [result.entry.run_id for result in warmup_results],
+                    "maximum_observed_peak_memory_bytes": max(
+                        (
+                            peak
+                            for result in warmup_results
+                            if (peak := _peak_bytes(result)) is not None
+                        ),
+                        default=None,
+                    ),
+                    "postflight": warmup_postflight.to_dict(),
+                    "blockers": list(warmup_blockers),
+                }
+            )
+            state["stopped_during"] = {
+                "tier": tier.value,
+                "phase": "warmup_safety",
+            }
+            state["stopped_before_tier"] = None
+            state["unattempted_tiers"] = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stop_reasons"] = list(warmup_blockers)
+            break
+
+        tier_results: list[RowResult] = []
+        for workload_pin in manifest.workloads:
+            workload = workload_by_id(workload_pin.workload_id)
+            prompt = materialize_prompt(workload, tier)
+            prompt_path = (
+                workspace / "prompts" / (f"{workload.workload_id}-{tier.value}.txt")
+            )
+            _write_prompt(prompt_path, prompt)
+            for index in range(manifest.repetitions.measured_per_workload):
+                entry = _entry(
+                    manifest,
+                    workload_id=workload.workload_id,
+                    tier=tier,
+                    repetition_index=index,
+                    prompt=prompt,
+                    prompt_path=prompt_path,
+                    output_dir=results_root,
+                    warmup=False,
+                )
+                result = execute_row(
+                    entry,
+                    manifest_dir=workspace,
+                    output_dir=results_root,
+                    model_id=manifest.model.repository_id,
+                    binding=_binding(
+                        manifest,
+                        model_path,
+                        repetition_index=index,
+                        hardware_fingerprint=hardware_fingerprint,
+                    ),
+                    resume=resume,
+                    runtime_factory=runtime_factory,
+                )
+                tier_results.append(result)
+                if (
+                    manifest.safety.stop_on_any_failed_row
+                    and result.verification.status
+                    not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+                ):
+                    break
+            if (
+                tier_results
+                and manifest.safety.stop_on_any_failed_row
+                and tier_results[-1].verification.status
+                not in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+            ):
+                break
+
+        postflight = assess_safety(manifest, workspace, include_download=False)
+        safe, blockers = _tier_is_safe(manifest, tuple(tier_results), postflight)
+        state["tiers"].append(
+            {
+                "tier": tier.value,
+                "status": "passed" if safe else "failed",
+                "run_ids": [result.entry.run_id for result in tier_results],
+                "maximum_observed_peak_memory_bytes": max(
+                    (
+                        peak
+                        for result in tier_results
+                        if (peak := _peak_bytes(result)) is not None
+                    ),
+                    default=None,
+                ),
+                "postflight": postflight.to_dict(),
+                "blockers": list(blockers),
+            }
+        )
+        atomic_write_text(
+            workspace / "state.json",
+            json.dumps(state, indent=2, sort_keys=False) + "\n",
+        )
+        if not safe:
+            remaining = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stopped_before_tier"] = remaining[0] if remaining else None
+            state["stopped_during"] = {
+                "tier": tier.value,
+                "phase": "measured_or_postflight",
+            }
+            state["unattempted_tiers"] = remaining
+            state["stop_reasons"] = list(blockers)
+            break
+
+    state["ended_at"] = utc_now_iso()
+    state["status"] = "stopped" if state["stop_reasons"] else "completed"
+    atomic_write_text(
+        workspace / "state.json",
+        json.dumps(state, indent=2, sort_keys=False) + "\n",
+    )
+    return state
+
+
+def _measurement(record: ExperimentRecord, name: str) -> float | None:
+    value = getattr(record.timing, name)
+    return None if value is None else value.value
+
+
+def _tier_summary(
+    tier: str, rows: list[tuple[RowVerification, ExperimentRecord]]
+) -> dict[str, Any]:
+    evaluated = [
+        (verification, record)
+        for verification, record in rows
+        if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+    ]
+    passed = [record for _, record in evaluated if record.outcome.success]
+
+    def average(values: list[float]) -> float | None:
+        return mean(values) if values else None
+
+    total_values = [
+        value
+        for _, record in evaluated
+        if (value := _measurement(record, "total")) is not None
+    ]
+    pass_total = sum(
+        value
+        for record in passed
+        if (value := _measurement(record, "total")) is not None
+    )
+    peaks = [
+        record.memory.peak.value
+        for _, record in evaluated
+        if record.memory.peak is not None
+    ]
+    quality = [
+        record.outcome.quality_score
+        for _, record in evaluated
+        if record.outcome.quality_score is not None
+    ]
+    decode_ms = [
+        value
+        for _, record in evaluated
+        if (value := _measurement(record, "decode")) is not None and value > 0
+    ]
+    token_rates = []
+    for _, record in evaluated:
+        tokens = record.tokens.generated_tokens
+        duration = _measurement(record, "decode")
+        if tokens is not None and tokens > 1 and duration is not None and duration > 0:
+            # ``decode`` starts when the first token is observed, so only
+            # subsequent tokens belong in its derived throughput numerator.
+            token_rates.append((tokens - 1) / (duration / 1000))
+    return {
+        "tier": tier,
+        "runs": len(rows),
+        "evaluated_runs": len(evaluated),
+        "passing_runs": len(passed),
+        "pass_rate": len(passed) / len(evaluated) if evaluated else None,
+        "mean_quality_score": average([float(value) for value in quality]),
+        "mean_total_ms": average(total_values),
+        "mean_prefill_ms": average(
+            [
+                value
+                for _, record in evaluated
+                if (value := _measurement(record, "prefill")) is not None
+            ]
+        ),
+        "mean_decode_ms": average(decode_ms),
+        "mean_decode_tokens_per_second": average(token_rates),
+        "max_peak_memory_bytes": max(peaks) if peaks else None,
+        "correct_cases_per_minute": correct_cases_per_minute(len(passed), pass_total),
+        "timing_provenance": MetricProvenance.MEASURED_WALL_CLOCK.value,
+        "memory_provenance": (
+            MetricProvenance.MEASURED_NATIVE.value if peaks else None
+        ),
+        "token_rate_provenance": (
+            MetricProvenance.DERIVED.value if token_rates else None
+        ),
+    }
+
+
+def _argv_value(record: ExperimentRecord, flag: str) -> str | None:
+    argv = record.command.argv
+    try:
+        index = argv.index(flag)
+    except ValueError:
+        return None
+    return argv[index + 1] if index + 1 < len(argv) else None
+
+
+def _record_matches_manifest(
+    manifest: LabManifest,
+    verification: RowVerification,
+    record: ExperimentRecord,
+    *,
+    warmup: bool,
+    allowed_tiers: set[str],
+) -> bool:
+    workload_pins = {workload.workload_id: workload for workload in manifest.workloads}
+    workload = workload_pins.get(verification.workload_id)
+    if workload is None or verification.context_tier not in allowed_tiers:
+        return False
+    expected_hash = workload.prompt_hashes.get(verification.context_tier)
+    if (
+        verification.workload_version != workload.version
+        or verification.verified_prompt_hash != expected_hash
+        or record.command.workload_hash != expected_hash
+    ):
+        return False
+    label = "warmup" if warmup else "rep"
+    expected_run_id = (
+        f"{workload.workload_id}-{verification.context_tier}-{label}-"
+        f"{record.repetition.repetition_index + 1:02d}"
+    )
+    if verification.run_id != expected_run_id or record.run_id != expected_run_id:
+        return False
+    expected_measured = (
+        max(manifest.repetitions.warmup_per_tier, 1)
+        if warmup
+        else manifest.repetitions.measured_per_workload
+    )
+    expected_warmups = manifest.repetitions.warmup_per_tier
+    if (
+        record.repetition.measured_repetitions != expected_measured
+        or record.repetition.warmup_repetitions != expected_warmups
+        or record.repetition.seed != manifest.generation.seed
+    ):
+        return False
+    expected_memory_gb = manifest.safety.required_total_memory_bytes / 1024**3
+    expected_config_hash = mlx_collection_contract_hash(
+        model_id=manifest.model.repository_id,
+        model_revision=manifest.model.revision,
+        tokenizer_revision=manifest.model.revision,
+        quantization=manifest.model.quantization,
+        model_family="qwen3_5",
+        max_tokens=manifest.generation.max_output_tokens,
+        seed=manifest.generation.seed,
+        temperature=manifest.generation.temperature,
+        top_p=manifest.generation.top_p,
+        enable_thinking=manifest.generation.enable_thinking,
+        prefill_step_size=manifest.runtime.prefill_step_size,
+        draft_enabled=False,
+        num_draft_tokens=2,
+        timeout_seconds=manifest.cooperative_timeout_seconds,
+    )
+    return (
+        record.model.model_id == manifest.model.repository_id
+        and record.model.model_revision == manifest.model.revision
+        and record.model.tokenizer_revision == manifest.model.revision
+        and record.model.quantization == manifest.model.quantization
+        and record.model.model_family == "qwen3_5"
+        and record.runtime.name == manifest.runtime.name
+        and record.runtime.version == manifest.runtime.version
+        and record.platform.accelerator == manifest.safety.required_chip
+        and record.platform.total_memory_gb == expected_memory_gb
+        and _argv_value(record, "--max-tokens")
+        == str(manifest.generation.max_output_tokens)
+        and _argv_value(record, "--temperature") == str(manifest.generation.temperature)
+        and _argv_value(record, "--top-p") == str(manifest.generation.top_p)
+        and record.command.config_hash == expected_config_hash
+    )
+
+
+def _environment_errors(
+    manifest: LabManifest, environment_path: Path
+) -> tuple[str, ...]:
+    try:
+        payload = json.loads(environment_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return (f"environment artifact is unreadable: {exc}",)
+    if not isinstance(payload, dict):
+        return ("environment artifact must be a JSON object",)
+    versions = payload.get("package_versions")
+    if not isinstance(versions, dict):
+        return ("environment package_versions is missing",)
+    expected = {
+        "mlx": manifest.runtime.mlx_version,
+        "mlx-lm": manifest.runtime.mlx_lm_version,
+        "mlx-vlm": manifest.runtime.version,
+        "transformers": manifest.runtime.transformers_version,
+    }
+    errors = [
+        f"{package} recorded as {versions.get(package)!r}, expected {version!r}"
+        for package, version in expected.items()
+        if versions.get(package) != version
+    ]
+    return tuple(errors)
+
+
+def _current_state_scope(
+    manifest: LabManifest, state: dict[str, Any]
+) -> tuple[set[str], set[str], set[str]]:
+    measured_run_ids: set[str] = set()
+    warmup_run_ids: set[str] = set()
+    attempted_tiers: set[str] = set()
+    for tier_state in state.get("tiers", []):
+        if not isinstance(tier_state, dict):
+            continue
+        tier_name = tier_state.get("tier")
+        if isinstance(tier_name, str):
+            attempted_tiers.add(tier_name)
+        if tier_state.get("status") in {
+            "failed_warmup",
+            "failed_warmup_safety",
+        }:
+            warmup_run_ids.update(
+                run_id
+                for run_id in tier_state.get("run_ids", [])
+                if isinstance(run_id, str)
+            )
+        else:
+            measured_run_ids.update(
+                run_id
+                for run_id in tier_state.get("run_ids", [])
+                if isinstance(run_id, str)
+            )
+            if isinstance(tier_name, str):
+                warmup_run_ids.update(
+                    f"{manifest.workloads[0].workload_id}-{tier_name}-"
+                    f"warmup-{index + 1:02d}"
+                    for index in range(manifest.repetitions.warmup_per_tier)
+                )
+    stopped_during = state.get("stopped_during")
+    if isinstance(stopped_during, dict):
+        tier_name = stopped_during.get("tier")
+        if isinstance(tier_name, str):
+            attempted_tiers.add(tier_name)
+    legacy_stopped = state.get("stopped_before_tier")
+    if (
+        "stopped_during" not in state
+        and not attempted_tiers
+        and isinstance(legacy_stopped, str)
+    ):
+        attempted_tiers.add(legacy_stopped)
+    valid_tiers = {tier.name for tier in manifest.context_tiers}
+    attempted_tiers.intersection_update(valid_tiers)
+    if not warmup_run_ids and "stopped_during" not in state:
+        warmup_run_ids.update(
+            f"{manifest.workloads[0].workload_id}-{tier}-warmup-01"
+            for tier in attempted_tiers
+        )
+    return attempted_tiers, measured_run_ids, warmup_run_ids
+
+
+def build_shareable_report(manifest: LabManifest, *, workspace: Path) -> dict[str, Any]:
+    state_path = workspace / "state.json"
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
+    if state.get("status") == "running":
+        raise LabError(
+            "current lab execution is incomplete; report generation is refused"
+        )
+    allowed_tiers, measured_run_ids, warmup_run_ids = _current_state_scope(
+        manifest, state
+    )
+    environment: dict[str, Any] | None = None
+    rows_by_tier: dict[str, list[tuple[RowVerification, ExperimentRecord]]] = {}
+    runs_dir = workspace / "results" / "runs"
+    if runs_dir.is_dir():
+        for verification_path in sorted(runs_dir.glob("*/verification.json")):
+            verification = RowVerification.read_json(verification_path)
+            if (
+                verification.final_record_path is None
+                or verification.run_id not in measured_run_ids
+            ):
+                continue
+            record = ExperimentRecord.read_json(
+                verification_path.parent / "final_record.json"
+            )
+            if not _record_matches_manifest(
+                manifest,
+                verification,
+                record,
+                warmup=False,
+                allowed_tiers=allowed_tiers,
+            ):
+                continue
+            if _environment_errors(
+                manifest,
+                verification_path.parent / "collection" / "environment.json",
+            ):
+                continue
+            environment_path = (
+                verification_path.parent / "collection" / "environment.json"
+            )
+            if environment is None and environment_path.is_file():
+                raw_environment = json.loads(
+                    environment_path.read_text(encoding="utf-8")
+                )
+                environment = {
+                    "os_name": raw_environment.get("os_name"),
+                    "os_release": raw_environment.get("os_release"),
+                    "architecture": raw_environment.get("architecture"),
+                    "python_implementation": raw_environment.get(
+                        "python_implementation"
+                    ),
+                    "python_version": raw_environment.get("python_version"),
+                    "cpu_count": raw_environment.get("cpu_count"),
+                    "total_memory_gb": raw_environment.get("total_memory_gb"),
+                    "accelerator": record.platform.accelerator,
+                    "package_versions": raw_environment.get("package_versions", {}),
+                }
+            rows_by_tier.setdefault(verification.context_tier, []).append(
+                (verification, record)
+            )
+    tier_order = {tier.name: tier.order for tier in manifest.context_tiers}
+    tiers = [
+        _tier_summary(name, rows)
+        for name, rows in sorted(
+            rows_by_tier.items(), key=lambda item: tier_order[item[0]]
+        )
+    ]
+    failed_attempts: list[dict[str, Any]] = []
+    warmups_dir = workspace / "warmups"
+    if warmups_dir.is_dir():
+        for verification_path in sorted(warmups_dir.glob("*/runs/*/verification.json")):
+            verification = RowVerification.read_json(verification_path)
+            if verification.run_id not in warmup_run_ids:
+                continue
+            record_path = verification_path.parent / "final_record.json"
+            failed_record = (
+                ExperimentRecord.read_json(record_path)
+                if verification.final_record_path is not None and record_path.is_file()
+                else None
+            )
+            if failed_record is not None and not _record_matches_manifest(
+                manifest,
+                verification,
+                failed_record,
+                warmup=True,
+                allowed_tiers=allowed_tiers,
+            ):
+                continue
+            if failed_record is not None and _environment_errors(
+                manifest,
+                verification_path.parent / "collection" / "environment.json",
+            ):
+                continue
+            environment_path = (
+                verification_path.parent / "collection" / "environment.json"
+            )
+            if (
+                environment is None
+                and verification.collection_dir is not None
+                and environment_path.is_file()
+            ):
+                raw_environment = json.loads(
+                    environment_path.read_text(encoding="utf-8")
+                )
+                environment = {
+                    "os_name": raw_environment.get("os_name"),
+                    "os_release": raw_environment.get("os_release"),
+                    "architecture": raw_environment.get("architecture"),
+                    "python_implementation": raw_environment.get(
+                        "python_implementation"
+                    ),
+                    "python_version": raw_environment.get("python_version"),
+                    "cpu_count": raw_environment.get("cpu_count"),
+                    "total_memory_gb": raw_environment.get("total_memory_gb"),
+                    "accelerator": (
+                        failed_record.platform.accelerator
+                        if failed_record is not None
+                        else None
+                    ),
+                    "package_versions": raw_environment.get("package_versions", {}),
+                }
+            if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED):
+                continue
+            failed_attempts.append(
+                {
+                    "run_id": verification.run_id,
+                    "tier": verification.context_tier,
+                    "phase": "warmup",
+                    "status": verification.status.value,
+                    "reason": verification.reason,
+                    "input_tokens": (
+                        failed_record.tokens.input_tokens
+                        if failed_record is not None
+                        else None
+                    ),
+                    "total_ms": (
+                        _measurement(failed_record, "total")
+                        if failed_record is not None
+                        else None
+                    ),
+                    "prefill_ms": (
+                        _measurement(failed_record, "prefill")
+                        if failed_record is not None
+                        else None
+                    ),
+                    "decode_ms": (
+                        _measurement(failed_record, "decode")
+                        if failed_record is not None
+                        else None
+                    ),
+                    "peak_memory_bytes": (
+                        failed_record.memory.peak.value
+                        if failed_record is not None
+                        and failed_record.memory.peak is not None
+                        else None
+                    ),
+                }
+            )
+    for tier_rows in rows_by_tier.values():
+        for verification, record in tier_rows:
+            if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED):
+                continue
+            failed_attempts.append(
+                {
+                    "run_id": verification.run_id,
+                    "tier": verification.context_tier,
+                    "phase": "measured",
+                    "status": verification.status.value,
+                    "reason": verification.reason,
+                    "input_tokens": record.tokens.input_tokens,
+                    "total_ms": _measurement(record, "total"),
+                    "prefill_ms": _measurement(record, "prefill"),
+                    "decode_ms": _measurement(record, "decode"),
+                    "peak_memory_bytes": (
+                        record.memory.peak.value
+                        if record.memory.peak is not None
+                        else None
+                    ),
+                }
+            )
+    stop_reasons = state.get("stop_reasons", [])
+    if failed_attempts:
+        stop_reasons = [
+            attempt["reason"]
+            for attempt in failed_attempts
+            if attempt["reason"] is not None
+        ]
+    stopped_during = state.get("stopped_during")
+    if stopped_during is None and failed_attempts:
+        stopped_during = {
+            "tier": failed_attempts[0]["tier"],
+            "phase": failed_attempts[0]["phase"],
+        }
+    unattempted_tiers = state.get("unattempted_tiers")
+    if not isinstance(unattempted_tiers, list) and stopped_during is not None:
+        stopped_tier = manifest.tier(stopped_during["tier"])
+        unattempted_tiers = [
+            tier.name
+            for tier in manifest.context_tiers
+            if tier.order > stopped_tier.order
+        ]
+    stopped_before_tier = (
+        state.get("stopped_before_tier") if stopped_during is None else None
+    )
+    requested_max_tier = state.get("requested_max_tier")
+    executed_tiers = set(allowed_tiers)
+    not_executed_tiers = [
+        tier.name for tier in manifest.context_tiers if tier.name not in executed_tiers
+    ]
+    preflight_snapshot = state.get("preflight", {}).get("snapshot", {})
+    tier_states = state.get("tiers", [])
+    last_postflight = (
+        tier_states[-1].get("postflight", {}).get("snapshot", {})
+        if tier_states and isinstance(tier_states[-1], dict)
+        else {}
+    )
+    report = {
+        "schema_version": LAB_REPORT_SCHEMA_VERSION,
+        "lab_id": manifest.lab_id,
+        "generated_at": state.get("ended_at"),
+        "model": {
+            "official_id": manifest.model.official_id,
+            "official_revision": manifest.model.official_revision,
+            "repository_id": manifest.model.repository_id,
+            "revision": manifest.model.revision,
+            "license": manifest.model.license,
+            "quantization": manifest.model.quantization,
+            "converter": manifest.model.converter,
+            "converter_revision": manifest.model.converter_revision,
+            "download_bytes": manifest.model.expected_download_bytes,
+            "sources": list(manifest.model.sources),
+        },
+        "environment": environment,
+        "runtime_contract": asdict(manifest.runtime),
+        "generation": asdict(manifest.generation),
+        "repetitions": asdict(manifest.repetitions),
+        "cooperative_timeout_seconds": manifest.cooperative_timeout_seconds,
+        "safety": asdict(manifest.safety),
+        "safety_observations": {
+            "provenance": "macOS memory_pressure and sysctl",
+            "preflight_memory_free_percent": preflight_snapshot.get(
+                "memory_free_percent"
+            ),
+            "preflight_swap_used_bytes": preflight_snapshot.get("swap_used_bytes"),
+            "postflight_memory_free_percent": last_postflight.get(
+                "memory_free_percent"
+            ),
+            "postflight_swap_used_bytes": last_postflight.get("swap_used_bytes"),
+        },
+        "tiers": tiers,
+        "failed_attempts": failed_attempts,
+        "stopped_before_tier": stopped_before_tier,
+        "stopped_during": stopped_during,
+        "requested_max_tier": requested_max_tier,
+        "unattempted_tiers": unattempted_tiers or [],
+        "not_executed_tiers": not_executed_tiers,
+        "stop_reasons": stop_reasons,
+        "limitations": [
+            "Results apply only to the pinned model, runtime, workloads, context tiers, and this 24 GB M5 Pro configuration.",
+            "Total, prefill, and decode durations are host wall-clock boundaries; they are not kernel timings.",
+            "Peak memory is MLX allocator peak memory when available, not whole-system resident memory.",
+            "Decode token rate is derived from measured generated tokens and decode wall time.",
+            "The configured timeout is cooperative and cannot preempt a blocked native model-load or prefill call.",
+            "No GPU utilization, bandwidth, power, energy, or kernel timing is measured or inferred.",
+            "The 4-bit conversion card names the upstream model but does not cryptographically bind its source revision.",
+        ],
+    }
+    assert_shareable(report)
+    return report
+
+
+def _stale_result_run_ids(manifest: LabManifest, *, workspace: Path) -> tuple[str, ...]:
+    state_path = workspace / "state.json"
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
+    allowed_tiers, measured_run_ids, _ = _current_state_scope(manifest, state)
+    stale: list[str] = []
+    runs_dir = workspace / "results" / "runs"
+    if not runs_dir.is_dir():
+        return ()
+    for verification_path in sorted(runs_dir.glob("*/verification.json")):
+        try:
+            verification = RowVerification.read_json(verification_path)
+            record = ExperimentRecord.read_json(
+                verification_path.parent / "final_record.json"
+            )
+        except (OSError, ValueError):
+            if verification_path.parent.name in measured_run_ids:
+                stale.append(verification_path.parent.name)
+            continue
+        if verification.run_id not in measured_run_ids:
+            continue
+        if not _record_matches_manifest(
+            manifest,
+            verification,
+            record,
+            warmup=False,
+            allowed_tiers=allowed_tiers,
+        ):
+            stale.append(verification.run_id)
+            continue
+        environment_errors = _environment_errors(
+            manifest,
+            verification_path.parent / "collection" / "environment.json",
+        )
+        if environment_errors:
+            stale.append(verification.run_id)
+    return tuple(stale)
+
+
+def _materialize_current_results(manifest: LabManifest, *, workspace: Path) -> Path:
+    state_path = workspace / "state.json"
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
+    _, measured_run_ids, _ = _current_state_scope(manifest, state)
+    state_digest = config_hash(state).removeprefix("sha256:")[:16]
+    filtered = workspace / "reports" / f"current-results-{state_digest}"
+    for run_id in sorted(measured_run_ids):
+        source = workspace / "results" / "runs" / run_id
+        verification = RowVerification.read_json(source / "verification.json")
+        record = ExperimentRecord.read_json(source / "final_record.json")
+        destination = filtered / "runs" / run_id
+        final_record_path = destination / "final_record.json"
+        record.write_json(final_record_path)
+        filtered_verification = replace(
+            verification,
+            final_record_path=str(final_record_path.resolve()),
+            collection_dir=None,
+        )
+        atomic_write_text(
+            destination / "verification.json",
+            filtered_verification.to_json(),
+        )
+    return filtered
+
+
+def assert_shareable(value: Any, *, context: str = "report") -> None:
+    if isinstance(value, dict):
+        forbidden_keys = {
+            "serial",
+            "serial_number",
+            "hardware_uuid",
+            "hostname",
+            "username",
+            "home",
+            "model_path",
+            "workspace",
+        }
+        overlap = forbidden_keys.intersection(str(key).lower() for key in value)
+        if overlap:
+            raise LabError(f"{context} contains private key(s): {sorted(overlap)}")
+        for key, item in value.items():
+            assert_shareable(item, context=f"{context}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            assert_shareable(item, context=f"{context}[{index}]")
+    elif isinstance(value, str):
+        for pattern in _PRIVATE_PATTERNS:
+            if pattern.search(value):
+                raise LabError(f"{context} contains private path or credential data")
+
+
+def _fmt(value: float | int | None, *, digits: int = 2) -> str:
+    return "n/a" if value is None else f"{value:.{digits}f}"
+
+
+def _bar_chart(
+    tiers: list[dict[str, Any]],
+    *,
+    metric: str,
+    title: str,
+    unit: str,
+    scale: float = 1.0,
+) -> str:
+    values = [
+        None if tier[metric] is None else float(tier[metric]) / scale for tier in tiers
+    ]
+    maximum = max((value for value in values if value is not None), default=1.0)
+    rows: list[str] = []
+    for index, (tier, value) in enumerate(zip(tiers, values, strict=True)):
+        y = 36 + index * 54
+        width = 0 if value is None or maximum <= 0 else 420 * value / maximum
+        label = "n/a" if value is None else f"{value:.2f} {unit}"
+        rows.append(
+            f'<text x="0" y="{y + 18}" class="axis">'
+            f"{html.escape(str(tier['tier']))}</text>"
+            f'<rect x="52" y="{y}" width="{width:.2f}" height="28" rx="3" '
+            'class="bar"/>'
+            f'<text x="{58 + width:.2f}" y="{y + 19}" class="value">{label}</text>'
+        )
+    height = 64 + len(tiers) * 54
+    return (
+        f'<section class="chart"><h2>{title}</h2>'
+        f'<svg viewBox="0 0 620 {height}" role="img" aria-label="{title}">'
+        + "".join(rows)
+        + "</svg></section>"
+    )
+
+
+def render_lab_report_html(report: dict[str, Any]) -> str:
+    assert_shareable(report)
+    tiers = list(report["tiers"])
+    model = report["model"]
+    environment = report["environment"] or {}
+    safety_observations = report["safety_observations"]
+
+    def esc(value: Any) -> str:
+        return html.escape(str(value), quote=True)
+
+    rows = "".join(
+        "<tr>"
+        f"<td>{esc(tier['tier'])}</td>"
+        f"<td>{tier['evaluated_runs']}</td>"
+        f"<td>{_fmt(tier['pass_rate'])}</td>"
+        f"<td>{_fmt(tier['mean_quality_score'])}</td>"
+        f"<td>{_fmt(tier['mean_total_ms'])}</td>"
+        f"<td>{_fmt(tier['mean_prefill_ms'])}</td>"
+        f"<td>{_fmt(tier['mean_decode_ms'])}</td>"
+        f"<td>{_fmt(tier['mean_decode_tokens_per_second'])}</td>"
+        f"<td>{_fmt(tier['correct_cases_per_minute'])}</td>"
+        "</tr>"
+        for tier in tiers
+    )
+    limitations = "".join(f"<li>{esc(item)}</li>" for item in report["limitations"])
+    failed_rows = "".join(
+        "<tr>"
+        f"<td>{esc(attempt['tier'])}</td>"
+        f"<td>{esc(attempt['phase'])}</td>"
+        f"<td>{esc(attempt['status'])}</td>"
+        f"<td>{esc(attempt['input_tokens'] if attempt['input_tokens'] is not None else 'n/a')}</td>"
+        f"<td>{esc(attempt['reason'] or 'unrecorded')}</td>"
+        "</tr>"
+        for attempt in report["failed_attempts"]
+    )
+    stopped_during = report["stopped_during"]
+    stopped_label = (
+        f"{stopped_during['tier']} / {stopped_during['phase']}"
+        if isinstance(stopped_during, dict)
+        else (
+            f"before {report['stopped_before_tier']}"
+            if report["stopped_before_tier"]
+            else "none"
+        )
+    )
+    charts = "".join(
+        (
+            _bar_chart(
+                tiers,
+                metric="mean_total_ms",
+                title="Mean total latency by safe context tier",
+                unit="ms",
+            ),
+            _bar_chart(
+                tiers,
+                metric="pass_rate",
+                title="Deterministic evaluator pass rate",
+                unit="",
+            ),
+            _bar_chart(
+                tiers,
+                metric="correct_cases_per_minute",
+                title="Correct cases per minute",
+                unit="cases/min",
+            ),
+            _bar_chart(
+                tiers,
+                metric="max_peak_memory_bytes",
+                title="Observed MLX peak memory",
+                unit="GiB",
+                scale=1024**3,
+            ),
+        )
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>M5 Pro Qwen3.8 local inference lab</title>
+<style>
+:root{{--ink:#17202a;--muted:#5d6670;--paper:#f7f3ea;--panel:#fffdf8;--accent:#f05d23;}}
+*{{box-sizing:border-box}} body{{margin:0;background:var(--paper);color:var(--ink);
+font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}} main{{max-width:1120px;
+margin:auto;padding:40px 24px}} h1{{font-size:clamp(28px,5vw,54px);line-height:1.02}}
+.stamp{{color:var(--muted)}} .card,.chart{{background:var(--panel);border:1px solid #d9d1c3;
+padding:20px;margin:20px 0;overflow:auto}} table{{width:100%;border-collapse:collapse;
+min-width:900px}} th,td{{text-align:right;padding:10px;border-bottom:1px solid #ddd5c8}}
+th:first-child,td:first-child{{text-align:left}} svg{{width:100%;min-width:560px}}
+.bar{{fill:var(--accent)}} .axis,.value{{font:14px ui-monospace,SFMono-Regular,Menlo,monospace;
+fill:var(--ink)}} code{{overflow-wrap:anywhere}} .warning{{border-left:5px solid var(--accent)}}
+</style>
+</head>
+<body><main>
+<p class="stamp">LLMTraceFX / local evidence / no external references</p>
+<h1>M5 Pro × Qwen3.8-27B</h1>
+<p>Measured evidence for <code>{esc(model['repository_id'])}@{esc(model['revision'])}</code>,
+{esc(model['quantization'])}, under the pinned workloads and constraints below. This
+is not a universal fastest-model claim.</p>
+<section class="card"><h2>Run contract</h2>
+<p>Official model: <code>{esc(model['official_id'])}@{esc(model['official_revision'])}</code><br>
+License: {esc(model['license'])}<br>Converter: {esc(model['converter'])} at
+<code>{esc(model['converter_revision'])}</code><br>Generated:
+{esc(report['generated_at'] or 'not run')}</p></section>
+<section class="card"><h2>Environment</h2><p>
+Accelerator: {esc(environment.get('accelerator') or 'unrecorded')}<br>
+Memory: {esc(environment.get('total_memory_gb') or 'unrecorded')} GiB<br>
+OS: {esc(environment.get('os_name') or 'unrecorded')}
+{esc(environment.get('os_release') or '')} / {esc(environment.get('architecture') or 'unrecorded')}<br>
+Python: {esc(environment.get('python_version') or 'unrecorded')}<br>
+Runtime: mlx-vlm {esc(environment.get('package_versions', {}).get('mlx-vlm', 'unrecorded'))},
+MLX {esc(environment.get('package_versions', {}).get('mlx', 'unrecorded'))}
+</p></section>
+<section class="card"><h2>Safety observations</h2><p>
+Preflight free memory: {esc(safety_observations['preflight_memory_free_percent'])}%,
+swap used: {esc(safety_observations['preflight_swap_used_bytes'])} bytes.<br>
+Postflight free memory: {esc(safety_observations['postflight_memory_free_percent'])}%,
+swap used: {esc(safety_observations['postflight_swap_used_bytes'])} bytes.<br>
+Provenance: {esc(safety_observations['provenance'])}.
+</p></section>
+<section class="card"><h2>Measured outcomes</h2><table><thead><tr>
+<th>Tier</th><th>Runs</th><th>Pass rate</th><th>Mean quality</th>
+<th>Total ms</th><th>Prefill ms</th><th>Decode ms</th><th>Decode tok/s</th>
+<th>Correct/min</th></tr></thead><tbody>{rows}</tbody></table></section>
+<section class="card warning"><h2>Stopped attempts</h2><table><thead><tr>
+<th>Tier</th><th>Phase</th><th>Status</th><th>Input tokens</th><th>Reason</th>
+</tr></thead><tbody>{failed_rows}</tbody></table></section>
+{charts}
+<section class="card warning"><h2>Limits and provenance</h2><ul>{limitations}</ul>
+<p>Stop point: {esc(stopped_label)}. Requested maximum:
+{esc(report['requested_max_tier'] or 'unrecorded')}. Not executed:
+{esc(', '.join(report['not_executed_tiers']) or 'none')}.</p></section>
+</main></body></html>
+"""
+
+
+def write_reports(
+    manifest: LabManifest,
+    *,
+    workspace: Path,
+    shareable_dir: Path | None = None,
+) -> dict[str, Any]:
+    evidence_verification = verify_evidence(manifest, workspace=workspace)
+    if not evidence_verification["verified"]:
+        raise LabError(
+            "report generation refused unverified current-run evidence: "
+            + "; ".join(evidence_verification["failures"])
+        )
+    stale = _stale_result_run_ids(manifest, workspace=workspace)
+    if stale:
+        raise LabError(
+            "report generation refused stale or mismatched run evidence: "
+            + ", ".join(stale)
+        )
+    report = build_shareable_report(manifest, workspace=workspace)
+    reports_dir = workspace / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        reports_dir / "lab-report.json",
+        json.dumps(report, indent=2, sort_keys=False) + "\n",
+    )
+    atomic_write_text(reports_dir / "lab-report.html", render_lab_report_html(report))
+
+    results_dir = _materialize_current_results(manifest, workspace=workspace)
+    tune_policy = TunePolicy(
+        name="M5 Pro constraints-first local evidence",
+        description=(
+            "Rank only repetitions that pass deterministic evaluation, remain "
+            "under the configured MLX peak-memory ceiling, and share identity."
+        ),
+        objective=TuneObjective.MAX_CORRECT_CASES_PER_MINUTE,
+        constraints=TuneConstraints(
+            min_pass_rate=1.0,
+            max_peak_memory_bytes=float(manifest.safety.maximum_peak_memory_bytes),
+            allowed_provenances=frozenset(
+                {
+                    MetricProvenance.MEASURED_WALL_CLOCK,
+                    MetricProvenance.MEASURED_NATIVE,
+                }
+            ),
+            min_measured_repetitions=manifest.repetitions.measured_per_workload,
+        ),
+    )
+    tune_report = tune(results_dirs=(results_dir,), policy=tune_policy)
+    atomic_write_text(reports_dir / "tune-report.json", tune_report.to_json() + "\n")
+    atomic_write_text(
+        reports_dir / "tune-report.html",
+        render_tune_report_html(tune_report, redact_paths=True),
+    )
+
+    compare_policy = ComparePolicy(
+        name="Pinned local-system evidence",
+        description=(
+            "Apply the same deterministic pass-rate and repetition bar through "
+            "the merged comparison layer; no hosted systems are included."
+        ),
+        objective=CompareObjective.MAX_CORRECT_CASES_PER_MINUTE,
+        constraints=CompareConstraints(
+            min_pass_rate=1.0,
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_WALL_CLOCK}),
+            min_measured_repetitions=manifest.repetitions.measured_per_workload,
+        ),
+    )
+    compare_report = compare(results_dirs=(results_dir,), policy=compare_policy)
+    atomic_write_text(
+        reports_dir / "compare-report.json",
+        compare_report.to_json() + "\n",
+    )
+    atomic_write_text(
+        reports_dir / "compare-report.html",
+        render_compare_report_html(compare_report, redact_paths=True),
+    )
+
+    if shareable_dir is not None:
+        shareable_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(
+            shareable_dir / "evidence-summary.json",
+            json.dumps(report, indent=2, sort_keys=False) + "\n",
+        )
+        atomic_write_text(shareable_dir / "report.html", render_lab_report_html(report))
+    return report
+
+
+def verify_evidence(manifest: LabManifest, *, workspace: Path) -> dict[str, Any]:
+    verify_catalog(manifest)
+    state_path = workspace / "state.json"
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
+    if state.get("status") == "running":
+        return {
+            "schema_version": "1",
+            "verified": False,
+            "records_checked": 0,
+            "failures": [
+                "current lab execution is incomplete; verification is refused"
+            ],
+        }
+    allowed_tiers, measured_run_ids, warmup_run_ids = _current_state_scope(
+        manifest, state
+    )
+    checked = 0
+    found_run_ids: set[str] = set()
+    failures: list[str] = []
+    roots = (
+        (
+            workspace / "results" / "runs",
+            "*/verification.json",
+            measured_run_ids,
+            False,
+        ),
+        (
+            workspace / "warmups",
+            "*/runs/*/verification.json",
+            warmup_run_ids,
+            True,
+        ),
+    )
+    for root, pattern, current_run_ids, warmup in roots:
+        verification_paths = sorted(root.glob(pattern)) if root.is_dir() else []
+        for verification_path in verification_paths:
+            try:
+                verification = RowVerification.read_json(verification_path)
+                if verification.run_id not in current_run_ids:
+                    continue
+                found_run_ids.add(verification.run_id)
+                if verification.final_record_path is None:
+                    failures.append(f"{verification_path.parent.name}: no final record")
+                    continue
+                record_path = verification_path.parent / "final_record.json"
+                record = ExperimentRecord.read_json(record_path)
+                if not _record_matches_manifest(
+                    manifest,
+                    verification,
+                    record,
+                    warmup=warmup,
+                    allowed_tiers=allowed_tiers,
+                ):
+                    failures.append(
+                        f"{verification.run_id}: current manifest binding mismatch"
+                    )
+                    continue
+                environment_errors = _environment_errors(
+                    manifest,
+                    verification_path.parent / "collection" / "environment.json",
+                )
+                if environment_errors:
+                    failures.extend(
+                        f"{verification.run_id}: {error}"
+                        for error in environment_errors
+                    )
+                    continue
+                checked += 1
+            except (OSError, ValueError) as exc:
+                failures.append(f"{verification_path.parent.name}: {exc}")
+    for missing_run_id in sorted((measured_run_ids | warmup_run_ids) - found_run_ids):
+        failures.append(f"{missing_run_id}: expected current-run artifact is missing")
+    report_path = workspace / "reports" / "lab-report.json"
+    if report_path.exists():
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            assert_shareable(report)
+        except (OSError, ValueError, LabError) as exc:
+            failures.append(f"shareable report: {exc}")
+    return {
+        "schema_version": "1",
+        "verified": not failures and checked > 0,
+        "records_checked": checked,
+        "failures": failures,
+    }

--- a/llmtracefx/optimizer/lab/data/lab-manifest-v1.json
+++ b/llmtracefx/optimizer/lab/data/lab-manifest-v1.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": "1",
+  "lab_id": "m5-pro-qwen3.8-27b-v1",
+  "model": {
+    "official_id": "Qwen/Qwen3.8-27B",
+    "official_revision": "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+    "repository_id": "mlx-community/Qwen3.8-27B-4bit",
+    "revision": "3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+    "license": "Apache-2.0",
+    "quantization": "MLX affine 4-bit, group size 64",
+    "converter": "mlx-vlm 0.6.8",
+    "converter_revision": "61990c9054f2bc7bb8f32541e3238b4a58fe64e5",
+    "expected_download_bytes": 16081490933,
+    "files": [
+      {
+        "path": ".gitattributes",
+        "size_bytes": 1570,
+        "sha256": "34448b82c17d60fec9b65b1f093c115ddbaadc04beb1b0140b6bfed2e012a930"
+      },
+      {
+        "path": "README.md",
+        "size_bytes": 632,
+        "sha256": "860ff845b4746d0b3e1d1afa4f13aac691ef49c7165054cedfb199371568c4c2"
+      },
+      {
+        "path": "chat_template.jinja",
+        "size_bytes": 8952,
+        "sha256": "c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041"
+      },
+      {
+        "path": "config.json",
+        "size_bytes": 4932,
+        "sha256": "14b65a0ee06517060a6bbd979bb1a8ff54e7b304b1a1f01d54344b88b8285e85"
+      },
+      {
+        "path": "generation_config.json",
+        "size_bytes": 202,
+        "sha256": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e"
+      },
+      {
+        "path": "model-00001-of-00003.safetensors",
+        "size_bytes": 5343268662,
+        "sha256": "6cc1508e96fb5d0865dfd5753a79f4ec60651bf3e2a82844a7e8ae9c60528c0d"
+      },
+      {
+        "path": "model-00002-of-00003.safetensors",
+        "size_bytes": 5354185130,
+        "sha256": "83f2a20ca8058f486a3634a27faf99587f4cd3c156a83dee34fb99e6ac178670"
+      },
+      {
+        "path": "model-00003-of-00003.safetensors",
+        "size_bytes": 5357087557,
+        "sha256": "31b8c91ef899f79efaaa69e3d2c096f6e2ebeb2ff20e29222abbd9ebc79e560a"
+      },
+      {
+        "path": "model.safetensors.index.json",
+        "size_bytes": 218281,
+        "sha256": "13b840162b4cb35c66fef7df072f7dbb4717908204364f5e5d9f9655a2758fa8"
+      },
+      {
+        "path": "preprocessor_config.json",
+        "size_bytes": 390,
+        "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516"
+      },
+      {
+        "path": "processor_config.json",
+        "size_bytes": 991,
+        "sha256": "45fc17c8dd2474af6b493b52483c26c0584b0082d368c480f9fa611e73070040"
+      },
+      {
+        "path": "tokenizer.json",
+        "size_bytes": 19989325,
+        "sha256": "06b9509352d2af50381ab2247e083b80d32d5c0aba91c272ca9ff729b6a0e523"
+      },
+      {
+        "path": "tokenizer_config.json",
+        "size_bytes": 1165,
+        "sha256": "792fa3f0cb88b111e54ef3134c873531008c4df471d108da17903426e308aa7b"
+      },
+      {
+        "path": "video_preprocessor_config.json",
+        "size_bytes": 385,
+        "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13"
+      },
+      {
+        "path": "vocab.json",
+        "size_bytes": 6722759,
+        "sha256": "ce99b4cb2983d118806ce0a8b777a35b093e2000a503ebde25853284c9dfa003"
+      }
+    ],
+    "sources": [
+      "https://huggingface.co/Qwen/Qwen3.8-27B/tree/1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+      "https://huggingface.co/mlx-community/Qwen3.8-27B-4bit/tree/3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+      "https://github.com/Blaizzy/mlx-vlm/tree/61990c9054f2bc7bb8f32541e3238b4a58fe64e5"
+    ]
+  },
+  "runtime": {
+    "name": "mlx-vlm",
+    "version": "0.6.8",
+    "mlx_version": "0.32.2",
+    "mlx_lm_version": "0.31.3",
+    "transformers_version": "5.16.1",
+    "prefill_step_size": 2048
+  },
+  "generation": {
+    "max_output_tokens": 96,
+    "seed": 20260831,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "enable_thinking": false
+  },
+  "repetitions": {
+    "warmup_per_tier": 1,
+    "measured_per_workload": 2
+  },
+  "cooperative_timeout_seconds": 1800,
+  "safety": {
+    "required_chip": "Apple M5 Pro",
+    "required_total_memory_bytes": 25769803776,
+    "minimum_free_disk_after_download_bytes": 107374182400,
+    "minimum_memory_free_percent": 25,
+    "maximum_peak_memory_bytes": 21474836480,
+    "maximum_swap_used_bytes": 12884901888,
+    "stop_on_any_failed_row": true
+  },
+  "artifacts": {
+    "workspace": ".cache/llmtracefx/m5-pro-qwen3.8-27b-v1",
+    "model_cache": ".cache/models/qwen3.8-27b-4bit-3e6447f",
+    "shareable_example_dir": "examples/optimizer/m5-pro-qwen3.8-27b",
+    "commit_raw_artifacts": false
+  },
+  "environment_capture": [
+    "os_name",
+    "os_release",
+    "architecture",
+    "python_implementation",
+    "python_version",
+    "cpu_count",
+    "total_memory_gb",
+    "accelerator",
+    "package_versions"
+  ],
+  "context_tiers": [
+    {
+      "name": "2k",
+      "target_tokens": 2048,
+      "order": 1
+    },
+    {
+      "name": "8k",
+      "target_tokens": 8192,
+      "order": 2
+    },
+    {
+      "name": "16k",
+      "target_tokens": 16384,
+      "order": 3
+    }
+  ],
+  "workloads": [
+    {
+      "workload_id": "structured-json-profile-extraction",
+      "version": "1",
+      "prompt_hashes": {
+        "2k": "sha256:4a4a49e8368a99919fff1d1e68586466e279267d9de8d081ba8c08adac592fcd",
+        "8k": "sha256:5efe059227fd5eeeb07884207aaad68780b53c2198f4dc1bbfb03f409bb152dd",
+        "16k": "sha256:837d22b5c550cf616ea86e7d64a637c2d387b2b9fd00577f64186ae621804f99"
+      }
+    },
+    {
+      "workload_id": "prose-reasoning-two-train-gap",
+      "version": "1",
+      "prompt_hashes": {
+        "2k": "sha256:f583af51b9a3e6cb49cd53a71d0737924329492701508af226515734c4f9f568",
+        "8k": "sha256:954c0e8c1e0060c34e954e107c8b812926fcbfb5d3f5ca7e8904f0dba2d0e3c9",
+        "16k": "sha256:4ddc616d1772e3ead314a5247729778b21bec55376465a276ab805bcde29ce41"
+      }
+    }
+  ]
+}

--- a/llmtracefx/optimizer/lab/manifest.py
+++ b/llmtracefx/optimizer/lab/manifest.py
@@ -1,0 +1,475 @@
+"""Strict, versioned configuration for the M5 Pro local inference lab."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from .._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+    reject_non_finite_json_constant,
+)
+
+LAB_MANIFEST_SCHEMA_VERSION = "1"
+
+
+class LabManifestError(ValueError):
+    """Raised when a lab manifest is malformed or internally inconsistent."""
+
+
+def _object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise LabManifestError(f"{context} must be an object")
+    return value
+
+
+def _string(data: dict[str, Any], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise LabManifestError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _integer(data: dict[str, Any], key: str, context: str, *, minimum: int = 0) -> int:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise LabManifestError(f"{context}.{key} must be an integer >= {minimum}")
+    return value
+
+
+def _number(
+    data: dict[str, Any],
+    key: str,
+    context: str,
+    *,
+    minimum: float = 0.0,
+    exclusive_minimum: bool = False,
+) -> float:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise LabManifestError(f"{context}.{key} must be a number")
+    numeric = float(value)
+    valid_minimum = numeric > minimum if exclusive_minimum else numeric >= minimum
+    if not math.isfinite(numeric) or not valid_minimum:
+        operator = ">" if exclusive_minimum else ">="
+        raise LabManifestError(
+            f"{context}.{key} must be finite and {operator} {minimum}"
+        )
+    return numeric
+
+
+def _boolean(data: dict[str, Any], key: str, context: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise LabManifestError(f"{context}.{key} must be a boolean")
+    return value
+
+
+def _sha256(value: str, context: str) -> str:
+    digest = value.removeprefix("sha256:")
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise LabManifestError(f"{context} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _git_revision(value: str, context: str) -> str:
+    if len(value) != 40 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise LabManifestError(f"{context} must be a 40-character git revision")
+    return value
+
+
+@dataclass(frozen=True)
+class ModelFilePin:
+    path: str
+    size_bytes: int
+    sha256: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelFilePin:
+        context = "model.files[]"
+        path = _string(data, "path", context)
+        if Path(path).is_absolute() or ".." in Path(path).parts:
+            raise LabManifestError(
+                "model.files[].path must be a repository-relative path"
+            )
+        return cls(
+            path=path,
+            size_bytes=_integer(data, "size_bytes", context, minimum=1),
+            sha256=_sha256(_string(data, "sha256", context), f"{context}.sha256"),
+        )
+
+
+@dataclass(frozen=True)
+class ModelPin:
+    official_id: str
+    official_revision: str
+    repository_id: str
+    revision: str
+    license: str
+    quantization: str
+    converter: str
+    converter_revision: str
+    expected_download_bytes: int
+    files: tuple[ModelFilePin, ...]
+    sources: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelPin:
+        context = "model"
+        files_raw = data.get("files")
+        if not isinstance(files_raw, list) or not files_raw:
+            raise LabManifestError("model.files must be a non-empty list")
+        files = tuple(
+            ModelFilePin.from_dict(_object(item, "model.files[]")) for item in files_raw
+        )
+        sources_raw = data.get("sources")
+        if (
+            not isinstance(sources_raw, list)
+            or not sources_raw
+            or not all(
+                isinstance(source, str)
+                and (parts := urlsplit(source)).scheme == "https"
+                and bool(parts.netloc)
+                and parts.username is None
+                and parts.password is None
+                and not parts.query
+                and not parts.fragment
+                and parts.hostname in {"huggingface.co", "github.com"}
+                and "%" not in parts.path
+                for source in sources_raw
+            )
+        ):
+            raise LabManifestError(
+                "model.sources must be credential-free Hugging Face or GitHub "
+                "HTTPS URLs without encoded paths, queries, or fragments"
+            )
+        if len({item.path for item in files}) != len(files):
+            raise LabManifestError("model.files paths must be unique")
+        expected_download_bytes = _integer(
+            data, "expected_download_bytes", context, minimum=1
+        )
+        if sum(item.size_bytes for item in files) != expected_download_bytes:
+            raise LabManifestError(
+                "model.expected_download_bytes must equal the pinned file sizes"
+            )
+        return cls(
+            official_id=_string(data, "official_id", context),
+            official_revision=_git_revision(
+                _string(data, "official_revision", context),
+                "model.official_revision",
+            ),
+            repository_id=_string(data, "repository_id", context),
+            revision=_git_revision(
+                _string(data, "revision", context), "model.revision"
+            ),
+            license=_string(data, "license", context),
+            quantization=_string(data, "quantization", context),
+            converter=_string(data, "converter", context),
+            converter_revision=_git_revision(
+                _string(data, "converter_revision", context),
+                "model.converter_revision",
+            ),
+            expected_download_bytes=expected_download_bytes,
+            files=files,
+            sources=tuple(sources_raw),
+        )
+
+
+@dataclass(frozen=True)
+class RuntimePin:
+    name: str
+    version: str
+    mlx_version: str
+    mlx_lm_version: str
+    transformers_version: str
+    prefill_step_size: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RuntimePin:
+        context = "runtime"
+        return cls(
+            name=_string(data, "name", context),
+            version=_string(data, "version", context),
+            mlx_version=_string(data, "mlx_version", context),
+            mlx_lm_version=_string(data, "mlx_lm_version", context),
+            transformers_version=_string(data, "transformers_version", context),
+            prefill_step_size=_integer(data, "prefill_step_size", context, minimum=1),
+        )
+
+
+@dataclass(frozen=True)
+class GenerationConfig:
+    max_output_tokens: int
+    seed: int
+    temperature: float
+    top_p: float
+    enable_thinking: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GenerationConfig:
+        context = "generation"
+        top_p = _number(data, "top_p", context, exclusive_minimum=True)
+        if top_p > 1:
+            raise LabManifestError("generation.top_p must be <= 1")
+        return cls(
+            max_output_tokens=_integer(data, "max_output_tokens", context, minimum=1),
+            seed=_integer(data, "seed", context),
+            temperature=_number(data, "temperature", context),
+            top_p=top_p,
+            enable_thinking=_boolean(data, "enable_thinking", context),
+        )
+
+
+@dataclass(frozen=True)
+class RepetitionConfig:
+    warmup_per_tier: int
+    measured_per_workload: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RepetitionConfig:
+        context = "repetitions"
+        return cls(
+            warmup_per_tier=_integer(data, "warmup_per_tier", context),
+            measured_per_workload=_integer(
+                data, "measured_per_workload", context, minimum=1
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class SafetyConfig:
+    required_chip: str
+    required_total_memory_bytes: int
+    minimum_free_disk_after_download_bytes: int
+    minimum_memory_free_percent: float
+    maximum_peak_memory_bytes: int
+    maximum_swap_used_bytes: int
+    stop_on_any_failed_row: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SafetyConfig:
+        context = "safety"
+        memory_percent = _number(data, "minimum_memory_free_percent", context)
+        if memory_percent > 100:
+            raise LabManifestError("safety.minimum_memory_free_percent must be <= 100")
+        return cls(
+            required_chip=_string(data, "required_chip", context),
+            required_total_memory_bytes=_integer(
+                data, "required_total_memory_bytes", context, minimum=1
+            ),
+            minimum_free_disk_after_download_bytes=_integer(
+                data,
+                "minimum_free_disk_after_download_bytes",
+                context,
+                minimum=1,
+            ),
+            minimum_memory_free_percent=memory_percent,
+            maximum_peak_memory_bytes=_integer(
+                data, "maximum_peak_memory_bytes", context, minimum=1
+            ),
+            maximum_swap_used_bytes=_integer(
+                data, "maximum_swap_used_bytes", context, minimum=1
+            ),
+            stop_on_any_failed_row=_boolean(data, "stop_on_any_failed_row", context),
+        )
+
+
+@dataclass(frozen=True)
+class WorkloadPin:
+    workload_id: str
+    version: str
+    prompt_hashes: dict[str, str]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WorkloadPin:
+        context = "workloads[]"
+        raw_hashes = data.get("prompt_hashes")
+        if not isinstance(raw_hashes, dict) or not raw_hashes:
+            raise LabManifestError(
+                "workloads[].prompt_hashes must be a non-empty object"
+            )
+        hashes: dict[str, str] = {}
+        for tier, digest in raw_hashes.items():
+            if not isinstance(tier, str) or not isinstance(digest, str):
+                raise LabManifestError(
+                    "workloads[].prompt_hashes must map strings to strings"
+                )
+            hashes[tier] = _sha256(digest, f"workloads[].prompt_hashes.{tier}")
+        return cls(
+            workload_id=_string(data, "workload_id", context),
+            version=_string(data, "version", context),
+            prompt_hashes=hashes,
+        )
+
+
+@dataclass(frozen=True)
+class ContextTierPin:
+    name: str
+    target_tokens: int
+    order: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ContextTierPin:
+        context = "context_tiers[]"
+        return cls(
+            name=_string(data, "name", context),
+            target_tokens=_integer(data, "target_tokens", context, minimum=1),
+            order=_integer(data, "order", context),
+        )
+
+
+@dataclass(frozen=True)
+class ArtifactConfig:
+    workspace: str
+    model_cache: str
+    shareable_example_dir: str
+    commit_raw_artifacts: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactConfig:
+        context = "artifacts"
+        values = {
+            key: _string(data, key, context)
+            for key in ("workspace", "model_cache", "shareable_example_dir")
+        }
+        for key, value in values.items():
+            if Path(value).is_absolute() or ".." in Path(value).parts:
+                raise LabManifestError(
+                    f"artifacts.{key} must be a repository-relative path"
+                )
+        commit_raw = _boolean(data, "commit_raw_artifacts", context)
+        if commit_raw:
+            raise LabManifestError("artifacts.commit_raw_artifacts must remain false")
+        return cls(
+            workspace=values["workspace"],
+            model_cache=values["model_cache"],
+            shareable_example_dir=values["shareable_example_dir"],
+            commit_raw_artifacts=commit_raw,
+        )
+
+
+@dataclass(frozen=True)
+class LabManifest:
+    schema_version: str
+    lab_id: str
+    model: ModelPin
+    runtime: RuntimePin
+    generation: GenerationConfig
+    repetitions: RepetitionConfig
+    cooperative_timeout_seconds: float
+    safety: SafetyConfig
+    workloads: tuple[WorkloadPin, ...]
+    context_tiers: tuple[ContextTierPin, ...]
+    artifacts: ArtifactConfig
+    environment_capture: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LabManifest:
+        data = _object(data, "manifest")
+        schema_version = _string(data, "schema_version", "manifest")
+        if schema_version != LAB_MANIFEST_SCHEMA_VERSION:
+            raise LabManifestError(
+                f"unsupported lab manifest schema_version {schema_version!r}"
+            )
+        workloads_raw = data.get("workloads")
+        tiers_raw = data.get("context_tiers")
+        if not isinstance(workloads_raw, list) or not workloads_raw:
+            raise LabManifestError("workloads must be a non-empty list")
+        if not isinstance(tiers_raw, list) or not tiers_raw:
+            raise LabManifestError("context_tiers must be a non-empty list")
+        workloads = tuple(
+            WorkloadPin.from_dict(_object(item, "workloads[]"))
+            for item in workloads_raw
+        )
+        tiers = tuple(
+            ContextTierPin.from_dict(_object(item, "context_tiers[]"))
+            for item in tiers_raw
+        )
+        tier_names = [tier.name for tier in tiers]
+        if len(set(tier_names)) != len(tier_names):
+            raise LabManifestError("context tier names must be unique")
+        if [tier.order for tier in tiers] != sorted(tier.order for tier in tiers):
+            raise LabManifestError("context_tiers must be ordered by ascending order")
+        if len({workload.workload_id for workload in workloads}) != len(workloads):
+            raise LabManifestError("workload IDs must be unique")
+        for workload in workloads:
+            if set(workload.prompt_hashes) != set(tier_names):
+                raise LabManifestError(
+                    f"workload {workload.workload_id!r} must pin every context tier"
+                )
+        capture_raw = data.get("environment_capture")
+        if (
+            not isinstance(capture_raw, list)
+            or not capture_raw
+            or not all(isinstance(item, str) and item for item in capture_raw)
+        ):
+            raise LabManifestError(
+                "environment_capture must be a non-empty list of strings"
+            )
+        forbidden_capture = {
+            "serial",
+            "serial_number",
+            "hardware_uuid",
+            "hostname",
+            "username",
+            "environment_variables",
+        }
+        if forbidden_capture.intersection(item.lower() for item in capture_raw):
+            raise LabManifestError("environment_capture includes a private field")
+        return cls(
+            schema_version=schema_version,
+            lab_id=_string(data, "lab_id", "manifest"),
+            model=ModelPin.from_dict(_object(data.get("model"), "model")),
+            runtime=RuntimePin.from_dict(_object(data.get("runtime"), "runtime")),
+            generation=GenerationConfig.from_dict(
+                _object(data.get("generation"), "generation")
+            ),
+            repetitions=RepetitionConfig.from_dict(
+                _object(data.get("repetitions"), "repetitions")
+            ),
+            cooperative_timeout_seconds=_number(
+                data,
+                "cooperative_timeout_seconds",
+                "manifest",
+                exclusive_minimum=True,
+            ),
+            safety=SafetyConfig.from_dict(_object(data.get("safety"), "safety")),
+            workloads=workloads,
+            context_tiers=tiers,
+            artifacts=ArtifactConfig.from_dict(
+                _object(data.get("artifacts"), "artifacts")
+            ),
+            environment_capture=tuple(capture_raw),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> LabManifest:
+        try:
+            data = json.loads(payload, parse_constant=reject_non_finite_json_constant)
+        except (ValueError, RecursionError) as exc:
+            raise LabManifestError(f"invalid lab manifest JSON: {exc}") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> LabManifest:
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise LabManifestError(f"invalid lab manifest file: {exc}") from exc
+        return cls.from_json(payload)
+
+    def tier(self, name: str) -> ContextTierPin:
+        for tier in self.context_tiers:
+            if tier.name == name:
+                return tier
+        raise LabManifestError(f"unknown context tier {name!r}")

--- a/llmtracefx/optimizer/workloads/verify.py
+++ b/llmtracefx/optimizer/workloads/verify.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import math
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -258,6 +259,19 @@ class RunBinding:
     draft_model_path: Path | None = None
     seed: int = 0
     num_draft_tokens: int = 2
+    temperature: float = 0.0
+    top_p: float = 1.0
+    enable_thinking: bool = False
+    prefill_step_size: int | None = None
+    model_revision: str | None = None
+    tokenizer_revision: str | None = None
+    quantization: str | None = None
+    model_family: str | None = None
+    timeout_seconds: float | None = None
+    warmup_repetitions: int = 0
+    measured_repetitions: int = 1
+    repetition_index: int = 0
+    hardware_fingerprint: str | None = None
 
     def __post_init__(self) -> None:
         if (
@@ -278,6 +292,53 @@ class RunBinding:
                 "Provide an existing local model path; models are never "
                 "downloaded by this pipeline."
             )
+        if self.timeout_seconds is not None and (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or self.timeout_seconds <= 0
+        ):
+            raise VerifyError("timeout_seconds must be positive when set")
+        if (
+            isinstance(self.temperature, bool)
+            or not isinstance(self.temperature, (int, float))
+            or not math.isfinite(self.temperature)
+            or not 0 <= self.temperature
+        ):
+            raise VerifyError("temperature must be non-negative")
+        if (
+            isinstance(self.top_p, bool)
+            or not isinstance(self.top_p, (int, float))
+            or not math.isfinite(self.top_p)
+            or not 0 < self.top_p <= 1
+        ):
+            raise VerifyError("top_p must be within (0, 1]")
+        if not isinstance(self.enable_thinking, bool):
+            raise VerifyError("enable_thinking must be a boolean")
+        if self.prefill_step_size is not None and (
+            isinstance(self.prefill_step_size, bool)
+            or not isinstance(self.prefill_step_size, int)
+            or self.prefill_step_size < 1
+        ):
+            raise VerifyError("prefill_step_size must be positive when set")
+        if (
+            isinstance(self.warmup_repetitions, bool)
+            or not isinstance(self.warmup_repetitions, int)
+            or self.warmup_repetitions < 0
+        ):
+            raise VerifyError("warmup_repetitions must be a non-negative integer")
+        if (
+            isinstance(self.measured_repetitions, bool)
+            or not isinstance(self.measured_repetitions, int)
+            or self.measured_repetitions < 1
+        ):
+            raise VerifyError("measured_repetitions must be a positive integer")
+        if (
+            isinstance(self.repetition_index, bool)
+            or not isinstance(self.repetition_index, int)
+            or self.repetition_index < 0
+            or self.repetition_index >= self.measured_repetitions
+        ):
+            raise VerifyError("repetition_index must identify a measured repetition")
 
     def hash_payload(self, *, max_tokens: int) -> dict[str, Any]:
         return {
@@ -290,6 +351,19 @@ class RunBinding:
             "seed": self.seed,
             "num_draft_tokens": self.num_draft_tokens,
             "max_tokens": max_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "enable_thinking": self.enable_thinking,
+            "prefill_step_size": self.prefill_step_size,
+            "model_revision": self.model_revision,
+            "tokenizer_revision": self.tokenizer_revision,
+            "quantization": self.quantization,
+            "model_family": self.model_family,
+            "timeout_seconds": self.timeout_seconds,
+            "warmup_repetitions": self.warmup_repetitions,
+            "measured_repetitions": self.measured_repetitions,
+            "repetition_index": self.repetition_index,
+            "hardware_fingerprint": self.hardware_fingerprint,
         }
 
     def run_binding_hash(self, *, max_tokens: int) -> str:
@@ -601,6 +675,10 @@ def _build_command_argv(
         str(entry.max_tokens),
         "--seed",
         str(binding.seed),
+        "--temperature",
+        str(binding.temperature),
+        "--top-p",
+        str(binding.top_p),
     ]
     if binding.draft_model_path is not None:
         argv.extend(
@@ -611,6 +689,13 @@ def _build_command_argv(
                 str(binding.num_draft_tokens),
             )
         )
+    for flag, value in (
+        ("--model-revision", binding.model_revision),
+        ("--tokenizer-revision", binding.tokenizer_revision),
+        ("--quantization", binding.quantization),
+    ):
+        if value is not None:
+            argv.extend((flag, value))
     return tuple(argv)
 
 
@@ -806,8 +891,20 @@ def execute_row(
             command_argv=_build_command_argv(entry, binding=binding, model_id=model_id),
             max_tokens=entry.max_tokens,
             seed=binding.seed,
+            temperature=binding.temperature,
+            top_p=binding.top_p,
+            enable_thinking=binding.enable_thinking,
+            prefill_step_size=binding.prefill_step_size,
+            model_revision=binding.model_revision,
+            tokenizer_revision=binding.tokenizer_revision,
+            quantization=binding.quantization,
+            model_family=binding.model_family,
             draft_model_path=binding.draft_model_path,
             num_draft_tokens=binding.num_draft_tokens,
+            timeout_seconds=binding.timeout_seconds,
+            warmup_repetitions=binding.warmup_repetitions,
+            measured_repetitions=binding.measured_repetitions,
+            repetition_index=binding.repetition_index,
         )
     except MLXCollectorError as exc:
         return _finish(

--- a/llmtracefx/profiler/mlx_tracer.py
+++ b/llmtracefx/profiler/mlx_tracer.py
@@ -63,7 +63,7 @@ class MLXTraceRecorder:
     @staticmethod
     def _load_mlx() -> Any:
         try:
-            import mlx.core as mx  # type: ignore[import-not-found]
+            import mlx.core as mx
         except ImportError as exc:
             raise RuntimeError(
                 "MLX tracing requires MLX. On Apple Silicon run "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,10 @@ test = [
 ]
 
 mlx = [
-    "mlx>=0.25.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "mlx-lm>=0.31.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx==0.32.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-lm==0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-vlm==0.6.8; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "transformers==5.16.1; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 
 docs = [
@@ -93,6 +95,7 @@ llmtracefx-serve = "llmtracefx.api.serve:main"
 llmtracefx-dashboard = "llmtracefx.realtime_dashboard:main"
 llmtracefx-optimizer = "llmtracefx.optimizer.cli:main"
 llmtracefx-deploy = "llmtracefx.deploy.cli:main"
+llmtracefx-m5-lab = "llmtracefx.optimizer.lab.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -100,7 +103,11 @@ include = ["llmtracefx*"]
 exclude = ["tests*"]
 
 [tool.setuptools.package-data]
-llmtracefx = ["test_traces/*.json", "*.md"]
+llmtracefx = [
+    "test_traces/*.json",
+    "*.md",
+    "optimizer/lab/data/*.json",
+]
 
 # Black configuration
 [tool.black]
@@ -152,6 +159,9 @@ module = [
     "numpy.*",
     "modal.*",
     "huggingface_hub.*",
+    "mlx.*",
+    "mlx_lm.*",
+    "mlx_vlm.*",
     "uvicorn.*",
     "streamlit.*",
 ]

--- a/tests/optimizer/test_m5_lab.py
+++ b/tests/optimizer/test_m5_lab.py
@@ -1,0 +1,459 @@
+"""Safety, reproducibility, resume, and privacy tests for the M5 lab."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.lab import cli
+from llmtracefx.optimizer.lab.core import (
+    HostSnapshot,
+    LabError,
+    SafetyDecision,
+    assert_shareable,
+    assess_safety,
+    build_shareable_report,
+    render_lab_report_html,
+    run_lab,
+    verify_catalog,
+    verify_evidence,
+    write_reports,
+)
+from llmtracefx.optimizer.lab.manifest import (
+    LabManifest,
+    LabManifestError,
+    ModelFilePin,
+)
+from llmtracefx.optimizer.manifest import EnvironmentManifest
+from llmtracefx.optimizer.schema import PlatformInfo
+from llmtracefx.optimizer.workloads.verify import RowStatus, RowVerification
+
+MANIFEST_PATH = Path("llmtracefx/optimizer/lab/data/lab-manifest-v1.json")
+
+
+@pytest.fixture(autouse=True)
+def stable_m5_platform(monkeypatch):
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.mlx.record_platform",
+        lambda accelerator: PlatformInfo(
+            os_name="Darwin",
+            os_version="25.6.0",
+            architecture="arm64",
+            cpu_cores=18,
+            total_memory_gb=24.0,
+            accelerator=accelerator,
+        ),
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.mlx.collect_environment_manifest",
+        lambda **kwargs: EnvironmentManifest(
+            schema_version="1",
+            collected_at="2026-08-31T00:00:00.000000Z",
+            os_name="Darwin",
+            os_release="25.6.0",
+            architecture="arm64",
+            python_implementation="CPython",
+            python_version="3.13.15",
+            cpu_count=18,
+            total_memory_gb=24.0,
+            package_versions={
+                "mlx": "0.32.2",
+                "mlx-lm": "0.31.3",
+                "mlx-vlm": "0.6.8",
+                "transformers": "5.16.1",
+            },
+        ),
+    )
+
+
+@dataclass
+class FakeResponse:
+    text: str
+    from_draft: bool = False
+    prompt_tokens: int = 3
+    generation_tokens: int = 1
+    finish_reason: str | None = None
+
+
+class FakeTokenizer:
+    bos_token = None
+
+
+class FakeRuntime:
+    mlx_version = "0.32.2"
+    mlx_lm_version = "0.6.8"
+    runtime_name = "mlx-vlm"
+    runtime_version = "0.6.8"
+    generate_calls = 0
+    peak_bytes = 1024**3
+    fail_generation = False
+
+    def __init__(self, **kwargs):
+        self.prompt = ""
+
+    def load_model(self, path):
+        return object(), FakeTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        self.prompt = prompt
+        return [1, 2, 3]
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return MLXMemorySnapshot(
+            active_bytes=512 * 1024**2,
+            cache_bytes=128 * 1024**2,
+            peak_bytes=type(self).peak_bytes,
+        )
+
+    def accelerator_name(self):
+        return "Apple M5 Pro"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        type(self).generate_calls += 1
+        if type(self).fail_generation:
+            raise RuntimeError("simulated warmup failure")
+        text = (
+            '{"name":"Priya","age":34,"is_active":true}'
+            if "Priya Nakamura" in self.prompt
+            else "3 hours. The combined closing speed is 70 miles per hour."
+        )
+        yield FakeResponse(text=text)
+
+
+def _safe_decision() -> SafetyDecision:
+    return SafetyDecision(
+        safe=True,
+        blockers=(),
+        snapshot=HostSnapshot(
+            collected_at="2026-08-31T00:00:00.000000Z",
+            os_name="Darwin",
+            os_release="25.0",
+            architecture="arm64",
+            python_implementation="CPython",
+            python_version="3.13.15",
+            cpu_count=18,
+            chip="Apple M5 Pro",
+            total_memory_bytes=24 * 1024**3,
+            memory_free_percent=50.0,
+            swap_used_bytes=0,
+            disk_free_bytes=500 * 1024**3,
+            package_versions={
+                "mlx": "0.32.2",
+                "mlx-lm": "0.31.3",
+                "mlx-vlm": "0.6.8",
+            },
+        ),
+    )
+
+
+def test_pinned_manifest_and_catalog_validate() -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    verify_catalog(manifest)
+    assert manifest.model.repository_id == "mlx-community/Qwen3.8-27B-4bit"
+    assert manifest.model.revision == "3e6447f082e89cc7f0bc6e5441afd38dfce760ff"
+    assert manifest.model.license == "Apache-2.0"
+
+
+def test_manifest_rejects_unpinned_revision() -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["model"]["revision"] = "main"
+    with pytest.raises(LabManifestError, match="40-character git revision"):
+        LabManifest.from_dict(payload)
+
+
+def test_model_verification_rejects_unpinned_root_entries(
+    tmp_path, monkeypatch
+) -> None:
+    from llmtracefx.optimizer.lab.core import verify_model
+
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    pinned_file = ModelFilePin(
+        path="config.json",
+        size_bytes=1,
+        sha256="0" * 64,
+    )
+    manifest = replace(
+        manifest,
+        model=replace(
+            manifest.model,
+            expected_download_bytes=1,
+            files=(pinned_file,),
+        ),
+    )
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "config.json").write_bytes(b"x")
+    (model_path / "stale-tokenizer.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core._sha256_file",
+        lambda path: "0" * 64,
+    )
+    with pytest.raises(LabError, match="unpinned model-root entry"):
+        verify_model(manifest, model_path)
+
+
+def test_manifest_rejects_credential_bearing_source_url() -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["model"]["sources"][0] = "https://token@example.com/model"
+    with pytest.raises(LabManifestError, match="credential-free"):
+        LabManifest.from_dict(payload)
+
+
+def test_manifest_rejects_source_url_query_credentials() -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["model"]["sources"][0] = "https://example.com/model?token=secret"
+    with pytest.raises(LabManifestError, match="credential-free"):
+        LabManifest.from_dict(payload)
+
+
+def test_manifest_rejects_encoded_or_unapproved_source_url() -> None:
+    payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["model"]["sources"][0] = "https://example.com/%68%66_abcdefghijklmnopqrstuv"
+    with pytest.raises(LabManifestError, match="credential-free"):
+        LabManifest.from_dict(payload)
+
+
+def test_default_cli_action_is_no_download_plan(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "assess_safety", lambda *args, **kwargs: _safe_decision())
+    monkeypatch.setattr(cli, "model_files_present", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        cli,
+        "acquire_model",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("plan must not download")
+        ),
+    )
+    assert cli.main(["--manifest", str(MANIFEST_PATH)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["no_spend"] is True
+    assert payload["downloads_performed"] is False
+
+
+def test_default_manifest_loads_outside_source_checkout(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    args = cli.build_parser().parse_args([])
+    manifest, source, _, _ = cli._load(args)
+    assert manifest.model.repository_id == "mlx-community/Qwen3.8-27B-4bit"
+    assert source == ("package:llmtracefx.optimizer.lab/data/lab-manifest-v1.json")
+
+
+def test_safety_fails_closed_when_swap_is_unavailable(tmp_path, monkeypatch) -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    snapshot = _safe_decision().snapshot
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.collect_host_snapshot",
+        lambda path: HostSnapshot(**{**snapshot.to_dict(), "swap_used_bytes": None}),
+    )
+    decision = assess_safety(manifest, tmp_path, include_download=False)
+    assert decision.safe is False
+    assert any("swap usage could not be measured" in item for item in decision.blockers)
+
+
+def test_run_resumes_hash_matching_rows(tmp_path, monkeypatch) -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    workspace = tmp_path / "workspace"
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.verify_model",
+        lambda *args, **kwargs: {"verified": True},
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.assess_safety",
+        lambda *args, **kwargs: _safe_decision(),
+    )
+    monkeypatch.setattr("llmtracefx.optimizer.lab.core.MLXVLMRuntime", FakeRuntime)
+    FakeRuntime.generate_calls = 0
+    FakeRuntime.peak_bytes = 1024**3
+    FakeRuntime.fail_generation = False
+
+    run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier="2k",
+        resume=True,
+    )
+    first_calls = FakeRuntime.generate_calls
+    run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier="2k",
+        resume=True,
+    )
+
+    assert first_calls == 5
+    assert FakeRuntime.generate_calls == first_calls + 1
+    statuses = [
+        RowVerification.read_json(path).status
+        for path in (workspace / "results" / "runs").glob("*/verification.json")
+    ]
+    assert statuses and set(statuses) == {RowStatus.SKIPPED}
+
+    missing = next((workspace / "results" / "runs").glob("*/verification.json"))
+    missing.unlink()
+    verification = verify_evidence(manifest, workspace=workspace)
+    assert verification["verified"] is False
+    assert any(
+        "expected current-run artifact is missing" in failure
+        for failure in verification["failures"]
+    )
+
+
+def test_warmup_memory_gate_stops_before_measurements(tmp_path, monkeypatch) -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    workspace = tmp_path / "workspace"
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.verify_model",
+        lambda *args, **kwargs: {"verified": True},
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.assess_safety",
+        lambda *args, **kwargs: _safe_decision(),
+    )
+    monkeypatch.setattr("llmtracefx.optimizer.lab.core.MLXVLMRuntime", FakeRuntime)
+    FakeRuntime.generate_calls = 0
+    FakeRuntime.peak_bytes = manifest.safety.maximum_peak_memory_bytes + 1
+    FakeRuntime.fail_generation = False
+
+    state = run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier="2k",
+        resume=True,
+    )
+
+    assert FakeRuntime.generate_calls == 1
+    assert state["tiers"][0]["status"] == "failed_warmup_safety"
+    assert not (workspace / "results" / "runs").exists()
+    write_reports(manifest, workspace=workspace)
+
+
+def test_multiple_warmups_stop_and_verify_only_attempted_runs(
+    tmp_path, monkeypatch
+) -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    manifest = replace(
+        manifest,
+        repetitions=replace(manifest.repetitions, warmup_per_tier=2),
+    )
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    workspace = tmp_path / "workspace"
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.verify_model",
+        lambda *args, **kwargs: {"verified": True},
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.assess_safety",
+        lambda *args, **kwargs: _safe_decision(),
+    )
+    monkeypatch.setattr("llmtracefx.optimizer.lab.core.MLXVLMRuntime", FakeRuntime)
+    FakeRuntime.generate_calls = 0
+    FakeRuntime.peak_bytes = 1024**3
+    FakeRuntime.fail_generation = True
+
+    state = run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier="2k",
+        resume=True,
+    )
+    verification = verify_evidence(manifest, workspace=workspace)
+
+    assert FakeRuntime.generate_calls == 1
+    assert state["tiers"][0]["run_ids"] == [
+        "structured-json-profile-extraction-2k-warmup-01"
+    ]
+    assert verification["verified"] is True
+
+
+def test_shareable_report_and_chart_are_deterministic_and_private(
+    tmp_path, monkeypatch
+) -> None:
+    manifest = LabManifest.read_json(MANIFEST_PATH)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    workspace = tmp_path / "private-user-name" / "workspace"
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.verify_model",
+        lambda *args, **kwargs: {"verified": True},
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.lab.core.assess_safety",
+        lambda *args, **kwargs: _safe_decision(),
+    )
+    monkeypatch.setattr("llmtracefx.optimizer.lab.core.MLXVLMRuntime", FakeRuntime)
+    FakeRuntime.peak_bytes = 1024**3
+    FakeRuntime.fail_generation = False
+    run_lab(
+        manifest,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier="2k",
+        resume=True,
+    )
+    report = build_shareable_report(manifest, workspace=workspace)
+    first = render_lab_report_html(report)
+    second = render_lab_report_html(report)
+    shareable = tmp_path / "shareable"
+    written = write_reports(manifest, workspace=workspace, shareable_dir=shareable)
+
+    assert first == second
+    assert str(tmp_path) not in json.dumps(report)
+    assert str(tmp_path) not in first
+    assert "http://" not in first
+    assert "https://" not in first
+    assert_shareable(report)
+    assert written == report
+    assert (workspace / "reports" / "tune-report.json").is_file()
+    assert (workspace / "reports" / "compare-report.json").is_file()
+    assert (shareable / "evidence-summary.json").is_file()
+    assert (shareable / "report.html").read_text(encoding="utf-8") == first
+
+    record_path = next((workspace / "results" / "runs").glob("*/final_record.json"))
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    payload["command"]["config_hash"] = "sha256:" + "0" * 64
+    record_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(LabError, match="unverified current-run evidence"):
+        write_reports(manifest, workspace=workspace)
+
+
+@pytest.mark.parametrize(
+    "private_value",
+    [
+        "/Users/alice/private/run.json",
+        "/Volumes/PrivateSSD/alice/model/config.json",
+        "hf_abcdefghijklmnopqrstuv",
+    ],
+)
+def test_shareable_artifacts_reject_private_values(private_value) -> None:
+    with pytest.raises(LabError, match="private"):
+        assert_shareable({"value": private_value})

--- a/uv.lock
+++ b/uv.lock
@@ -450,6 +450,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1a/4b2f7c92293ba05cbd4a9a1b28faaf0326272d9488e6354657571c48a7aa/cffi-2.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca82be1a1d406ecfe1d25dc16cb33488e5a16bf4438c9fb590484ea29d92478b", size = 184178, upload-time = "2026-08-03T21:19:16.67Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1282,6 +1307,16 @@ wheels = [
 ]
 
 [[package]]
+name = "llguidance"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/27/972de1ba4c93072fce816b967972e1d18bc48b04b145b5c77b5bd1dc9662/llguidance-1.8.0.tar.gz", hash = "sha256:18d1579eabb040e65c870d50c6df19a7bef140c5260d12ad35b7f0dc446312e0", size = 1181409, upload-time = "2026-08-11T00:06:56.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c4/85bcfe5cee1daecba57f5a6ac4edfdfc8f1185b4ef2c46391bd87c67d850/llguidance-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:06aa5dc26e87de2d152ffb3f0131ec531620963b677f0d73ab05f49adc8c4133", size = 3151131, upload-time = "2026-08-11T00:06:25.243Z" },
+    { url = "https://files.pythonhosted.org/packages/78/98/568132150d3f6f09200f389191f4f863b405f1c46429dd8d27a120c1518d/llguidance-1.8.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bb9a89e8cdd7c8b5cf4f84e45b04177e79acdcc4d5116fbc775e511f7314df44", size = 3168313, upload-time = "2026-08-11T00:06:40.597Z" },
+]
+
+[[package]]
 name = "llmtracefx"
 version = "1.0.0"
 source = { editable = "." }
@@ -1315,6 +1350,8 @@ docs = [
 mlx = [
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
+    { name = "transformers", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
 ]
 modal = [
     { name = "modal" },
@@ -1337,8 +1374,9 @@ requires-dist = [
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
-    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.25.0" },
-    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.31.0" },
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = "==0.32.2" },
+    { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = "==0.31.3" },
+    { name = "mlx-vlm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = "==0.6.8" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -1353,6 +1391,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "streamlit", specifier = ">=1.34.0" },
+    { name = "transformers", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'mlx'", specifier = "==5.16.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
 provides-extras = ["modal", "dev", "test", "mlx", "docs"]
@@ -1461,6 +1500,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "miniaudio"
+version = "1.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/3a/645db5b3ba8f7c1ff319e38a7150054f35818795ed312a3a5e4f061624b0/miniaudio-1.71-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aee8e4eec8d7bde4ee78066561329235a04231a221c9b247f1ffaf850551087d", size = 351407, upload-time = "2026-04-29T21:20:02.286Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/4b13ac3c36a2574e0d70f322246d80259606cd24523279f542abc9ac6063/miniaudio-1.71-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5009b4e29cd43de3631d2d5ab09cc074192c085b4c8dd8a121b856ce1af6bab7", size = 351405, upload-time = "2026-04-29T21:20:10.533Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ac/30a324f758bed1b193e017ec25183cfb10a79e549656331f5d068a2d343a/miniaudio-1.71-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fc1a4f084cc1b4b25c567d22f54d1e46bfa505c17ed777c8b198e5c53d0f785", size = 351485, upload-time = "2026-04-29T21:20:17.761Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d1/071a560000c8ce903dc919968ecce40fbe7a73213ac399051b887184f8a3/miniaudio-1.71-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9dc15eff711bcfc62a9d05e0c78e4bc34821a455595e049629f2fea7491a523", size = 351488, upload-time = "2026-04-29T21:20:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ea/f5940232d0c83777562e802f376a841046d78e94753450fb9a6685a44190/miniaudio-1.71-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:84139a10ef172acd762ccf120142877b037a1aaf71def99d2c75f66329f89d8b", size = 351473, upload-time = "2026-04-29T21:20:32.464Z" },
 ]
 
 [[package]]
@@ -1615,6 +1670,27 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx-audio"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sounddevice" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d0/6e2e6c548dbc9d4d996e959e3a0e34faf64ca357462733ee94a42046664b/mlx_audio-0.5.0.tar.gz", hash = "sha256:d5aba4b99c006acd735408189d127eaf6ed53be0cad789e2eb51aa57f4f6bf13", size = 1584608, upload-time = "2026-08-17T17:47:57.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/76/b2c80758d610f507beb9fd89690e0a43c0028d222738a37b722ba7ff44eb/mlx_audio-0.5.0-py3-none-any.whl", hash = "sha256:90f4619186708a2cd4df9824d2ef3d2e427707264414fb604a3ca9dc499cc820", size = 1915152, upload-time = "2026-08-17T17:47:55.692Z" },
+]
+
+[[package]]
 name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1640,6 +1716,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ab/ba1952908c5d2a5070cf1cfbfea0161c4751ea62299e2776819810917483/mlx_metal-0.32.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:3825fff379dbc107dd3413e564a06caeaa24819910ec49c0439e454c06a1b9b8", size = 42516623, upload-time = "2026-08-25T10:31:18.396Z" },
     { url = "https://files.pythonhosted.org/packages/79/ec/34f37376e26d537fadffb99af3a760d6545e37f5e1a30a552baadf237fc5/mlx_metal-0.32.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:55a369250d220b2cf10213a87a2ac1b1a420608c5b35b1df4e7147ac8e32f121", size = 42512323, upload-time = "2026-08-25T10:31:22.673Z" },
     { url = "https://files.pythonhosted.org/packages/dd/cd/4e50bf325100e7165e13d025f264362bf0009196269f9eaf87f2c6e738a2/mlx_metal-0.32.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e6abeac9ac5265830c9c1541b6f96e9be37a85c2446763a46ad466c63a3837ab", size = 64367860, upload-time = "2026-08-25T10:31:28.056Z" },
+]
+
+[[package]]
+name = "mlx-vlm"
+version = "0.6.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "llguidance" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "mlx-audio" },
+    { name = "mlx-lm" },
+    { name = "numpy" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/a3/8ee5bbc0c32a061bda3fe17873f81d7b85c7fe2ceb39daacccb1caad7671/mlx_vlm-0.6.8.tar.gz", hash = "sha256:acbd4f2652a61e71c0942177b9570331d3ed2d654c4f60f4e356680721bc09c2", size = 1654754, upload-time = "2026-07-27T19:33:51.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/6d/8ce3e2874e98e2e9b1a1d0331d5766a916bf63031ef9857ba76ed630d22a/mlx_vlm-0.6.8-py3-none-any.whl", hash = "sha256:5250c8245076e576274009b3c6c9ecd6672c686aeede5ed03e9b61ee836dac4f", size = 2090215, upload-time = "2026-07-27T19:33:50.196Z" },
 ]
 
 [[package]]
@@ -1923,6 +2025,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
     { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
     { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "opencv-python"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
 ]
 
 [[package]]
@@ -2322,6 +2436,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -2876,6 +2999,84 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
+]
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:e708533e8b2ae2497d65346538a7dcc92814410b25b81432eac66de0f2af8265", size = 28733332, upload-time = "2026-08-21T23:23:50.015Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f6/a5b82f8abbe14d134691b8b903696f701d25a081353a29dc655c364d9e62/scipy-1.18.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7bbf207c4453ce1ad2e00b17313852b33310b83090c2311bdaf97f93c0380d12", size = 20475078, upload-time = "2026-08-21T23:23:54.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/769f36d14922b8071a43e95d24d18b6bdafad10d7f5cf647867e1ac052bc/scipy-1.18.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6fb6a55cc0ba97b59a1f288fb86dc6fce8bdfc0fffcbfd015e3a954bf2a2d93", size = 28715106, upload-time = "2026-08-21T23:24:40.775Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d7/21d890274f75ea37a8209d5519e72da3da90302e3b9fb8397a0918386a62/scipy-1.18.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ea324d9dd34c38bfb9bec8ca4d1b407db97dbb74029f566b8e322b1b6fe56fe6", size = 20456846, upload-time = "2026-08-21T23:24:45.066Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/59ea385dc3a62ff498ddf3cfff7c2b41b0f9f9d3c4122b3f1dcb6d6327fe/scipy-1.18.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:9554bcc6d715ee87a633a3cc8e7703c6628b100dd29cb8a2efc4c0533c7ff729", size = 28725221, upload-time = "2026-08-21T23:25:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/6b0c288c50942d78193696c9f15f9a0874f5178aa0ddf40f83d9924b3e8d/scipy-1.18.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:011413b7426b75012840e35649e00fe0a2c3bae89fed433876e3a99251572efc", size = 20466839, upload-time = "2026-08-21T23:25:37.516Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b2/e3067c487982d4eeab2938928529410370c06fea84a4d3f4925e7d96647d/scipy-1.18.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ddef79fb382df40104a19bb7151b3b23e57c1778fcf857c71ceecd9bd264513f", size = 29174642, upload-time = "2026-08-21T23:26:25.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ab/374c9fe2d1ec014e576c781a4b5d8e1ba340e8f6b4638c16f711d2b194f0/scipy-1.18.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:0e82073ecc7acc6436fac4b31674109c7e1d3e596789767eda01258a8c9e8123", size = 20916357, upload-time = "2026-08-21T23:26:30.112Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c5/ba929d7feb9b2332f96827c12e0e924b61973b59b4dea383b603372c65ce/scipy-1.18.1-cp315-cp315-macosx_12_0_arm64.whl", hash = "sha256:30f464bee641fa8e282577c7dce027308403213c6ca8270bba73285c91024bc5", size = 28725057, upload-time = "2026-08-21T23:27:15.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/19/68f1c50f609d955d230e66d25d02bd3e1e167ec540232135354fb9a4b9e3/scipy-1.18.1-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:1bca3b943fc2567ea49cd02c99abde49da4d5178ec46f624bd8255cda8755beb", size = 20466734, upload-time = "2026-08-21T23:27:20.044Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/58/dcb79161e56efbedc50079fcd2f5fe427a0ebb53022eb476aa73c015ad8f/scipy-1.18.1-cp315-cp315t-macosx_12_0_arm64.whl", hash = "sha256:1d73131e358976663dd969e1fb4ed1404b815cd977eaaedc3b3a133ba2d81c35", size = 29164940, upload-time = "2026-08-21T23:28:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d3/1eeea80c817fcb8ef7bd4a05a58824977a0e57a375cfc3d7ea7c911c01ad/scipy-1.18.1-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:bff0b729edd992766136b34e39cc76bc2fad905aa58897ee72a9cd000a6d8443", size = 20906742, upload-time = "2026-08-21T23:28:07.642Z" },
+]
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2922,6 +3123,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sounddevice"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/db/0c890e2d9aab9ba284021efc02e1d3aebfecab1b611762d7434602209bcf/sounddevice-0.5.6.tar.gz", hash = "sha256:8ec9fbfde2e32f020b167e348f3ab3bac6625a5f15af524d790108ac7147a410", size = 1120094, upload-time = "2026-08-17T07:55:05.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/1f/62eef605172bddc1017508469a12f75bc7c4194ece35c734f822795f53b1/sounddevice-0.5.6-py3-none-any.whl", hash = "sha256:de099612311ad81e55d31ccbd83f43ea6bf4d87b48f9b6ea55a1fbcde0eee4e0", size = 32793, upload-time = "2026-08-17T07:54:57.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/84/85e719d49cf98b2f406d9ac9c338892286c4448eb42ef0b2625ccf159616/sounddevice-0.5.6-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:e3aef00ad8b1d1740eb66d9a7671eab88a4d2b8fa4ab33498d742e63b65c309c", size = 1009647, upload-time = "2026-08-17T07:54:58.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a versioned, safety-gated M5 Pro local inference lab using the existing MLX collector, deterministic workload verifier, constraints-first tuner, merged compare layer, and self-contained reporting
- package the canonical lab manifest inside the wheel and resolve the default with `importlib.resources`; source-checkout Make targets remain convenient
- pin the official Apache-2.0 `Qwen/Qwen3.8-27B` revision `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0` and `mlx-community/Qwen3.8-27B-4bit` revision `3e6447f082e89cc7f0bc6e5441afd38dfce760ff`
- pin and capture `mlx==0.32.2`, `mlx-lm==0.31.3`, `mlx-vlm==0.6.8`, and `transformers==5.16.1`
- verify all 15 downloaded files by size and SHA-256; model payload is 16,081,490,933 bytes (14.98 GiB)
- add offline/no-sync planning plus explicit acquire, run/resume, verify, tune/compare, and report targets
- add current-run scoping, hardware/environment-bound resume, fail-closed disk/memory/swap gates, privacy checks, deterministic inline SVG charts, and tests for manifest validation, safe defaults, resume, partial warmups, stale evidence, report determinism, and installed-wheel execution outside the checkout

## Local evidence

Hardware: Apple M5 Pro, 24 GiB unified memory, 18 CPU cores.

The SHA-256-verified checkpoint loaded successfully and the 2K structured-extraction warmup tokenized to 1,657 tokens. Metal then failed during prefill after 22,730.87 ms:

```text
[METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory).
```

No output token or evaluator result was produced. Prefill/decode timing, token rate, MLX peak memory, pass rate, quality, and correct cases/minute therefore remain `null`. No measured repetitions ran. The 8K and 16K tiers were not executed.

This is evidence that this exact checkpoint/runtime did not fit the observed machine state; it is not a universal claim about all 24 GB M5 Pro systems. The safest next attempt is the same pinned experiment after a clean boot with other memory-heavy applications closed. Any smaller model or different quantization should use a separate pinned manifest.

## Validation

- 3,066 tests passed on the clean squashed tree
- changed-file quality ratchet passed: Ruff, Black, isort, mypy
- wheel build and clean-wheel import passed
- installed `llmtracefx-m5-lab --help` and default `plan` passed from a temporary cwd outside the source tree and loaded the packaged manifest
- model snapshot file sizes and SHA-256 digests verified
- fresh exact-head review reported no significant issues
- branch contains one PR commit on `main`; author and committer are exactly `Siddhant Khare <siddhantkhare2694@gmail.com>`; no trailers

Exact head: `8723eb8d96cf7e715ebc3e9989673a9fd18286e3`