### PR TITLE
feat: add evidence-honest MLX OOM autopsy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,7 @@ jobs:
           print('version', md.version('llmtracefx'))
           "
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" --help
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" autopsy --help
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-frontier" --help
           set +e
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" plan > m5-plan.json
@@ -244,5 +245,20 @@ jobs:
           plan = json.loads(Path('frontier-plan.json').read_text())
           assert plan['manifest'].startswith('package:')
           assert plan['weights_loaded'] is False
+          assert plan['model']['revision'] == '3e6447f082e89cc7f0bc6e5441afd38dfce760ff'
+          "
+          set +e
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" autopsy plan > autopsy-plan.json
+          autopsy_status="$?"
+          set -e
+          test "$autopsy_status" -eq 2
+          "$GITHUB_WORKSPACE/.wheel-check/bin/python" -c "
+          import json
+          from pathlib import Path
+          plan = json.loads(Path('autopsy-plan.json').read_text())
+          assert plan['manifest'].startswith('package:')
+          assert plan['weights_loaded'] is False
+          assert plan['downloads_performed'] is False
+          assert plan['model']['repository_id'] == 'mlx-community/Qwen3.8-27B-4bit'
           assert plan['model']['revision'] == '3e6447f082e89cc7f0bc6e5441afd38dfce760ff'
           "

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence m5-lab m5-lab-acquire m5-lab-run m5-lab-verify m5-lab-report m5-frontier m5-frontier-run m5-frontier-publication
+.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence m5-lab m5-lab-acquire m5-lab-run m5-lab-verify m5-lab-report m5-frontier m5-frontier-run m5-frontier-publication m5-autopsy m5-autopsy-run m5-autopsy-publication
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - evidence-first inference toolkit"
@@ -137,6 +137,22 @@ m5-frontier-run:  ## Run/resume an exploratory process-isolated frontier
 
 m5-frontier-publication:  ## Run publication mode after an operator-confirmed clean boot
 	uv run --offline --no-sync --extra mlx llmtracefx-m5-frontier run --mode publication --confirm-clean-boot --manifest $(M5_FRONTIER_MANIFEST) --workspace $(M5_FRONTIER_WORKSPACE) --model-path $(M5_FRONTIER_MODEL) --max-tier $(FRONTIER_MAX_TIER)
+
+# Process-isolated OOM autopsy bound to the fit frontier manifest and its t256
+# tier. Planning is offline and never loads weights. Runs collect only stage
+# checkpoints (no periodic sampling) and refuse without the cached pinned model.
+M5_AUTOPSY_MANIFEST ?= llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json
+M5_AUTOPSY_WORKSPACE ?= .cache/llmtracefx/m5-pro-qwen3.8-27b-oom-autopsy-v1
+M5_AUTOPSY_MODEL ?= .cache/models/qwen3.8-27b-4bit-3e6447f
+
+m5-autopsy:  ## Plan the OOM autopsy without loading weights
+	uv run --offline --no-sync --extra mlx llmtracefx-m5-lab autopsy plan --manifest $(M5_AUTOPSY_MANIFEST) --workspace $(M5_AUTOPSY_WORKSPACE) --model-path $(M5_AUTOPSY_MODEL)
+
+m5-autopsy-run:  ## Run/resume an exploratory process-isolated OOM autopsy at t256
+	uv run --offline --no-sync --extra mlx llmtracefx-m5-lab autopsy run --manifest $(M5_AUTOPSY_MANIFEST) --workspace $(M5_AUTOPSY_WORKSPACE) --model-path $(M5_AUTOPSY_MODEL)
+
+m5-autopsy-publication:  ## Run publication mode after an operator-confirmed clean boot
+	uv run --offline --no-sync --extra mlx llmtracefx-m5-lab autopsy run --mode publication --confirm-clean-boot --manifest $(M5_AUTOPSY_MANIFEST) --workspace $(M5_AUTOPSY_WORKSPACE) --model-path $(M5_AUTOPSY_MODEL)
 
 metal-evidence:  ## Capture privacy-safe Metal evidence (requires OUTPUT_DIR)
 	@test -n "$(OUTPUT_DIR)" || { echo "OUTPUT_DIR is required" >&2; exit 2; }

--- a/examples/optimizer/m5-pro-qwen3.8-27b-fit-frontier/README.md
+++ b/examples/optimizer/m5-pro-qwen3.8-27b-fit-frontier/README.md
@@ -22,3 +22,8 @@ Passing `--confirm-clean-boot` through that target is an operator assertion.
 The lab does not infer clean-boot status, and it still refuses publication mode
 if the pinned hardware, runtime, memory-headroom, swap, disk, model-hash, or
 artifact-integrity gates fail.
+
+A separately namespaced autopsy binds to this exact manifest and its `t256`
+tier to instrument the same failing request with privacy-safe stage
+checkpoints (MLX allocator, host process, and host swap memory scopes). See
+`../m5-pro-qwen3.8-27b-oom-autopsy/README.md`.

--- a/examples/optimizer/m5-pro-qwen3.8-27b-oom-autopsy/README.md
+++ b/examples/optimizer/m5-pro-qwen3.8-27b-oom-autopsy/README.md
@@ -1,0 +1,90 @@
+# Qwen3.8-27B OOM autopsy
+
+This directory is reserved for sanitized reports from the separately
+namespaced `m5-pro-qwen3.8-27b-oom-autopsy-v1` autopsy. It binds by SHA-256
+and identity to the packaged `m5-pro-qwen3.8-27b-fit-frontier-v1` manifest and
+runs only the exact pinned `t256` tier (256 requested tokens, 48 max output
+tokens) that the fit-frontier exploratory evidence in
+`../m5-pro-qwen3.8-27b-fit-frontier/exploratory/` already showed failing with
+insufficient memory before a first token. It never modifies or reinterprets
+that existing #51/#52 evidence.
+
+The no-load exploratory plan passed the current host safety gates, but the
+pinned checkpoint was not present in this worktree's cache. The model run was
+therefore refused without a download, and this change contains no invented
+checkpoint values or synthetic stand-in. This README documents the evidence
+contract a later real run must satisfy; `oom-autopsy-summary.json`,
+`oom-autopsy-checkpoints.csv`, and `oom-autopsy-report.html` land here only once
+an operator runs the autopsy on the pinned hardware and copies the sanitized
+output over.
+
+## What the autopsy adds beyond the fit frontier
+
+The fit frontier records only pass/fail per tier. The autopsy instruments the
+exact same `t256` request with privacy-safe *stage checkpoints* (no periodic
+sampling) so a failure can be read as a sequence of allocator/process/system
+observations instead of a single opaque error:
+
+`child_start -> before_model_load -> after_model_load ->
+after_prompt_tokenization -> immediately_before_prefill_generation ->
+[after_first_token, if reached] -> completion or caught_oom -> cleanup`
+
+Each checkpoint records three independent scopes, each with explicit API
+provenance, and `null` (never `0` or an estimate) when a probe is unavailable
+or errors:
+
+- **MLX allocator** - `mlx.core.get_active_memory` / `get_cache_memory` /
+  `get_peak_memory`, probed as callables on the installed MLX build rather
+  than assumed present.
+- **Host process** - current and max RSS in bytes, normalized from
+  platform-specific units and tools (macOS `ps -o rss=` in KiB plus
+  `getrusage().ru_maxrss` in bytes; Linux `/proc/self/status` `VmRSS` in kB
+  plus `getrusage().ru_maxrss` in KiB).
+- **Host system** - swap total/used in bytes (macOS `sysctl vm.swapusage`;
+  Linux `/proc/meminfo` `SwapTotal`/`SwapFree`).
+
+MLX allocator scope is not GPU capacity or free memory, and host process RSS
+is not GPU memory. No PIDs, paths, hostnames, usernames, prompts, or response
+text ever appear in the journal or the report.
+
+## Commands
+
+```bash
+# Default: offline plan only. Probes MLX counter APIs, never constructs a
+# runtime or loads weights.
+make m5-autopsy
+
+# Resume (or start) the exploratory, process-isolated t256 autopsy. Refuses
+# unless the pinned model is already cached and verified, and unless the
+# existing safety gates pass. There is no acquire/download surface here; use
+# `make m5-lab-acquire` or `make m5-frontier` first.
+make m5-autopsy-run
+
+# After an operator-confirmed clean boot only:
+make m5-autopsy-publication
+```
+
+Passing `--confirm-clean-boot` (wired through `m5-autopsy-publication`) is an
+operator assertion; the autopsy never infers clean-boot status, and
+exploratory mode refuses the flag outright. Raw journals, per-attempt working
+directories, and any path- or host-bearing artifacts stay under
+`.cache/llmtracefx/m5-pro-qwen3.8-27b-oom-autopsy-v1/` and are ignored by Git.
+Only the sanitized `oom-autopsy-summary.json` / `oom-autopsy-checkpoints.csv` /
+`oom-autopsy-report.html` produced by `llmtracefx-m5-lab autopsy report` are
+suitable to copy into this example directory.
+
+## Strict limitations that carry into every report
+
+- No unified-memory free-space or GPU capacity precision; process RSS is not
+  GPU memory.
+- No GPU utilization, free GPU memory, memory bandwidth, power, energy, or
+  kernel time.
+- Stage deltas are observed checkpoint-to-checkpoint changes, not a causal
+  explanation of what allocated the memory in between.
+- Not evidence of a universal 24 GB boundary; this is one pinned model,
+  runtime, and request on one machine.
+- A committed report's `synthetic` field is `false` only for real evidence
+  from an actual run; synthetic reports (used only in tests) are always
+  `synthetic: true` and are never placed in this directory.
+- Observer overhead is limited to the stage-boundary probes themselves and is
+  not separately measured or subtracted.

--- a/llmtracefx/optimizer/lab/autopsy.py
+++ b/llmtracefx/optimizer/lab/autopsy.py
@@ -517,7 +517,7 @@ def host_process_rss_bytes(
                         return None, None
                     return (
                         kibibytes * 1024,
-                        "/proc/self/status VmRSS (kB, current process RSS)",
+                        "Linux procfs self status VmRSS (kB, current process RSS)",
                     )
         return None, None
     return None, None
@@ -599,7 +599,7 @@ def host_swap_bytes(
         total = values.get("SwapTotal")
         free = values.get("SwapFree")
         used = None if total is None or free is None else total - free
-        return total, used, "/proc/meminfo SwapTotal/SwapFree (Linux)"
+        return total, used, "Linux procfs meminfo SwapTotal/SwapFree"
     return None, None, None
 
 
@@ -806,14 +806,17 @@ def _record_signal_checkpoint(
             "signal_received", mlx_module, extra={"signal_received": name}
         )
     except (LabError, MemoryError, OSError):
+        # Preserve any earlier checkpoint and continue the best-effort sequence.
         pass
     try:
         journal.checkpoint("cleanup", mlx_module)
     except (LabError, MemoryError, OSError):
+        # A signal must still terminate even when cleanup evidence cannot persist.
         pass
     try:
         journal.finalize(complete=False, terminal="signal")
     except (LabError, MemoryError, OSError):
+        # The last valid atomic journal remains usable if finalization fails.
         pass
 
 
@@ -1205,7 +1208,7 @@ def execute_autopsy_child(
         runtime.synchronize()
         journal.checkpoint("immediately_before_prefill_generation", mlx_module)
         first_token_seen = False
-        for _response in runtime.stream_generate(
+        for response in runtime.stream_generate(
             model,
             processor,
             prompt_tokens,
@@ -1213,6 +1216,8 @@ def execute_autopsy_child(
             draft_model=None,
             num_draft_tokens=0,
         ):
+            if response is None:
+                raise LabError("MLX-VLM generation yielded an invalid response")
             if not first_token_seen:
                 journal.checkpoint("after_first_token", mlx_module)
                 first_token_seen = True

--- a/llmtracefx/optimizer/lab/autopsy.py
+++ b/llmtracefx/optimizer/lab/autopsy.py
@@ -1,0 +1,2377 @@
+"""Focused MLX OOM autopsy for the pinned M5 Pro Qwen3.8-27B checkpoint.
+
+Runs exactly one process-isolated attempt at the frontier's ``t256`` tier and
+records discrete stage-boundary checkpoints (never periodic samples) of the
+MLX allocator, host process, and host system swap scopes. The evidence is a
+bounded, atomically-persisted journal that remains usable failure evidence
+even after an abrupt timeout, signal, or forced parent cleanup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import io
+import json
+import math
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from .._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+    reject_non_finite_json_constant,
+)
+from ..collectors._shared import atomic_write_text, config_hash
+from ..collectors.mlx import MLXVLMRuntime
+from ..schema import utc_now_iso
+from ..workloads.catalog import workload_by_id
+from .core import (
+    LabError,
+    assert_shareable,
+    assess_safety,
+    model_files_present,
+    verify_model,
+)
+from .frontier import (
+    RUN_MODES,
+    ChildProcessResult,
+    FrontierManifest,
+    FrontierManifestError,
+    _classify_error,
+    _clean_process_group,
+    _file_sha256,
+    _read_json,
+    fit_prompt,
+    frontier_manifest_hash,
+    load_bound_base_manifest,
+    machine_state,
+)
+from .manifest import LabManifest
+
+AUTOPSY_MANIFEST_SCHEMA_VERSION = "1"
+AUTOPSY_JOURNAL_SCHEMA_VERSION = "1"
+AUTOPSY_RESULT_SCHEMA_VERSION = "1"
+AUTOPSY_STATE_SCHEMA_VERSION = "1"
+AUTOPSY_REPORT_SCHEMA_VERSION = "1"
+DEFAULT_AUTOPSY_MANIFEST_RESOURCE = "data/autopsy-manifest-v1.json"
+DEFAULT_FRONTIER_MANIFEST_RESOURCE_NAME = "data/fit-frontier-manifest-v1.json"
+RESUMABLE_TERMINAL_STATUSES = ("completed", "oom", "timeout", "failed")
+
+# Ordered "main path" stages: each may appear at most once and only in this
+# relative order. ``caught_oom``, ``signal_received``, and ``cleanup`` are
+# terminal-only stages that may follow the main path but never each other in
+# more than one instance, and ``cleanup`` (when present) must be the final
+# checkpoint.
+MAIN_STAGE_SEQUENCE = (
+    "child_start",
+    "before_model_load",
+    "after_model_load",
+    "after_prompt_tokenization",
+    "immediately_before_prefill_generation",
+    "after_first_token",
+    "completion",
+)
+TERMINAL_ONLY_STAGES = ("caught_oom", "signal_received", "cleanup")
+STAGE_SEQUENCE = MAIN_STAGE_SEQUENCE + TERMINAL_ONLY_STAGES
+_HANDLED_SIGNAL_NAMES = frozenset({"SIGTERM", "SIGINT"})
+_COMPLETE_TERMINALS = frozenset({"completed", "oom", "timeout", "failed"})
+_INCOMPLETE_TERMINALS = frozenset({"signal"})
+_JOURNAL_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "autopsy_id",
+        "autopsy_manifest_hash",
+        "frontier_manifest_hash",
+        "model",
+        "tier",
+        "run_mode",
+        "clean_boot_confirmed",
+        "synthetic",
+        "started_at",
+        "sampling",
+        "peak_memory_reset",
+        "checkpoints",
+        "complete",
+        "terminal",
+        "envelope_sha256",
+    }
+)
+_CHECKPOINT_TOP_LEVEL_KEYS = frozenset(
+    {
+        "stage",
+        "sequence",
+        "wall_clock_utc",
+        "wall_clock_provenance",
+        "monotonic_offset_seconds",
+        "monotonic_offset_unit",
+        "monotonic_offset_provenance",
+        "mlx_allocator",
+        "host_process",
+        "host_system",
+        "signal_received",
+    }
+)
+
+
+class AutopsyManifestError(ValueError):
+    """Raised when the autopsy manifest is invalid or its bindings drift."""
+
+
+def _object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AutopsyManifestError(f"{context} must be an object")
+    return value
+
+
+def _string(data: dict[str, Any], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise AutopsyManifestError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _integer(data: dict[str, Any], key: str, context: str, *, minimum: int = 0) -> int:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise AutopsyManifestError(f"{context}.{key} must be an integer >= {minimum}")
+    return value
+
+
+def _number(data: dict[str, Any], key: str, context: str, *, minimum: float) -> float:
+    value = data.get(key)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < minimum
+    ):
+        raise AutopsyManifestError(f"{context}.{key} must be >= {minimum}")
+    return float(value)
+
+
+def _relative_path(value: str, context: str) -> str:
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise AutopsyManifestError(f"{context} must be a relative safe path")
+    return value
+
+
+def _sha256_hex(value: str, context: str) -> str:
+    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise AutopsyManifestError(f"{context} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _git_revision(value: str, context: str) -> str:
+    if len(value) != 40 or any(char not in "0123456789abcdef" for char in value):
+        raise AutopsyManifestError(f"{context} must be a 40-character git revision")
+    return value
+
+
+@dataclass(frozen=True)
+class AutopsyArtifacts:
+    workspace: str
+    shareable_example_dir: str
+    commit_raw_artifacts: bool
+
+
+@dataclass(frozen=True)
+class AutopsyManifest:
+    schema_version: str
+    autopsy_id: str
+    frontier_manifest_resource: str
+    frontier_manifest_sha256: str
+    frontier_id: str
+    base_lab_id: str
+    model_repository_id: str
+    model_revision: str
+    model_expected_download_bytes: int
+    tier_name: str
+    tier_requested_tokens: int
+    child_timeout_seconds: float
+    process_cleanup_grace_seconds: float
+    journal_max_checkpoints: int
+    journal_max_bytes: int
+    artifacts: AutopsyArtifacts
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> AutopsyManifest:
+        try:
+            model = _object(raw["model"], "model")
+            tier = _object(raw["tier"], "tier")
+            journal = _object(raw["journal"], "journal")
+            artifacts_raw = _object(raw["artifacts"], "artifacts")
+        except KeyError as exc:
+            raise AutopsyManifestError(f"missing autopsy field: {exc}") from exc
+        schema_version = _string(raw, "schema_version", "manifest")
+        if schema_version != AUTOPSY_MANIFEST_SCHEMA_VERSION:
+            raise AutopsyManifestError(
+                f"unsupported autopsy schema_version {schema_version!r}"
+            )
+        commit_raw = artifacts_raw.get("commit_raw_artifacts")
+        if commit_raw is not False:
+            raise AutopsyManifestError(
+                "artifacts.commit_raw_artifacts must remain false"
+            )
+        journal_max_bytes = _integer(journal, "max_bytes", "journal", minimum=1)
+        if journal_max_bytes > MAX_METADATA_ARTIFACT_BYTES:
+            raise AutopsyManifestError(
+                "journal.max_bytes must not exceed the "
+                f"{MAX_METADATA_ARTIFACT_BYTES}-byte metadata artifact limit"
+            )
+        return cls(
+            schema_version=schema_version,
+            autopsy_id=_string(raw, "autopsy_id", "manifest"),
+            frontier_manifest_resource=_relative_path(
+                _string(raw, "frontier_manifest_resource", "manifest"),
+                "frontier_manifest_resource",
+            ),
+            frontier_manifest_sha256=_sha256_hex(
+                _string(raw, "frontier_manifest_sha256", "manifest"),
+                "frontier_manifest_sha256",
+            ),
+            frontier_id=_string(raw, "frontier_id", "manifest"),
+            base_lab_id=_string(raw, "base_lab_id", "manifest"),
+            model_repository_id=_string(model, "repository_id", "model"),
+            model_revision=_git_revision(
+                _string(model, "revision", "model"), "model.revision"
+            ),
+            model_expected_download_bytes=_integer(
+                model, "expected_download_bytes", "model", minimum=1
+            ),
+            tier_name=_string(tier, "name", "tier"),
+            tier_requested_tokens=_integer(tier, "requested_tokens", "tier", minimum=1),
+            child_timeout_seconds=_number(
+                raw, "child_timeout_seconds", "manifest", minimum=1
+            ),
+            process_cleanup_grace_seconds=_number(
+                raw, "process_cleanup_grace_seconds", "manifest", minimum=0.1
+            ),
+            journal_max_checkpoints=_integer(
+                journal, "max_checkpoints", "journal", minimum=1
+            ),
+            journal_max_bytes=journal_max_bytes,
+            artifacts=AutopsyArtifacts(
+                workspace=_relative_path(
+                    _string(artifacts_raw, "workspace", "artifacts"),
+                    "artifacts.workspace",
+                ),
+                shareable_example_dir=_relative_path(
+                    _string(artifacts_raw, "shareable_example_dir", "artifacts"),
+                    "artifacts.shareable_example_dir",
+                ),
+                commit_raw_artifacts=False,
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> AutopsyManifest:
+        try:
+            raw = json.loads(payload, parse_constant=reject_non_finite_json_constant)
+        except (ValueError, RecursionError) as exc:
+            raise AutopsyManifestError(f"invalid autopsy JSON: {exc}") from exc
+        return cls.from_dict(_object(raw, "manifest"))
+
+    @classmethod
+    def read_json(cls, path: Path) -> AutopsyManifest:
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise AutopsyManifestError(f"invalid autopsy file: {exc}") from exc
+        return cls.from_json(payload)
+
+
+def load_packaged_autopsy_manifest() -> tuple[AutopsyManifest, str]:
+    resource = resources.files("llmtracefx.optimizer.lab").joinpath(
+        DEFAULT_AUTOPSY_MANIFEST_RESOURCE
+    )
+    payload = resource.read_text(encoding="utf-8")
+    return (
+        AutopsyManifest.from_json(payload),
+        f"package:llmtracefx.optimizer.lab/{DEFAULT_AUTOPSY_MANIFEST_RESOURCE}",
+    )
+
+
+def load_autopsy_manifest(path: Path | None) -> tuple[AutopsyManifest, str]:
+    if path is None:
+        return load_packaged_autopsy_manifest()
+    return AutopsyManifest.read_json(path), str(path)
+
+
+def autopsy_manifest_hash(autopsy: AutopsyManifest) -> str:
+    """Deterministic binding hash of the autopsy manifest's own fields.
+
+    Evidence must be bound to the exact autopsy manifest, not only to the
+    frontier manifest it is layered on top of: a change to this manifest
+    (for example its timeout, checkpoint, or byte bounds) that leaves the
+    frontier manifest untouched must still stale-out any prior journal,
+    result, state, or report. Local artifact paths are excluded, mirroring
+    ``frontier_manifest_hash``'s exclusion of its own artifact section.
+    """
+    return config_hash(
+        {
+            "schema_version": autopsy.schema_version,
+            "autopsy_id": autopsy.autopsy_id,
+            "frontier_manifest_resource": autopsy.frontier_manifest_resource,
+            "frontier_manifest_sha256": autopsy.frontier_manifest_sha256,
+            "frontier_id": autopsy.frontier_id,
+            "base_lab_id": autopsy.base_lab_id,
+            "model_repository_id": autopsy.model_repository_id,
+            "model_revision": autopsy.model_revision,
+            "model_expected_download_bytes": autopsy.model_expected_download_bytes,
+            "tier_name": autopsy.tier_name,
+            "tier_requested_tokens": autopsy.tier_requested_tokens,
+            "child_timeout_seconds": autopsy.child_timeout_seconds,
+            "process_cleanup_grace_seconds": autopsy.process_cleanup_grace_seconds,
+            "journal_max_checkpoints": autopsy.journal_max_checkpoints,
+            "journal_max_bytes": autopsy.journal_max_bytes,
+        }
+    )
+
+
+def _packaged_frontier_text() -> str:
+    resource = resources.files("llmtracefx.optimizer.lab").joinpath(
+        DEFAULT_FRONTIER_MANIFEST_RESOURCE_NAME
+    )
+    return resource.read_text(encoding="utf-8")
+
+
+def load_bound_frontier(
+    autopsy: AutopsyManifest, *, frontier_manifest_path: Path | None
+) -> tuple[FrontierManifest, LabManifest]:
+    if frontier_manifest_path is None:
+        payload = _packaged_frontier_text()
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        frontier = FrontierManifest.from_json(payload)
+    else:
+        payload = read_bounded_regular_text(
+            frontier_manifest_path, MAX_METADATA_ARTIFACT_BYTES
+        )
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        frontier = FrontierManifest.from_json(payload)
+    if digest != autopsy.frontier_manifest_sha256:
+        raise AutopsyManifestError(
+            "frontier manifest does not match the autopsy binding"
+        )
+    if frontier.frontier_id != autopsy.frontier_id:
+        raise AutopsyManifestError("autopsy frontier_id binding drifted")
+    if frontier.base_lab_id != autopsy.base_lab_id:
+        raise AutopsyManifestError("autopsy base_lab_id binding drifted")
+    identity = (
+        frontier.model_repository_id,
+        frontier.model_revision,
+        frontier.model_expected_download_bytes,
+    )
+    expected = (
+        autopsy.model_repository_id,
+        autopsy.model_revision,
+        autopsy.model_expected_download_bytes,
+    )
+    if identity != expected:
+        raise AutopsyManifestError("autopsy model identity binding drifted")
+    try:
+        tier = frontier.tier(autopsy.tier_name)
+    except FrontierManifestError as exc:
+        raise AutopsyManifestError(
+            f"autopsy tier {autopsy.tier_name!r} is not defined by the frontier"
+        ) from exc
+    if tier.requested_tokens != autopsy.tier_requested_tokens:
+        raise AutopsyManifestError("autopsy tier token binding drifted")
+    base = load_bound_base_manifest(frontier)
+    return frontier, base
+
+
+# ---------------------------------------------------------------------------
+# Direct MLX allocator counter probes. Never estimate: an absent API records
+# a null value with a null API name rather than a fabricated zero.
+# ---------------------------------------------------------------------------
+
+_MLX_COUNTER_FUNCTIONS: tuple[tuple[str, str], ...] = (
+    ("get_active_memory", "active_bytes"),
+    ("get_cache_memory", "cache_bytes"),
+    ("get_peak_memory", "peak_bytes"),
+)
+
+
+def _qualified_name(function: Any, fallback: str) -> str:
+    module = getattr(function, "__module__", None) or "mlx.core"
+    qualname = getattr(function, "__qualname__", None) or fallback
+    return f"{module}.{qualname}"
+
+
+def probe_mlx_counters(mlx_module: Any | None) -> dict[str, dict[str, Any]]:
+    """Return one probe entry per direct MLX allocator counter.
+
+    Each entry records the exact callable's qualified name and whether it is
+    available on the installed MLX build, alongside its current value in
+    bytes. A missing or failing counter is recorded as ``None``, never a
+    guessed zero. ``error_category`` distinguishes "the API call raised" from
+    "the API is simply unavailable", recording only the exception's type
+    name -- never its message, which could carry unsanitized detail.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for function_name, output_key in _MLX_COUNTER_FUNCTIONS:
+        function = getattr(mlx_module, function_name, None) if mlx_module else None
+        if not callable(function):
+            result[output_key] = {
+                "api": None,
+                "value": None,
+                "unit": "bytes",
+                "error_category": None,
+            }
+            continue
+        error_category: str | None = None
+        try:
+            value: int | None = int(function())
+        except (RuntimeError, ValueError, TypeError, OSError, MemoryError) as exc:
+            value = None
+            error_category = type(exc).__name__
+        result[output_key] = {
+            "api": _qualified_name(function, function_name),
+            "value": value,
+            "unit": "bytes",
+            "error_category": error_category,
+        }
+    return result
+
+
+def probe_mlx_reset_peak_memory_api(mlx_module: Any | None) -> str | None:
+    function = getattr(mlx_module, "reset_peak_memory", None) if mlx_module else None
+    if not callable(function):
+        return None
+    return _qualified_name(function, "reset_peak_memory")
+
+
+def _import_mlx_core() -> Any | None:
+    try:
+        import mlx.core as mlx_module
+    except ImportError:
+        return None
+    return mlx_module
+
+
+# ---------------------------------------------------------------------------
+# Host process/system probes. Every provenance string names the exact source
+# and unit; unavailable measurements are null, never a silent default.
+# ---------------------------------------------------------------------------
+
+
+def _run_probe_text(argv: list[str]) -> str | None:
+    try:
+        return subprocess.run(
+            argv,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            shell=False,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def host_process_rss_bytes(
+    *,
+    system: str | None = None,
+    run_text: Callable[[list[str]], str | None] = _run_probe_text,
+    linux_status_path: Path = Path("/proc/self/status"),
+) -> tuple[int | None, str | None]:
+    import platform as _platform
+
+    resolved = system or _platform.system()
+    if resolved == "Darwin":
+        text = run_text(["ps", "-o", "rss=", "-p", str(os.getpid())])
+        if text is None:
+            return None, None
+        try:
+            kibibytes = int(text.strip())
+        except ValueError:
+            return None, None
+        return kibibytes * 1024, "ps -o rss= (KiB, current process RSS)"
+    if resolved == "Linux":
+        try:
+            status_text = read_bounded_regular_text(
+                linux_status_path, MAX_METADATA_ARTIFACT_BYTES
+            )
+        except (ArtifactReadError, OSError):
+            return None, None
+        for line in status_text.splitlines():
+            if line.startswith("VmRSS:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        kibibytes = int(parts[1])
+                    except ValueError:
+                        return None, None
+                    return (
+                        kibibytes * 1024,
+                        "/proc/self/status VmRSS (kB, current process RSS)",
+                    )
+        return None, None
+    return None, None
+
+
+def host_process_max_rss_bytes(
+    *,
+    system: str | None = None,
+    getrusage: Callable[[], Any] | None = None,
+) -> tuple[int | None, str | None]:
+    import platform as _platform
+
+    resolved = system or _platform.system()
+    if getrusage is None:
+        try:
+            import resource
+
+            getrusage = lambda: resource.getrusage(resource.RUSAGE_SELF)  # noqa: E731
+        except ImportError:
+            return None, None
+    try:
+        usage = getrusage()
+        raw = int(usage.ru_maxrss)
+    except (OSError, ValueError, AttributeError, TypeError):
+        return None, None
+    if resolved == "Darwin":
+        return raw, "getrusage(RUSAGE_SELF).ru_maxrss (bytes, macOS, process max RSS)"
+    if resolved == "Linux":
+        return (
+            raw * 1024,
+            "getrusage(RUSAGE_SELF).ru_maxrss (KiB, Linux, process max RSS)",
+        )
+    return None, None
+
+
+def _parse_byte_quantity(value: str) -> int | None:
+    import re
+
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)([KMG])", value)
+    if match is None:
+        return None
+    factors = {"K": 1024, "M": 1024**2, "G": 1024**3}
+    return int(float(match.group(1)) * factors[match.group(2)])
+
+
+def host_swap_bytes(
+    *,
+    system: str | None = None,
+    run_text: Callable[[list[str]], str | None] = _run_probe_text,
+    linux_meminfo_path: Path = Path("/proc/meminfo"),
+) -> tuple[int | None, int | None, str | None]:
+    import platform as _platform
+    import re
+
+    resolved = system or _platform.system()
+    if resolved == "Darwin":
+        text = run_text(["sysctl", "-n", "vm.swapusage"])
+        if text is None:
+            return None, None, None
+        total_match = re.search(r"total\s*=\s*([0-9.]+[KMG])", text)
+        used_match = re.search(r"used\s*=\s*([0-9.]+[KMG])", text)
+        total = _parse_byte_quantity(total_match.group(1)) if total_match else None
+        used = _parse_byte_quantity(used_match.group(1)) if used_match else None
+        return total, used, "sysctl vm.swapusage (macOS)"
+    if resolved == "Linux":
+        try:
+            meminfo_text = read_bounded_regular_text(
+                linux_meminfo_path, MAX_METADATA_ARTIFACT_BYTES
+            )
+        except (ArtifactReadError, OSError):
+            return None, None, None
+        values: dict[str, int] = {}
+        for line in meminfo_text.splitlines():
+            key, _, remainder = line.partition(":")
+            if key.strip() in ("SwapTotal", "SwapFree"):
+                match = re.search(r"([0-9]+)", remainder)
+                if match:
+                    values[key.strip()] = int(match.group(1)) * 1024
+        total = values.get("SwapTotal")
+        free = values.get("SwapFree")
+        used = None if total is None or free is None else total - free
+        return total, used, "/proc/meminfo SwapTotal/SwapFree (Linux)"
+    return None, None, None
+
+
+def build_checkpoint(
+    stage: str,
+    sequence: int,
+    *,
+    mlx_module: Any | None,
+    started_monotonic: float,
+    extra: dict[str, Any] | None = None,
+    rss_probe: Callable[[], tuple[int | None, str | None]] = host_process_rss_bytes,
+    max_rss_probe: Callable[
+        [], tuple[int | None, str | None]
+    ] = host_process_max_rss_bytes,
+    swap_probe: Callable[
+        [], tuple[int | None, int | None, str | None]
+    ] = host_swap_bytes,
+) -> dict[str, Any]:
+    """Build one privacy-safe stage checkpoint with exact scopes.
+
+    Never carries a PID, path, hostname, username, prompt, or response.
+    """
+    counters = probe_mlx_counters(mlx_module)
+    try:
+        rss_value, rss_provenance = rss_probe()
+    except (MemoryError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        rss_value, rss_provenance = None, f"probe failed ({type(exc).__name__})"
+    try:
+        max_rss_value, max_rss_provenance = max_rss_probe()
+    except (MemoryError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        max_rss_value, max_rss_provenance = (
+            None,
+            f"probe failed ({type(exc).__name__})",
+        )
+    try:
+        swap_total, swap_used, swap_provenance = swap_probe()
+    except (MemoryError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        swap_total, swap_used, swap_provenance = (
+            None,
+            None,
+            f"probe failed ({type(exc).__name__})",
+        )
+    entry: dict[str, Any] = {
+        "stage": stage,
+        "sequence": sequence,
+        "wall_clock_utc": utc_now_iso(),
+        "wall_clock_provenance": "schema.utc_now_iso (ISO-8601, UTC)",
+        "monotonic_offset_seconds": max(0.0, time.monotonic() - started_monotonic),
+        "monotonic_offset_unit": "seconds",
+        "monotonic_offset_provenance": (
+            "time.monotonic() delta since the child process's own start"
+        ),
+        "mlx_allocator": {
+            "scope": "mlx_allocator",
+            "unit": "bytes",
+            "active_bytes": counters["active_bytes"],
+            "cache_bytes": counters["cache_bytes"],
+            "peak_bytes": counters["peak_bytes"],
+        },
+        "host_process": {
+            "scope": "host_process",
+            "unit": "bytes",
+            "rss_bytes": {"value": rss_value, "provenance": rss_provenance},
+            "max_rss_bytes": {"value": max_rss_value, "provenance": max_rss_provenance},
+        },
+        "host_system": {
+            "scope": "host_system_swap",
+            "unit": "bytes",
+            "swap_total_bytes": {"value": swap_total, "provenance": swap_provenance},
+            "swap_used_bytes": {"value": swap_used, "provenance": swap_provenance},
+        },
+    }
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Bounded, atomically-persisted journal.
+# ---------------------------------------------------------------------------
+
+
+class AutopsyJournal:
+    """Bounded, replace-safe checkpoint journal for one isolated attempt.
+
+    Persisted through ``atomic_write_text`` after every checkpoint so an
+    abrupt timeout, signal, or forced parent cleanup leaves the last valid
+    checkpoint on disk as usable failure evidence rather than nothing.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        autopsy_id: str,
+        autopsy_manifest_hash_value: str,
+        frontier_manifest_hash_value: str,
+        model_repository_id: str,
+        model_revision: str,
+        tier: str,
+        run_mode: str,
+        clean_boot_confirmed: bool,
+        max_checkpoints: int,
+        max_bytes: int,
+    ) -> None:
+        self.path = path
+        self.autopsy_id = autopsy_id
+        self.autopsy_manifest_hash = autopsy_manifest_hash_value
+        self.frontier_manifest_hash = frontier_manifest_hash_value
+        self.model_repository_id = model_repository_id
+        self.model_revision = model_revision
+        self.tier = tier
+        self.run_mode = run_mode
+        self.clean_boot_confirmed = clean_boot_confirmed
+        self.max_checkpoints = max_checkpoints
+        self.max_bytes = max_bytes
+        self.checkpoints: list[dict[str, Any]] = []
+        self.complete = False
+        self.terminal: str | None = None
+        self.started_monotonic = time.monotonic()
+        self.started_at = utc_now_iso()
+
+    def checkpoint(
+        self, stage: str, mlx_module: Any | None, *, extra: dict[str, Any] | None = None
+    ) -> None:
+        if len(self.checkpoints) >= self.max_checkpoints:
+            raise LabError("autopsy journal exceeded the maximum checkpoint count")
+        entry = build_checkpoint(
+            stage,
+            len(self.checkpoints),
+            mlx_module=mlx_module,
+            started_monotonic=self.started_monotonic,
+            extra=extra,
+        )
+        self.checkpoints.append(entry)
+        self._persist()
+
+    def finalize(self, *, complete: bool, terminal: str) -> None:
+        self.complete = complete
+        self.terminal = terminal
+        self._persist()
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": AUTOPSY_JOURNAL_SCHEMA_VERSION,
+            "autopsy_id": self.autopsy_id,
+            "autopsy_manifest_hash": self.autopsy_manifest_hash,
+            "frontier_manifest_hash": self.frontier_manifest_hash,
+            "model": {
+                "repository_id": self.model_repository_id,
+                "revision": self.model_revision,
+            },
+            "tier": self.tier,
+            "run_mode": self.run_mode,
+            "clean_boot_confirmed": self.clean_boot_confirmed,
+            "synthetic": False,
+            "started_at": self.started_at,
+            "sampling": {
+                "periodic_sampling_enabled": False,
+                "note": (
+                    "Only discrete stage-boundary checkpoints are recorded; "
+                    "no interval polling occurs."
+                ),
+            },
+            "peak_memory_reset": {
+                "applied": False,
+                "api": None,
+                "note": (
+                    "Peak memory is never reset after model load, so a fresh "
+                    "subprocess's peak reading includes load growth."
+                ),
+            },
+            "checkpoints": self.checkpoints,
+            "complete": self.complete,
+            "terminal": self.terminal,
+        }
+
+    def _persist(self) -> None:
+        body = self._payload()
+        envelope_hash = config_hash(body)
+        body_with_hash = dict(body)
+        body_with_hash["envelope_sha256"] = envelope_hash
+        text = json.dumps(body_with_hash, indent=2, sort_keys=False) + "\n"
+        if len(text.encode("utf-8")) > self.max_bytes:
+            raise LabError("autopsy journal exceeded the maximum artifact size")
+        atomic_write_text(self.path, text)
+
+
+def _record_signal_checkpoint(
+    journal: AutopsyJournal, mlx_module: Any | None, signum: int
+) -> None:
+    """Best-effort signal evidence: each write is independent of the others.
+
+    The ``signal_received`` stage is never mislabeled as ``cleanup``; the two
+    are recorded as distinct checkpoints so an abrupt-termination trace is
+    unambiguous. A failure writing one checkpoint (for example the
+    checkpoint or byte bound already being exhausted) must not prevent the
+    remaining best-effort writes, and must never prevent the process from
+    still exiting.
+    """
+    name = signal.Signals(signum).name
+    try:
+        journal.checkpoint(
+            "signal_received", mlx_module, extra={"signal_received": name}
+        )
+    except (LabError, MemoryError, OSError):
+        pass
+    try:
+        journal.checkpoint("cleanup", mlx_module)
+    except (LabError, MemoryError, OSError):
+        pass
+    try:
+        journal.finalize(complete=False, terminal="signal")
+    except (LabError, MemoryError, OSError):
+        pass
+
+
+def install_signal_handlers(journal: AutopsyJournal, mlx_module: Any | None) -> None:
+    def handler(signum: int, frame: Any) -> None:
+        try:
+            _record_signal_checkpoint(journal, mlx_module, signum)
+        finally:
+            os._exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, handler)
+    signal.signal(signal.SIGINT, handler)
+
+
+def _validate_measurement(value: Any, *, allow_provenance: bool) -> str | None:
+    if not isinstance(value, dict):
+        return "measurement is not an object"
+    raw = value.get("value")
+    if raw is not None and (
+        isinstance(raw, bool) or not isinstance(raw, int) or raw < 0
+    ):
+        return "measurement value must be a non-negative integer or null"
+    if allow_provenance:
+        provenance = value.get("provenance")
+        if provenance is not None and not isinstance(provenance, str):
+            return "measurement provenance must be a string or null"
+    else:
+        api = value.get("api")
+        if api is not None and not isinstance(api, str):
+            return "measurement api must be a string or null"
+        if value.get("unit") != "bytes":
+            return "measurement unit must be 'bytes'"
+        error_category = value.get("error_category")
+        if error_category is not None and not isinstance(error_category, str):
+            return "measurement error_category must be a string or null"
+    return None
+
+
+def _validate_scope(
+    scope: Any, *, key: str, expected_scope: str, sub_keys: tuple[str, ...]
+) -> str | None:
+    if not isinstance(scope, dict):
+        return f"checkpoint {key} scope must be an object"
+    if scope.get("scope") != expected_scope:
+        return f"checkpoint {key} scope label must be {expected_scope!r}"
+    if scope.get("unit") != "bytes":
+        return f"checkpoint {key} unit must be 'bytes'"
+    for sub_key in sub_keys:
+        reason = _validate_measurement(
+            scope.get(sub_key), allow_provenance=(key != "mlx_allocator")
+        )
+        if reason is not None:
+            return f"checkpoint {key}.{sub_key}: {reason}"
+    return None
+
+
+def _validate_checkpoint_shape(entry: dict[str, Any], *, stage: str) -> str | None:
+    unknown = set(entry) - _CHECKPOINT_TOP_LEVEL_KEYS
+    if unknown:
+        return f"checkpoint carries unexpected field(s): {sorted(unknown)}"
+    wall_clock = entry.get("wall_clock_utc")
+    if not isinstance(wall_clock, str) or not wall_clock:
+        return "checkpoint wall_clock_utc must be a non-empty string"
+    if entry.get("wall_clock_provenance") is not None and not isinstance(
+        entry.get("wall_clock_provenance"), str
+    ):
+        return "checkpoint wall_clock_provenance must be a string or null"
+    offset = entry.get("monotonic_offset_seconds")
+    if (
+        isinstance(offset, bool)
+        or not isinstance(offset, (int, float))
+        or not math.isfinite(float(offset))
+        or offset < 0
+    ):
+        return "checkpoint monotonic_offset_seconds must be finite and non-negative"
+    if entry.get("monotonic_offset_unit") not in (None, "seconds"):
+        return "checkpoint monotonic_offset_unit must be 'seconds' or null"
+    reason = _validate_scope(
+        entry.get("mlx_allocator"),
+        key="mlx_allocator",
+        expected_scope="mlx_allocator",
+        sub_keys=("active_bytes", "cache_bytes", "peak_bytes"),
+    )
+    if reason is not None:
+        return reason
+    reason = _validate_scope(
+        entry.get("host_process"),
+        key="host_process",
+        expected_scope="host_process",
+        sub_keys=("rss_bytes", "max_rss_bytes"),
+    )
+    if reason is not None:
+        return reason
+    reason = _validate_scope(
+        entry.get("host_system"),
+        key="host_system",
+        expected_scope="host_system_swap",
+        sub_keys=("swap_total_bytes", "swap_used_bytes"),
+    )
+    if reason is not None:
+        return reason
+    signal_received = entry.get("signal_received")
+    if stage == "signal_received":
+        if signal_received not in _HANDLED_SIGNAL_NAMES:
+            return "signal_received checkpoint must record a known signal name"
+    elif signal_received is not None:
+        return "only the signal_received checkpoint may carry signal_received"
+    return None
+
+
+def _validate_checkpoint_sequence(checkpoints: Any) -> str | None:
+    if not isinstance(checkpoints, list) or not checkpoints:
+        return "journal checkpoints must be a non-empty list"
+    if checkpoints[0].get("stage") != "child_start":
+        return "the first checkpoint must be child_start"
+    highest_main_index = -1
+    seen_terminal_only: set[str] = set()
+    for index, entry in enumerate(checkpoints):
+        if not isinstance(entry, dict):
+            return "checkpoint entries must be objects"
+        sequence = entry.get("sequence")
+        if isinstance(sequence, bool) or sequence != index:
+            return "checkpoint sequence numbers must be contiguous from zero"
+        stage = entry.get("stage")
+        if stage not in STAGE_SEQUENCE:
+            return f"checkpoint stage {stage!r} is not an allowed stage"
+        if stage in MAIN_STAGE_SEQUENCE:
+            stage_index = MAIN_STAGE_SEQUENCE.index(stage)
+            if stage_index <= highest_main_index:
+                return "main-path checkpoint stages are out of order or repeated"
+            highest_main_index = stage_index
+        else:
+            if stage in seen_terminal_only:
+                return f"checkpoint stage {stage!r} appears more than once"
+            seen_terminal_only.add(stage)
+            if stage == "cleanup" and index != len(checkpoints) - 1:
+                return "a cleanup checkpoint must be the final checkpoint"
+        reason = _validate_checkpoint_shape(entry, stage=stage)
+        if reason is not None:
+            return reason
+    return None
+
+
+def _validate_terminal_semantics(
+    checkpoints: list[dict[str, Any]], *, complete: Any, terminal: Any
+) -> str | None:
+    if not isinstance(complete, bool):
+        return "journal complete flag must be a boolean"
+    if terminal is not None and not isinstance(terminal, str):
+        return "journal terminal must be a string or null"
+    stages = {entry.get("stage") for entry in checkpoints}
+    has_completion = "completion" in stages
+    has_caught_oom = "caught_oom" in stages
+    has_signal = "signal_received" in stages
+    if terminal is None:
+        if complete:
+            return "a journal cannot be complete with no terminal outcome"
+        if has_completion or has_caught_oom or has_signal:
+            return (
+                "a journal without a terminal outcome must not record a "
+                "terminal-only checkpoint"
+            )
+        return None
+    if terminal in _COMPLETE_TERMINALS:
+        if not complete:
+            return f"journal terminal {terminal!r} requires complete=true"
+        if terminal == "completed":
+            if not has_completion or has_caught_oom or has_signal:
+                return (
+                    "a completed journal must record completion and no "
+                    "failure checkpoints"
+                )
+        elif terminal == "oom":
+            if not has_caught_oom or has_completion or has_signal:
+                return (
+                    "an oom journal must record caught_oom and no "
+                    "completion/signal checkpoints"
+                )
+        elif has_completion or has_caught_oom or has_signal:
+            return (
+                f"a {terminal} journal must not record completion/caught_oom/"
+                "signal checkpoints"
+            )
+        return None
+    if terminal in _INCOMPLETE_TERMINALS:
+        if complete:
+            return "a signal journal must have complete=false"
+        if not has_signal:
+            return "a signal journal must record a signal_received checkpoint"
+        if has_completion or has_caught_oom:
+            return (
+                "a signal journal must not record completion/caught_oom " "checkpoints"
+            )
+        return None
+    return f"journal terminal {terminal!r} is not a recognized outcome"
+
+
+def _journal_invalid_reason(
+    journal: Any,
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+) -> str | None:
+    """Return why ``journal`` is not usable evidence, or ``None`` if valid.
+
+    Every check is explicit so a stale, tampered, or foreign journal is
+    never silently treated as merely absent (see ``JournalLoadResult``).
+    """
+    if not isinstance(journal, dict):
+        return "journal is not an object"
+    unknown = set(journal) - _JOURNAL_TOP_LEVEL_KEYS
+    if unknown:
+        return f"journal carries unexpected field(s): {sorted(unknown)}"
+    envelope = journal.get("envelope_sha256")
+    canonical = {
+        key: value for key, value in journal.items() if key != "envelope_sha256"
+    }
+    if not isinstance(envelope, str) or config_hash(canonical) != envelope:
+        return "journal envelope hash does not match its own contents"
+    if journal.get("schema_version") != AUTOPSY_JOURNAL_SCHEMA_VERSION:
+        return "journal schema_version is unsupported"
+    if journal.get("autopsy_id") != autopsy.autopsy_id:
+        return "journal autopsy_id does not match the bound manifest"
+    if journal.get("autopsy_manifest_hash") != autopsy_manifest_hash(autopsy):
+        return "journal autopsy_manifest_hash does not match the bound manifest"
+    if journal.get("frontier_manifest_hash") != frontier_manifest_hash(frontier):
+        return "journal frontier_manifest_hash does not match the bound frontier"
+    model = journal.get("model")
+    if (
+        not isinstance(model, dict)
+        or set(model) != {"repository_id", "revision"}
+        or model.get("repository_id") != frontier.model_repository_id
+        or model.get("revision") != frontier.model_revision
+    ):
+        return "journal model identity does not match the bound frontier"
+    if journal.get("tier") != autopsy.tier_name:
+        return "journal tier does not match the bound manifest"
+    if journal.get("run_mode") != run_mode:
+        return "journal run_mode does not match the requested run"
+    if journal.get("clean_boot_confirmed") is not clean_boot_confirmed:
+        return "journal clean_boot_confirmed does not match the requested run"
+    if journal.get("synthetic") is not False:
+        return "journal synthetic flag must be false"
+    if not isinstance(journal.get("started_at"), str) or not journal["started_at"]:
+        return "journal started_at must be a non-empty string"
+    sampling = journal.get("sampling")
+    if (
+        not isinstance(sampling, dict)
+        or set(sampling) - {"periodic_sampling_enabled", "note"}
+        or sampling.get("periodic_sampling_enabled") is not False
+    ):
+        return "journal sampling.periodic_sampling_enabled must be false"
+    peak_reset = journal.get("peak_memory_reset")
+    if (
+        not isinstance(peak_reset, dict)
+        or set(peak_reset) - {"applied", "api", "note"}
+        or peak_reset.get("applied") is not False
+        or peak_reset.get("api") is not None
+    ):
+        return (
+            "journal peak_memory_reset must explicitly record that peak "
+            "memory was never reset after model load"
+        )
+    checkpoints = journal.get("checkpoints")
+    if not isinstance(checkpoints, list):
+        return "journal checkpoints must be a list"
+    reason = _validate_checkpoint_sequence(checkpoints)
+    if reason is not None:
+        return reason
+    if len(checkpoints) > autopsy.journal_max_checkpoints:
+        return "journal checkpoints exceed the manifest-bound maximum count"
+    return _validate_terminal_semantics(
+        checkpoints, complete=journal.get("complete"), terminal=journal.get("terminal")
+    )
+
+
+@dataclass(frozen=True)
+class JournalLoadResult:
+    """Explicit outcome of loading a journal artifact from disk.
+
+    ``status`` is one of ``"missing"`` (no journal artifact exists),
+    ``"invalid"`` (an artifact exists but is stale, tampered, foreign, a
+    symlink, or otherwise fails full contract validation -- ``reason``
+    explains why), or ``"valid"`` (fully parsed and validated, regardless of
+    whether it records a complete or an incomplete attempt).
+    """
+
+    status: str
+    journal: dict[str, Any] | None
+    digest: str | None
+    reason: str | None
+
+
+def _load_journal_if_valid(
+    path: Path,
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+) -> JournalLoadResult:
+    if path.is_symlink():
+        return JournalLoadResult("invalid", None, None, "journal path is a symlink")
+    if not path.is_file():
+        return JournalLoadResult("missing", None, None, None)
+    try:
+        journal = _read_json(path)
+    except LabError as exc:
+        return JournalLoadResult("invalid", None, None, f"journal is unreadable: {exc}")
+    reason = _journal_invalid_reason(
+        journal,
+        autopsy,
+        frontier,
+        run_mode=run_mode,
+        clean_boot_confirmed=clean_boot_confirmed,
+    )
+    if reason is not None:
+        return JournalLoadResult("invalid", None, None, reason)
+    return JournalLoadResult("valid", journal, _file_sha256(path), None)
+
+
+# ---------------------------------------------------------------------------
+# Isolated child execution.
+# ---------------------------------------------------------------------------
+
+
+def execute_autopsy_child(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    base: LabManifest,
+    *,
+    model_path: Path,
+    output_dir: Path,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+    runtime_factory: Callable[[], Any] | None = None,
+    mlx_module_factory: Callable[[], Any | None] = _import_mlx_core,
+) -> dict[str, Any]:
+    tier = frontier.tier(autopsy.tier_name)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    journal_path = output_dir / "journal.json"
+    result_path = output_dir / "result.json"
+    mlx_module = mlx_module_factory()
+    journal = AutopsyJournal(
+        path=journal_path,
+        autopsy_id=autopsy.autopsy_id,
+        autopsy_manifest_hash_value=autopsy_manifest_hash(autopsy),
+        frontier_manifest_hash_value=frontier_manifest_hash(frontier),
+        model_repository_id=frontier.model_repository_id,
+        model_revision=frontier.model_revision,
+        tier=autopsy.tier_name,
+        run_mode=run_mode,
+        clean_boot_confirmed=clean_boot_confirmed,
+        max_checkpoints=autopsy.journal_max_checkpoints,
+        max_bytes=autopsy.journal_max_bytes,
+    )
+    install_signal_handlers(journal, mlx_module)
+    journal.checkpoint("child_start", mlx_module)
+    actual_tokens: int | None = None
+    status = "failed"
+    reason: str | None = "autopsy child did not reach a terminal stage"
+    try:
+        factory = runtime_factory or (
+            lambda: MLXVLMRuntime(
+                temperature=base.generation.temperature,
+                top_p=base.generation.top_p,
+                enable_thinking=base.generation.enable_thinking,
+                prefill_step_size=base.runtime.prefill_step_size,
+            )
+        )
+        runtime = factory()
+        journal.checkpoint("before_model_load", mlx_module)
+        model, processor = runtime.load_model(model_path)
+        runtime.synchronize()
+        journal.checkpoint("after_model_load", mlx_module)
+        workload = workload_by_id(frontier.workload_id)
+        prompt, prompt_tokens = fit_prompt(
+            lambda text: runtime.encode(processor, text),
+            base_prompt=workload.base_prompt,
+            requested_tokens=tier.requested_tokens,
+            maximum_shortfall=frontier.maximum_token_shortfall,
+        )
+        del prompt
+        actual_tokens = len(prompt_tokens)
+        journal.checkpoint("after_prompt_tokenization", mlx_module)
+        runtime.seed(base.generation.seed)
+        runtime.synchronize()
+        journal.checkpoint("immediately_before_prefill_generation", mlx_module)
+        first_token_seen = False
+        for _response in runtime.stream_generate(
+            model,
+            processor,
+            prompt_tokens,
+            max_tokens=frontier.max_output_tokens,
+            draft_model=None,
+            num_draft_tokens=0,
+        ):
+            if not first_token_seen:
+                journal.checkpoint("after_first_token", mlx_module)
+                first_token_seen = True
+        runtime.synchronize()
+        journal.checkpoint("completion", mlx_module)
+        status, reason = "completed", None
+    except (
+        KeyError,
+        RuntimeError,
+        ValueError,
+        OSError,
+        MemoryError,
+        TimeoutError,
+    ) as exc:
+        classified_status, classified_reason = _classify_error(
+            type(exc).__name__, str(exc)
+        )
+        if classified_status == "oom":
+            journal.checkpoint("caught_oom", mlx_module)
+        status, reason = classified_status, classified_reason
+    finally:
+        journal.checkpoint("cleanup", mlx_module)
+        journal.finalize(complete=True, terminal=status)
+
+    result = {
+        "schema_version": AUTOPSY_RESULT_SCHEMA_VERSION,
+        "autopsy_id": autopsy.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+        "frontier_manifest_hash": frontier_manifest_hash(frontier),
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "tier": autopsy.tier_name,
+        "requested_tokens": tier.requested_tokens,
+        "actual_tokens": actual_tokens,
+        "status": status,
+        "reason": reason,
+        "journal_sha256": _file_sha256(journal_path),
+        "journal_complete": journal.complete,
+        "journal_terminal": journal.terminal,
+        "synthetic": False,
+    }
+    atomic_write_text(result_path, json.dumps(result, indent=2, sort_keys=False) + "\n")
+    return result
+
+
+def _validate_autopsy_result(
+    result: dict[str, Any],
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+) -> None:
+    if not isinstance(result, dict):
+        raise LabError("invalid autopsy artifact: result is not an object")
+    expected = {
+        "schema_version": AUTOPSY_RESULT_SCHEMA_VERSION,
+        "autopsy_id": autopsy.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+        "frontier_manifest_hash": frontier_manifest_hash(frontier),
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "tier": autopsy.tier_name,
+        "requested_tokens": frontier.tier(autopsy.tier_name).requested_tokens,
+    }
+    for key, value in expected.items():
+        if result.get(key) != value:
+            raise LabError(f"stale autopsy artifact: {key} does not match")
+    status = result.get("status")
+    if status not in RESUMABLE_TERMINAL_STATUSES:
+        raise LabError("invalid autopsy artifact: unsupported status")
+    if result.get("synthetic") is not False:
+        raise LabError("invalid autopsy artifact: synthetic must be false")
+    reason = result.get("reason")
+    if status == "completed":
+        if reason is not None:
+            raise LabError(
+                "invalid autopsy artifact: completed result must have no reason"
+            )
+    elif not isinstance(reason, str) or not reason:
+        raise LabError(
+            "invalid autopsy artifact: non-completed result must carry a reason"
+        )
+    journal_complete = result.get("journal_complete")
+    if journal_complete is not None and not isinstance(journal_complete, bool):
+        raise LabError(
+            "invalid autopsy artifact: journal_complete must be a boolean or null"
+        )
+    journal_terminal = result.get("journal_terminal")
+    if journal_terminal is not None and not isinstance(journal_terminal, str):
+        raise LabError(
+            "invalid autopsy artifact: journal_terminal must be a string or null"
+        )
+    journal_digest = result.get("journal_sha256")
+    if journal_digest is not None and (
+        not isinstance(journal_digest, str)
+        or len(journal_digest) != 64
+        or any(char not in "0123456789abcdef" for char in journal_digest)
+    ):
+        raise LabError("invalid autopsy artifact: journal digest is malformed")
+    journal_claimed = journal_complete is not None or journal_terminal is not None
+    if journal_claimed and journal_digest is None:
+        raise LabError(
+            "invalid autopsy artifact: a claimed journal outcome requires a digest"
+        )
+    if status == "completed" and not (
+        journal_complete is True
+        and journal_terminal == "completed"
+        and journal_digest is not None
+    ):
+        raise LabError(
+            "invalid autopsy artifact: completed status requires a valid, "
+            "complete, terminal=completed journal"
+        )
+    actual = result.get("actual_tokens")
+    requested = frontier.tier(autopsy.tier_name).requested_tokens
+    if actual is not None:
+        if isinstance(actual, bool) or not isinstance(actual, int) or actual < 0:
+            raise LabError(
+                "invalid autopsy artifact: actual token count must be a "
+                "non-negative integer or null"
+            )
+        if actual > requested:
+            raise LabError(
+                "invalid autopsy artifact: actual token count exceeds the "
+                "requested tier"
+            )
+        if requested - actual > frontier.maximum_token_shortfall:
+            raise LabError(
+                "invalid autopsy artifact: actual token count shortfall "
+                "exceeds the frontier's maximum"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Process-isolated parent orchestration.
+# ---------------------------------------------------------------------------
+
+
+def launch_autopsy_subprocess(
+    *,
+    autopsy_manifest_path: Path | None,
+    frontier_manifest_path: Path | None,
+    model_path: Path,
+    output_dir: Path,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+    timeout_seconds: float,
+    cleanup_grace_seconds: float,
+) -> ChildProcessResult:
+    argv = [
+        sys.executable,
+        "-m",
+        "llmtracefx.optimizer.lab.autopsy",
+        "_child",
+        "--model-path",
+        str(model_path),
+        "--output-dir",
+        str(output_dir),
+        "--mode",
+        run_mode,
+    ]
+    if autopsy_manifest_path is not None:
+        argv.extend(("--manifest", str(autopsy_manifest_path)))
+    if frontier_manifest_path is not None:
+        argv.extend(("--frontier-manifest", str(frontier_manifest_path)))
+    if clean_boot_confirmed:
+        argv.append("--confirm-clean-boot")
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        shell=False,
+    )
+    process_group = process.pid
+    timed_out = False
+    try:
+        process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+    descendants_cleaned = _clean_process_group(
+        process, process_group, cleanup_grace_seconds
+    )
+    if process.poll() is None:
+        try:
+            process.wait(timeout=cleanup_grace_seconds)
+        except subprocess.TimeoutExpired:
+            descendants_cleaned = False
+    return ChildProcessResult(
+        exit_code=process.returncode,
+        timed_out=timed_out,
+        descendants_cleaned=descendants_cleaned,
+    )
+
+
+def _finalize_autopsy_attempt(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+    attempt_dir: Path,
+    child: ChildProcessResult,
+) -> dict[str, Any]:
+    result_path = attempt_dir / "result.json"
+    journal_path = attempt_dir / "journal.json"
+    process_evidence = {
+        "fresh_subprocess": True,
+        "new_session": True,
+        "child_exit_code": child.exit_code,
+        "timed_out": child.timed_out,
+        "descendants_cleaned": child.descendants_cleaned,
+    }
+    journal_load = _load_journal_if_valid(
+        journal_path,
+        autopsy,
+        frontier,
+        run_mode=run_mode,
+        clean_boot_confirmed=clean_boot_confirmed,
+    )
+    journal_complete = (
+        journal_load.journal.get("complete")
+        if journal_load.status == "valid" and journal_load.journal is not None
+        else None
+    )
+    journal_terminal = (
+        journal_load.journal.get("terminal")
+        if journal_load.status == "valid" and journal_load.journal is not None
+        else None
+    )
+
+    def synth(status: str, reason: str) -> dict[str, Any]:
+        return {
+            "schema_version": AUTOPSY_RESULT_SCHEMA_VERSION,
+            "autopsy_id": autopsy.autopsy_id,
+            "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+            "frontier_manifest_hash": frontier_manifest_hash(frontier),
+            "run_mode": run_mode,
+            "clean_boot_confirmed": clean_boot_confirmed,
+            "tier": autopsy.tier_name,
+            "requested_tokens": frontier.tier(autopsy.tier_name).requested_tokens,
+            "actual_tokens": None,
+            "status": status,
+            "reason": reason,
+            "journal_sha256": journal_load.digest,
+            "journal_complete": journal_complete,
+            "journal_terminal": journal_terminal,
+            "synthetic": False,
+        }
+
+    if not child.descendants_cleaned:
+        result = synth("failed", "child process group cleanup could not be verified")
+    elif child.timed_out:
+        # A parent-enforced timeout may legitimately race a valid-but-
+        # incomplete journal (the child was mid-attempt); that evidence is
+        # preserved rather than discarded. A missing or invalid journal
+        # stays explicitly null.
+        result = synth("timeout", "autopsy exceeded parent-enforced timeout")
+    elif not result_path.is_file():
+        result = synth("failed", "child exited without producing a result artifact")
+    else:
+        try:
+            candidate = _read_json(result_path)
+            _validate_autopsy_result(
+                candidate,
+                autopsy,
+                frontier,
+                run_mode=run_mode,
+                clean_boot_confirmed=clean_boot_confirmed,
+            )
+        except LabError:
+            result = synth("failed", "child artifact failed validation")
+        else:
+            if journal_load.status != "valid":
+                result = synth(
+                    "failed",
+                    "child artifact claims a journal that is missing or invalid: "
+                    f"{journal_load.reason or 'no journal was written'}",
+                )
+            elif candidate.get("journal_sha256") != journal_load.digest:
+                result = synth(
+                    "failed",
+                    "child artifact journal digest does not match the actual "
+                    "validated journal on disk",
+                )
+            elif (
+                candidate.get("journal_complete") != journal_complete
+                or candidate.get("journal_terminal") != journal_terminal
+            ):
+                result = synth(
+                    "failed",
+                    "child artifact journal completion/terminal claims do not "
+                    "match the actual validated journal",
+                )
+            elif candidate["status"] != journal_terminal:
+                result = synth(
+                    "failed",
+                    "child artifact status does not match the actual validated "
+                    "journal terminal",
+                )
+            elif candidate["status"] == "completed" and not (
+                journal_complete is True and journal_terminal == "completed"
+            ):
+                result = synth(
+                    "failed",
+                    "completed status requires a valid, complete, "
+                    "terminal=completed journal",
+                )
+            elif candidate["status"] == "completed" and child.exit_code != 0:
+                result = synth(
+                    "failed", "successful child artifact has a nonzero exit code"
+                )
+            elif candidate["status"] != "completed" and child.exit_code == 0:
+                result = synth("failed", "failed child artifact has a zero exit code")
+            else:
+                result = candidate
+    result["process"] = process_evidence
+    atomic_write_text(result_path, json.dumps(result, indent=2, sort_keys=False) + "\n")
+    return result
+
+
+def run_autopsy(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    base: LabManifest,
+    *,
+    autopsy_manifest_path: Path | None,
+    frontier_manifest_path: Path | None,
+    workspace: Path,
+    model_path: Path,
+    run_mode: str,
+    clean_boot_confirmed: bool,
+    resume: bool,
+    launcher: Callable[..., ChildProcessResult] = launch_autopsy_subprocess,
+) -> dict[str, Any]:
+    if run_mode not in RUN_MODES:
+        raise LabError(f"unsupported run mode {run_mode!r}")
+    if run_mode == "publication" and not clean_boot_confirmed:
+        raise LabError(
+            "publication mode requires the operator assertion --confirm-clean-boot"
+        )
+    if run_mode == "exploratory" and clean_boot_confirmed:
+        raise LabError("--confirm-clean-boot is only valid in publication mode")
+    verify_model(base, model_path)
+    preflight = assess_safety(base, workspace, include_download=False)
+    if not preflight.safe:
+        raise LabError(
+            "autopsy run blocked by safety preflight: " + "; ".join(preflight.blockers)
+        )
+    mode_workspace = workspace / run_mode
+    result_path = mode_workspace / "result.json"
+    state_path = mode_workspace / "state.json"
+    if resume and result_path.is_file():
+        prior = _read_json(result_path)
+        _validate_autopsy_result(
+            prior,
+            autopsy,
+            frontier,
+            run_mode=run_mode,
+            clean_boot_confirmed=clean_boot_confirmed,
+        )
+        if prior.get("status") in RESUMABLE_TERMINAL_STATUSES:
+            journal_path = mode_workspace / "journal.json"
+            prior_digest = prior.get("journal_sha256")
+            journal_load = _load_journal_if_valid(
+                journal_path,
+                autopsy,
+                frontier,
+                run_mode=run_mode,
+                clean_boot_confirmed=clean_boot_confirmed,
+            )
+            if journal_load.status == "invalid":
+                raise LabError(
+                    "cannot resume: prior checkpoint journal is invalid: "
+                    f"{journal_load.reason}"
+                )
+            if prior_digest is not None:
+                if (
+                    journal_load.status != "valid"
+                    or journal_load.digest != prior_digest
+                    or journal_load.journal is None
+                    or journal_load.journal.get("complete")
+                    != prior.get("journal_complete")
+                    or journal_load.journal.get("terminal")
+                    != prior.get("journal_terminal")
+                ):
+                    raise LabError(
+                        "cannot resume: prior result's journal binding no longer "
+                        "matches a valid, consistent journal on disk"
+                    )
+            elif journal_load.status == "valid":
+                raise LabError(
+                    "cannot resume: a valid checkpoint journal exists but the "
+                    "prior result does not bind it"
+                )
+            resumed = dict(prior)
+            resumed["reason"] = (
+                resumed.get("reason") or "resumed prior terminal attempt"
+            )
+            state = {
+                "schema_version": AUTOPSY_STATE_SCHEMA_VERSION,
+                "autopsy_id": autopsy.autopsy_id,
+                "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+                "frontier_manifest_hash": frontier_manifest_hash(frontier),
+                "run_mode": run_mode,
+                "clean_boot_confirmed": clean_boot_confirmed,
+                "synthetic": False,
+                "started_at": utc_now_iso(),
+                "ended_at": utc_now_iso(),
+                "status": resumed["status"],
+                "resumed": True,
+                "pre_run_machine_state": machine_state(preflight),
+                "result": resumed,
+            }
+            atomic_write_text(state_path, json.dumps(state, indent=2) + "\n")
+            return state
+    mode_workspace.mkdir(parents=True, exist_ok=True)
+    state = {
+        "schema_version": AUTOPSY_STATE_SCHEMA_VERSION,
+        "autopsy_id": autopsy.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+        "frontier_manifest_hash": frontier_manifest_hash(frontier),
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "synthetic": False,
+        "started_at": utc_now_iso(),
+        "ended_at": None,
+        "status": "running",
+        "resumed": False,
+        "pre_run_machine_state": machine_state(preflight),
+        "result": None,
+    }
+    atomic_write_text(state_path, json.dumps(state, indent=2) + "\n")
+    child = launcher(
+        autopsy_manifest_path=autopsy_manifest_path,
+        frontier_manifest_path=frontier_manifest_path,
+        model_path=model_path,
+        output_dir=mode_workspace,
+        run_mode=run_mode,
+        clean_boot_confirmed=clean_boot_confirmed,
+        timeout_seconds=autopsy.child_timeout_seconds,
+        cleanup_grace_seconds=autopsy.process_cleanup_grace_seconds,
+    )
+    result = _finalize_autopsy_attempt(
+        autopsy,
+        frontier,
+        run_mode=run_mode,
+        clean_boot_confirmed=clean_boot_confirmed,
+        attempt_dir=mode_workspace,
+        child=child,
+    )
+    state["result"] = result
+    state["ended_at"] = utc_now_iso()
+    state["status"] = result["status"]
+    atomic_write_text(state_path, json.dumps(state, indent=2) + "\n")
+    return state
+
+
+def verify_autopsy_evidence(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    workspace: Path,
+    run_mode: str,
+) -> dict[str, Any]:
+    state_path = workspace / run_mode / "state.json"
+    failures: list[str] = []
+    if not state_path.is_file():
+        return {"verified": False, "failures": ["state artifact is missing"]}
+    state = _read_json(state_path)
+    if state.get("status") == "running":
+        failures.append("state artifact is incomplete")
+    if state.get("autopsy_manifest_hash") != autopsy_manifest_hash(autopsy):
+        failures.append("state autopsy manifest binding is stale")
+    if state.get("frontier_manifest_hash") != frontier_manifest_hash(frontier):
+        failures.append("state frontier manifest binding is stale")
+    if state.get("run_mode") != run_mode:
+        failures.append("state run mode does not match")
+    if state.get("autopsy_id") != autopsy.autopsy_id:
+        failures.append("state autopsy_id does not match")
+    if state.get("synthetic") is not False:
+        failures.append("state synthetic flag must be false")
+    clean_boot = state.get("clean_boot_confirmed")
+    if run_mode == "publication" and clean_boot is not True:
+        failures.append("publication state lacks operator clean-boot confirmation")
+    result = state.get("result")
+    if not isinstance(result, dict):
+        failures.append("state is missing a result")
+        return {"verified": not failures, "failures": failures}
+    if state.get("status") != result.get("status"):
+        failures.append("state status does not match its result")
+    try:
+        _validate_autopsy_result(
+            result,
+            autopsy,
+            frontier,
+            run_mode=run_mode,
+            clean_boot_confirmed=bool(clean_boot),
+        )
+    except LabError as exc:
+        failures.append(str(exc))
+    journal_path = workspace / run_mode / "journal.json"
+    digest = result.get("journal_sha256")
+    journal_load = _load_journal_if_valid(
+        journal_path,
+        autopsy,
+        frontier,
+        run_mode=run_mode,
+        clean_boot_confirmed=bool(clean_boot),
+    )
+    if journal_load.status == "invalid":
+        failures.append(
+            "journal fails full contract validation: "
+            f"{journal_load.reason or 'unknown validation failure'}"
+        )
+    if isinstance(digest, str):
+        if journal_load.status != "valid":
+            if journal_load.status == "missing":
+                failures.append("result binds a journal that is missing")
+        else:
+            if journal_load.digest != digest:
+                failures.append("journal digest does not match the persisted artifact")
+            if journal_load.journal is not None:
+                if journal_load.journal.get("complete") != result.get(
+                    "journal_complete"
+                ):
+                    failures.append(
+                        "result's claimed journal completion does not match "
+                        "the actual journal"
+                    )
+                if journal_load.journal.get("terminal") != result.get(
+                    "journal_terminal"
+                ):
+                    failures.append(
+                        "result's claimed journal terminal does not match "
+                        "the actual journal"
+                    )
+    elif journal_load.status == "valid":
+        failures.append("a valid journal exists but the result does not bind it")
+    return {"verified": not failures, "failures": failures}
+
+
+# ---------------------------------------------------------------------------
+# Sanitized, deterministic reporting.
+# ---------------------------------------------------------------------------
+
+_LIMITATIONS: tuple[str, ...] = (
+    "This is bounded evidence for one recorded machine state, one exact "
+    "checkpoint, runtime, and the t256 tier of one workload; it is not a "
+    "universal memory-capacity boundary and not a universal 24GB boundary.",
+    "There is no unified-memory free-space or GPU capacity precision here: "
+    "process RSS is host process memory, not GPU memory, and is never "
+    "substituted for a GPU free-memory measurement.",
+    "No GPU utilization, free GPU memory, memory bandwidth, power, energy, "
+    "or kernel time is measured or inferred.",
+    "Stage deltas are observed checkpoint-to-checkpoint changes only; no "
+    "causal claim is made from one checkpoint's change to another.",
+    "Operator clean boot is never inferred; publication mode requires an "
+    "explicit --confirm-clean-boot assertion.",
+    "Observer overhead consists only of the stage-boundary probes recorded "
+    "here (ps, getrusage, sysctl, or procfs reads); it is not separately "
+    "measured or subtracted.",
+    "Periodic sampling is disabled; only discrete stage-boundary checkpoints "
+    "are recorded.",
+)
+
+
+def _checkpoint_row(entry: dict[str, Any]) -> dict[str, Any]:
+    mlx_scope = entry.get("mlx_allocator", {})
+    host_scope = entry.get("host_process", {})
+    swap_scope = entry.get("host_system", {})
+
+    def value_of(scope: dict[str, Any], key: str) -> Any:
+        item = scope.get(key)
+        if isinstance(item, dict):
+            return item.get("value")
+        return None
+
+    def provenance_of(scope: dict[str, Any], key: str) -> Any:
+        item = scope.get(key)
+        if isinstance(item, dict):
+            return item.get("provenance")
+        return None
+
+    def mlx_field(key: str, field: str) -> Any:
+        item = mlx_scope.get(key)
+        if isinstance(item, dict):
+            return item.get(field)
+        return None
+
+    return {
+        "stage": entry.get("stage"),
+        "sequence": entry.get("sequence"),
+        "wall_clock_utc": entry.get("wall_clock_utc"),
+        "wall_clock_provenance": entry.get("wall_clock_provenance"),
+        "monotonic_offset_seconds": entry.get("monotonic_offset_seconds"),
+        "monotonic_offset_unit": entry.get("monotonic_offset_unit"),
+        "mlx_active_bytes": mlx_field("active_bytes", "value"),
+        "mlx_active_api": mlx_field("active_bytes", "api"),
+        "mlx_active_error_category": mlx_field("active_bytes", "error_category"),
+        "mlx_cache_bytes": mlx_field("cache_bytes", "value"),
+        "mlx_cache_api": mlx_field("cache_bytes", "api"),
+        "mlx_cache_error_category": mlx_field("cache_bytes", "error_category"),
+        "mlx_peak_bytes": mlx_field("peak_bytes", "value"),
+        "mlx_peak_api": mlx_field("peak_bytes", "api"),
+        "mlx_peak_error_category": mlx_field("peak_bytes", "error_category"),
+        "host_rss_bytes": value_of(host_scope, "rss_bytes"),
+        "host_rss_provenance": provenance_of(host_scope, "rss_bytes"),
+        "host_max_rss_bytes": value_of(host_scope, "max_rss_bytes"),
+        "host_max_rss_provenance": provenance_of(host_scope, "max_rss_bytes"),
+        "swap_total_bytes": value_of(swap_scope, "swap_total_bytes"),
+        "swap_used_bytes": value_of(swap_scope, "swap_used_bytes"),
+        "swap_provenance": provenance_of(swap_scope, "swap_total_bytes"),
+        "signal_received": entry.get("signal_received"),
+    }
+
+
+_DELTA_FIELDS = (
+    "mlx_active_bytes",
+    "mlx_cache_bytes",
+    "mlx_peak_bytes",
+    "host_rss_bytes",
+    "host_max_rss_bytes",
+    "swap_used_bytes",
+)
+
+
+def _observed_deltas(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deltas: list[dict[str, Any]] = []
+    for before, after in zip(rows[:-1], rows[1:], strict=True):
+        row: dict[str, Any] = {
+            "from_stage": before.get("stage"),
+            "to_stage": after.get("stage"),
+        }
+        for field in _DELTA_FIELDS:
+            before_value = before.get(field)
+            after_value = after.get(field)
+            row[f"{field}_delta"] = (
+                after_value - before_value
+                if isinstance(before_value, int)
+                and not isinstance(before_value, bool)
+                and isinstance(after_value, int)
+                and not isinstance(after_value, bool)
+                else None
+            )
+        deltas.append(row)
+    return deltas
+
+
+def build_autopsy_report(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    workspace: Path,
+    run_mode: str,
+) -> dict[str, Any]:
+    verification = verify_autopsy_evidence(
+        autopsy, frontier, workspace=workspace, run_mode=run_mode
+    )
+    if not verification["verified"]:
+        raise LabError(
+            "autopsy report refused invalid evidence: "
+            + "; ".join(verification["failures"])
+        )
+    state = _read_json(workspace / run_mode / "state.json")
+    result = state["result"]
+    journal_path = workspace / run_mode / "journal.json"
+    checkpoints_raw: list[dict[str, Any]] = []
+    if journal_path.is_file():
+        journal_load = _load_journal_if_valid(
+            journal_path,
+            autopsy,
+            frontier,
+            run_mode=run_mode,
+            clean_boot_confirmed=bool(state.get("clean_boot_confirmed")),
+        )
+        # ``verify_autopsy_evidence`` above already refused invalid evidence,
+        # so a non-valid load here would be an internal inconsistency; the
+        # report still must never fabricate checkpoints from an unvalidated
+        # journal, so an unexpected non-valid status yields an empty list
+        # rather than raw, unchecked data.
+        if journal_load.status == "valid" and journal_load.journal is not None:
+            raw = journal_load.journal.get("checkpoints")
+            if isinstance(raw, list):
+                checkpoints_raw = raw
+    rows = [_checkpoint_row(entry) for entry in checkpoints_raw]
+
+    def first_present(field: str) -> Any:
+        return next((row.get(field) for row in rows if row.get(field)), None)
+
+    provenance = {
+        "mlx_active_bytes": {
+            "scope": "mlx_allocator",
+            "unit": "bytes",
+            "api": first_present("mlx_active_api"),
+            "error_category": first_present("mlx_active_error_category"),
+        },
+        "mlx_cache_bytes": {
+            "scope": "mlx_allocator",
+            "unit": "bytes",
+            "api": first_present("mlx_cache_api"),
+            "error_category": first_present("mlx_cache_error_category"),
+        },
+        "mlx_peak_bytes": {
+            "scope": "mlx_allocator",
+            "unit": "bytes",
+            "api": first_present("mlx_peak_api"),
+            "error_category": first_present("mlx_peak_error_category"),
+        },
+        "host_rss_bytes": {
+            "scope": "host_process",
+            "unit": "bytes",
+            "provenance": first_present("host_rss_provenance"),
+        },
+        "host_max_rss_bytes": {
+            "scope": "host_process",
+            "unit": "bytes",
+            "provenance": first_present("host_max_rss_provenance"),
+        },
+        "swap_bytes": {
+            "scope": "host_system_swap",
+            "unit": "bytes",
+            "provenance": first_present("swap_provenance"),
+        },
+        "wall_clock": {"provenance": first_present("wall_clock_provenance")},
+        "monotonic_offset": {"unit": "seconds"},
+    }
+    report = {
+        "schema_version": AUTOPSY_REPORT_SCHEMA_VERSION,
+        "autopsy_id": autopsy.autopsy_id,
+        "generated_at": state.get("ended_at"),
+        "run_mode": run_mode,
+        "clean_boot_confirmed": state.get("clean_boot_confirmed"),
+        "synthetic": bool(state.get("synthetic", False)),
+        "bindings": {
+            "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+            "frontier_manifest_hash": frontier_manifest_hash(frontier),
+        },
+        "model": {
+            "repository_id": frontier.model_repository_id,
+            "revision": frontier.model_revision,
+        },
+        "tier": {
+            "name": autopsy.tier_name,
+            "requested_tokens": frontier.tier(autopsy.tier_name).requested_tokens,
+        },
+        "terminal_outcome": result.get("status"),
+        "reason": result.get("reason"),
+        "actual_tokens": result.get("actual_tokens"),
+        "journal_complete": result.get("journal_complete"),
+        "journal_terminal": result.get("journal_terminal"),
+        "pre_run_machine_state": state.get("pre_run_machine_state"),
+        "provenance": provenance,
+        "sampling": {"periodic_sampling_enabled": False},
+        "checkpoints": rows,
+        "observed_deltas": _observed_deltas(rows),
+        "limitations": list(_LIMITATIONS),
+    }
+    assert_shareable(report)
+    return report
+
+
+def build_autopsy_csv(report: dict[str, Any]) -> str:
+    header = (
+        "stage",
+        "sequence",
+        "wall_clock_utc",
+        "wall_clock_provenance",
+        "monotonic_offset_seconds",
+        "monotonic_offset_unit",
+        "mlx_active_bytes",
+        "mlx_active_api",
+        "mlx_cache_bytes",
+        "mlx_cache_api",
+        "mlx_peak_bytes",
+        "mlx_peak_api",
+        "host_rss_bytes",
+        "host_rss_provenance",
+        "host_max_rss_bytes",
+        "host_max_rss_provenance",
+        "swap_total_bytes",
+        "swap_used_bytes",
+        "swap_provenance",
+    )
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(header)
+    for row in report["checkpoints"]:
+        values = [row.get(key) for key in header]
+        writer.writerow(["n/a" if value is None else value for value in values])
+    return stream.getvalue()
+
+
+def _svg_series(
+    rows: list[dict[str, Any]], key: str, *, color: str, height: float, max_value: float
+) -> str:
+    points = [
+        (index, row[key]) for index, row in enumerate(rows) if row.get(key) is not None
+    ]
+    if not points or max_value <= 0:
+        return ""
+    step = 60.0
+
+    def coordinate(index: int, value: float) -> tuple[float, float]:
+        return index * step, height - (value / max_value) * height
+
+    coords = " ".join(
+        f"{x:.1f},{y:.1f}" for x, y in (coordinate(i, v) for i, v in points)
+    )
+    circles = "".join(
+        f'<circle cx="{x:.1f}" cy="{y:.1f}" r="3" fill="{color}"/>'
+        for x, y in (coordinate(i, v) for i, v in points)
+    )
+    return (
+        f'<polyline points="{coords}" fill="none" stroke="{color}" '
+        f'stroke-width="2"/>{circles}'
+    )
+
+
+def render_autopsy_chart_svg(report: dict[str, Any]) -> str:
+    rows = report["checkpoints"]
+    height = 120.0
+    width = max(60.0 * len(rows), 60.0)
+    series = (
+        ("mlx_peak_bytes", "#c0392b", "MLX allocator (peak)"),
+        ("host_rss_bytes", "#2471a3", "Host process (RSS)"),
+        ("swap_used_bytes", "#7d3c98", "Host system (swap used)"),
+    )
+    max_value = 0.0
+    for key, _color, _label in series:
+        for row in rows:
+            value = row.get(key)
+            if isinstance(value, (int, float)):
+                max_value = max(max_value, float(value))
+    body = "".join(
+        _svg_series(rows, key, color=color, height=height, max_value=max_value)
+        for key, color, _label in series
+    )
+    legend = "".join(
+        f'<span style="color:{color}">&#9632;</span> {html.escape(label)}'
+        for _key, color, label in series
+    )
+    return (
+        f'<svg viewBox="0 0 {max(width, 60.0):.1f} {height + 20:.1f}" '
+        f'role="img" aria-label="MLX allocator, host process, and host swap '
+        f'checkpoint series">{body}</svg>'
+        f'<div class="chart-legend">{legend}</div>'
+    )
+
+
+def render_autopsy_report_html(report: dict[str, Any]) -> str:
+    assert_shareable(report)
+
+    def esc(value: Any) -> str:
+        return html.escape(str(value), quote=True)
+
+    def cell(value: Any) -> str:
+        return esc(value) if value is not None else "n/a"
+
+    rows = "".join(
+        "<tr>"
+        f"<td>{esc(row['stage'])}</td>"
+        f"<td>{cell(row['mlx_active_bytes'])}</td>"
+        f"<td>{cell(row['mlx_cache_bytes'])}</td>"
+        f"<td>{cell(row['mlx_peak_bytes'])}</td>"
+        f"<td>{cell(row['host_rss_bytes'])}</td>"
+        f"<td>{cell(row['host_max_rss_bytes'])}</td>"
+        f"<td>{cell(row['swap_total_bytes'])}</td>"
+        f"<td>{cell(row['swap_used_bytes'])}</td>"
+        "</tr>"
+        for row in report["checkpoints"]
+    )
+    delta_rows = "".join(
+        "<tr>"
+        f"<td>{esc(row['from_stage'])} &rarr; {esc(row['to_stage'])}</td>"
+        f"<td>{cell(row['mlx_active_bytes_delta'])}</td>"
+        f"<td>{cell(row['mlx_cache_bytes_delta'])}</td>"
+        f"<td>{cell(row['mlx_peak_bytes_delta'])}</td>"
+        f"<td>{cell(row['host_rss_bytes_delta'])}</td>"
+        f"<td>{cell(row['host_max_rss_bytes_delta'])}</td>"
+        f"<td>{cell(row['swap_used_bytes_delta'])}</td>"
+        "</tr>"
+        for row in report["observed_deltas"]
+    )
+    limitations = "".join(f"<li>{esc(item)}</li>" for item in report["limitations"])
+    chart = render_autopsy_chart_svg(report)
+    provenance = report.get("provenance", {})
+    provenance_rows = "".join(
+        f"<tr><td>{esc(name)}</td><td>{cell(details.get('scope'))}</td>"
+        f"<td>{cell(details.get('unit'))}</td><td>{cell(details.get('api'))}</td>"
+        f"<td>{cell(details.get('provenance'))}</td>"
+        f"<td>{cell(details.get('error_category'))}</td></tr>"
+        for name, details in provenance.items()
+        if isinstance(details, dict)
+    )
+    bindings = report.get("bindings", {})
+    synthetic_banner = (
+        "<p><strong>SYNTHETIC</strong> fixture evidence, not a real run.</p>"
+        if report.get("synthetic")
+        else ""
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>Qwen3.8-27B OOM autopsy</title>
+<style>
+body{{margin:0;background:#f7f3ea;color:#17202a;font:15px/1.5 ui-monospace,monospace}}
+main{{max-width:980px;margin:auto;padding:36px 20px}}section{{background:#fffdf8;border:1px
+solid #d9d1c3;padding:18px;margin:18px 0;overflow:auto}}table{{width:100%;
+border-collapse:collapse}}th,td{{padding:9px;text-align:right;border-bottom:1px solid
+#ddd5c8}}th:first-child,td:first-child{{text-align:left}}.chart-legend{{display:flex;
+gap:16px;margin-top:8px;font-size:13px}}
+</style></head><body><main><p>LLMTraceFX / {esc(report['run_mode'])} evidence</p>
+<h1>MLX OOM autopsy</h1>{synthetic_banner}<p><code>{esc(report['model']['repository_id'])}@
+{esc(report['model']['revision'])}</code> tier <code>{esc(report['tier']['name'])}</code>
+({esc(report['tier']['requested_tokens'])} requested tokens)</p>
+<section><h2>Terminal outcome</h2><p>{esc(report['terminal_outcome'])}
+&mdash; {cell(report['reason'])}</p><p>actual tokens: {cell(report['actual_tokens'])}</p>
+</section><section><h2>Checkpoint series</h2>{chart}<table><thead><tr><th>Stage</th>
+<th>MLX active</th><th>MLX cache</th><th>MLX peak</th><th>Host RSS</th>
+<th>Host max RSS</th><th>Swap total</th><th>Swap used</th></tr></thead>
+<tbody>{rows}</tbody></table></section>
+<section><h2>Observed checkpoint deltas</h2><p>These differences locate observed
+growth between stage boundaries; they do not identify a cause.</p><table><thead><tr>
+<th>Boundary</th><th>MLX active</th><th>MLX cache</th><th>MLX peak</th>
+<th>Host RSS</th><th>Host max RSS</th><th>Swap used</th></tr></thead>
+<tbody>{delta_rows}</tbody></table></section>
+<section><h2>Provenance</h2><table><thead><tr><th>Measurement</th><th>Scope</th>
+<th>Unit</th><th>API</th><th>Provenance</th><th>Error category</th></tr></thead>
+<tbody>{provenance_rows}</tbody></table></section>
+<section><h2>Bindings</h2><p>autopsy_manifest_hash: {cell(bindings.get('autopsy_manifest_hash'))}</p>
+<p>frontier_manifest_hash: {cell(bindings.get('frontier_manifest_hash'))}</p></section>
+<section><h2>Limits</h2><ul>{limitations}</ul></section></main></body></html>"""
+
+
+def write_autopsy_report(
+    autopsy: AutopsyManifest,
+    frontier: FrontierManifest,
+    *,
+    workspace: Path,
+    run_mode: str,
+    shareable_dir: Path | None,
+) -> dict[str, Any]:
+    report = build_autopsy_report(
+        autopsy, frontier, workspace=workspace, run_mode=run_mode
+    )
+    reports = workspace / run_mode / "reports"
+    atomic_write_text(
+        reports / "oom-autopsy-summary.json",
+        json.dumps(report, indent=2, sort_keys=False) + "\n",
+    )
+    atomic_write_text(
+        reports / "oom-autopsy-report.html", render_autopsy_report_html(report)
+    )
+    atomic_write_text(
+        reports / "oom-autopsy-checkpoints.csv", build_autopsy_csv(report)
+    )
+    if shareable_dir is not None:
+        destination = shareable_dir / run_mode
+        atomic_write_text(
+            destination / "oom-autopsy-summary.json",
+            json.dumps(report, indent=2, sort_keys=False) + "\n",
+        )
+        atomic_write_text(
+            destination / "oom-autopsy-report.html",
+            render_autopsy_report_html(report),
+        )
+        atomic_write_text(
+            destination / "oom-autopsy-checkpoints.csv", build_autopsy_csv(report)
+        )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="llmtracefx-m5-lab autopsy",
+        description=(
+            "Focused MLX OOM autopsy for the exact pinned Qwen3.8-27B MLX "
+            "checkpoint at the t256 tier. The default action is a no-load "
+            "plan that only probes MLX allocator counter APIs."
+        ),
+    )
+    parser.add_argument(
+        "action",
+        nargs="?",
+        default="plan",
+        choices=("plan", "run", "report", "verify", "_child"),
+    )
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--frontier-manifest", type=Path)
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--model-path", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--mode", choices=RUN_MODES, default="exploratory")
+    parser.add_argument("--confirm-clean-boot", action="store_true")
+    parser.add_argument("--no-resume", action="store_true")
+    parser.add_argument("--shareable-dir", type=Path)
+    return parser
+
+
+def _paths(
+    args: argparse.Namespace, autopsy: AutopsyManifest, base: LabManifest
+) -> tuple[Path, Path]:
+    workspace = args.workspace or Path(autopsy.artifacts.workspace)
+    model_path = args.model_path or Path(base.artifacts.model_cache)
+    return workspace, model_path
+
+
+def _plan(args: argparse.Namespace) -> int:
+    autopsy, source = load_autopsy_manifest(args.manifest)
+    frontier, base = load_bound_frontier(
+        autopsy, frontier_manifest_path=args.frontier_manifest
+    )
+    workspace, model_path = _paths(args, autopsy, base)
+    decision = assess_safety(base, workspace, include_download=False)
+    mlx_module = _import_mlx_core()
+    payload = {
+        "action": "plan",
+        "weights_loaded": False,
+        "downloads_performed": False,
+        "manifest": source,
+        "autopsy_id": autopsy.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(autopsy),
+        "frontier_id": frontier.frontier_id,
+        "run_mode": args.mode,
+        "clean_boot_confirmed": args.confirm_clean_boot,
+        "publication_ready": (
+            args.mode == "publication" and args.confirm_clean_boot and decision.safe
+        ),
+        "model_present_by_size": model_files_present(base, model_path),
+        "model": {
+            "repository_id": frontier.model_repository_id,
+            "revision": frontier.model_revision,
+        },
+        "tier": {
+            "name": autopsy.tier_name,
+            "requested_tokens": frontier.tier(autopsy.tier_name).requested_tokens,
+        },
+        "mlx_counter_apis": probe_mlx_counters(mlx_module),
+        "mlx_reset_peak_memory_api": probe_mlx_reset_peak_memory_api(mlx_module),
+        "sampling": {"periodic_sampling_enabled": False},
+        "machine_state": machine_state(decision),
+        "safety": {"safe": decision.safe, "blockers": list(decision.blockers)},
+    }
+    print(json.dumps(payload, indent=2, sort_keys=False))
+    if args.mode == "publication" and not args.confirm_clean_boot:
+        return 2
+    return 0 if decision.safe else 2
+
+
+def _run(args: argparse.Namespace) -> int:
+    autopsy, _ = load_autopsy_manifest(args.manifest)
+    frontier, base = load_bound_frontier(
+        autopsy, frontier_manifest_path=args.frontier_manifest
+    )
+    workspace, model_path = _paths(args, autopsy, base)
+    state = run_autopsy(
+        autopsy,
+        frontier,
+        base,
+        autopsy_manifest_path=args.manifest,
+        frontier_manifest_path=args.frontier_manifest,
+        workspace=workspace,
+        model_path=model_path,
+        run_mode=args.mode,
+        clean_boot_confirmed=args.confirm_clean_boot,
+        resume=not args.no_resume,
+    )
+    report = write_autopsy_report(
+        autopsy,
+        frontier,
+        workspace=workspace,
+        run_mode=args.mode,
+        shareable_dir=args.shareable_dir,
+    )
+    print(json.dumps({"state": state, "report": report}, indent=2))
+    return 0 if state["status"] == "completed" else 2
+
+
+def _report(args: argparse.Namespace) -> int:
+    autopsy, _ = load_autopsy_manifest(args.manifest)
+    frontier, base = load_bound_frontier(
+        autopsy, frontier_manifest_path=args.frontier_manifest
+    )
+    workspace, _ = _paths(args, autopsy, base)
+    report = write_autopsy_report(
+        autopsy,
+        frontier,
+        workspace=workspace,
+        run_mode=args.mode,
+        shareable_dir=args.shareable_dir,
+    )
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+def _verify(args: argparse.Namespace) -> int:
+    autopsy, _ = load_autopsy_manifest(args.manifest)
+    frontier, base = load_bound_frontier(
+        autopsy, frontier_manifest_path=args.frontier_manifest
+    )
+    workspace, model_path = _paths(args, autopsy, base)
+    verify_model(base, model_path)
+    result = verify_autopsy_evidence(
+        autopsy, frontier, workspace=workspace, run_mode=args.mode
+    )
+    print(json.dumps(result, indent=2))
+    return 0 if result["verified"] else 2
+
+
+def _child(args: argparse.Namespace) -> int:
+    if args.output_dir is None or args.model_path is None:
+        raise LabError("_child requires --output-dir and --model-path")
+    autopsy, _ = load_autopsy_manifest(args.manifest)
+    frontier, base = load_bound_frontier(
+        autopsy, frontier_manifest_path=args.frontier_manifest
+    )
+    result = execute_autopsy_child(
+        autopsy,
+        frontier,
+        base,
+        model_path=args.model_path,
+        output_dir=args.output_dir,
+        run_mode=args.mode,
+        clean_boot_confirmed=args.confirm_clean_boot,
+    )
+    return 0 if result["status"] == "completed" else 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    commands = {
+        "plan": _plan,
+        "run": _run,
+        "report": _report,
+        "verify": _verify,
+        "_child": _child,
+    }
+    try:
+        return commands[args.action](args)
+    except (
+        AutopsyManifestError,
+        FrontierManifestError,
+        LabError,
+        OSError,
+        UnicodeError,
+        ValueError,
+    ) as exc:
+        print(f"M5 OOM autopsy failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llmtracefx/optimizer/lab/autopsy.py
+++ b/llmtracefx/optimizer/lab/autopsy.py
@@ -735,7 +735,11 @@ class AutopsyJournal:
             extra=extra,
         )
         self.checkpoints.append(entry)
-        self._persist()
+        try:
+            self._persist()
+        except (LabError, MemoryError, OSError):
+            self.checkpoints.pop()
+            raise
 
     def finalize(self, *, complete: bool, terminal: str) -> None:
         self.complete = complete
@@ -1239,7 +1243,11 @@ def execute_autopsy_child(
             journal.checkpoint("caught_oom", mlx_module)
         status, reason = classified_status, classified_reason
     finally:
-        journal.checkpoint("cleanup", mlx_module)
+        try:
+            journal.checkpoint("cleanup", mlx_module)
+        except (LabError, MemoryError, OSError):
+            # Finalization can still bind the preceding valid checkpoints.
+            pass
         journal.finalize(complete=True, terminal=status)
 
     result = {

--- a/llmtracefx/optimizer/lab/cli.py
+++ b/llmtracefx/optimizer/lab/cli.py
@@ -204,6 +204,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw_argv = sys.argv[1:] if argv is None else argv
+    if raw_argv[:1] == ["autopsy"]:
+        # Routed to the autopsy module's own self-contained argparse
+        # parser, mirroring the standalone `llmtracefx-m5-frontier`
+        # entrypoint, so the existing plan|acquire|run|report|verify
+        # actions and default action below are completely unaffected.
+        from . import autopsy
+
+        return autopsy.main(raw_argv[1:])
     args = build_parser().parse_args(argv)
     commands = {
         "plan": _cmd_plan,

--- a/llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json
+++ b/llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1",
+  "autopsy_id": "m5-pro-qwen3.8-27b-oom-autopsy-v1",
+  "frontier_manifest_resource": "data/fit-frontier-manifest-v1.json",
+  "frontier_manifest_sha256": "47ec7cdc11baedf3bdcc803502a584aeaa8d79fc57bdbc49f4a3e773294b5b00",
+  "frontier_id": "m5-pro-qwen3.8-27b-fit-frontier-v1",
+  "base_lab_id": "m5-pro-qwen3.8-27b-v1",
+  "model": {
+    "repository_id": "mlx-community/Qwen3.8-27B-4bit",
+    "revision": "3e6447f082e89cc7f0bc6e5441afd38dfce760ff",
+    "expected_download_bytes": 16081490933
+  },
+  "tier": {
+    "name": "t256",
+    "requested_tokens": 256
+  },
+  "child_timeout_seconds": 600,
+  "process_cleanup_grace_seconds": 5,
+  "journal": {
+    "max_checkpoints": 16,
+    "max_bytes": 65536
+  },
+  "artifacts": {
+    "workspace": ".cache/llmtracefx/m5-pro-qwen3.8-27b-oom-autopsy-v1",
+    "shareable_example_dir": "examples/optimizer/m5-pro-qwen3.8-27b-oom-autopsy",
+    "commit_raw_artifacts": false
+  }
+}

--- a/tests/optimizer/test_m5_autopsy.py
+++ b/tests/optimizer/test_m5_autopsy.py
@@ -7,6 +7,7 @@ import io
 import json
 import time
 import types
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -859,6 +860,7 @@ def test_journal_byte_size_bound_is_enforced(tmp_path: Path) -> None:
     journal = _new_journal(tmp_path, max_bytes=16)
     with pytest.raises(LabError, match="maximum artifact size"):
         journal.checkpoint("child_start", None)
+    assert journal.checkpoints == []
 
 
 def test_journal_never_records_pids_paths_or_hostnames(tmp_path: Path) -> None:
@@ -1120,6 +1122,30 @@ def test_execute_autopsy_child_seeds_and_synchronizes_at_correct_points_never_re
     assert runtime.seed_calls == [base.generation.seed]
     assert runtime.synchronize_calls == 3
     assert runtime.reset_peak_memory_calls == 0
+
+
+def test_cleanup_bound_failure_does_not_prevent_terminal_finalization(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    manifest = replace(manifest, journal_max_checkpoints=7)
+    output_dir = tmp_path / "output"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="completed"),
+        mlx_module_factory=lambda: None,
+    )
+    journal = json.loads((output_dir / "journal.json").read_text(encoding="utf-8"))
+    assert result["status"] == "completed"
+    assert journal["complete"] is True
+    assert journal["terminal"] == "completed"
+    assert journal["checkpoints"][-1]["stage"] == "completion"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/optimizer/test_m5_autopsy.py
+++ b/tests/optimizer/test_m5_autopsy.py
@@ -1,0 +1,1869 @@
+"""Contract tests for the process-isolated M5 MLX OOM autopsy."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.lab import autopsy
+from llmtracefx.optimizer.lab.autopsy import (
+    AutopsyJournal,
+    ChildProcessResult,
+    autopsy_manifest_hash,
+    build_autopsy_csv,
+    build_autopsy_report,
+    execute_autopsy_child,
+    host_process_max_rss_bytes,
+    host_process_rss_bytes,
+    host_swap_bytes,
+    load_autopsy_manifest,
+    load_bound_frontier,
+    probe_mlx_counters,
+    probe_mlx_reset_peak_memory_api,
+    render_autopsy_chart_svg,
+    render_autopsy_report_html,
+    run_autopsy,
+    verify_autopsy_evidence,
+)
+from llmtracefx.optimizer.lab.core import HostSnapshot, LabError, SafetyDecision
+from llmtracefx.optimizer.lab.frontier import frontier_manifest_hash
+
+AUTOPSY_MANIFEST_PATH = Path("llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json")
+
+
+def _safe_decision() -> SafetyDecision:
+    return SafetyDecision(
+        safe=True,
+        blockers=(),
+        snapshot=HostSnapshot(
+            collected_at="2026-09-01T00:00:00.000000Z",
+            os_name="Darwin",
+            os_release="25.6.0",
+            architecture="arm64",
+            python_implementation="CPython",
+            python_version="3.13.15",
+            cpu_count=18,
+            chip="Apple M5 Pro",
+            total_memory_bytes=24 * 1024**3,
+            memory_free_percent=50.0,
+            swap_used_bytes=0,
+            disk_free_bytes=500 * 1024**3,
+            package_versions={
+                "mlx": "0.32.2",
+                "mlx-lm": "0.31.3",
+                "mlx-vlm": "0.6.8",
+                "transformers": "5.16.1",
+            },
+        ),
+    )
+
+
+def _load():
+    manifest, _ = load_autopsy_manifest(AUTOPSY_MANIFEST_PATH)
+    frontier_manifest, base = load_bound_frontier(manifest, frontier_manifest_path=None)
+    return manifest, frontier_manifest, base
+
+
+def _prepare(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(autopsy, "verify_model", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        autopsy, "assess_safety", lambda *args, **kwargs: _safe_decision()
+    )
+
+
+def _checkpoints_for(*, terminal: str | None = "completed") -> list[dict]:
+    """Build a schema-valid checkpoint sequence for the given terminal outcome.
+
+    Uses the real ``build_checkpoint`` so every generated fixture already
+    satisfies the stricter shape/sequence/terminal-semantics validators
+    instead of relying on a hand-maintained parallel structure.
+    """
+    started = time.monotonic()
+    checkpoints: list[dict] = []
+
+    def add(stage: str, *, extra: dict | None = None) -> None:
+        checkpoints.append(
+            autopsy.build_checkpoint(
+                stage,
+                len(checkpoints),
+                mlx_module=None,
+                started_monotonic=started,
+                extra=extra,
+            )
+        )
+
+    add("child_start")
+    if terminal is None:
+        return checkpoints
+    if terminal == "completed":
+        for stage in autopsy.MAIN_STAGE_SEQUENCE[1:]:
+            add(stage)
+        add("cleanup")
+    elif terminal == "oom":
+        for stage in (
+            "before_model_load",
+            "after_model_load",
+            "after_prompt_tokenization",
+        ):
+            add(stage)
+        add("caught_oom")
+        add("cleanup")
+    elif terminal in ("timeout", "failed"):
+        add("before_model_load")
+        add("after_model_load")
+        add("cleanup")
+    elif terminal == "signal":
+        add("before_model_load")
+        add("signal_received", extra={"signal_received": "SIGTERM"})
+        add("cleanup")
+    else:
+        raise ValueError(f"unsupported terminal fixture {terminal!r}")
+    return checkpoints
+
+
+def _valid_journal_payload(
+    manifest,
+    frontier_manifest,
+    *,
+    run_mode: str = "exploratory",
+    clean_boot_confirmed: bool = False,
+    complete: bool | None = None,
+    terminal: str | None = "completed",
+    checkpoints: list[dict] | None = None,
+) -> dict:
+    if complete is None:
+        complete = (
+            terminal is not None and terminal not in autopsy._INCOMPLETE_TERMINALS
+        )
+    if checkpoints is None:
+        checkpoints = _checkpoints_for(terminal=terminal)
+    body = {
+        "schema_version": autopsy.AUTOPSY_JOURNAL_SCHEMA_VERSION,
+        "autopsy_id": manifest.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(manifest),
+        "frontier_manifest_hash": frontier_manifest_hash(frontier_manifest),
+        "model": {
+            "repository_id": frontier_manifest.model_repository_id,
+            "revision": frontier_manifest.model_revision,
+        },
+        "tier": manifest.tier_name,
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "synthetic": False,
+        "started_at": "2026-09-01T00:00:00.000000Z",
+        "sampling": {
+            "periodic_sampling_enabled": False,
+            "note": "only discrete checkpoints",
+        },
+        "peak_memory_reset": {
+            "applied": False,
+            "api": None,
+            "note": "peak memory is never reset after model load",
+        },
+        "checkpoints": checkpoints,
+        "complete": complete,
+        "terminal": terminal,
+    }
+    body["envelope_sha256"] = autopsy.config_hash(body)
+    return body
+
+
+def _valid_result_payload(
+    manifest,
+    frontier_manifest,
+    *,
+    status: str = "completed",
+    run_mode: str = "exploratory",
+    clean_boot_confirmed: bool = False,
+    journal_sha256: str | None = None,
+    journal_complete: bool | None = None,
+    journal_terminal: str | None = None,
+) -> dict:
+    if journal_complete is None:
+        journal_complete = status in autopsy._COMPLETE_TERMINALS
+    if journal_terminal is None:
+        journal_terminal = status
+    return {
+        "schema_version": autopsy.AUTOPSY_RESULT_SCHEMA_VERSION,
+        "autopsy_id": manifest.autopsy_id,
+        "autopsy_manifest_hash": autopsy_manifest_hash(manifest),
+        "frontier_manifest_hash": frontier_manifest_hash(frontier_manifest),
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "tier": manifest.tier_name,
+        "requested_tokens": manifest.tier_requested_tokens,
+        "actual_tokens": manifest.tier_requested_tokens - 1,
+        "status": status,
+        "reason": (
+            None if status == "completed" else "MLX/Metal reported insufficient memory"
+        ),
+        "journal_sha256": journal_sha256 or ("a" * 64),
+        "journal_complete": journal_complete,
+        "journal_terminal": journal_terminal,
+        "synthetic": False,
+    }
+
+
+def _launcher(manifest, frontier_manifest, *, status="completed", calls=None):
+    calls = calls if calls is not None else []
+
+    def launch(**kwargs):
+        calls.append(kwargs["run_mode"])
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        journal = _valid_journal_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            terminal=status,
+        )
+        (output_dir / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+        journal_digest = autopsy._file_sha256(output_dir / "journal.json")
+        result = _valid_result_payload(
+            manifest,
+            frontier_manifest,
+            status=status,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            journal_sha256=journal_digest,
+            journal_complete=journal["complete"],
+            journal_terminal=journal["terminal"],
+        )
+        (output_dir / "result.json").write_text(json.dumps(result), encoding="utf-8")
+        return ChildProcessResult(
+            exit_code=0 if status == "completed" else 2,
+            timed_out=False,
+            descendants_cleaned=True,
+        )
+
+    return launch
+
+
+class _FakeGenerationResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.from_draft = False
+        self.prompt_tokens = 0
+        self.generation_tokens = 1
+        self.finish_reason = None
+
+
+class _FakeRuntime:
+    """Injectable runtime double: never touches real weights or MLX."""
+
+    def __init__(
+        self, *, mode: str = "completed", tokens_before_failure: int = 1
+    ) -> None:
+        self.mode = mode
+        self.tokens_before_failure = tokens_before_failure
+        self.seed_calls: list[int] = []
+        self.synchronize_calls: int = 0
+        self.reset_peak_memory_calls: int = 0
+
+    def load_model(self, path: Path):
+        return object(), object()
+
+    def encode(self, processor, text: str) -> list[int]:
+        return list(range(len(text) // 4))
+
+    def seed(self, seed: int) -> None:
+        self.seed_calls.append(seed)
+
+    def synchronize(self) -> None:
+        self.synchronize_calls += 1
+
+    def reset_peak_memory(self) -> None:
+        self.reset_peak_memory_calls += 1
+
+    def stream_generate(
+        self,
+        model,
+        processor,
+        prompt_tokens,
+        *,
+        max_tokens: int,
+        draft_model,
+        num_draft_tokens: int,
+    ):
+        produced = 0
+        while produced < max_tokens:
+            if self.mode == "oom" and produced == self.tokens_before_failure:
+                raise MemoryError("Metal reported insufficient memory")
+            if self.mode == "timeout" and produced == self.tokens_before_failure:
+                raise TimeoutError("child exceeded its allotted generation window")
+            if self.mode == "failed" and produced == self.tokens_before_failure:
+                raise RuntimeError("unclassified runtime failure")
+            produced += 1
+            yield _FakeGenerationResponse(f"token-{produced}")
+            if self.mode == "short":
+                return
+
+
+# ---------------------------------------------------------------------------
+# Manifest binding.
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_binds_by_hash_and_identity_to_the_packaged_frontier() -> None:
+    manifest, frontier_manifest, base = _load()
+    assert manifest.autopsy_id == "m5-pro-qwen3.8-27b-oom-autopsy-v1"
+    assert manifest.frontier_id == frontier_manifest.frontier_id
+    assert manifest.model_repository_id == frontier_manifest.model_repository_id
+    assert manifest.model_revision == "3e6447f082e89cc7f0bc6e5441afd38dfce760ff"
+    assert manifest.model_expected_download_bytes == 16081490933
+    assert manifest.tier_name == "t256"
+    assert manifest.tier_requested_tokens == 256
+    assert base.model.revision == manifest.model_revision
+
+
+def test_frontier_binding_hash_drift_is_rejected(tmp_path: Path) -> None:
+    manifest, _, _ = _load()
+    tampered = tmp_path / "frontier.json"
+    payload = json.loads(
+        Path("llmtracefx/optimizer/lab/data/fit-frontier-manifest-v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    payload["frontier_id"] = "tampered"
+    tampered.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(autopsy.AutopsyManifestError, match="does not match"):
+        load_bound_frontier(manifest, frontier_manifest_path=tampered)
+
+
+def test_autopsy_manifest_hash_is_deterministic_and_prefixed() -> None:
+    manifest, _, _ = _load()
+    first = autopsy_manifest_hash(manifest)
+    second = autopsy_manifest_hash(manifest)
+    assert first == second
+    assert first.startswith("sha256:")
+    assert len(first) == len("sha256:") + 64
+
+
+def test_autopsy_manifest_hash_changes_when_own_field_drifts_but_frontier_does_not(
+    tmp_path: Path,
+) -> None:
+    import dataclasses
+
+    manifest, frontier_manifest, _ = _load()
+    baseline_hash = autopsy_manifest_hash(manifest)
+    tampered = dataclasses.replace(
+        manifest, child_timeout_seconds=manifest.child_timeout_seconds + 1
+    )
+    tampered_hash = autopsy_manifest_hash(tampered)
+    assert tampered_hash != baseline_hash
+    # The frontier binding fields are untouched by this manifest-local drift.
+    assert tampered.frontier_manifest_sha256 == manifest.frontier_manifest_sha256
+    assert frontier_manifest_hash(frontier_manifest) == frontier_manifest_hash(
+        frontier_manifest
+    )
+
+
+def test_stale_autopsy_manifest_hash_journal_is_rejected_not_silently_absent(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, _ = _load()
+    journal_path = tmp_path / "journal.json"
+    payload = _valid_journal_payload(manifest, frontier_manifest)
+    payload["autopsy_manifest_hash"] = "sha256:" + "0" * 64
+    payload["envelope_sha256"] = autopsy.config_hash(
+        {k: v for k, v in payload.items() if k != "envelope_sha256"}
+    )
+    journal_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = autopsy._load_journal_if_valid(
+        journal_path,
+        manifest,
+        frontier_manifest,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+    )
+    assert result.status == "invalid"
+    assert "autopsy_manifest_hash" in (result.reason or "")
+
+
+def test_stale_autopsy_manifest_hash_result_is_rejected(tmp_path: Path) -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["autopsy_manifest_hash"] = "sha256:" + "0" * 64
+    with pytest.raises(LabError, match="autopsy_manifest_hash"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_claimed_journal_outcome_without_digest() -> (
+    None
+):
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["journal_sha256"] = None
+    with pytest.raises(LabError, match="claimed journal outcome requires a digest"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_completed_without_complete_terminal_journal() -> (
+    None
+):
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["journal_complete"] = False
+    with pytest.raises(LabError, match="completed status requires"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_bool_as_actual_tokens() -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["actual_tokens"] = True
+    with pytest.raises(LabError, match="non-negative integer or null"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_shortfall_beyond_frontier_maximum() -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    max_shortfall = frontier_manifest.maximum_token_shortfall
+    result["actual_tokens"] = manifest.tier_requested_tokens - max_shortfall - 1
+    with pytest.raises(LabError, match="shortfall exceeds"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_tokens_above_requested_tier() -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["actual_tokens"] = manifest.tier_requested_tokens + 1
+    with pytest.raises(LabError, match="exceeds the requested tier"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_completed_status_with_a_reason() -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest)
+    result["reason"] = "should not be present for a completed result"
+    with pytest.raises(LabError, match="completed result must have no reason"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_validate_autopsy_result_rejects_noncompleted_status_missing_a_reason() -> None:
+    manifest, frontier_manifest, _ = _load()
+    result = _valid_result_payload(manifest, frontier_manifest, status="failed")
+    result["reason"] = None
+    with pytest.raises(LabError, match="must carry a reason"):
+        autopsy._validate_autopsy_result(
+            result,
+            manifest,
+            frontier_manifest,
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+        )
+
+
+def test_run_autopsy_state_and_report_bind_autopsy_manifest_hash(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest),
+    )
+    assert state["autopsy_manifest_hash"] == autopsy_manifest_hash(manifest)
+    assert state["result"]["autopsy_manifest_hash"] == autopsy_manifest_hash(manifest)
+    report = build_autopsy_report(
+        manifest, frontier_manifest, workspace=workspace, run_mode="exploratory"
+    )
+    assert report["bindings"]["autopsy_manifest_hash"] == autopsy_manifest_hash(
+        manifest
+    )
+    assert report["bindings"]["frontier_manifest_hash"] == frontier_manifest_hash(
+        frontier_manifest
+    )
+
+
+def test_journal_max_bytes_over_metadata_artifact_limit_is_rejected() -> None:
+    raw = json.loads(AUTOPSY_MANIFEST_PATH.read_text(encoding="utf-8"))
+    raw["journal"]["max_bytes"] = autopsy.MAX_METADATA_ARTIFACT_BYTES + 1
+    with pytest.raises(autopsy.AutopsyManifestError, match="max_bytes"):
+        autopsy.AutopsyManifest.from_dict(raw)
+
+
+def test_journal_max_bytes_at_metadata_artifact_limit_is_accepted() -> None:
+    raw = json.loads(AUTOPSY_MANIFEST_PATH.read_text(encoding="utf-8"))
+    raw["journal"]["max_bytes"] = autopsy.MAX_METADATA_ARTIFACT_BYTES
+    manifest = autopsy.AutopsyManifest.from_dict(raw)
+    assert manifest.journal_max_bytes == autopsy.MAX_METADATA_ARTIFACT_BYTES
+
+
+def test_packaged_manifest_loads_from_external_cwd(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    manifest, source = load_autopsy_manifest(None)
+    frontier_manifest, base = load_bound_frontier(manifest, frontier_manifest_path=None)
+    assert source.startswith("package:llmtracefx.optimizer.lab/")
+    assert base.model.revision == frontier_manifest.model_revision
+
+
+def test_plan_does_not_construct_runtime_or_load_weights(monkeypatch, capsys) -> None:
+    _prepare(monkeypatch)
+    monkeypatch.setattr(autopsy, "model_files_present", lambda *args: True)
+    monkeypatch.setattr(
+        autopsy,
+        "MLXVLMRuntime",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("plan loaded weights")
+        ),
+    )
+    assert autopsy.main(["plan", "--manifest", str(AUTOPSY_MANIFEST_PATH)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["weights_loaded"] is False
+    assert payload["downloads_performed"] is False
+    assert payload["manifest"] == str(AUTOPSY_MANIFEST_PATH)
+    assert payload["sampling"]["periodic_sampling_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Direct MLX counter probing.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_mlx_counters_records_exact_qualified_names_and_values() -> None:
+    def get_active_memory() -> int:
+        return 111
+
+    def get_cache_memory() -> int:
+        return 222
+
+    def get_peak_memory() -> int:
+        return 333
+
+    fake_mlx = types.SimpleNamespace(
+        get_active_memory=get_active_memory,
+        get_cache_memory=get_cache_memory,
+        get_peak_memory=get_peak_memory,
+    )
+    result = probe_mlx_counters(fake_mlx)
+    assert result["active_bytes"] == {
+        "api": autopsy._qualified_name(get_active_memory, "get_active_memory"),
+        "value": 111,
+        "unit": "bytes",
+        "error_category": None,
+    }
+    assert result["cache_bytes"]["value"] == 222
+    assert result["peak_bytes"]["value"] == 333
+    assert all(entry["error_category"] is None for entry in result.values())
+
+
+def test_probe_mlx_counters_missing_api_is_null_never_zero() -> None:
+    fake_mlx = types.SimpleNamespace(get_active_memory=lambda: 5)
+    result = probe_mlx_counters(fake_mlx)
+    assert result["active_bytes"]["value"] == 5
+    assert result["cache_bytes"] == {
+        "api": None,
+        "value": None,
+        "unit": "bytes",
+        "error_category": None,
+    }
+    assert result["peak_bytes"] == {
+        "api": None,
+        "value": None,
+        "unit": "bytes",
+        "error_category": None,
+    }
+
+
+def test_probe_mlx_counters_absent_module_is_entirely_null() -> None:
+    result = probe_mlx_counters(None)
+    for entry in result.values():
+        assert entry["api"] is None
+        assert entry["value"] is None
+        assert entry["error_category"] is None
+
+
+@pytest.mark.parametrize("error_type", [RuntimeError, MemoryError])
+def test_probe_mlx_counters_swallows_callable_errors_as_null(error_type) -> None:
+    def broken() -> int:
+        raise error_type("device unavailable, serial ABC123 detached")
+
+    fake_mlx = types.SimpleNamespace(
+        get_active_memory=broken, get_cache_memory=broken, get_peak_memory=broken
+    )
+    result = probe_mlx_counters(fake_mlx)
+    assert all(entry["value"] is None for entry in result.values())
+    assert all(entry["api"] is not None for entry in result.values())
+    assert all(
+        entry["error_category"] == error_type.__name__ for entry in result.values()
+    )
+    # The raw exception message (which could carry private detail) is never
+    # recorded -- only the exception's type name is.
+    serialized = json.dumps(result)
+    assert "device unavailable" not in serialized
+    assert "ABC123" not in serialized
+
+
+def test_probe_mlx_reset_peak_memory_api_reports_qualified_name_or_null() -> None:
+    def reset_peak_memory() -> None:
+        return None
+
+    assert probe_mlx_reset_peak_memory_api(
+        types.SimpleNamespace(reset_peak_memory=reset_peak_memory)
+    ) == autopsy._qualified_name(reset_peak_memory, "reset_peak_memory")
+    assert probe_mlx_reset_peak_memory_api(types.SimpleNamespace()) is None
+    assert probe_mlx_reset_peak_memory_api(None) is None
+
+
+def test_probe_mlx_counters_against_real_installed_mlx() -> None:
+    mlx_core = pytest.importorskip("mlx.core")
+    result = probe_mlx_counters(mlx_core)
+    assert result["active_bytes"]["api"] == "mlx.core.get_active_memory"
+    assert result["cache_bytes"]["api"] == "mlx.core.get_cache_memory"
+    assert result["peak_bytes"]["api"] == "mlx.core.get_peak_memory"
+    for entry in result.values():
+        assert isinstance(entry["value"], int)
+
+
+# ---------------------------------------------------------------------------
+# Host process/system probing (macOS and Linux code paths).
+# ---------------------------------------------------------------------------
+
+
+def test_host_process_rss_bytes_macos_parses_ps_kibibytes() -> None:
+    value, provenance = host_process_rss_bytes(
+        system="Darwin", run_text=lambda argv: "2048"
+    )
+    assert value == 2048 * 1024
+    assert "ps -o rss=" in provenance
+
+
+def test_host_process_rss_bytes_macos_null_when_ps_unavailable() -> None:
+    value, provenance = host_process_rss_bytes(
+        system="Darwin", run_text=lambda argv: None
+    )
+    assert value is None
+    assert provenance is None
+
+
+def test_host_process_rss_bytes_linux_parses_vmrss_kb(tmp_path: Path) -> None:
+    status_path = tmp_path / "status"
+    status_path.write_text("Name:\tpython\nVmRSS:\t   4096 kB\n", encoding="utf-8")
+    value, provenance = host_process_rss_bytes(
+        system="Linux", linux_status_path=status_path
+    )
+    assert value == 4096 * 1024
+    assert "VmRSS" in provenance
+
+
+def test_host_process_rss_bytes_linux_null_when_proc_missing(tmp_path: Path) -> None:
+    value, provenance = host_process_rss_bytes(
+        system="Linux", linux_status_path=tmp_path / "missing"
+    )
+    assert value is None
+    assert provenance is None
+
+
+def test_host_process_rss_bytes_unknown_platform_is_null() -> None:
+    assert host_process_rss_bytes(system="Windows") == (None, None)
+
+
+def test_host_process_max_rss_bytes_macos_is_already_bytes() -> None:
+    usage = types.SimpleNamespace(ru_maxrss=31_000_000)
+    value, provenance = host_process_max_rss_bytes(
+        system="Darwin", getrusage=lambda: usage
+    )
+    assert value == 31_000_000
+    assert "bytes" in provenance
+
+
+def test_host_process_max_rss_bytes_linux_converts_kib_to_bytes() -> None:
+    usage = types.SimpleNamespace(ru_maxrss=31_000)
+    value, provenance = host_process_max_rss_bytes(
+        system="Linux", getrusage=lambda: usage
+    )
+    assert value == 31_000 * 1024
+    assert "KiB" in provenance
+
+
+def test_host_process_max_rss_bytes_null_on_getrusage_failure() -> None:
+    def broken():
+        raise OSError("unsupported")
+
+    assert host_process_max_rss_bytes(system="Darwin", getrusage=broken) == (None, None)
+
+
+def test_host_swap_bytes_macos_parses_sysctl_swapusage() -> None:
+    text = "total = 12288.00M  used = 10744.75M  free = 1543.25M  (encrypted)"
+    total, used, provenance = host_swap_bytes(
+        system="Darwin", run_text=lambda argv: text
+    )
+    assert total == int(12288.00 * 1024 * 1024)
+    assert used == int(10744.75 * 1024 * 1024)
+    assert "sysctl" in provenance
+
+
+def test_host_swap_bytes_macos_null_when_sysctl_unavailable() -> None:
+    assert host_swap_bytes(system="Darwin", run_text=lambda argv: None) == (
+        None,
+        None,
+        None,
+    )
+
+
+def test_host_swap_bytes_linux_parses_meminfo(tmp_path: Path) -> None:
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:  1000 kB\nSwapTotal:  2048 kB\nSwapFree:   512 kB\n",
+        encoding="utf-8",
+    )
+    total, used, provenance = host_swap_bytes(
+        system="Linux", linux_meminfo_path=meminfo
+    )
+    assert total == 2048 * 1024
+    assert used == (2048 - 512) * 1024
+    assert "meminfo" in provenance
+
+
+def test_host_swap_bytes_unknown_platform_is_null() -> None:
+    assert host_swap_bytes(system="Solaris") == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Bounded, atomic journal persistence.
+# ---------------------------------------------------------------------------
+
+
+def _new_journal(tmp_path: Path, *, max_checkpoints: int = 16, max_bytes: int = 65536):
+    manifest, frontier_manifest, _base = _load()
+    return AutopsyJournal(
+        path=tmp_path / "journal.json",
+        autopsy_id=manifest.autopsy_id,
+        autopsy_manifest_hash_value=autopsy_manifest_hash(manifest),
+        frontier_manifest_hash_value=frontier_manifest_hash(frontier_manifest),
+        model_repository_id=frontier_manifest.model_repository_id,
+        model_revision=frontier_manifest.model_revision,
+        tier=manifest.tier_name,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        max_checkpoints=max_checkpoints,
+        max_bytes=max_bytes,
+    )
+
+
+def test_journal_checkpoint_persists_atomically_with_matching_envelope_hash(
+    tmp_path: Path,
+) -> None:
+    journal = _new_journal(tmp_path)
+    journal.checkpoint("child_start", None)
+    journal.checkpoint("before_model_load", None)
+    on_disk = json.loads(journal.path.read_text(encoding="utf-8"))
+    assert [entry["stage"] for entry in on_disk["checkpoints"]] == [
+        "child_start",
+        "before_model_load",
+    ]
+    canonical = {k: v for k, v in on_disk.items() if k != "envelope_sha256"}
+    assert autopsy.config_hash(canonical) == on_disk["envelope_sha256"]
+    assert on_disk["sampling"]["periodic_sampling_enabled"] is False
+    assert on_disk["complete"] is False
+
+
+def test_journal_finalize_marks_complete_and_terminal(tmp_path: Path) -> None:
+    journal = _new_journal(tmp_path)
+    journal.checkpoint("child_start", None)
+    journal.finalize(complete=True, terminal="completed")
+    on_disk = json.loads(journal.path.read_text(encoding="utf-8"))
+    assert on_disk["complete"] is True
+    assert on_disk["terminal"] == "completed"
+
+
+def test_journal_checkpoint_count_bound_is_enforced(tmp_path: Path) -> None:
+    journal = _new_journal(tmp_path, max_checkpoints=2)
+    journal.checkpoint("child_start", None)
+    journal.checkpoint("before_model_load", None)
+    with pytest.raises(LabError, match="maximum checkpoint count"):
+        journal.checkpoint("after_model_load", None)
+
+
+def test_journal_byte_size_bound_is_enforced(tmp_path: Path) -> None:
+    journal = _new_journal(tmp_path, max_bytes=16)
+    with pytest.raises(LabError, match="maximum artifact size"):
+        journal.checkpoint("child_start", None)
+
+
+def test_journal_never_records_pids_paths_or_hostnames(tmp_path: Path) -> None:
+    journal = _new_journal(tmp_path)
+    journal.checkpoint("child_start", None)
+    journal.finalize(complete=True, terminal="completed")
+    serialized = journal.path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in serialized
+    import os
+
+    assert str(os.getpid()) not in serialized
+
+
+def test_journal_records_peak_memory_is_never_reset_with_explicit_provenance(
+    tmp_path: Path,
+) -> None:
+    journal = _new_journal(tmp_path)
+    journal.checkpoint("child_start", None)
+    on_disk = json.loads(journal.path.read_text(encoding="utf-8"))
+    # Peak memory must never be silently reset after model load; the
+    # journal explicitly records that fact rather than omitting the field.
+    assert on_disk["peak_memory_reset"] == {
+        "applied": False,
+        "api": None,
+        "note": (
+            "Peak memory is never reset after model load, so a fresh "
+            "subprocess's peak reading includes load growth."
+        ),
+    }
+
+
+def test_build_checkpoint_includes_clock_unit_and_provenance() -> None:
+    checkpoint = autopsy.build_checkpoint(
+        "child_start", 0, mlx_module=None, started_monotonic=time.monotonic()
+    )
+    assert checkpoint["wall_clock_provenance"]
+    assert isinstance(checkpoint["wall_clock_provenance"], str)
+    assert checkpoint["monotonic_offset_unit"] == "seconds"
+    assert checkpoint["monotonic_offset_provenance"]
+    assert isinstance(checkpoint["monotonic_offset_provenance"], str)
+    assert checkpoint["monotonic_offset_seconds"] >= 0.0
+
+
+def test_build_checkpoint_keeps_other_scopes_when_one_probe_hits_memory_error() -> None:
+    def failed_rss():
+        raise MemoryError("private details must not escape")
+
+    checkpoint = autopsy.build_checkpoint(
+        "child_start",
+        0,
+        mlx_module=None,
+        started_monotonic=time.monotonic(),
+        rss_probe=failed_rss,
+        max_rss_probe=lambda: (2048, "getrusage"),
+        swap_probe=lambda: (4096, 1024, "sysctl"),
+    )
+    assert checkpoint["host_process"]["rss_bytes"] == {
+        "value": None,
+        "provenance": "probe failed (MemoryError)",
+    }
+    assert checkpoint["host_process"]["max_rss_bytes"]["value"] == 2048
+    assert checkpoint["host_system"]["swap_used_bytes"]["value"] == 1024
+    assert "private details" not in json.dumps(checkpoint)
+
+
+# ---------------------------------------------------------------------------
+# Signal handling.
+# ---------------------------------------------------------------------------
+
+
+def test_record_signal_checkpoint_marks_incomplete_with_signal_terminal(
+    tmp_path: Path,
+) -> None:
+    journal = _new_journal(tmp_path)
+    journal.checkpoint("child_start", None)
+    autopsy._record_signal_checkpoint(journal, None, autopsy.signal.SIGTERM)
+    on_disk = json.loads(journal.path.read_text(encoding="utf-8"))
+    assert on_disk["complete"] is False
+    assert on_disk["terminal"] == "signal"
+    stages = [entry["stage"] for entry in on_disk["checkpoints"]]
+    # signal_received is its own distinct stage, never mislabeled as cleanup.
+    assert stages == ["child_start", "signal_received", "cleanup"]
+    signal_entry = on_disk["checkpoints"][stages.index("signal_received")]
+    assert signal_entry["signal_received"] == "SIGTERM"
+    cleanup_entry = on_disk["checkpoints"][stages.index("cleanup")]
+    assert cleanup_entry.get("signal_received") is None
+
+
+def test_record_signal_checkpoint_is_best_effort_when_checkpoint_budget_exhausted(
+    tmp_path: Path,
+) -> None:
+    """A failure writing one best-effort checkpoint must not block the rest."""
+    journal = _new_journal(tmp_path, max_checkpoints=2)
+    journal.checkpoint("child_start", None)
+    journal.checkpoint("before_model_load", None)
+    # The checkpoint budget is now exhausted: signal_received/cleanup writes
+    # will each raise LabError internally, but finalize must still land so
+    # the journal's terminal outcome is never silently dropped.
+    autopsy._record_signal_checkpoint(journal, None, autopsy.signal.SIGTERM)
+    on_disk = json.loads(journal.path.read_text(encoding="utf-8"))
+    assert on_disk["complete"] is False
+    assert on_disk["terminal"] == "signal"
+    stages = [entry["stage"] for entry in on_disk["checkpoints"]]
+    assert stages == ["child_start", "before_model_load"]
+
+
+# ---------------------------------------------------------------------------
+# Isolated child execution.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_autopsy_child_success_walks_full_checkpoint_sequence(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="completed"),
+        mlx_module_factory=lambda: None,
+    )
+    assert result["status"] == "completed"
+    assert result["reason"] is None
+    assert result["journal_complete"] is True
+    assert result["journal_terminal"] == "completed"
+    journal = json.loads((output_dir / "journal.json").read_text(encoding="utf-8"))
+    stages = [entry["stage"] for entry in journal["checkpoints"]]
+    assert stages == [
+        "child_start",
+        "before_model_load",
+        "after_model_load",
+        "after_prompt_tokenization",
+        "immediately_before_prefill_generation",
+        "after_first_token",
+        "completion",
+        "cleanup",
+    ]
+
+
+def test_execute_autopsy_child_oom_writes_caught_oom_checkpoint(tmp_path: Path) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="oom", tokens_before_failure=0),
+        mlx_module_factory=lambda: None,
+    )
+    assert result["status"] == "oom"
+    assert result["reason"] == "MLX/Metal reported insufficient memory"
+    journal = json.loads((output_dir / "journal.json").read_text(encoding="utf-8"))
+    stages = [entry["stage"] for entry in journal["checkpoints"]]
+    assert "caught_oom" in stages
+    assert stages[-1] == "cleanup"
+    assert journal["complete"] is True
+    assert journal["terminal"] == "oom"
+
+
+def test_execute_autopsy_child_timeout_is_classified_and_cleaned_up(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="timeout", tokens_before_failure=0),
+        mlx_module_factory=lambda: None,
+    )
+    assert result["status"] == "timeout"
+    journal = json.loads((output_dir / "journal.json").read_text(encoding="utf-8"))
+    assert journal["terminal"] == "timeout"
+    assert journal["checkpoints"][-1]["stage"] == "cleanup"
+
+
+def test_execute_autopsy_child_generic_failure_still_reaches_cleanup(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="failed", tokens_before_failure=0),
+        mlx_module_factory=lambda: None,
+    )
+    assert result["status"] == "failed"
+    assert result["journal_complete"] is True
+    journal = json.loads((output_dir / "journal.json").read_text(encoding="utf-8"))
+    assert journal["checkpoints"][-1]["stage"] == "cleanup"
+    assert "caught_oom" not in [c["stage"] for c in journal["checkpoints"]]
+
+
+def test_execute_autopsy_child_result_binds_journal_hash(tmp_path: Path) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    result = execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=lambda: _FakeRuntime(mode="completed"),
+        mlx_module_factory=lambda: None,
+    )
+    assert result["journal_sha256"] == autopsy._file_sha256(output_dir / "journal.json")
+
+
+def test_execute_autopsy_child_seeds_and_synchronizes_at_correct_points_never_resets_peak(
+    tmp_path: Path,
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    output_dir = tmp_path / "attempt"
+    runtimes: list[_FakeRuntime] = []
+
+    def runtime_factory() -> _FakeRuntime:
+        runtime = _FakeRuntime(mode="completed")
+        runtimes.append(runtime)
+        return runtime
+
+    execute_autopsy_child(
+        manifest,
+        frontier_manifest,
+        base,
+        model_path=tmp_path / "model",
+        output_dir=output_dir,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        runtime_factory=runtime_factory,
+        mlx_module_factory=lambda: None,
+    )
+    (runtime,) = runtimes
+    # Seeded exactly once with the manifest's own generation seed, and
+    # synchronized after load, after seeding/before prefill, and after
+    # generation -- no periodic polling, and peak memory is never reset.
+    assert runtime.seed_calls == [base.generation.seed]
+    assert runtime.synchronize_calls == 3
+    assert runtime.reset_peak_memory_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Parent orchestration: resume, staleness, timeout/signal survival.
+# ---------------------------------------------------------------------------
+
+
+def test_run_autopsy_resumes_a_prior_completed_attempt_without_relaunching(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    first_calls: list[str] = []
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest, calls=first_calls),
+    )
+    second_calls: list[str] = []
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest, calls=second_calls),
+    )
+    assert first_calls == ["exploratory"]
+    assert second_calls == []
+    assert state["resumed"] is True
+    assert state["result"]["status"] == "completed"
+
+
+@pytest.mark.parametrize("status", ["oom", "timeout", "failed"])
+def test_run_autopsy_resumes_any_terminal_status_never_retries_expensive_runs(
+    tmp_path, monkeypatch, status
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest, status=status),
+    )
+    second_calls: list[str] = []
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(
+            manifest, frontier_manifest, calls=second_calls, status=status
+        ),
+    )
+    assert second_calls == []
+    assert state["result"]["status"] == status
+
+
+def test_run_autopsy_resume_rejects_stale_artifact(tmp_path, monkeypatch) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest),
+    )
+    result_path = workspace / "exploratory" / "result.json"
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    payload["frontier_manifest_hash"] = "sha256:" + "0" * 64
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(LabError, match="stale autopsy artifact"):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=workspace,
+            model_path=tmp_path / "model",
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )
+
+
+def test_missing_journal_is_reported_as_missing_not_invalid(tmp_path) -> None:
+    manifest, frontier_manifest, base = _load()
+    result = autopsy._load_journal_if_valid(
+        tmp_path / "does-not-exist.json",
+        manifest,
+        frontier_manifest,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+    )
+    assert result.status == "missing"
+    assert result.journal is None
+    assert result.digest is None
+    assert result.reason is None
+
+
+def test_stale_or_foreign_journal_fails_closed_and_is_ignored(tmp_path) -> None:
+    manifest, frontier_manifest, base = _load()
+    journal_path = tmp_path / "journal.json"
+    payload = _valid_journal_payload(manifest, frontier_manifest)
+    payload["autopsy_id"] = "some-other-autopsy"
+    payload["envelope_sha256"] = autopsy.config_hash(
+        {k: v for k, v in payload.items() if k != "envelope_sha256"}
+    )
+    journal_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = autopsy._load_journal_if_valid(
+        journal_path,
+        manifest,
+        frontier_manifest,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+    )
+    assert result.status == "invalid"
+    assert result.journal is None
+    assert result.digest is None
+    assert "autopsy_id" in (result.reason or "")
+
+
+def test_tampered_journal_envelope_hash_fails_closed(tmp_path) -> None:
+    manifest, frontier_manifest, base = _load()
+    journal_path = tmp_path / "journal.json"
+    payload = _valid_journal_payload(manifest, frontier_manifest)
+    payload["terminal"] = "completed-but-tampered"
+    journal_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = autopsy._load_journal_if_valid(
+        journal_path,
+        manifest,
+        frontier_manifest,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+    )
+    assert result.status == "invalid"
+    assert result.journal is None
+    assert result.digest is None
+    assert "envelope hash" in (result.reason or "")
+
+
+def test_symlinked_journal_is_rejected_not_followed(tmp_path) -> None:
+    manifest, frontier_manifest, base = _load()
+    real_target = tmp_path / "outside.json"
+    real_target.write_text(
+        json.dumps(_valid_journal_payload(manifest, frontier_manifest)),
+        encoding="utf-8",
+    )
+    journal_path = tmp_path / "journal.json"
+    journal_path.symlink_to(real_target)
+    result = autopsy._load_journal_if_valid(
+        journal_path,
+        manifest,
+        frontier_manifest,
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+    )
+    assert result.status == "invalid"
+    assert result.journal is None
+    assert result.digest is None
+    assert "symlink" in (result.reason or "")
+
+
+def test_invalid_unbound_journal_blocks_verify_and_resume(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+
+    def launch(**kwargs):
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "journal.json").write_text("{broken", encoding="utf-8")
+        return ChildProcessResult(
+            exit_code=1, timed_out=False, descendants_cleaned=True
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["journal_sha256"] is None
+    verification = verify_autopsy_evidence(
+        manifest, frontier_manifest, workspace=workspace, run_mode="exploratory"
+    )
+    assert verification["verified"] is False
+    assert any("full contract validation" in item for item in verification["failures"])
+    with pytest.raises(LabError, match="checkpoint journal is invalid"):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=workspace,
+            model_path=tmp_path / "model",
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )
+
+
+def test_finalize_rejects_candidate_result_with_a_digest_not_matching_the_real_journal(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+
+    def launch(**kwargs):
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        journal = _valid_journal_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+        )
+        (output_dir / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+        result = _valid_result_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            # A forged digest: does not match the real on-disk journal.
+            journal_sha256="a" * 64,
+        )
+        (output_dir / "result.json").write_text(json.dumps(result), encoding="utf-8")
+        return ChildProcessResult(
+            exit_code=0, timed_out=False, descendants_cleaned=True
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["status"] == "failed"
+    assert "digest does not match" in state["result"]["reason"]
+
+
+def test_finalize_rejects_candidate_completion_claim_mismatching_the_real_journal(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+
+    def launch(**kwargs):
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        journal = _valid_journal_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            terminal="oom",
+        )
+        (output_dir / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+        digest = autopsy._file_sha256(output_dir / "journal.json")
+        result = _valid_result_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            status="oom",
+            journal_sha256=digest,
+            # Lies about the journal's real terminal outcome.
+            journal_terminal="completed",
+        )
+        (output_dir / "result.json").write_text(json.dumps(result), encoding="utf-8")
+        return ChildProcessResult(
+            exit_code=1, timed_out=False, descendants_cleaned=True
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["status"] == "failed"
+    assert "completion/terminal claims do not match" in state["result"]["reason"]
+
+
+def test_incomplete_journal_after_signal_is_usable_failure_evidence_not_success(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+
+    def launch(**kwargs):
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        journal = _valid_journal_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            complete=False,
+            terminal="signal",
+        )
+        (output_dir / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+        # No result.json: the child was killed before its finally block ran.
+        return ChildProcessResult(
+            exit_code=None, timed_out=False, descendants_cleaned=True
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["status"] == "failed"
+    assert state["result"]["journal_complete"] is False
+    assert state["result"]["journal_terminal"] == "signal"
+    assert state["result"]["journal_sha256"] is not None
+    assert state["result"]["synthetic"] is False
+
+
+def test_parent_enforced_timeout_produces_failure_shaped_result(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+
+    def launch(**kwargs):
+        return ChildProcessResult(
+            exit_code=None, timed_out=True, descendants_cleaned=True
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["status"] == "timeout"
+    assert state["result"]["reason"] == "autopsy exceeded parent-enforced timeout"
+
+
+def test_cleanup_failure_produces_failure_shaped_result_never_success(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+
+    def launch(**kwargs):
+        return ChildProcessResult(
+            exit_code=1, timed_out=False, descendants_cleaned=False
+        )
+
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    assert state["result"]["status"] == "failed"
+    assert "cleanup could not be verified" in state["result"]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Publication / exploratory clean-boot gating.
+# ---------------------------------------------------------------------------
+
+
+def test_publication_requires_explicit_clean_boot_confirmation(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    with pytest.raises(LabError, match="operator assertion"):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=tmp_path,
+            model_path=tmp_path / "model",
+            run_mode="publication",
+            clean_boot_confirmed=False,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )
+
+
+def test_exploratory_cannot_accept_clean_boot_confirmation(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    with pytest.raises(LabError, match="only valid in publication mode"):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=tmp_path,
+            model_path=tmp_path / "model",
+            run_mode="exploratory",
+            clean_boot_confirmed=True,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )
+
+
+def test_publication_with_confirmation_proceeds(tmp_path, monkeypatch) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    calls: list[str] = []
+    state = run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=tmp_path,
+        model_path=tmp_path / "model",
+        run_mode="publication",
+        clean_boot_confirmed=True,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest, calls=calls),
+    )
+    assert calls == ["publication"]
+    assert state["clean_boot_confirmed"] is True
+    assert state["result"]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Reporting: deterministic, sanitized, never zero-filled for missing values.
+# ---------------------------------------------------------------------------
+
+
+def _run_with_checkpoints(tmp_path, monkeypatch, checkpoints):
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "private-user" / "workspace"
+
+    def launch(**kwargs):
+        output_dir = kwargs["output_dir"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        journal = _valid_journal_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            checkpoints=checkpoints,
+        )
+        (output_dir / "journal.json").write_text(json.dumps(journal), encoding="utf-8")
+        digest = autopsy._file_sha256(output_dir / "journal.json")
+        result = _valid_result_payload(
+            manifest,
+            frontier_manifest,
+            run_mode=kwargs["run_mode"],
+            clean_boot_confirmed=kwargs["clean_boot_confirmed"],
+            journal_sha256=digest,
+        )
+        (output_dir / "result.json").write_text(json.dumps(result), encoding="utf-8")
+        return ChildProcessResult(
+            exit_code=0, timed_out=False, descendants_cleaned=True
+        )
+
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=launch,
+    )
+    return manifest, frontier_manifest, workspace
+
+
+def test_report_is_deterministic_and_keeps_missing_values_null_not_zero(
+    tmp_path, monkeypatch
+) -> None:
+    # A schema-valid, complete "completed" sequence, with the
+    # before_model_load checkpoint swapped for a fixture whose probes
+    # deliberately leave some measurements null (never zero-filled).
+    fake_mlx = types.SimpleNamespace(
+        get_active_memory=lambda: 100,
+        get_peak_memory=lambda: 200,
+        # No get_cache_memory: cache_bytes must stay null, never 0.
+    )
+    checkpoints = _checkpoints_for(terminal="completed")
+    before_model_load_index = next(
+        i for i, cp in enumerate(checkpoints) if cp["stage"] == "before_model_load"
+    )
+    checkpoints[before_model_load_index] = autopsy.build_checkpoint(
+        "before_model_load",
+        before_model_load_index,
+        mlx_module=fake_mlx,
+        started_monotonic=time.monotonic(),
+        rss_probe=lambda: (4096, "ps"),
+        max_rss_probe=lambda: (None, None),
+        swap_probe=lambda: (None, 0, "sysctl"),
+    )
+    manifest, frontier_manifest, workspace = _run_with_checkpoints(
+        tmp_path, monkeypatch, checkpoints
+    )
+    report = build_autopsy_report(
+        manifest, frontier_manifest, workspace=workspace, run_mode="exploratory"
+    )
+    first = render_autopsy_report_html(report)
+    second = render_autopsy_report_html(report)
+    assert first == second
+    row = report["checkpoints"][before_model_load_index]
+    assert row["mlx_active_bytes"] == 100
+    assert row["mlx_cache_bytes"] is None
+    assert row["host_max_rss_bytes"] is None
+    assert row["swap_total_bytes"] is None
+    assert row["swap_used_bytes"] == 0
+    assert str(tmp_path) not in json.dumps(report)
+    assert report["synthetic"] is False
+    assert report["observed_deltas"]
+    delta = report["observed_deltas"][before_model_load_index - 1]
+    assert delta["to_stage"] == "before_model_load"
+    assert delta["mlx_cache_bytes_delta"] is None
+    assert "n/a" in first
+    assert (
+        "0.0" not in first.split("n/a")[0][-20:]
+    )  # sanity: no silent zero-fill marker
+    csv_text = build_autopsy_csv(report)
+    assert "n/a" in csv_text
+    csv_rows = list(csv.DictReader(io.StringIO(csv_text)))
+    assert csv_rows[0]["mlx_cache_bytes"] == "n/a"
+    assert csv_rows[0]["wall_clock_provenance"] == (
+        "schema.utc_now_iso (ISO-8601, UTC)"
+    )
+
+
+def test_report_svg_chart_has_three_labeled_series() -> None:
+    report = {
+        "checkpoints": [
+            {
+                "stage": "before_model_load",
+                "mlx_peak_bytes": 100,
+                "host_rss_bytes": 200,
+                "swap_used_bytes": 0,
+            },
+            {
+                "stage": "after_model_load",
+                "mlx_peak_bytes": 300,
+                "host_rss_bytes": 400,
+                "swap_used_bytes": None,
+            },
+        ]
+    }
+    svg = render_autopsy_chart_svg(report)
+    assert svg.count("<polyline") == 3
+    assert "MLX allocator" in svg
+    assert "Host process" in svg
+    assert "Host system" in svg
+
+
+def test_report_refuses_when_evidence_is_invalid(tmp_path) -> None:
+    manifest, frontier_manifest, base = _load()
+    with pytest.raises(LabError, match="refused invalid evidence"):
+        build_autopsy_report(
+            manifest, frontier_manifest, workspace=tmp_path, run_mode="exploratory"
+        )
+
+
+def test_verify_autopsy_evidence_detects_journal_hash_mismatch(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest),
+    )
+    journal_path = workspace / "exploratory" / "journal.json"
+    journal_path.write_text(
+        journal_path.read_text(encoding="utf-8") + " ", encoding="utf-8"
+    )
+    result = verify_autopsy_evidence(
+        manifest, frontier_manifest, workspace=workspace, run_mode="exploratory"
+    )
+    assert result["verified"] is False
+    assert any("journal digest" in failure for failure in result["failures"])
+
+
+def test_verify_autopsy_evidence_passes_for_a_clean_completed_run(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, frontier_manifest, base = _load()
+    _prepare(monkeypatch)
+    workspace = tmp_path / "workspace"
+    run_autopsy(
+        manifest,
+        frontier_manifest,
+        base,
+        autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+        frontier_manifest_path=None,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        run_mode="exploratory",
+        clean_boot_confirmed=False,
+        resume=True,
+        launcher=_launcher(manifest, frontier_manifest),
+    )
+    result = verify_autopsy_evidence(
+        manifest, frontier_manifest, workspace=workspace, run_mode="exploratory"
+    )
+    assert result == {"verified": True, "failures": []}
+
+
+# ---------------------------------------------------------------------------
+# Run refuses without a cached model / passing safety gate.
+# ---------------------------------------------------------------------------
+
+
+def test_run_refuses_when_model_is_not_present(tmp_path, monkeypatch) -> None:
+    manifest, frontier_manifest, base = _load()
+    monkeypatch.setattr(
+        autopsy, "assess_safety", lambda *args, **kwargs: _safe_decision()
+    )
+    with pytest.raises(LabError):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=tmp_path,
+            model_path=tmp_path / "model",
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )
+
+
+def test_run_refuses_when_safety_gate_fails(tmp_path, monkeypatch) -> None:
+    manifest, frontier_manifest, base = _load()
+    monkeypatch.setattr(autopsy, "verify_model", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        autopsy,
+        "assess_safety",
+        lambda *args, **kwargs: SafetyDecision(
+            safe=False,
+            blockers=("insufficient memory",),
+            snapshot=_safe_decision().snapshot,
+        ),
+    )
+    with pytest.raises(LabError, match="safety preflight"):
+        run_autopsy(
+            manifest,
+            frontier_manifest,
+            base,
+            autopsy_manifest_path=AUTOPSY_MANIFEST_PATH,
+            frontier_manifest_path=None,
+            workspace=tmp_path,
+            model_path=tmp_path / "model",
+            run_mode="exploratory",
+            clean_boot_confirmed=False,
+            resume=True,
+            launcher=_launcher(manifest, frontier_manifest),
+        )

--- a/tests/optimizer/test_m5_autopsy.py
+++ b/tests/optimizer/test_m5_autopsy.py
@@ -31,7 +31,12 @@ from llmtracefx.optimizer.lab.autopsy import (
     run_autopsy,
     verify_autopsy_evidence,
 )
-from llmtracefx.optimizer.lab.core import HostSnapshot, LabError, SafetyDecision
+from llmtracefx.optimizer.lab.core import (
+    HostSnapshot,
+    LabError,
+    SafetyDecision,
+    assert_shareable,
+)
 from llmtracefx.optimizer.lab.frontier import frontier_manifest_hash
 
 AUTOPSY_MANIFEST_PATH = Path("llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json")
@@ -774,6 +779,20 @@ def test_host_swap_bytes_linux_parses_meminfo(tmp_path: Path) -> None:
     assert total == 2048 * 1024
     assert used == (2048 - 512) * 1024
     assert "meminfo" in provenance
+
+
+def test_linux_procfs_provenance_is_precise_but_shareable(tmp_path: Path) -> None:
+    status = tmp_path / "status"
+    status.write_text("VmRSS: 1024 kB\n", encoding="utf-8")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("SwapTotal: 2048 kB\nSwapFree: 1024 kB\n", encoding="utf-8")
+    _, rss_provenance = host_process_rss_bytes(system="Linux", linux_status_path=status)
+    _, _, swap_provenance = host_swap_bytes(system="Linux", linux_meminfo_path=meminfo)
+    assert "procfs" in rss_provenance
+    assert "procfs" in swap_provenance
+    assert_shareable(
+        {"rss_provenance": rss_provenance, "swap_provenance": swap_provenance}
+    )
 
 
 def test_host_swap_bytes_unknown_platform_is_null() -> None:


### PR DESCRIPTION
## Summary

- add `llmtracefx-m5-lab autopsy plan|run|verify|report` for one process-isolated, safety-gated `t256` attempt bound by SHA-256 and identity to the existing M5 Pro lab and fit-frontier manifests
- persist bounded, atomic, hash-bound stage checkpoints across MLX allocator, host-process RSS, host-system swap, and wall-clock scopes so last-known evidence can survive OOM, timeout, signal, or parent cleanup
- generate deterministic sanitized JSON, CSV, and self-contained HTML with an original scope-distinguishing checkpoint chart and observed (non-causal) boundary deltas
- keep exploratory and publication evidence in separate versioned namespaces; publication still requires an explicit clean-boot operator assertion

## Evidence contract

The autopsy preserves the existing PR #51/#52 artifacts unchanged. It binds to:

- `mlx-community/Qwen3.8-27B-4bit@3e6447f082e89cc7f0bc6e5441afd38dfce760ff`
- 16,081,490,933 expected bytes and the existing 15-file verification manifest
- fit-frontier `t256` (256 requested tokens, 48 maximum output tokens)

Checkpoints are stage-boundary only; periodic polling is disabled. Missing measurements remain `null`. MLX allocator counters are not GPU capacity or free unified memory, and process RSS is not GPU memory.

## Current host outcome

The no-load plan found the current host safety gates allowed an exploratory attempt, but the pinned checkpoint was not present in this worktree cache (`model_present_by_size: false`). The expensive model run was therefore refused without downloading or retrying, and no fake/synthetic observed values or report artifacts were generated.

Installed MLX 0.32.2 directly exposed:

- `mlx.core.get_active_memory` (bytes)
- `mlx.core.get_cache_memory` (bytes)
- `mlx.core.get_peak_memory` (bytes)
- `mlx.core.reset_peak_memory` (available, but the autopsy does not reset peak after load)

## Validation

- targeted M5 lab/frontier/autopsy tests: 117 passed
- full pytest: 3,167 passed
- changed-file quality ratchet: ruff, black, isort, and mypy passed
- wheel/sdist build and clean external-CWD installed-wheel autopsy plan passed
- independent review fixed one material cleanup-bound evidence-fidelity finding; final exact-head review of `9c641cb06f3a41eab2be3bc531e1a510e30343cc` found no remaining material issues across OOM survival, scope/provenance, observer effect, artifact integrity/privacy, or evidence claims

## Later clean-boot publication action

After a real clean boot, with the exact pinned cache available at the explicit path and all safety gates still passing:

```bash
make m5-autopsy-publication \
  M5_AUTOPSY_MODEL=/absolute/path/to/qwen3.8-27b-4bit-3e6447f
```

`--confirm-clean-boot` is an operator assertion supplied by that target; the lab never infers clean boot.