### PR TITLE
feat: prepare provenance-safe Qwen3-8B M5 control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" --help
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" autopsy --help
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-frontier" --help
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-control" --help
           set +e
           "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-lab" plan > m5-plan.json
           plan_status="$?"
@@ -261,4 +262,26 @@ jobs:
           assert plan['downloads_performed'] is False
           assert plan['model']['repository_id'] == 'mlx-community/Qwen3.8-27B-4bit'
           assert plan['model']['revision'] == '3e6447f082e89cc7f0bc6e5441afd38dfce760ff'
+          "
+          set +e
+          "$GITHUB_WORKSPACE/.wheel-check/bin/llmtracefx-m5-control" plan > m5-control-plan.json
+          control_status="$?"
+          set -e
+          test "$control_status" -eq 2
+          "$GITHUB_WORKSPACE/.wheel-check/bin/python" -c "
+          import json
+          from pathlib import Path
+          plan = json.loads(Path('m5-control-plan.json').read_text())
+          assert plan['conversion_manifest'].startswith(
+              'package:llmtracefx.optimizer.lab.qwen3_8b/'
+          )
+          assert plan['downloads_performed'] is False
+          assert plan['model']['official_id'] == 'Qwen/Qwen3-8B'
+          assert plan['model']['official_revision'] == (
+              'b968826d9c46dd6066d109eabc6255188de91218'
+          )
+          assert plan['model']['expected_source_bytes'] == 16397461266
+          # Fully namespace-separated from the packaged 27B lab: never the
+          # same repository ID as the mlx-community Qwen3.8-27B checkpoint.
+          assert plan['model']['official_id'] != 'Qwen/Qwen3.8-27B'
           "

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LLMTraceFX Makefile
 
-.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence m5-lab m5-lab-acquire m5-lab-run m5-lab-verify m5-lab-report m5-frontier m5-frontier-run m5-frontier-publication m5-autopsy m5-autopsy-run m5-autopsy-publication
+.PHONY: help install install-dev sync test lint lint-changed test-ratchet format format-check clean run-sample run-server deploy-modal install-modal glm-recipe glm-budget glm-plan test-deploy metal-evidence m5-lab m5-lab-acquire m5-lab-run m5-lab-verify m5-lab-report m5-frontier m5-frontier-run m5-frontier-publication m5-autopsy m5-autopsy-run m5-autopsy-publication m5-control-plan m5-control-convert m5-control-bind m5-control-run m5-control-verify m5-control-report
 
 help:  ## Show this help message
 	@echo "LLMTraceFX - evidence-first inference toolkit"
@@ -153,6 +153,40 @@ m5-autopsy-run:  ## Run/resume an exploratory process-isolated OOM autopsy at t2
 
 m5-autopsy-publication:  ## Run publication mode after an operator-confirmed clean boot
 	uv run --offline --no-sync --extra mlx llmtracefx-m5-lab autopsy run --mode publication --confirm-clean-boot --manifest $(M5_AUTOPSY_MANIFEST) --workspace $(M5_AUTOPSY_WORKSPACE) --model-path $(M5_AUTOPSY_MODEL)
+
+# Planned, preparatory Qwen3-8B M5 Pro self-conversion control (no
+# conversion or benchmark has run yet). Fully namespace-separated from the
+# pinned 27B lab above: separate manifests, caches, and workspace. Planning
+# is offline; `convert` self-converts with the repository's pinned mlx-lm,
+# behind a live pre-conversion safety gate, and is never automatically
+# retried; `run` requires a bound manifest (see `bind`) and the converted
+# checkpoint already present on disk.
+M5_CONTROL_CONVERSION_MANIFEST ?= llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-conversion-manifest-v1.json
+M5_CONTROL_TEMPLATE ?= llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-control-manifest-template-v1.json
+M5_CONTROL_SOURCE ?= .cache/models/qwen3-8b-source-b968826
+M5_CONTROL_OUTPUT ?= .cache/models/qwen3-8b-mlx-q4g64-b968826
+M5_CONTROL_CONVERSION_WORKSPACE ?= .cache/llmtracefx/qwen3-8b-conversion-v1
+M5_CONTROL_MANIFEST ?= .cache/llmtracefx/qwen3-8b-conversion-v1/control-manifest.bound.json
+M5_CONTROL_WORKSPACE ?= .cache/llmtracefx/qwen3-8b-m5-control-v1
+CONTROL_MAX_TIER ?= 2k
+
+m5-control-plan:  ## Plan the Qwen3-8B self-conversion without downloading or converting
+	uv run --offline --no-sync --extra mlx llmtracefx-m5-control plan --conversion-manifest $(M5_CONTROL_CONVERSION_MANIFEST) --source-path $(M5_CONTROL_SOURCE) --output-path $(M5_CONTROL_OUTPUT) --conversion-workspace $(M5_CONTROL_CONVERSION_WORKSPACE)
+
+m5-control-convert:  ## Download the official Qwen3-8B source and self-convert it once (no retry)
+	uv run --extra mlx llmtracefx-m5-control convert --conversion-manifest $(M5_CONTROL_CONVERSION_MANIFEST) --source-path $(M5_CONTROL_SOURCE) --output-path $(M5_CONTROL_OUTPUT) --conversion-workspace $(M5_CONTROL_CONVERSION_WORKSPACE)
+
+m5-control-bind:  ## Materialize a bound control manifest from a completed conversion receipt
+	uv run --extra mlx llmtracefx-m5-control bind --control-template $(M5_CONTROL_TEMPLATE) --receipt $(M5_CONTROL_CONVERSION_WORKSPACE)/conversion-receipt.json --output $(M5_CONTROL_MANIFEST)
+
+m5-control-run:  ## Resume the subprocess-isolated benchmark against the bound manifest
+	uv run --extra mlx llmtracefx-m5-control run --manifest $(M5_CONTROL_MANIFEST) --workspace $(M5_CONTROL_WORKSPACE) --model-path $(M5_CONTROL_OUTPUT) --max-tier $(CONTROL_MAX_TIER)
+
+m5-control-verify:  ## Verify pinned model files and evidence bindings
+	uv run --extra mlx llmtracefx-m5-control verify --manifest $(M5_CONTROL_MANIFEST) --workspace $(M5_CONTROL_WORKSPACE) --model-path $(M5_CONTROL_OUTPUT)
+
+m5-control-report:  ## Rebuild self-contained control/tune/compare reports
+	uv run --extra mlx llmtracefx-m5-control report --manifest $(M5_CONTROL_MANIFEST) --workspace $(M5_CONTROL_WORKSPACE)
 
 metal-evidence:  ## Capture privacy-safe Metal evidence (requires OUTPUT_DIR)
 	@test -n "$(OUTPUT_DIR)" || { echo "OUTPUT_DIR is required" >&2; exit 2; }

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -109,6 +109,14 @@ composite score.
 - `tests/optimizer/_tune_fixtures.py`: builds `workloads run`-shaped artifact trees for tests.
 - **No real Qwen3.8-27B benchmark results exist.** No performance number may be presented as
   measured. There are no customers, no pricing, and no third-party endorsements to cite.
+- **No real Qwen3-8B M5 Pro self-conversion or benchmark results exist.** The planned, preparatory
+  self-conversion control (`llmtracefx-m5-control`, `llmtracefx/optimizer/lab/qwen3_8b/`) ships its
+  conversion/benchmark manifests, subprocess-isolated runner, and offline tests; the packaged
+  benchmark manifest is a template only (deliberately missing the output file hashes) until a real
+  conversion produces a receipt to bind it from -- no fabricated hash may ever be committed to fill
+  that gap. The one real attempt so far was refused by the pre-conversion safety gate before any
+  download (see the committed refusal artifact in `examples/optimizer/qwen3-8b-m5-control/`);
+  execution remains blocked pending a clean reboot and a passing safe preflight.
 - The older public Modal analyzer endpoint and video-led synthetic dashboard walkthrough have been
   removed from the current README. Legacy analyzer code remains for compatibility but is not the
   primary product path.

--- a/examples/optimizer/qwen3-8b-m5-control/README.md
+++ b/examples/optimizer/qwen3-8b-m5-control/README.md
@@ -1,0 +1,107 @@
+# Qwen3-8B M5 Pro self-conversion control (planned, preparatory)
+
+**Status: no conversion or benchmark has run yet.** This directory ships the
+offline framework -- manifests, the self-conversion runner, the bound-manifest
+binder, the subprocess-isolated benchmark runner, and their tests -- for a
+*future* self-converted Qwen3-8B positive control. It is not the pinned
+Qwen3.8-27B lab in `../m5-pro-qwen3.8-27b/`, and unlike that lab, no model has
+been downloaded, converted, or benchmarked here: the one real attempt on this
+machine so far was refused before any download by the pre-conversion safety
+gate (see `conversion-preflight-refusal-example.json` below). Execution
+remains blocked pending a clean reboot and a passing safe preflight.
+
+Once it does run, this control is intended to self-convert the official,
+public, ungated `Qwen/Qwen3-8B` at `b968826d9c46dd6066d109eabc6255188de91218`
+(Apache-2.0) with this repository's own pinned `mlx-lm==0.31.3`
+(`ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd`), using explicit, recorded
+quantization parameters: `quantize=true`, `q_group_size=64`, `q_bits=4`,
+`q_mode=affine`. It is designed to never claim byte-equivalence with any
+third-party conversion (e.g. `mlx-community`); a completed run
+cryptographically binds its own source revision, converter revision, and
+output file hashes instead. None of that has happened yet.
+
+Every manifest, cache path, and CLI entrypoint here (`llmtracefx-m5-control`)
+lives in its own `qwen3-8b` namespace, fully separate from the packaged 27B
+lab's `llmtracefx-m5-lab`/`llmtracefx-m5-frontier` artifacts.
+
+## Commands
+
+```bash
+# Default: offline plan only. No download or conversion.
+make m5-control-plan
+
+# Self-convert the official source once. Never retried automatically.
+# Refuses before any download if the live safety gate is not satisfied.
+make m5-control-convert
+
+# Materialize a bound benchmark manifest from a completed conversion receipt.
+make m5-control-bind
+
+# Resume the subprocess-isolated benchmark, starting at 2K.
+make m5-control-run
+
+# Request gated escalation through 8K and 16K.
+make m5-control-run CONTROL_MAX_TIER=16k
+
+# Re-verify model/evidence bindings and render reports.
+make m5-control-verify
+make m5-control-report
+```
+
+Local weights, prompts, raw responses, and absolute-path-bearing artifacts
+live under `.cache/llmtracefx/` and `.cache/models/` and are ignored by Git.
+Only sanitized aggregate evidence and self-contained reports are suitable to
+copy into this example directory -- and only once a real conversion and
+benchmark run have actually produced them.
+
+## How this is designed to differ from the 27B lab, once it runs
+
+- **Self-converted, not pinned pre-quantized.** The 27B lab downloads an
+  already-quantized `mlx-community` checkpoint byte-for-byte. This control is
+  designed to download the official *unquantized* source and run the
+  conversion itself, in a fresh, no-shell subprocess/process group with a
+  bounded timeout and TERM->KILL cleanup escalation; it is never retried
+  automatically, and a live safety gate (chip, memory, swap, free disk,
+  installed converter version) must pass before any download or subprocess
+  launch.
+- **Requested vs. actual tokenizer counts.** The workload catalog's context
+  tiers target an approximate, model-independent token count. This control's
+  own mlx-lm chat template (`enable_thinking=false`) and tokenizer generally
+  produce a different *actual* input token count than that *requested*
+  target; every tier is designed to report both, never conflated.
+- **Per-row subprocess isolation.** Every warmup and every measured
+  repetition is designed to run in its own fresh subprocess and process
+  group, with a parent-enforced wall-clock timeout independent of the
+  collector's own cooperative in-process timeout.
+- **Not comparable to the 27B lab.** Different model, different quantized
+  checkpoint, different memory/timing envelope. Any future report from this
+  control would only show completion under the host state actually observed
+  during that run.
+
+## What would be measured, once a run exists
+
+Identical evidence surface to the 27B lab: host wall-clock phase timings,
+requested/actual input and generated token counts, decode tokens/second,
+MLX allocator active/cache/peak memory when exposed by the runtime,
+deterministic structured-extraction and reasoning evaluator results, pass
+rate, and correct cases per minute. Missing measurements would remain `null`.
+No GPU utilization, bandwidth, power, energy, or kernel timing is measured or
+inferred. None of this has been produced yet.
+
+## Recorded refusal on this machine
+
+`conversion-preflight-refusal-example.json` is a sanitized **refusal
+artifact**, not benchmark evidence: it records that the live, conservative
+pre-conversion safety gate refused with the host at 39.0% free memory
+(40.0% required) before any download, conversion, or benchmark attempt.
+No model weights were downloaded, no conversion subprocess was started, no
+retry was attempted, and no existing cache was created, deleted, or
+modified. `memory_free_percent`/`swap_used_bytes` are macOS
+`memory_pressure`/`sysctl` host memory headroom, not free GPU memory. This
+reflects only the host state observed at one point in time on one machine.
+
+No `evidence-summary.json` or `report.html` exists in this directory: those
+require an actual self-conversion and benchmark run on real M5 Pro hardware,
+which has not happened. Populate them (and rewrite this section as recorded
+*results*, not a refusal) only after `make m5-control-convert && make
+m5-control-bind && make m5-control-run` actually complete.

--- a/examples/optimizer/qwen3-8b-m5-control/conversion-preflight-refusal-example.json
+++ b/examples/optimizer/qwen3-8b-m5-control/conversion-preflight-refusal-example.json
@@ -1,0 +1,36 @@
+{
+  "artifact_type": "conversion_preflight_refusal",
+  "schema_version": "1",
+  "conversion_id": "qwen3-8b-mlx-q4g64-self-convert-v1",
+  "phase": "pre_conversion_safety",
+  "status": "safety_blocked",
+  "downloads_performed": false,
+  "conversion_process_started": false,
+  "retried": false,
+  "cache_modified": false,
+  "blockers": [
+    "memory free 39% is below 40%"
+  ],
+  "safety_thresholds": {
+    "required_chip": "Apple M5 Pro",
+    "required_total_memory_bytes": 25769803776,
+    "minimum_memory_free_percent": 40.0,
+    "maximum_swap_used_bytes": 12884901888,
+    "required_free_disk_bytes": 128395428637
+  },
+  "observed": {
+    "chip": "Apple M5 Pro",
+    "os_name": "Darwin",
+    "architecture": "arm64",
+    "total_memory_bytes": 25769803776,
+    "memory_free_percent": 39.0,
+    "swap_used_bytes": 10148705730,
+    "disk_free_bytes": 721039908864
+  },
+  "limitations": [
+    "This is a refusal artifact produced by the pre-conversion safety gate before any download, conversion, or benchmark ran; it is not benchmark evidence and contains no performance measurement.",
+    "memory_free_percent and swap_used_bytes are derived from macOS memory_pressure/sysctl host memory headroom, not free GPU memory or MLX allocator state.",
+    "This reflects only the host state observed at one point in time on one machine and is not a claim about any other machine, or about this machine at a different time.",
+    "No model weights were downloaded, no conversion subprocess was started, no retry was attempted, and no existing cache was created, deleted, or modified."
+  ]
+}

--- a/llmtracefx/optimizer/lab/core.py
+++ b/llmtracefx/optimizer/lab/core.py
@@ -403,7 +403,7 @@ def _binding(
         model_revision=manifest.model.revision,
         tokenizer_revision=manifest.model.revision,
         quantization=manifest.model.quantization,
-        model_family="qwen3_5",
+        model_family=manifest.model.model_family,
         timeout_seconds=manifest.cooperative_timeout_seconds,
         warmup_repetitions=manifest.repetitions.warmup_per_tier,
         measured_repetitions=(
@@ -887,7 +887,7 @@ def _record_matches_manifest(
         model_revision=manifest.model.revision,
         tokenizer_revision=manifest.model.revision,
         quantization=manifest.model.quantization,
-        model_family="qwen3_5",
+        model_family=manifest.model.model_family,
         max_tokens=manifest.generation.max_output_tokens,
         seed=manifest.generation.seed,
         temperature=manifest.generation.temperature,
@@ -903,7 +903,7 @@ def _record_matches_manifest(
         and record.model.model_revision == manifest.model.revision
         and record.model.tokenizer_revision == manifest.model.revision
         and record.model.quantization == manifest.model.quantization
-        and record.model.model_family == "qwen3_5"
+        and record.model.model_family == manifest.model.model_family
         and record.runtime.name == manifest.runtime.name
         and record.runtime.version == manifest.runtime.version
         and record.platform.accelerator == manifest.safety.required_chip
@@ -931,9 +931,13 @@ def _environment_errors(
     expected = {
         "mlx": manifest.runtime.mlx_version,
         "mlx-lm": manifest.runtime.mlx_lm_version,
-        "mlx-vlm": manifest.runtime.version,
         "transformers": manifest.runtime.transformers_version,
     }
+    # The runtime's own package (``manifest.runtime.name``, e.g. "mlx-vlm"
+    # for the VLM-based 27B lab or "mlx-lm" for a plain mlx-lm control) is
+    # keyed dynamically so this check generalizes to any pinned runtime
+    # package instead of assuming "mlx-vlm" is always present.
+    expected[manifest.runtime.name] = manifest.runtime.version
     errors = [
         f"{package} recorded as {versions.get(package)!r}, expected {version!r}"
         for package, version in expected.items()

--- a/llmtracefx/optimizer/lab/manifest.py
+++ b/llmtracefx/optimizer/lab/manifest.py
@@ -122,6 +122,13 @@ class ModelPin:
     expected_download_bytes: int
     files: tuple[ModelFilePin, ...]
     sources: tuple[str, ...]
+    model_family: str = "qwen3_5"
+    """The mlx-lm/mlx-vlm model-family identifier this pin's checkpoint
+    loads as (for example ``mlx_lm/models/qwen3_5.py``'s ``qwen3_5``, or
+    plain ``qwen3`` for a dense non-MTP mlx-lm checkpoint such as a
+    self-converted Qwen3-8B). Optional and defaulted to the historical
+    ``"qwen3_5"`` so every manifest packaged before this field existed
+    keeps parsing to the exact identity it always resolved to."""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ModelPin:
@@ -162,6 +169,9 @@ class ModelPin:
             raise LabManifestError(
                 "model.expected_download_bytes must equal the pinned file sizes"
             )
+        model_family_raw = data.get("model_family", "qwen3_5")
+        if not isinstance(model_family_raw, str) or not model_family_raw:
+            raise LabManifestError("model.model_family must be a non-empty string")
         return cls(
             official_id=_string(data, "official_id", context),
             official_revision=_git_revision(
@@ -182,6 +192,7 @@ class ModelPin:
             expected_download_bytes=expected_download_bytes,
             files=files,
             sources=tuple(sources_raw),
+            model_family=model_family_raw,
         )
 
 

--- a/llmtracefx/optimizer/lab/qwen3_8b/__init__.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/__init__.py
@@ -1,0 +1,25 @@
+"""Qwen3-8B M5 Pro self-conversion control -- planned, preparatory.
+
+**No conversion or benchmark has run yet.** This subpackage ships the
+offline framework (manifests, self-conversion runner, bound-manifest
+binder, subprocess-isolated benchmark runner) for a future self-converted
+Qwen3-8B positive control; it is intended to eventually serve that role,
+but nothing here should be read as a claim that a conversion, benchmark,
+or comparison has actually completed.
+
+This subpackage is deliberately isolated from the packaged Qwen3.8-27B
+lab (``llmtracefx.optimizer.lab.manifest``/``core``/``frontier``/
+``autopsy``): every packaged manifest, cache path, workspace path, and
+CLI entrypoint here lives in its own ``qwen3-8b`` namespace so nothing in
+this subpackage can read, write, or overwrite the 27B artifacts.
+
+Unlike the 27B lab, which pins an already-quantized ``mlx-community``
+checkpoint byte-for-byte, this control is designed to self-convert the
+official, public, ungated ``Qwen/Qwen3-8B`` checkpoint with the
+repository's own pinned ``mlx-lm`` using explicit, recorded quantization
+parameters. It is designed to never claim byte-equivalence with any
+third-party conversion; see ``conversion_manifest.py`` for the exact
+provenance recorded once a real conversion exists.
+"""
+
+from __future__ import annotations

--- a/llmtracefx/optimizer/lab/qwen3_8b/benchmark.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/benchmark.py
@@ -1,0 +1,781 @@
+"""Subprocess-isolated benchmark runner for the Qwen3-8B M5 Pro control.
+
+This differs from the packaged 27B lab's ``lab.core.run_lab`` in exactly
+the ways this control requires and the 27B lab does not:
+
+* every warmup and every measured repetition runs in its own fresh,
+  no-shell subprocess and process group (``run_lab`` executes an entire
+  tiered sweep in one long-lived process);
+* a parent-enforced wall-clock timeout with TERM->KILL escalation wraps
+  each of those subprocesses, independent of ``collect_mlx``'s own
+  cooperative in-process timeout;
+* the checkpoint's own mlx-lm chat template (``enable_thinking=false``)
+  tokenizes every prompt, so each row's *actual* tokenizer count is
+  tracked next to the workload catalog's *requested* target-tier token
+  count instead of assuming they coincide;
+* a run mode gate (``exploratory`` by default; ``publication`` only with
+  an explicit clean-boot assertion) matches ``lab.frontier``'s pattern.
+
+It otherwise deliberately reuses the load-bearing pieces of the 27B lab
+unmodified: ``LabManifest`` parsing/validation, ``verify_model``/
+``verify_catalog``/``assess_safety``, the workload catalog and
+deterministic prompt materialization, the safe evaluators and MLX
+collector (both reached through ``workloads.verify.execute_row``, which
+this module's child subprocess calls directly), and the tune/compare/
+report layers in ``lab.core`` once results are written in the exact
+directory shape ``lab.core`` already expects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ...collectors._shared import atomic_write_text, config_hash
+from ...schema import ExperimentRecord, utc_now_iso
+from ...workloads.catalog import workload_by_id
+from ...workloads.materialize import MaterializedPrompt, materialize_prompt
+from ...workloads.matrix import DECODE_MODE_AUTOREGRESSIVE, MatrixEntry
+from ...workloads.schema import ContextTier
+from ...workloads.verify import RowResult, RowStatus, RowVerification, execute_row
+from ..core import (
+    LabError,
+    _binding,
+    _peak_bytes,
+    _record_matches_manifest,
+    _tier_is_safe,
+    assess_safety,
+    verify_catalog,
+    verify_model,
+)
+from ..frontier import _clean_process_group
+from ..manifest import LabManifest
+from .runtime import Qwen3ChatMLXLMRuntime
+
+BENCHMARK_STATE_SCHEMA_VERSION = "1"
+RUN_MODES = ("exploratory", "publication")
+DEFAULT_ROW_TIMEOUT_SECONDS = 300.0
+DEFAULT_CLEANUP_GRACE_SECONDS = 15.0
+
+
+def _row_run_id(
+    workload_id: str, tier: ContextTier, *, warmup: bool, index: int
+) -> str:
+    label = "warmup" if warmup else "rep"
+    return f"{workload_id}-{tier.value}-{label}-{index + 1:02d}"
+
+
+def _control_entry(
+    manifest: LabManifest,
+    *,
+    workload_id: str,
+    tier: ContextTier,
+    repetition_index: int,
+    prompt: MaterializedPrompt,
+    prompt_path: Path,
+    output_dir: Path,
+    warmup: bool,
+) -> MatrixEntry:
+    run_id = _row_run_id(workload_id, tier, warmup=warmup, index=repetition_index)
+    return MatrixEntry(
+        run_id=run_id,
+        workload_id=workload_id,
+        workload_version=workload_by_id(workload_id).version,
+        category=workload_by_id(workload_id).category.value,
+        context_tier=tier.value,
+        decode_mode=DECODE_MODE_AUTOREGRESSIVE,
+        configured_depth=None,
+        prompt=prompt,
+        prompt_path=str(prompt_path.resolve()),
+        runner_results_dir=str((output_dir / "runner" / run_id).resolve()),
+        collector_output_dir=str(
+            (output_dir / "runs" / run_id / "collection").resolve()
+        ),
+        runnable=True,
+        unsupported_reason=None,
+        command_argv=("llmtracefx-m5-control", "run"),
+        max_tokens=manifest.generation.max_output_tokens,
+    )
+
+
+def _write_prompt(path: Path, prompt: MaterializedPrompt) -> None:
+    atomic_write_text(path, prompt.text)
+
+
+def _row_is_ok(result: RowResult) -> bool:
+    """Whether a row's evidence is trustworthy *and* task-successful.
+
+    A row whose collector status is ``COMPLETED``/``SKIPPED`` but whose
+    evaluator reported ``outcome_success=False`` executed cleanly but
+    failed the task -- an evaluator failure, not merely an infrastructure
+    one. It must gate exactly like any other failed row (stop immediately,
+    warmup or measured, never let the tier or the next tier pass), so it
+    is never treated as "ok" here even though its collector status looks
+    like success.
+    """
+    return (
+        result.verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+        and result.verification.outcome_success is True
+    )
+
+
+def _evaluator_failure_blockers(results: tuple[RowResult, ...]) -> tuple[str, ...]:
+    return tuple(
+        f"{result.entry.run_id} completed but the evaluator reported "
+        "outcome_success=False (task quality failure)"
+        for result in results
+        if result.verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+        and result.verification.outcome_success is False
+    )
+
+
+def _row_result_from_disk(entry: MatrixEntry, *, output_dir: Path) -> RowResult | None:
+    run_dir = output_dir / "runs" / entry.run_id
+    verification_path = run_dir / "verification.json"
+    if not verification_path.is_file():
+        return None
+    verification = RowVerification.read_json(verification_path)
+    record = (
+        ExperimentRecord.read_json(run_dir / "final_record.json")
+        if verification.final_record_path is not None
+        and (run_dir / "final_record.json").is_file()
+        else None
+    )
+    return RowResult(entry=entry, verification=verification, final_record=record)
+
+
+def _synthetic_failure_result(
+    entry: MatrixEntry, *, reason: str, started_at: str
+) -> RowResult:
+    verification = RowVerification(
+        schema_version="2",
+        run_id=entry.run_id,
+        workload_id=entry.workload_id,
+        workload_version=entry.workload_version,
+        category=entry.category,
+        context_tier=entry.context_tier,
+        decode_mode=entry.decode_mode,
+        status=RowStatus.FAILED,
+        reason=reason,
+        recorded_prompt_hash=entry.prompt.prompt_hash,
+        verified_prompt_hash=None,
+        run_binding_hash=None,
+        resumed=False,
+        outcome_success=False,
+        quality_score=None,
+        total_ms=None,
+        started_at=started_at,
+        ended_at=utc_now_iso(),
+        final_record_path=None,
+        collection_dir=None,
+    )
+    return RowResult(entry=entry, verification=verification, final_record=None)
+
+
+class ChildLaunchResult:
+    """Outcome of one row's isolated child subprocess."""
+
+    __slots__ = ("exit_code", "timed_out", "descendants_cleaned")
+
+    def __init__(
+        self, *, exit_code: int | None, timed_out: bool, descendants_cleaned: bool
+    ):
+        self.exit_code = exit_code
+        self.timed_out = timed_out
+        self.descendants_cleaned = descendants_cleaned
+
+
+def launch_row_subprocess(
+    *,
+    manifest_path: Path,
+    workload_id: str,
+    tier: ContextTier,
+    repetition_index: int,
+    warmup: bool,
+    model_path: Path,
+    output_dir: Path,
+    resume: bool,
+    timeout_seconds: float,
+    cleanup_grace_seconds: float,
+) -> ChildLaunchResult:
+    argv = [
+        sys.executable,
+        "-m",
+        "llmtracefx.optimizer.lab.qwen3_8b.benchmark",
+        "_child",
+        "--manifest",
+        str(manifest_path),
+        "--workload-id",
+        workload_id,
+        "--tier",
+        tier.value,
+        "--repetition-index",
+        str(repetition_index),
+        "--model-path",
+        str(model_path),
+        "--output-dir",
+        str(output_dir),
+        "--warmup" if warmup else "--no-warmup",
+        "--resume" if resume else "--no-resume",
+    ]
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        shell=False,
+    )
+    process_group = process.pid
+    timed_out = False
+    try:
+        process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+    descendants_cleaned = _clean_process_group(
+        process, process_group, cleanup_grace_seconds
+    )
+    if process.poll() is None:
+        try:
+            process.wait(timeout=cleanup_grace_seconds)
+        except subprocess.TimeoutExpired:
+            descendants_cleaned = False
+    return ChildLaunchResult(
+        exit_code=process.returncode,
+        timed_out=timed_out,
+        descendants_cleaned=descendants_cleaned,
+    )
+
+
+def _run_row_isolated(
+    manifest: LabManifest,
+    *,
+    manifest_path: Path,
+    workload_id: str,
+    tier: ContextTier,
+    repetition_index: int,
+    warmup: bool,
+    model_path: Path,
+    output_dir: Path,
+    resume: bool,
+    timeout_seconds: float,
+    cleanup_grace_seconds: float,
+    launcher: Callable[..., ChildLaunchResult],
+) -> RowResult:
+    started_at = utc_now_iso()
+    entry_tier_value = tier.value
+    run_id = _row_run_id(workload_id, tier, warmup=warmup, index=repetition_index)
+    child = launcher(
+        manifest_path=manifest_path,
+        workload_id=workload_id,
+        tier=tier,
+        repetition_index=repetition_index,
+        warmup=warmup,
+        model_path=model_path,
+        output_dir=output_dir,
+        resume=resume,
+        timeout_seconds=timeout_seconds,
+        cleanup_grace_seconds=cleanup_grace_seconds,
+    )
+    workload = workload_by_id(workload_id)
+    prompt = materialize_prompt(workload, tier)
+    fallback_entry = MatrixEntry(
+        run_id=run_id,
+        workload_id=workload_id,
+        workload_version=workload.version,
+        category=workload.category.value,
+        context_tier=entry_tier_value,
+        decode_mode=DECODE_MODE_AUTOREGRESSIVE,
+        configured_depth=None,
+        prompt=prompt,
+        prompt_path="",
+        runner_results_dir="",
+        collector_output_dir="",
+        runnable=True,
+        unsupported_reason=None,
+        command_argv=("llmtracefx-m5-control", "run"),
+        max_tokens=manifest.generation.max_output_tokens,
+    )
+    if child.timed_out:
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=f"row {run_id} exceeded its {timeout_seconds:g}s parent-enforced timeout",
+            started_at=started_at,
+        )
+    if not child.descendants_cleaned:
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=f"row {run_id} process-group cleanup failed after TERM/KILL escalation",
+            started_at=started_at,
+        )
+    if child.exit_code not in (0, None):
+        # A non-zero exit means the child process itself errored (an
+        # uncaught exception, an import failure, etc.), not that
+        # ``execute_row`` cleanly recorded a row failure. Never trust
+        # whatever verification.json happens to exist at that path in
+        # this case -- it could be stale evidence left over from an
+        # earlier, unrelated attempt; treat this purely as a failure
+        # instead of ever reading the child's own claimed artifact.
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=(
+                f"row {run_id} child exited with a non-zero status "
+                f"({child.exit_code}); its own written evidence, if any, "
+                "is never trusted after a crash"
+            ),
+            started_at=started_at,
+        )
+    result = _row_result_from_disk(fallback_entry, output_dir=output_dir)
+    if result is None:
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=(
+                f"row {run_id} child exited (code {child.exit_code}) without "
+                "writing supported evidence"
+            ),
+            started_at=started_at,
+        )
+    verification = result.verification
+    expected_identity = (
+        run_id,
+        workload_id,
+        workload.version,
+        tier.value,
+        DECODE_MODE_AUTOREGRESSIVE,
+    )
+    observed_identity = (
+        verification.run_id,
+        verification.workload_id,
+        verification.workload_version,
+        verification.context_tier,
+        verification.decode_mode,
+    )
+    if observed_identity != expected_identity:
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=f"row {run_id} child artifact identity is stale or mismatched",
+            started_at=started_at,
+        )
+    if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED) and (
+        result.final_record is None
+        or not _record_matches_manifest(
+            manifest,
+            verification,
+            result.final_record,
+            warmup=warmup,
+            allowed_tiers={tier.value},
+        )
+    ):
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=f"row {run_id} child artifact binding is stale or mismatched",
+            started_at=started_at,
+        )
+    if (
+        verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+        and verification.outcome_success is None
+    ):
+        return _synthetic_failure_result(
+            fallback_entry,
+            reason=f"row {run_id} child artifact lacks evaluator evidence",
+            started_at=started_at,
+        )
+    return result
+
+
+def run_child_row(
+    manifest: LabManifest,
+    *,
+    workload_id: str,
+    tier: ContextTier,
+    repetition_index: int,
+    warmup: bool,
+    model_path: Path,
+    output_dir: Path,
+    manifest_dir: Path,
+    resume: bool,
+    hardware_fingerprint: str,
+) -> RowResult:
+    """Executed inside the isolated child subprocess: build the exact same
+    ``MatrixEntry``/``RunBinding`` the parent would have, then reuse
+    ``execute_row`` verbatim (safe evaluators, MLX collector, resume-by-
+    hash, atomic artifact writes)."""
+    workload = workload_by_id(workload_id)
+    prompt = materialize_prompt(workload, tier)
+    prompt_path = manifest_dir / "prompts" / f"{workload_id}-{tier.value}.txt"
+    _write_prompt(prompt_path, prompt)
+    entry = _control_entry(
+        manifest,
+        workload_id=workload_id,
+        tier=tier,
+        repetition_index=repetition_index,
+        prompt=prompt,
+        prompt_path=prompt_path,
+        output_dir=output_dir,
+        warmup=warmup,
+    )
+    binding = _binding(
+        manifest,
+        model_path,
+        repetition_index=repetition_index,
+        hardware_fingerprint=hardware_fingerprint,
+        measured_repetitions=(
+            max(manifest.repetitions.warmup_per_tier, 1)
+            if warmup
+            else manifest.repetitions.measured_per_workload
+        ),
+    )
+
+    def runtime_factory() -> Qwen3ChatMLXLMRuntime:
+        return Qwen3ChatMLXLMRuntime(
+            temperature=manifest.generation.temperature,
+            top_p=manifest.generation.top_p,
+            enable_thinking=manifest.generation.enable_thinking,
+        )
+
+    return execute_row(
+        entry,
+        manifest_dir=manifest_dir,
+        output_dir=output_dir,
+        model_id=manifest.model.repository_id,
+        binding=binding,
+        resume=resume,
+        runtime_factory=runtime_factory,
+    )
+
+
+def run_benchmark(
+    manifest: LabManifest,
+    *,
+    manifest_path: Path,
+    workspace: Path,
+    model_path: Path,
+    max_tier: str,
+    run_mode: str = "exploratory",
+    clean_boot_confirmed: bool = False,
+    resume: bool = True,
+    row_timeout_seconds: float = DEFAULT_ROW_TIMEOUT_SECONDS,
+    cleanup_grace_seconds: float = DEFAULT_CLEANUP_GRACE_SECONDS,
+    launcher: Callable[..., ChildLaunchResult] = launch_row_subprocess,
+) -> dict[str, Any]:
+    if run_mode not in RUN_MODES:
+        raise LabError(f"unsupported run mode {run_mode!r}")
+    if run_mode == "publication" and not clean_boot_confirmed:
+        raise LabError(
+            "publication mode requires the operator assertion --confirm-clean-boot"
+        )
+    if run_mode == "exploratory" and clean_boot_confirmed:
+        raise LabError("--confirm-clean-boot is only valid in publication mode")
+
+    verify_catalog(manifest)
+    verify_model(manifest, model_path)
+    preflight = assess_safety(manifest, workspace, include_download=False)
+    if not preflight.safe:
+        raise LabError(
+            "benchmark run blocked by safety preflight: "
+            + "; ".join(preflight.blockers)
+        )
+
+    selected_max = manifest.tier(max_tier)
+    tiers = tuple(
+        tier for tier in manifest.context_tiers if tier.order <= selected_max.order
+    )
+    hardware_fingerprint = config_hash(
+        {
+            "os_name": preflight.snapshot.os_name,
+            "os_release": preflight.snapshot.os_release,
+            "architecture": preflight.snapshot.architecture,
+            "python_implementation": preflight.snapshot.python_implementation,
+            "python_version": preflight.snapshot.python_version,
+            "cpu_count": preflight.snapshot.cpu_count,
+            "chip": preflight.snapshot.chip,
+            "total_memory_bytes": preflight.snapshot.total_memory_bytes,
+            "package_versions": preflight.snapshot.package_versions,
+        }
+    )
+
+    state: dict[str, Any] = {
+        "schema_version": BENCHMARK_STATE_SCHEMA_VERSION,
+        "lab_id": manifest.lab_id,
+        "run_mode": run_mode,
+        "clean_boot_confirmed": clean_boot_confirmed,
+        "started_at": utc_now_iso(),
+        "status": "running",
+        "requested_max_tier": max_tier,
+        "preflight": preflight.to_dict(),
+        "tiers": [],
+        "stopped_before_tier": None,
+        "stopped_during": None,
+        "unattempted_tiers": [],
+        "stop_reasons": [],
+    }
+    state["execution_id"] = config_hash(
+        {
+            "lab_id": manifest.lab_id,
+            "started_at": state["started_at"],
+            "hardware_fingerprint": hardware_fingerprint,
+            "run_mode": run_mode,
+        }
+    )
+    workspace.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        workspace / "state.json", json.dumps(state, indent=2, sort_keys=False) + "\n"
+    )
+
+    results_root = workspace / "results"
+
+    for tier_pin in tiers:
+        tier = ContextTier(tier_pin.name)
+        tier_preflight = assess_safety(manifest, workspace, include_download=False)
+        if not tier_preflight.safe:
+            state["stopped_before_tier"] = tier.value
+            state["unattempted_tiers"] = [
+                candidate.name
+                for candidate in manifest.context_tiers
+                if tier_pin.order <= candidate.order <= selected_max.order
+            ]
+            state["stop_reasons"] = list(tier_preflight.blockers)
+            break
+
+        warmup_results: list[RowResult] = []
+        if manifest.repetitions.warmup_per_tier:
+            warmup_workload_id = manifest.workloads[0].workload_id
+            for index in range(manifest.repetitions.warmup_per_tier):
+                result = _run_row_isolated(
+                    manifest,
+                    manifest_path=manifest_path,
+                    workload_id=warmup_workload_id,
+                    tier=tier,
+                    repetition_index=index,
+                    warmup=True,
+                    model_path=model_path,
+                    output_dir=workspace / "warmups" / tier.value,
+                    resume=False,
+                    timeout_seconds=row_timeout_seconds,
+                    cleanup_grace_seconds=cleanup_grace_seconds,
+                    launcher=launcher,
+                )
+                warmup_results.append(result)
+                if manifest.safety.stop_on_any_failed_row and not _row_is_ok(result):
+                    break
+
+        if any(not _row_is_ok(result) for result in warmup_results):
+            reasons = [
+                result.verification.reason
+                or (
+                    f"{result.entry.run_id} completed but the evaluator "
+                    "reported outcome_success=False (task quality failure)"
+                    if result.verification.status
+                    in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+                    else f"{result.entry.run_id} ended as {result.verification.status.value}"
+                )
+                for result in warmup_results
+                if not _row_is_ok(result)
+            ]
+            state["tiers"].append(
+                {
+                    "tier": tier.value,
+                    "status": "failed_warmup",
+                    "run_ids": [result.entry.run_id for result in warmup_results],
+                    "maximum_observed_peak_memory_bytes": max(
+                        (
+                            peak
+                            for result in warmup_results
+                            if (peak := _peak_bytes(result)) is not None
+                        ),
+                        default=None,
+                    ),
+                    "postflight": assess_safety(
+                        manifest, workspace, include_download=False
+                    ).to_dict(),
+                    "blockers": reasons,
+                }
+            )
+            state["stopped_during"] = {"tier": tier.value, "phase": "warmup"}
+            state["unattempted_tiers"] = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stop_reasons"] = reasons
+            break
+
+        warmup_postflight = assess_safety(manifest, workspace, include_download=False)
+        warmup_safe, warmup_blockers = _tier_is_safe(
+            manifest, tuple(warmup_results), warmup_postflight
+        )
+        warmup_evaluator_blockers = _evaluator_failure_blockers(tuple(warmup_results))
+        if warmup_evaluator_blockers:
+            warmup_safe = False
+            warmup_blockers = tuple(warmup_blockers) + warmup_evaluator_blockers
+        if not warmup_safe:
+            state["tiers"].append(
+                {
+                    "tier": tier.value,
+                    "status": "failed_warmup_safety",
+                    "run_ids": [result.entry.run_id for result in warmup_results],
+                    "maximum_observed_peak_memory_bytes": max(
+                        (
+                            peak
+                            for result in warmup_results
+                            if (peak := _peak_bytes(result)) is not None
+                        ),
+                        default=None,
+                    ),
+                    "postflight": warmup_postflight.to_dict(),
+                    "blockers": list(warmup_blockers),
+                }
+            )
+            state["stopped_during"] = {"tier": tier.value, "phase": "warmup_safety"}
+            state["unattempted_tiers"] = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stop_reasons"] = list(warmup_blockers)
+            break
+
+        tier_results: list[RowResult] = []
+        stopped = False
+        for workload_pin in manifest.workloads:
+            for index in range(manifest.repetitions.measured_per_workload):
+                result = _run_row_isolated(
+                    manifest,
+                    manifest_path=manifest_path,
+                    workload_id=workload_pin.workload_id,
+                    tier=tier,
+                    repetition_index=index,
+                    warmup=False,
+                    model_path=model_path,
+                    output_dir=results_root,
+                    resume=resume,
+                    timeout_seconds=row_timeout_seconds,
+                    cleanup_grace_seconds=cleanup_grace_seconds,
+                    launcher=launcher,
+                )
+                tier_results.append(result)
+                if manifest.safety.stop_on_any_failed_row and not _row_is_ok(result):
+                    stopped = True
+                    break
+            if stopped:
+                break
+
+        postflight = assess_safety(manifest, workspace, include_download=False)
+        safe, blockers = _tier_is_safe(manifest, tuple(tier_results), postflight)
+        evaluator_blockers = _evaluator_failure_blockers(tuple(tier_results))
+        if evaluator_blockers:
+            safe = False
+            blockers = tuple(blockers) + evaluator_blockers
+        state["tiers"].append(
+            {
+                "tier": tier.value,
+                "status": "passed" if safe else "failed",
+                "run_ids": [result.entry.run_id for result in tier_results],
+                "maximum_observed_peak_memory_bytes": max(
+                    (
+                        peak
+                        for result in tier_results
+                        if (peak := _peak_bytes(result)) is not None
+                    ),
+                    default=None,
+                ),
+                "postflight": postflight.to_dict(),
+                "blockers": list(blockers),
+            }
+        )
+        atomic_write_text(
+            workspace / "state.json",
+            json.dumps(state, indent=2, sort_keys=False) + "\n",
+        )
+        if not safe:
+            remaining = [
+                later.name
+                for later in manifest.context_tiers
+                if later.order > tier_pin.order and later.order <= selected_max.order
+            ]
+            state["stopped_before_tier"] = remaining[0] if remaining else None
+            state["stopped_during"] = {
+                "tier": tier.value,
+                "phase": "measured_or_postflight",
+            }
+            state["unattempted_tiers"] = remaining
+            state["stop_reasons"] = list(blockers)
+            break
+
+    state["ended_at"] = utc_now_iso()
+    state["status"] = "stopped" if state["stop_reasons"] else "completed"
+    atomic_write_text(
+        workspace / "state.json", json.dumps(state, indent=2, sort_keys=False) + "\n"
+    )
+    return state
+
+
+def _read_manifest(path: Path) -> LabManifest:
+    return LabManifest.read_json(path)
+
+
+def _child_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="qwen3-8b-benchmark-child")
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--workload-id", required=True)
+    parser.add_argument("--tier", required=True)
+    parser.add_argument("--repetition-index", required=True, type=int)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--warmup", dest="warmup", action="store_true")
+    parser.add_argument("--no-warmup", dest="warmup", action="store_false")
+    parser.add_argument("--resume", dest="resume", action="store_true")
+    parser.add_argument("--no-resume", dest="resume", action="store_false")
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    manifest = _read_manifest(manifest_path)
+    output_dir = Path(args.output_dir)
+    manifest_dir = manifest_path.parent
+    preflight = assess_safety(manifest, manifest_dir, include_download=False)
+    if not preflight.safe:
+        raise LabError(
+            "isolated row blocked by safety preflight: " + "; ".join(preflight.blockers)
+        )
+    hardware_fingerprint = config_hash(
+        {
+            "os_name": preflight.snapshot.os_name,
+            "os_release": preflight.snapshot.os_release,
+            "architecture": preflight.snapshot.architecture,
+            "python_implementation": preflight.snapshot.python_implementation,
+            "python_version": preflight.snapshot.python_version,
+            "cpu_count": preflight.snapshot.cpu_count,
+            "chip": preflight.snapshot.chip,
+            "total_memory_bytes": preflight.snapshot.total_memory_bytes,
+            "package_versions": preflight.snapshot.package_versions,
+        }
+    )
+    run_child_row(
+        manifest,
+        workload_id=args.workload_id,
+        tier=ContextTier(args.tier),
+        repetition_index=args.repetition_index,
+        warmup=args.warmup,
+        model_path=Path(args.model_path),
+        output_dir=output_dir,
+        manifest_dir=manifest_dir,
+        resume=args.resume,
+        hardware_fingerprint=hardware_fingerprint,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = sys.argv[1:] if argv is None else argv
+    if raw_argv[:1] == ["_child"]:
+        return _child_main(raw_argv[1:])
+    raise SystemExit("this module only supports the internal `_child` action")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llmtracefx/optimizer/lab/qwen3_8b/cli.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/cli.py
@@ -1,0 +1,326 @@
+"""Command line entrypoint for the planned Qwen3-8B M5 Pro control.
+
+Packaged as ``llmtracefx-m5-control`` (see ``pyproject.toml``), fully
+namespace-separated from ``llmtracefx-m5-lab``/``llmtracefx-m5-frontier``:
+every default manifest, cache path, and workspace path here lives under
+a ``qwen3-8b`` prefix so nothing this CLI does can read, write, or
+overwrite the packaged Qwen3.8-27B lab's artifacts. No conversion or
+benchmark has run on any machine yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+
+from ...collectors._shared import atomic_write_text
+from ..core import LabError, model_files_present, verify_catalog, verify_model
+from ..manifest import LabManifest, LabManifestError
+from .benchmark import run_benchmark
+from .control_manifest import (
+    ControlManifestError,
+    ControlManifestTemplate,
+    bind_control_manifest,
+    build_bound_manifest_payload,
+)
+from .conversion import (
+    ConversionError,
+    ConversionReceipt,
+    assess_conversion_safety,
+    run_conversion,
+    source_cache_has_existing_content,
+)
+from .conversion_manifest import ConversionManifest, ConversionManifestError
+from .report import verify_control_evidence, write_control_reports
+
+DEFAULT_CONVERSION_MANIFEST_RESOURCE = "data/qwen3-8b-conversion-manifest-v1.json"
+DEFAULT_CONTROL_TEMPLATE_RESOURCE = "data/qwen3-8b-control-manifest-template-v1.json"
+
+
+def _packaged_text(name: str) -> str:
+    resource = resources.files("llmtracefx.optimizer.lab.qwen3_8b").joinpath(name)
+    return resource.read_text(encoding="utf-8")
+
+
+def _load_conversion_manifest(path: str | None) -> tuple[ConversionManifest, str]:
+    if path is None:
+        payload = _packaged_text(DEFAULT_CONVERSION_MANIFEST_RESOURCE)
+        return (
+            ConversionManifest.from_json(payload),
+            f"package:llmtracefx.optimizer.lab.qwen3_8b/{DEFAULT_CONVERSION_MANIFEST_RESOURCE}",
+        )
+    return ConversionManifest.read_json(Path(path)), str(path)
+
+
+def _load_control_template(path: str | None) -> tuple[ControlManifestTemplate, str]:
+    if path is None:
+        payload = _packaged_text(DEFAULT_CONTROL_TEMPLATE_RESOURCE)
+        return (
+            ControlManifestTemplate.from_json(payload),
+            f"package:llmtracefx.optimizer.lab.qwen3_8b/{DEFAULT_CONTROL_TEMPLATE_RESOURCE}",
+        )
+    return ControlManifestTemplate.read_json(Path(path)), str(path)
+
+
+def _cmd_plan(args: argparse.Namespace) -> int:
+    conversion, conversion_source = _load_conversion_manifest(args.conversion_manifest)
+    source_path = Path(args.source_path or conversion.artifacts.source_cache)
+    output_path = Path(args.output_path or conversion.artifacts.output_cache)
+    conversion_workspace = Path(
+        args.conversion_workspace or conversion.artifacts.workspace
+    )
+    conversion_decision = assess_conversion_safety(
+        conversion,
+        conversion_workspace,
+        include_source_download=not source_cache_has_existing_content(source_path),
+    )
+    receipt_path = conversion_workspace / "conversion-receipt.json"
+    payload = {
+        "action": "plan",
+        "no_spend": True,
+        "downloads_performed": False,
+        "conversion_manifest": conversion_source,
+        "conversion_id": conversion.conversion_id,
+        "source_path": str(source_path),
+        "output_path": str(output_path),
+        "conversion_workspace": str(conversion_workspace),
+        "source_fully_pinned": conversion.source.fully_pinned,
+        "output_already_present": output_path.exists(),
+        "conversion_receipt_present": receipt_path.is_file(),
+        "model": {
+            "official_id": conversion.source.official_id,
+            "official_revision": conversion.source.official_revision,
+            "expected_source_bytes": conversion.source.expected_source_bytes,
+            "expected_output_bytes": conversion.expected_output_bytes,
+            "converter": conversion.converter.package,
+            "converter_version": conversion.converter.version,
+            "converter_git_revision": conversion.converter.git_revision,
+        },
+        "required_free_disk_bytes": conversion_decision.required_free_disk_bytes,
+        "observed_free_disk_bytes": conversion_decision.snapshot.disk_free_bytes,
+        "conversion_safety": conversion_decision.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=False))
+    return 0 if conversion_decision.safe else 2
+
+
+def _cmd_convert(args: argparse.Namespace) -> int:
+    conversion, _ = _load_conversion_manifest(args.conversion_manifest)
+    source_path = Path(args.source_path or conversion.artifacts.source_cache)
+    output_path = Path(args.output_path or conversion.artifacts.output_cache)
+    workspace = Path(args.conversion_workspace or conversion.artifacts.workspace)
+    journal = run_conversion(
+        conversion,
+        source_path=source_path,
+        output_path=output_path,
+        workspace=workspace,
+    )
+    print(json.dumps(journal, indent=2, sort_keys=False))
+    return 0 if journal["status"] == "completed" else 2
+
+
+def _cmd_bind(args: argparse.Namespace) -> int:
+    if args.receipt is None or args.output is None:
+        raise ControlManifestError("bind requires both --receipt and --output")
+    conversion, _ = _load_conversion_manifest(args.conversion_manifest)
+    template, _ = _load_control_template(args.control_template)
+    receipt = ConversionReceipt.read_json(Path(args.receipt))
+    payload = build_bound_manifest_payload(
+        template, receipt, conversion_manifest=conversion
+    )
+    bound = LabManifest.from_dict(payload)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        output_path, json.dumps(payload, indent=2, sort_keys=False) + "\n"
+    )
+    print(
+        json.dumps(
+            {
+                "action": "bind",
+                "manifest_path": str(output_path),
+                "lab_id": bound.lab_id,
+                "model_binding_fingerprint": bound.model.revision,
+                "model_binding_fingerprint_type": (
+                    "self_conversion_identity_fingerprint_not_a_git_commit"
+                ),
+                "output_total_bytes": bound.model.expected_download_bytes,
+            },
+            indent=2,
+            sort_keys=False,
+        )
+    )
+    return 0
+
+
+def _load_bound_manifest(args: argparse.Namespace) -> tuple[LabManifest, str]:
+    if args.manifest is not None:
+        return LabManifest.read_json(Path(args.manifest)), str(args.manifest)
+    if args.receipt is not None:
+        conversion, _ = _load_conversion_manifest(args.conversion_manifest)
+        template, _ = _load_control_template(args.control_template)
+        receipt = ConversionReceipt.read_json(Path(args.receipt))
+        bound = bind_control_manifest(template, receipt, conversion_manifest=conversion)
+        return bound, f"bound-from-receipt:{args.receipt}"
+    raise LabError(
+        "either --manifest (an already-bound control manifest) or --receipt "
+        "(a completed conversion receipt to bind on the fly) is required"
+    )
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    manifest, _ = _load_bound_manifest(args)
+    manifest_path = Path(args.manifest) if args.manifest is not None else None
+    if manifest_path is None:
+        raise LabError(
+            "run requires --manifest pointing at a materialized bound "
+            "manifest file (each isolated row subprocess re-reads it); "
+            "use `bind` first if you only have a receipt"
+        )
+    workspace = Path(args.workspace or manifest.artifacts.workspace)
+    model_path = Path(args.model_path or manifest.artifacts.model_cache)
+    verify_catalog(manifest)
+    if not model_files_present(manifest, model_path):
+        raise LabError(
+            "the self-converted model is not present at the expected path; "
+            "run `convert` (and `bind`) first"
+        )
+    verify_model(manifest, model_path)
+    state = run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=model_path,
+        max_tier=args.max_tier,
+        run_mode=args.run_mode,
+        clean_boot_confirmed=args.confirm_clean_boot,
+        resume=not args.no_resume,
+        row_timeout_seconds=args.row_timeout_seconds,
+    )
+    report = write_control_reports(
+        manifest,
+        workspace=workspace,
+        shareable_dir=(
+            Path(args.shareable_dir)
+            if args.shareable_dir
+            else Path(manifest.artifacts.shareable_example_dir)
+        ),
+    )
+    print(json.dumps({"state": state, "report": report}, indent=2, sort_keys=False))
+    return 0 if not state["stop_reasons"] else 2
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    manifest, _ = _load_bound_manifest(args)
+    workspace = Path(args.workspace or manifest.artifacts.workspace)
+    report = write_control_reports(
+        manifest,
+        workspace=workspace,
+        shareable_dir=(
+            Path(args.shareable_dir)
+            if args.shareable_dir
+            else Path(manifest.artifacts.shareable_example_dir)
+        ),
+    )
+    print(json.dumps(report, indent=2, sort_keys=False))
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    manifest, _ = _load_bound_manifest(args)
+    workspace = Path(args.workspace or manifest.artifacts.workspace)
+    model_path = Path(args.model_path or manifest.artifacts.model_cache)
+    verify_model(manifest, model_path)
+    result = verify_control_evidence(manifest, workspace=workspace)
+    print(json.dumps(result, indent=2, sort_keys=False))
+    return 0 if result["verified"] else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="llmtracefx-m5-control",
+        description=(
+            "Planned, preparatory Qwen3-8B MLX-LM self-conversion control for "
+            "the M5 Pro lab (no conversion or benchmark has run yet), fully "
+            "namespace-separated from the packaged Qwen3.8-27B lab. The "
+            "default action is an offline/no-download plan."
+        ),
+    )
+    parser.add_argument(
+        "action",
+        nargs="?",
+        default="plan",
+        choices=("plan", "convert", "bind", "run", "report", "verify"),
+    )
+    parser.add_argument("--conversion-manifest", default=None)
+    parser.add_argument("--control-template", default=None)
+    parser.add_argument("--source-path", default=None)
+    parser.add_argument("--output-path", default=None)
+    parser.add_argument("--conversion-workspace", default=None)
+    parser.add_argument(
+        "--receipt", default=None, help="Path to a completed conversion-receipt.json"
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Destination path for `bind`'s materialized control manifest",
+    )
+    parser.add_argument(
+        "--manifest", default=None, help="Path to an already-bound control manifest"
+    )
+    parser.add_argument("--workspace", default=None)
+    parser.add_argument("--model-path", default=None)
+    parser.add_argument(
+        "--max-tier",
+        choices=("2k", "8k", "16k"),
+        default="2k",
+        help="Highest requested tier; every prior tier must pass its safety gate",
+    )
+    parser.add_argument(
+        "--run-mode",
+        choices=("exploratory", "publication"),
+        default="exploratory",
+        help="`publication` requires --confirm-clean-boot",
+    )
+    parser.add_argument("--confirm-clean-boot", action="store_true")
+    parser.add_argument("--no-resume", action="store_true")
+    parser.add_argument(
+        "--row-timeout-seconds",
+        type=float,
+        default=300.0,
+        help="Parent-enforced wall-clock bound for each isolated row subprocess",
+    )
+    parser.add_argument("--shareable-dir", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    commands = {
+        "plan": _cmd_plan,
+        "convert": _cmd_convert,
+        "bind": _cmd_bind,
+        "run": _cmd_run,
+        "report": _cmd_report,
+        "verify": _cmd_verify,
+    }
+    try:
+        return commands[args.action](args)
+    except (
+        OSError,
+        UnicodeError,
+        LabManifestError,
+        LabError,
+        ConversionManifestError,
+        ConversionError,
+        ControlManifestError,
+    ) as exc:
+        print(f"M5 control failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llmtracefx/optimizer/lab/qwen3_8b/control_manifest.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/control_manifest.py
@@ -1,0 +1,296 @@
+"""The Qwen3-8B benchmark/control manifest: a template bound from a receipt.
+
+The packaged control-manifest template intentionally omits
+``model.files``, ``model.expected_download_bytes``, and
+``model.revision``: those three fields can only be known once a real
+self-conversion has actually produced and hashed output files, and this
+project never commits fabricated hashes to make a manifest "look"
+complete. ``bind_control_manifest`` fills them in from a verified
+``ConversionReceipt`` and returns a fully valid
+``llmtracefx.optimizer.lab.manifest.LabManifest`` -- the exact same
+class the packaged 27B lab manifest parses as, so every existing
+``lab.core`` verification/report/evidence function keeps working
+unmodified against it.
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ..._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+    reject_non_finite_json_constant,
+)
+from ..manifest import LabManifest, LabManifestError
+from .conversion import ConversionReceipt, conversion_manifest_hash
+from .conversion_manifest import ConversionManifest
+
+CONTROL_MANIFEST_TEMPLATE_SCHEMA_VERSION = "1"
+
+#: ``model`` fields a template must NOT carry: they can only be known
+#: from a verified, completed conversion receipt (see module docstring).
+_PENDING_MODEL_FIELDS = ("files", "expected_download_bytes", "revision")
+
+#: Placeholder used only to validate every *other* template section
+#: through the real ``LabManifest`` parser without ever writing a fake
+#: hash anywhere persistent. Never returned to a caller.
+_PROBE_FILE_SHA256 = "0" * 64
+_PROBE_REVISION = "0" * 40
+
+
+class ControlManifestError(ValueError):
+    """Raised when the control manifest template or a bind attempt is invalid."""
+
+
+def _probe_model(model_template: dict[str, Any]) -> dict[str, Any]:
+    probe = copy.deepcopy(model_template)
+    probe["files"] = [
+        {"path": "PENDING-CONVERSION", "size_bytes": 1, "sha256": _PROBE_FILE_SHA256}
+    ]
+    probe["expected_download_bytes"] = 1
+    probe["revision"] = _PROBE_REVISION
+    return probe
+
+
+class ControlManifestTemplate:
+    """A control-manifest template, valid in every section but ``model``'s
+    conversion-derived identity, which is bound in later from a receipt."""
+
+    def __init__(self, raw: dict[str, Any]) -> None:
+        self._raw = raw
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ControlManifestTemplate:
+        if not isinstance(data, dict):
+            raise ControlManifestError("control manifest template must be an object")
+        schema_version = data.get("schema_version")
+        if schema_version != CONTROL_MANIFEST_TEMPLATE_SCHEMA_VERSION:
+            raise ControlManifestError(
+                "unsupported control manifest template schema_version "
+                f"{schema_version!r}"
+            )
+        model_template = data.get("model")
+        if not isinstance(model_template, dict):
+            raise ControlManifestError(
+                "control manifest template.model must be an object"
+            )
+        present_pending_fields = [
+            field for field in _PENDING_MODEL_FIELDS if field in model_template
+        ]
+        if present_pending_fields:
+            raise ControlManifestError(
+                "control manifest template.model must not pre-commit "
+                f"{present_pending_fields}; those are only known after a "
+                "verified conversion receipt is bound"
+            )
+        # Validate every other section (runtime/generation/repetitions/
+        # safety/workloads/context_tiers/artifacts/environment_capture)
+        # through the real, load-bearing LabManifest parser by injecting
+        # a clearly-fake, never-persisted probe identity. This reuses the
+        # existing manifest validators completely instead of duplicating
+        # them, and it never risks a real hash being read from this path.
+        probe = dict(data)
+        probe["model"] = _probe_model(model_template)
+        try:
+            LabManifest.from_dict(probe)
+        except LabManifestError as exc:
+            raise ControlManifestError(
+                f"control manifest template is invalid: {exc}"
+            ) from exc
+        return cls(data)
+
+    @classmethod
+    def from_json(cls, payload: str) -> ControlManifestTemplate:
+        try:
+            data = json.loads(payload, parse_constant=reject_non_finite_json_constant)
+        except (ValueError, RecursionError) as exc:
+            raise ControlManifestError(
+                f"invalid control manifest template JSON: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> ControlManifestTemplate:
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise ControlManifestError(
+                f"invalid control manifest template file: {exc}"
+            ) from exc
+        return cls.from_json(payload)
+
+    def to_dict(self) -> dict[str, Any]:
+        return copy.deepcopy(self._raw)
+
+
+def _synthetic_revision(receipt: ConversionReceipt) -> str:
+    """A deterministic 40-hex identity fingerprint for one self-converted
+    output, used exactly like ``ModelPin.revision`` is used elsewhere: to
+    detect a stale or drifted binding, never as a claim of an upstream
+    git commit. Documented in the bound manifest's own sources list.
+
+    Callers must never present this value as an upstream git commit
+    hash; it is a locally derived fingerprint of the conversion
+    identity (see ``binding_revision_provenance`` in ``report.py``),
+    coincidentally sharing a git-revision-shaped 40-hex-character
+    encoding only because ``ModelPin.revision`` requires that shape.
+    """
+    payload = {
+        "conversion_id": receipt.conversion_id,
+        "source_official_revision": receipt.source["official_revision"],
+        "converter_git_revision": receipt.converter["git_revision"],
+        "converter_version": receipt.converter["version"],
+        "parameters": receipt.parameters,
+        "output_files": [dict(item) for item in receipt.output_files],
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return digest[:40]
+
+
+def _provenance_mismatches(
+    receipt: ConversionReceipt, conversion_manifest: ConversionManifest
+) -> tuple[str, ...]:
+    """Every field where the receipt disagrees with the packaged spec.
+
+    A receipt binds only if it describes *this exact* pinned official
+    source identity, converter identity, conversion ID, and full
+    quantization parameter set -- never a receipt that merely has the
+    right shape.
+    """
+    mismatches: list[str] = []
+
+    def check(label: str, actual: Any, expected: Any) -> None:
+        if actual != expected:
+            mismatches.append(f"{label}: receipt has {actual!r}, expected {expected!r}")
+
+    check(
+        "source.official_id",
+        receipt.source.get("official_id"),
+        conversion_manifest.source.official_id,
+    )
+    check(
+        "source.official_revision",
+        receipt.source.get("official_revision"),
+        conversion_manifest.source.official_revision,
+    )
+    check(
+        "source.license",
+        receipt.source.get("license"),
+        conversion_manifest.source.license,
+    )
+    check(
+        "converter.package",
+        receipt.converter.get("package"),
+        conversion_manifest.converter.package,
+    )
+    check(
+        "converter.version",
+        receipt.converter.get("version"),
+        conversion_manifest.converter.version,
+    )
+    check(
+        "converter.git_revision",
+        receipt.converter.get("git_revision"),
+        conversion_manifest.converter.git_revision,
+    )
+    check("conversion_id", receipt.conversion_id, conversion_manifest.conversion_id)
+    check(
+        "parameters",
+        receipt.parameters,
+        dataclasses.asdict(conversion_manifest.parameters),
+    )
+    check(
+        "conversion_manifest_hash",
+        receipt.conversion_manifest_hash,
+        conversion_manifest_hash(conversion_manifest),
+    )
+    return tuple(mismatches)
+
+
+def build_bound_manifest_payload(
+    template: ControlManifestTemplate,
+    receipt: ConversionReceipt,
+    *,
+    conversion_manifest: ConversionManifest,
+) -> dict[str, Any]:
+    """The plain JSON-shaped dict a bound control manifest would contain.
+
+    Exposed separately from ``bind_control_manifest`` so callers that
+    need to persist the exact bound manifest to disk (the ``bind`` CLI
+    action) never have to reconstruct ``model.files``/``revision`` by
+    hand from the returned ``LabManifest`` -- there is exactly one place
+    that assembles this shape.
+    """
+    if receipt.status != "completed":
+        raise ControlManifestError(
+            "cannot bind a control manifest from a non-completed conversion receipt"
+        )
+    mismatches = _provenance_mismatches(receipt, conversion_manifest)
+    if mismatches:
+        raise ControlManifestError(
+            "conversion receipt provenance does not match the packaged "
+            "conversion spec, refusing to bind: " + "; ".join(mismatches)
+        )
+    data = template.to_dict()
+    model = dict(data["model"])
+    model["files"] = [
+        {
+            "path": item["path"],
+            "size_bytes": item["size_bytes"],
+            "sha256": item["sha256"],
+        }
+        for item in receipt.output_files
+    ]
+    model["expected_download_bytes"] = receipt.output_total_bytes
+    model["revision"] = _synthetic_revision(receipt)
+    data["model"] = model
+    return data
+
+
+def bind_control_manifest(
+    template: ControlManifestTemplate,
+    receipt: ConversionReceipt,
+    *,
+    conversion_manifest: ConversionManifest,
+) -> LabManifest:
+    """Fill in ``model.files``/``expected_download_bytes``/``revision``
+    from a verified, completed conversion receipt and return a fully
+    valid ``LabManifest``.
+
+    ``conversion_manifest`` is the packaged (or explicitly pinned)
+    conversion spec this receipt claims to be the output of. Binding is
+    refused if the receipt's official source ID/revision/license,
+    converter package/version/git revision, conversion ID, or full
+    quantization parameters differ from it in any way -- a receipt with
+    the right *shape* but the wrong *identity* must never silently bind.
+
+    Raises ``ControlManifestError`` if the receipt is not a completed
+    conversion, if its provenance disagrees with ``conversion_manifest``,
+    or if binding still produces an internally inconsistent manifest
+    (``LabManifest.from_dict`` re-validates everything).
+    """
+    data = build_bound_manifest_payload(
+        template, receipt, conversion_manifest=conversion_manifest
+    )
+    try:
+        return LabManifest.from_dict(data)
+    except LabManifestError as exc:
+        raise ControlManifestError(f"bound control manifest is invalid: {exc}") from exc
+
+
+__all__ = [
+    "CONTROL_MANIFEST_TEMPLATE_SCHEMA_VERSION",
+    "ControlManifestError",
+    "ControlManifestTemplate",
+    "bind_control_manifest",
+    "build_bound_manifest_payload",
+]

--- a/llmtracefx/optimizer/lab/qwen3_8b/conversion.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/conversion.py
@@ -1,0 +1,778 @@
+"""Self-conversion runner for the planned Qwen3-8B M5 Pro control.
+
+No conversion has completed on any machine yet; this module is the
+offline framework for one. A live, conservative safety gate (chip,
+physical memory, free memory percent, swap, free disk, installed
+converter version) must pass, with no network call, subprocess launch,
+or filesystem write to any cache/output path, before anything else
+happens. Only once that gate and a pre-existing-output check both pass
+does this download (or reuse a verified local cache of) the official
+Qwen3-8B checkpoint and convert it with the repository's own pinned
+``mlx-lm``, in a fresh, no-shell subprocess/process group with a
+parent-enforced bounded timeout and TERM->KILL cleanup escalation. On
+success, the converted output directory is recursively inventoried
+(regular files only; symlinks and unsafe paths are rejected) and a
+conversion receipt is written. On any failure -- a refused safety gate,
+non-zero exit, timeout, or cleanup failure -- a bounded, privacy-safe
+failure record is written instead; this module never retries
+automatically and never deletes or overwrites an existing cache or
+output directory on the caller's behalf.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+from ..._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+)
+from ...collectors._shared import atomic_write_text, config_hash
+from ..core import HostSnapshot, collect_host_snapshot
+from ..frontier import _clean_process_group
+from .conversion_manifest import ConversionManifest
+
+CONVERSION_RECEIPT_SCHEMA_VERSION = "1"
+CONVERSION_JOURNAL_SCHEMA_VERSION = "1"
+
+
+class ConversionError(RuntimeError):
+    """Raised when a conversion cannot proceed or cannot be trusted."""
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def source_files_present(manifest: ConversionManifest, source_path: Path) -> bool:
+    """Whether every pinned source file already exists at the expected size."""
+    return all(
+        (source_path / pin.path).is_file()
+        and not (source_path / pin.path).is_symlink()
+        and (source_path / pin.path).stat().st_size == pin.size_bytes
+        for pin in manifest.source.files
+    )
+
+
+def verify_source(manifest: ConversionManifest, source_path: Path) -> dict[str, Any]:
+    """Verify a local source directory against every pinned file.
+
+    Files with no pinned SHA-256 (``SourceFilePin.sha256 is None``) are
+    size-checked only; the returned payload marks them
+    ``"exactly_pinned": false`` so callers never mistake a size-only
+    match for a byte-identical one. Symlinks and unpinned root entries
+    are rejected the same way ``lab.core.verify_model`` rejects them.
+    """
+    failures: list[str] = []
+    files: list[dict[str, Any]] = []
+    expected_paths = {pin.path for pin in manifest.source.files}
+    if source_path.is_dir():
+        unexpected = sorted(
+            path.name
+            for path in source_path.iterdir()
+            if path.name != ".cache" and path.name not in expected_paths
+        )
+        failures.extend(f"unpinned source-root entry: {name}" for name in unexpected)
+    for pin in manifest.source.files:
+        path = source_path / pin.path
+        if not path.is_file() or path.is_symlink():
+            failures.append(f"missing regular source file: {pin.path}")
+            continue
+        size = path.stat().st_size
+        if size != pin.size_bytes:
+            failures.append(f"{pin.path} size {size} does not match {pin.size_bytes}")
+            continue
+        digest = _sha256_file(path)
+        if digest != pin.sha256:
+            failures.append(f"{pin.path} sha256 {digest} does not match {pin.sha256}")
+            continue
+        files.append(
+            {
+                "path": pin.path,
+                "size_bytes": size,
+                "sha256": digest,
+                "exactly_pinned": True,
+            }
+        )
+    result = {
+        "schema_version": "1",
+        "official_id": manifest.source.official_id,
+        "official_revision": manifest.source.official_revision,
+        "verified": not failures,
+        "fully_pinned": manifest.source.fully_pinned,
+        "failures": failures,
+        "files": files,
+    }
+    if failures:
+        raise ConversionError("source verification failed: " + "; ".join(failures))
+    return result
+
+
+def source_cache_has_existing_content(source_path: Path) -> bool:
+    return source_path.is_dir() and any(source_path.iterdir())
+
+
+def acquire_source(
+    manifest: ConversionManifest, *, source_path: Path, workspace: Path
+) -> dict[str, Any]:
+    """Download the pinned official source, reusing a verified cache.
+
+    ``source_path`` is trusted only after every pinned file verifies
+    exactly (``verify_source``). If anything already exists at
+    ``source_path`` -- any file or subdirectory at all, not only a
+    complete, correctly sized set -- and that content fails
+    verification, this refuses (``ConversionError`` propagates) instead
+    of falling through to a network write that would land on top of a
+    possibly corrupt or stale cache. A network download is only
+    attempted when ``source_path`` does not exist yet or is empty.
+    ``source_path`` itself is never deleted or overwritten by this
+    function.
+    """
+    if source_cache_has_existing_content(source_path):
+        return verify_source(manifest, source_path)
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise ConversionError(
+            "huggingface-hub is required; install the `mlx` extra"
+        ) from exc
+    downloaded = Path(
+        snapshot_download(
+            repo_id=manifest.source.repository_id,
+            revision=manifest.source.official_revision,
+            local_dir=source_path,
+            allow_patterns=[pin.path for pin in manifest.source.files],
+        )
+    )
+    result = verify_source(manifest, downloaded)
+    workspace.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        workspace / "source-verification.json",
+        json.dumps(result, indent=2, sort_keys=False) + "\n",
+    )
+    return result
+
+
+def _installed_version(distribution: str) -> str | None:
+    try:
+        return importlib_metadata.version(distribution)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+@dataclass(frozen=True)
+class ConversionSafetyDecision:
+    safe: bool
+    blockers: tuple[str, ...]
+    snapshot: HostSnapshot
+    required_free_disk_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "safe": self.safe,
+            "blockers": list(self.blockers),
+            "snapshot": self.snapshot.to_dict(),
+            "required_free_disk_bytes": self.required_free_disk_bytes,
+            "observed_free_disk_bytes": self.snapshot.disk_free_bytes,
+        }
+
+
+def assess_conversion_safety(
+    manifest: ConversionManifest,
+    path: Path,
+    *,
+    include_source_download: bool,
+) -> ConversionSafetyDecision:
+    """Preflight check reusing ``lab.core.collect_host_snapshot`` verbatim.
+
+    ``required_free_disk_bytes`` is always
+    ``safety.minimum_residual_free_disk_bytes + expected_output_bytes``,
+    plus ``source.expected_source_bytes`` on top of that when
+    ``include_source_download`` is true (a source that still needs
+    downloading). This is deliberately conservative: it is the disk this
+    conversion could still need to write, not an estimate of what is
+    already cached.
+    """
+    snapshot = collect_host_snapshot(path)
+    blockers: list[str] = []
+    required_free = (
+        manifest.safety.minimum_residual_free_disk_bytes
+        + manifest.expected_output_bytes
+    )
+    if include_source_download:
+        required_free += manifest.source.expected_source_bytes
+    if snapshot.disk_free_bytes < required_free:
+        blockers.append(
+            f"disk free {snapshot.disk_free_bytes} bytes is below required "
+            f"{required_free} bytes"
+        )
+    if snapshot.os_name != "Darwin" or snapshot.architecture != "arm64":
+        blockers.append("self-conversion requires Apple Silicon macOS")
+    if snapshot.chip != manifest.safety.required_chip:
+        blockers.append(
+            f"chip is {snapshot.chip or 'unavailable'}, expected "
+            f"{manifest.safety.required_chip}"
+        )
+    if snapshot.total_memory_bytes is None:
+        blockers.append("total physical memory could not be measured")
+    elif snapshot.total_memory_bytes != manifest.safety.required_total_memory_bytes:
+        blockers.append(
+            f"physical memory is {snapshot.total_memory_bytes} bytes, expected "
+            f"{manifest.safety.required_total_memory_bytes} bytes"
+        )
+    if snapshot.memory_free_percent is None:
+        blockers.append("current memory headroom could not be measured")
+    elif snapshot.memory_free_percent < manifest.safety.minimum_memory_free_percent:
+        blockers.append(
+            f"memory free {snapshot.memory_free_percent:g}% is below "
+            f"{manifest.safety.minimum_memory_free_percent:g}%"
+        )
+    if snapshot.swap_used_bytes is None:
+        blockers.append("current swap usage could not be measured")
+    elif snapshot.swap_used_bytes > manifest.safety.maximum_swap_used_bytes:
+        blockers.append(
+            f"swap used {snapshot.swap_used_bytes} bytes exceeds "
+            f"{manifest.safety.maximum_swap_used_bytes} bytes"
+        )
+    installed_mlx_lm = snapshot.package_versions.get("mlx-lm")
+    if installed_mlx_lm != manifest.converter.version:
+        blockers.append(
+            f"installed mlx-lm is {installed_mlx_lm or 'not installed'}, expected "
+            f"pinned converter version {manifest.converter.version}"
+        )
+    return ConversionSafetyDecision(
+        safe=not blockers,
+        blockers=tuple(blockers),
+        snapshot=snapshot,
+        required_free_disk_bytes=required_free,
+    )
+
+
+def _bounded_tail(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[-max_bytes:].decode("utf-8", errors="replace")
+
+
+def _argv(manifest: ConversionManifest, *, hf_path: Path, mlx_path: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "mlx_lm",
+        *manifest.parameters.argv(hf_path=str(hf_path), mlx_path=str(mlx_path)),
+    ]
+
+
+def _unsafe_output_reason(root: Path, entry: Path) -> str | None:
+    try:
+        resolved = entry.resolve()
+        resolved_root = root.resolve()
+    except OSError:
+        return "path could not be resolved"
+    if resolved_root not in resolved.parents and resolved != resolved_root:
+        return "escapes the output directory"
+    return None
+
+
+def _inventory_output(output_path: Path) -> tuple[dict[str, Any], ...]:
+    """Recursively inventory regular output files; reject symlinks/unsafe paths."""
+    entries: list[dict[str, Any]] = []
+    for entry in sorted(output_path.rglob("*")):
+        if entry.is_dir():
+            continue
+        if entry.is_symlink():
+            raise ConversionError(f"conversion output contains a symlink: {entry}")
+        unsafe = _unsafe_output_reason(output_path, entry)
+        if unsafe is not None:
+            raise ConversionError(
+                f"conversion output path is unsafe ({unsafe}): {entry}"
+            )
+        if not entry.is_file():
+            raise ConversionError(
+                f"conversion output contains a non-regular file: {entry}"
+            )
+        relative = entry.relative_to(output_path)
+        entries.append(
+            {
+                "path": str(relative),
+                "size_bytes": entry.stat().st_size,
+                "sha256": _sha256_file(entry),
+            }
+        )
+    if not entries:
+        raise ConversionError("conversion output directory is empty")
+    return tuple(entries)
+
+
+def _required_string(data: dict[str, Any], key: str, *, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ConversionError(
+            f"conversion receipt {context}.{key} must be a non-empty string"
+        )
+    return value
+
+
+def _required_object(data: dict[str, Any], key: str, *, context: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict) or not value:
+        raise ConversionError(
+            f"conversion receipt {context}.{key} must be a non-empty object"
+        )
+    return value
+
+
+def _required_positive_int(data: dict[str, Any], key: str, *, context: str) -> int:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ConversionError(
+            f"conversion receipt {context}.{key} must be a positive integer"
+        )
+    return value
+
+
+def _required_sha256(value: Any, *, context: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise ConversionError(
+            f"conversion receipt {context} must be a lowercase SHA-256 hex digest"
+        )
+    return value
+
+
+def _required_relative_path(value: Any, *, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ConversionError(
+            f"conversion receipt {context} must be a non-empty string"
+        )
+    candidate = Path(value)
+    if (
+        candidate.is_absolute()
+        or ".." in candidate.parts
+        or any(part in ("", ".") for part in candidate.parts)
+    ):
+        raise ConversionError(
+            f"conversion receipt {context} must be a safe relative path: {value!r}"
+        )
+    return value
+
+
+def _validate_output_file_entry(item: Any, *, index: int) -> dict[str, Any]:
+    context = f"output_files[{index}]"
+    if not isinstance(item, dict):
+        raise ConversionError(f"conversion receipt {context} must be an object")
+    return {
+        "path": _required_relative_path(item.get("path"), context=f"{context}.path"),
+        "size_bytes": _required_positive_int(item, "size_bytes", context=context),
+        "sha256": _required_sha256(item.get("sha256"), context=f"{context}.sha256"),
+    }
+
+
+#: Sub-keys that must be present (identity, not full typing) on a
+#: receipt's ``source``/``converter``/``parameters`` objects so a receipt
+#: can never bind against a packaged spec it does not actually describe.
+_RECEIPT_SOURCE_IDENTITY_KEYS = ("official_id", "official_revision", "license")
+_RECEIPT_CONVERTER_IDENTITY_KEYS = ("package", "version", "git_revision")
+_RECEIPT_PARAMETER_KEYS = (
+    "quantize",
+    "q_group_size",
+    "q_bits",
+    "q_mode",
+    "dtype",
+    "quant_predicate",
+    "dequantize",
+    "trust_remote_code",
+    "upload_repo",
+)
+
+
+@dataclass(frozen=True)
+class ConversionReceipt:
+    """The durable, verifiable record of one completed self-conversion.
+
+    Strictly typed and bounded on parse: every output file entry is a
+    unique, safe, repository-relative path with a positive size and a
+    lowercase SHA-256 digest, the recorded total equals their sum, and
+    the ``source``/``converter``/``parameters`` identity sub-keys this
+    binds against later must actually be present. None of this alone
+    proves the receipt matches a *specific* packaged conversion spec --
+    that cross-check is ``bind_control_manifest``'s job (see
+    ``control_manifest.py``), using ``conversion_manifest_hash`` and the
+    individual identity fields recorded here.
+    """
+
+    schema_version: str
+    conversion_id: str
+    conversion_manifest_hash: str
+    status: str
+    started_at: str
+    ended_at: str
+    source: dict[str, Any]
+    converter: dict[str, Any]
+    parameters: dict[str, Any]
+    argv: tuple[str, ...]
+    output_files: tuple[dict[str, Any], ...]
+    output_total_bytes: int
+    host: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "conversion_id": self.conversion_id,
+            "conversion_manifest_hash": self.conversion_manifest_hash,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "source": self.source,
+            "converter": self.converter,
+            "parameters": self.parameters,
+            "argv": list(self.argv),
+            "output_files": [dict(item) for item in self.output_files],
+            "output_total_bytes": self.output_total_bytes,
+            "host": self.host,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversionReceipt:
+        if not isinstance(data, dict):
+            raise ConversionError("conversion receipt must be an object")
+        if data.get("schema_version") != CONVERSION_RECEIPT_SCHEMA_VERSION:
+            raise ConversionError("unsupported conversion receipt schema_version")
+        if data.get("status") != "completed":
+            raise ConversionError(
+                "conversion receipt does not describe a completed conversion"
+            )
+        conversion_id = _required_string(data, "conversion_id", context="receipt")
+        started_at = _required_string(data, "started_at", context="receipt")
+        ended_at = _required_string(data, "ended_at", context="receipt")
+
+        source = _required_object(data, "source", context="receipt")
+        for key in _RECEIPT_SOURCE_IDENTITY_KEYS:
+            _required_string(source, key, context="receipt.source")
+
+        converter = _required_object(data, "converter", context="receipt")
+        for key in _RECEIPT_CONVERTER_IDENTITY_KEYS:
+            _required_string(converter, key, context="receipt.converter")
+
+        parameters = _required_object(data, "parameters", context="receipt")
+        missing_parameters = [
+            key for key in _RECEIPT_PARAMETER_KEYS if key not in parameters
+        ]
+        if missing_parameters:
+            raise ConversionError(
+                f"conversion receipt.parameters is missing {missing_parameters}"
+            )
+
+        argv_raw = data.get("argv")
+        if not isinstance(argv_raw, list) or not argv_raw:
+            raise ConversionError("conversion receipt.argv must be a non-empty list")
+        if not all(isinstance(item, str) and item for item in argv_raw):
+            raise ConversionError(
+                "conversion receipt.argv must be all non-empty strings"
+            )
+
+        output_files_raw = data.get("output_files")
+        if not isinstance(output_files_raw, list) or not output_files_raw:
+            raise ConversionError("conversion receipt output_files must be non-empty")
+        output_files = tuple(
+            _validate_output_file_entry(item, index=index)
+            for index, item in enumerate(output_files_raw)
+        )
+        paths = [item["path"] for item in output_files]
+        if len(set(paths)) != len(paths):
+            raise ConversionError(
+                "conversion receipt output_files paths must be unique"
+            )
+        output_total_bytes = _required_positive_int(
+            data, "output_total_bytes", context="receipt"
+        )
+        computed_total = sum(item["size_bytes"] for item in output_files)
+        if computed_total != output_total_bytes:
+            raise ConversionError(
+                "conversion receipt output_total_bytes "
+                f"({output_total_bytes}) does not equal the sum of "
+                f"output_files sizes ({computed_total})"
+            )
+
+        host = _required_object(data, "host", context="receipt")
+        manifest_hash = data.get("conversion_manifest_hash")
+        if (
+            not isinstance(manifest_hash, str)
+            or not manifest_hash.startswith("sha256:")
+            or len(manifest_hash) != 71
+            or any(
+                char not in "0123456789abcdef"
+                for char in manifest_hash.removeprefix("sha256:")
+            )
+        ):
+            raise ConversionError(
+                "conversion receipt.conversion_manifest_hash must be a "
+                "sha256:-prefixed lowercase digest"
+            )
+
+        return cls(
+            schema_version=data["schema_version"],
+            conversion_id=conversion_id,
+            conversion_manifest_hash=manifest_hash,
+            status=data["status"],
+            started_at=started_at,
+            ended_at=ended_at,
+            source=source,
+            converter=converter,
+            parameters=parameters,
+            argv=tuple(argv_raw),
+            output_files=output_files,
+            output_total_bytes=output_total_bytes,
+            host=host,
+        )
+
+    @classmethod
+    def read_json(cls, path: Path) -> ConversionReceipt:
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise ConversionError(f"invalid conversion receipt file: {exc}") from exc
+        try:
+            data = json.loads(payload)
+        except ValueError as exc:
+            raise ConversionError(f"invalid conversion receipt JSON: {exc}") from exc
+        return cls.from_dict(data)
+
+
+def run_conversion(
+    manifest: ConversionManifest,
+    *,
+    source_path: Path,
+    output_path: Path,
+    workspace: Path,
+    utc_now: Any = None,
+) -> dict[str, Any]:
+    """Run exactly one self-conversion attempt; never retries automatically.
+
+    Order of operations, all before any network activity or subprocess
+    launch: (1) the live conservative safety gate (chip, physical memory,
+    free memory percent, swap, free disk, installed converter version),
+    which never downloads or converts anything and never deletes or
+    modifies anything on disk; (2) the pre-existing-output-path check.
+    Only once both pass does this acquire (download or verify-in-place)
+    the source and launch the isolated conversion subprocess.
+
+    Returns a bounded, privacy-safe journal dict describing the attempt.
+    On a ``"completed"`` status, ``workspace/conversion-receipt.json`` is
+    also written. On any other status -- including a safety-gate refusal
+    -- a bounded ``workspace/conversion-failure.json`` is written instead
+    and no receipt is produced or implied.
+    """
+    from ...schema import utc_now_iso
+
+    now = utc_now or utc_now_iso
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    # --- Phase 1: live safety gate. No network call, no subprocess, no
+    # write to any cache or output path may happen before this passes. ---
+    include_source_download = not source_cache_has_existing_content(source_path)
+    preflight = assess_conversion_safety(
+        manifest, source_path.parent, include_source_download=include_source_download
+    )
+    if not preflight.safe:
+        journal: dict[str, Any] = {
+            "schema_version": CONVERSION_JOURNAL_SCHEMA_VERSION,
+            "conversion_id": manifest.conversion_id,
+            "conversion_manifest_hash": conversion_manifest_hash(manifest),
+            "phase": "pre_conversion_safety",
+            "status": "safety_blocked",
+            "started_at": now(),
+            "ended_at": now(),
+            "downloads_performed": False,
+            "conversion_process_started": False,
+            "retried": False,
+            "blockers": list(preflight.blockers),
+            "required_free_disk_bytes": preflight.required_free_disk_bytes,
+            "host": preflight.snapshot.to_dict(),
+            "stages": ["pre_conversion_safety"],
+        }
+        atomic_write_text(
+            workspace / "conversion-failure.json",
+            json.dumps(journal, indent=2, sort_keys=False) + "\n",
+        )
+        return journal
+
+    # --- Phase 2: pre-existing-output check, still before any network
+    # activity. Never deletes or overwrites an existing output path. ---
+    if output_path.exists():
+        raise ConversionError(
+            f"conversion output path already exists: {output_path}. This "
+            "project never deletes an existing output directory on the "
+            "caller's behalf; remove or relocate it explicitly first."
+        )
+
+    # --- Phase 3: acquire (download or verify-in-place) the source. Only
+    # reached once the safety gate and output check both passed. ---
+    downloads_performed = include_source_download
+    source_result = acquire_source(
+        manifest, source_path=source_path, workspace=workspace
+    )
+
+    argv = _argv(manifest, hf_path=source_path, mlx_path=output_path)
+    started_at = now()
+    stdout_path = workspace / "convert-stdout.log"
+    stderr_path = workspace / "convert-stderr.log"
+    journal = {
+        "schema_version": CONVERSION_JOURNAL_SCHEMA_VERSION,
+        "conversion_id": manifest.conversion_id,
+        "conversion_manifest_hash": conversion_manifest_hash(manifest),
+        "phase": "conversion_process",
+        "started_at": started_at,
+        "argv": argv,
+        "converter_version_installed": _installed_version("mlx-lm"),
+        "converter_version_expected": manifest.converter.version,
+        "downloads_performed": downloads_performed,
+        "conversion_process_started": True,
+        "retried": False,
+        "stages": ["source_verified", "preflight_passed", "launching"],
+    }
+
+    with (
+        stdout_path.open("wb") as stdout_handle,
+        stderr_path.open("wb") as stderr_handle,
+    ):
+        process = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            start_new_session=True,
+            shell=False,
+        )
+        process_group = process.pid
+        timed_out = False
+        try:
+            process.wait(timeout=manifest.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+        descendants_cleaned = _clean_process_group(
+            process, process_group, manifest.cleanup_grace_seconds
+        )
+        if process.poll() is None:
+            try:
+                process.wait(timeout=manifest.cleanup_grace_seconds)
+            except subprocess.TimeoutExpired:
+                descendants_cleaned = False
+    ended_at = now()
+    exit_code = process.returncode
+    stdout_tail = _bounded_tail(
+        stdout_path.read_text(encoding="utf-8", errors="replace"),
+        manifest.max_journal_bytes // 2,
+    )
+    stderr_tail = _bounded_tail(
+        stderr_path.read_text(encoding="utf-8", errors="replace"),
+        manifest.max_journal_bytes // 2,
+    )
+    journal.update(
+        {
+            "ended_at": ended_at,
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "descendants_cleaned": descendants_cleaned,
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+        }
+    )
+
+    if timed_out:
+        journal["status"] = "timeout"
+    elif not descendants_cleaned:
+        journal["status"] = "cleanup_failed"
+    elif exit_code != 0:
+        journal["status"] = "failed"
+    else:
+        journal["status"] = "completed"
+    journal["stages"].append(journal["status"])
+
+    if journal["status"] != "completed":
+        atomic_write_text(
+            workspace / "conversion-failure.json",
+            json.dumps(journal, indent=2, sort_keys=False) + "\n",
+        )
+        return journal
+
+    try:
+        output_files = _inventory_output(output_path)
+    except ConversionError as exc:
+        journal["status"] = "unsafe_output"
+        journal["stages"].append(journal["status"])
+        journal["unsafe_output_reason"] = str(exc)
+        atomic_write_text(
+            workspace / "conversion-failure.json",
+            json.dumps(journal, indent=2, sort_keys=False) + "\n",
+        )
+        return journal
+    host_snapshot = collect_host_snapshot(workspace)
+    receipt = ConversionReceipt(
+        schema_version=CONVERSION_RECEIPT_SCHEMA_VERSION,
+        conversion_id=manifest.conversion_id,
+        conversion_manifest_hash=conversion_manifest_hash(manifest),
+        status="completed",
+        started_at=started_at,
+        ended_at=ended_at,
+        source={
+            "official_id": manifest.source.official_id,
+            "official_revision": manifest.source.official_revision,
+            "repository_id": manifest.source.repository_id,
+            "license": manifest.source.license,
+            "expected_source_bytes": manifest.source.expected_source_bytes,
+            "files_verified": source_result["files"],
+        },
+        converter={
+            "package": manifest.converter.package,
+            "version": manifest.converter.version,
+            "git_repository": manifest.converter.git_repository,
+            "git_revision": manifest.converter.git_revision,
+            "installed_version": journal["converter_version_installed"],
+        },
+        parameters=asdict(manifest.parameters),
+        argv=tuple(argv),
+        output_files=output_files,
+        output_total_bytes=sum(item["size_bytes"] for item in output_files),
+        host=host_snapshot.to_dict(),
+    )
+    atomic_write_text(
+        workspace / "conversion-receipt.json",
+        json.dumps(receipt.to_dict(), indent=2, sort_keys=False) + "\n",
+    )
+    journal["receipt_path"] = str((workspace / "conversion-receipt.json").resolve())
+    return journal
+
+
+def conversion_manifest_hash(manifest: ConversionManifest) -> str:
+    return config_hash(asdict(manifest))
+
+
+__all__ = [
+    "ConversionError",
+    "ConversionReceipt",
+    "ConversionSafetyDecision",
+    "acquire_source",
+    "assess_conversion_safety",
+    "conversion_manifest_hash",
+    "run_conversion",
+    "source_cache_has_existing_content",
+    "source_files_present",
+    "verify_source",
+]

--- a/llmtracefx/optimizer/lab/qwen3_8b/conversion_manifest.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/conversion_manifest.py
@@ -158,9 +158,7 @@ class SourceFilePin:
         return cls(
             path=path,
             size_bytes=_integer(data, "size_bytes", context, minimum=1),
-            sha256=_sha256(
-                _string(data, "sha256", context), f"{context}.sha256"
-            ),
+            sha256=_sha256(_string(data, "sha256", context), f"{context}.sha256"),
         )
 
 

--- a/llmtracefx/optimizer/lab/qwen3_8b/conversion_manifest.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/conversion_manifest.py
@@ -1,0 +1,479 @@
+"""Strict, versioned self-conversion specification for Qwen3-8B.
+
+Binds the exact official upstream source, the exact converter package
+and its own upstream git revision, and the exact quantization
+parameters used to produce a local MLX checkpoint. This module never
+downloads anything or runs a conversion; it only parses and validates
+the pinned specification (see ``conversion.py`` for execution).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from ..._artifact_io import (
+    MAX_METADATA_ARTIFACT_BYTES,
+    ArtifactReadError,
+    read_bounded_regular_text,
+    reject_non_finite_json_constant,
+)
+
+CONVERSION_MANIFEST_SCHEMA_VERSION = "1"
+
+#: Quantization modes ``mlx_lm.convert`` accepts for ``--q-mode``.
+SUPPORTED_QUANT_MODES = ("affine", "mxfp4", "nvfp4", "mxfp8")
+
+#: ``mlx_lm.convert --dtype`` accepts only these three values (or None,
+#: meaning "use the source config's dtype"), see ``mlx_lm/convert.py``.
+SUPPORTED_CONVERSION_DTYPES = ("float16", "bfloat16", "float32")
+
+
+class ConversionManifestError(ValueError):
+    """Raised when the self-conversion manifest is malformed or inconsistent."""
+
+
+def _object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ConversionManifestError(f"{context} must be an object")
+    return value
+
+
+def _string(data: dict[str, Any], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ConversionManifestError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(data: dict[str, Any], key: str, context: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ConversionManifestError(
+            f"{context}.{key} must be a non-empty string or null"
+        )
+    return value
+
+
+def _integer(data: dict[str, Any], key: str, context: str, *, minimum: int = 0) -> int:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ConversionManifestError(
+            f"{context}.{key} must be an integer >= {minimum}"
+        )
+    return value
+
+
+def _number(
+    data: dict[str, Any],
+    key: str,
+    context: str,
+    *,
+    minimum: float,
+    exclusive: bool = False,
+) -> float:
+    value = data.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ConversionManifestError(f"{context}.{key} must be a number")
+    numeric = float(value)
+    valid = numeric > minimum if exclusive else numeric >= minimum
+    if not math.isfinite(numeric) or not valid:
+        operator = ">" if exclusive else ">="
+        raise ConversionManifestError(
+            f"{context}.{key} must be finite and {operator} {minimum}"
+        )
+    return numeric
+
+
+def _boolean(data: dict[str, Any], key: str, context: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise ConversionManifestError(f"{context}.{key} must be a boolean")
+    return value
+
+
+def _sha256(value: str, context: str) -> str:
+    digest = value.removeprefix("sha256:")
+    if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise ConversionManifestError(
+            f"{context} must be a lowercase SHA-256 hex digest"
+        )
+    return digest
+
+
+def _git_revision(value: str, context: str) -> str:
+    if len(value) != 40 or any(c not in "0123456789abcdef" for c in value):
+        raise ConversionManifestError(f"{context} must be a 40-character git revision")
+    return value
+
+
+def _relative_path(value: str, context: str) -> str:
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ConversionManifestError(f"{context} must be a repository-relative path")
+    return value
+
+
+def _https_url(value: str, *, allowed_hosts: frozenset[str], context: str) -> str:
+    parts = urlsplit(value)
+    if (
+        parts.scheme != "https"
+        or not parts.netloc
+        or parts.username is not None
+        or parts.password is not None
+        or parts.query
+        or parts.fragment
+        or parts.hostname not in allowed_hosts
+        or "%" in parts.path
+    ):
+        raise ConversionManifestError(
+            f"{context} must be a credential-free HTTPS URL on "
+            f"{sorted(allowed_hosts)} without encoded paths, queries, or fragments"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class SourceFilePin:
+    """One official-source file with exact size and SHA-256 pins."""
+
+    path: str
+    size_bytes: int
+    sha256: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SourceFilePin:
+        context = "source.files[]"
+        path = _string(data, "path", context)
+        if Path(path).is_absolute() or ".." in Path(path).parts:
+            raise ConversionManifestError(
+                "source.files[].path must be a repository-relative path"
+            )
+        return cls(
+            path=path,
+            size_bytes=_integer(data, "size_bytes", context, minimum=1),
+            sha256=_sha256(
+                _string(data, "sha256", context), f"{context}.sha256"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class SourcePin:
+    """Exact upstream identity for the official Qwen3-8B checkpoint."""
+
+    official_id: str
+    official_revision: str
+    repository_id: str
+    license: str
+    expected_source_bytes: int
+    files: tuple[SourceFilePin, ...]
+    sources: tuple[str, ...]
+
+    @property
+    def fully_pinned(self) -> bool:
+        return all(pin.sha256 is not None for pin in self.files)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SourcePin:
+        context = "source"
+        files_raw = data.get("files")
+        if not isinstance(files_raw, list) or not files_raw:
+            raise ConversionManifestError("source.files must be a non-empty list")
+        files = tuple(
+            SourceFilePin.from_dict(_object(item, "source.files[]"))
+            for item in files_raw
+        )
+        if len({pin.path for pin in files}) != len(files):
+            raise ConversionManifestError("source.files paths must be unique")
+        expected_source_bytes = _integer(
+            data, "expected_source_bytes", context, minimum=1
+        )
+        if sum(pin.size_bytes for pin in files) != expected_source_bytes:
+            raise ConversionManifestError(
+                "source.expected_source_bytes must equal the pinned file sizes"
+            )
+        sources_raw = data.get("sources")
+        if not isinstance(sources_raw, list) or not sources_raw:
+            raise ConversionManifestError("source.sources must be a non-empty list")
+        sources = tuple(
+            _https_url(
+                item,
+                allowed_hosts=frozenset({"huggingface.co", "github.com"}),
+                context="source.sources[]",
+            )
+            for item in sources_raw
+            if isinstance(item, str)
+        )
+        if len(sources) != len(sources_raw):
+            raise ConversionManifestError("source.sources[] must all be strings")
+        return cls(
+            official_id=_string(data, "official_id", context),
+            official_revision=_git_revision(
+                _string(data, "official_revision", context),
+                "source.official_revision",
+            ),
+            repository_id=_string(data, "repository_id", context),
+            license=_string(data, "license", context),
+            expected_source_bytes=expected_source_bytes,
+            files=files,
+            sources=sources,
+        )
+
+
+@dataclass(frozen=True)
+class ConverterPin:
+    """Exact converter package/version and its own upstream git revision."""
+
+    package: str
+    version: str
+    git_repository: str
+    git_revision: str
+    entrypoint: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConverterPin:
+        context = "converter"
+        return cls(
+            package=_string(data, "package", context),
+            version=_string(data, "version", context),
+            git_repository=_https_url(
+                _string(data, "git_repository", context),
+                allowed_hosts=frozenset({"github.com"}),
+                context="converter.git_repository",
+            ),
+            git_revision=_git_revision(
+                _string(data, "git_revision", context), "converter.git_revision"
+            ),
+            entrypoint=_string(data, "entrypoint", context),
+        )
+
+
+@dataclass(frozen=True)
+class ConversionParameters:
+    """Explicit, deterministic ``mlx_lm.convert`` parameters.
+
+    Every field mirrors an actual ``mlx_lm.convert`` keyword argument
+    (see ``mlx_lm/convert.py``) so the recorded provenance and the
+    literal subprocess argv this project builds can never silently
+    diverge. ``dtype``/``quant_predicate`` of ``None`` mean "use the
+    converter's own default for this source model", which is itself a
+    deterministic function of the pinned converter version and source
+    config -- never an unrecorded ambient default.
+    """
+
+    quantize: bool
+    q_group_size: int
+    q_bits: int
+    q_mode: str
+    dtype: str | None
+    quant_predicate: str | None
+    dequantize: bool
+    trust_remote_code: bool
+    upload_repo: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversionParameters:
+        context = "parameters"
+        quantize = _boolean(data, "quantize", context)
+        if not quantize:
+            raise ConversionManifestError(
+                "parameters.quantize must be true for this self-conversion control"
+            )
+        dequantize = _boolean(data, "dequantize", context)
+        if dequantize:
+            raise ConversionManifestError("parameters.dequantize must be false")
+        trust_remote_code = _boolean(data, "trust_remote_code", context)
+        if trust_remote_code:
+            raise ConversionManifestError(
+                "parameters.trust_remote_code must stay false"
+            )
+        upload_repo = _optional_string(data, "upload_repo", context)
+        if upload_repo is not None:
+            raise ConversionManifestError(
+                "parameters.upload_repo must be null; this control never "
+                "uploads the converted checkpoint anywhere"
+            )
+        q_mode = _string(data, "q_mode", context)
+        if q_mode not in SUPPORTED_QUANT_MODES:
+            raise ConversionManifestError(
+                f"parameters.q_mode must be one of {SUPPORTED_QUANT_MODES}"
+            )
+        dtype = _optional_string(data, "dtype", context)
+        if dtype is not None and dtype not in SUPPORTED_CONVERSION_DTYPES:
+            raise ConversionManifestError(
+                f"parameters.dtype must be null or one of {SUPPORTED_CONVERSION_DTYPES}"
+            )
+        return cls(
+            quantize=quantize,
+            q_group_size=_integer(data, "q_group_size", context, minimum=1),
+            q_bits=_integer(data, "q_bits", context, minimum=1),
+            q_mode=q_mode,
+            dtype=dtype,
+            quant_predicate=_optional_string(data, "quant_predicate", context),
+            dequantize=dequantize,
+            trust_remote_code=trust_remote_code,
+            upload_repo=upload_repo,
+        )
+
+    def argv(self, *, hf_path: str, mlx_path: str) -> tuple[str, ...]:
+        """The exact, deterministic ``mlx_lm convert`` argv this control runs."""
+        argv = [
+            "convert",
+            "--hf-path",
+            hf_path,
+            "--mlx-path",
+            mlx_path,
+            "--quantize",
+            "--q-group-size",
+            str(self.q_group_size),
+            "--q-bits",
+            str(self.q_bits),
+            "--q-mode",
+            self.q_mode,
+        ]
+        if self.dtype is not None:
+            argv.extend(("--dtype", self.dtype))
+        if self.quant_predicate is not None:
+            argv.extend(("--quant-predicate", self.quant_predicate))
+        return tuple(argv)
+
+
+@dataclass(frozen=True)
+class ConversionSafety:
+    """Conservative preflight thresholds for the conversion process only.
+
+    ``minimum_residual_free_disk_bytes`` is the free-disk floor that must
+    remain *after* the largest write this conversion could still need to
+    perform: the official source download (only when not already cached)
+    plus the self-converted output. ``assess_conversion_safety`` adds
+    ``ConversionManifest.expected_output_bytes`` (and, only when a
+    download is actually still needed, ``source.expected_source_bytes``)
+    on top of this floor -- so a missing-source preflight requires
+    exactly ``source + output + residual`` bytes free, never less.
+    """
+
+    required_chip: str
+    required_total_memory_bytes: int
+    minimum_residual_free_disk_bytes: int
+    minimum_memory_free_percent: float
+    maximum_swap_used_bytes: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversionSafety:
+        context = "safety"
+        memory_percent = _number(
+            data, "minimum_memory_free_percent", context, minimum=0
+        )
+        if memory_percent > 100:
+            raise ConversionManifestError(
+                "safety.minimum_memory_free_percent must be <= 100"
+            )
+        return cls(
+            required_chip=_string(data, "required_chip", context),
+            required_total_memory_bytes=_integer(
+                data, "required_total_memory_bytes", context, minimum=1
+            ),
+            minimum_residual_free_disk_bytes=_integer(
+                data, "minimum_residual_free_disk_bytes", context, minimum=1
+            ),
+            minimum_memory_free_percent=memory_percent,
+            maximum_swap_used_bytes=_integer(
+                data, "maximum_swap_used_bytes", context, minimum=1
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ConversionArtifacts:
+    """Repo-relative cache/workspace paths, fully separate from the 27B lab."""
+
+    source_cache: str
+    output_cache: str
+    workspace: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversionArtifacts:
+        context = "artifacts"
+        values = {
+            key: _relative_path(_string(data, key, context), f"artifacts.{key}")
+            for key in ("source_cache", "output_cache", "workspace")
+        }
+        return cls(**values)
+
+
+@dataclass(frozen=True)
+class ConversionManifest:
+    schema_version: str
+    conversion_id: str
+    source: SourcePin
+    converter: ConverterPin
+    parameters: ConversionParameters
+    expected_output_bytes: int
+    safety: ConversionSafety
+    timeout_seconds: float
+    cleanup_grace_seconds: float
+    max_journal_bytes: int
+    artifacts: ConversionArtifacts
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConversionManifest:
+        data = _object(data, "manifest")
+        schema_version = _string(data, "schema_version", "manifest")
+        if schema_version != CONVERSION_MANIFEST_SCHEMA_VERSION:
+            raise ConversionManifestError(
+                f"unsupported conversion manifest schema_version {schema_version!r}"
+            )
+        return cls(
+            schema_version=schema_version,
+            conversion_id=_string(data, "conversion_id", "manifest"),
+            source=SourcePin.from_dict(_object(data.get("source"), "source")),
+            converter=ConverterPin.from_dict(
+                _object(data.get("converter"), "converter")
+            ),
+            parameters=ConversionParameters.from_dict(
+                _object(data.get("parameters"), "parameters")
+            ),
+            expected_output_bytes=_integer(
+                data, "expected_output_bytes", "manifest", minimum=1
+            ),
+            safety=ConversionSafety.from_dict(_object(data.get("safety"), "safety")),
+            timeout_seconds=_number(
+                data, "timeout_seconds", "manifest", minimum=0, exclusive=True
+            ),
+            cleanup_grace_seconds=_number(
+                data, "cleanup_grace_seconds", "manifest", minimum=0, exclusive=True
+            ),
+            max_journal_bytes=_integer(
+                data, "max_journal_bytes", "manifest", minimum=1024
+            ),
+            artifacts=ConversionArtifacts.from_dict(
+                _object(data.get("artifacts"), "artifacts")
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> ConversionManifest:
+        try:
+            data = json.loads(payload, parse_constant=reject_non_finite_json_constant)
+        except (ValueError, RecursionError) as exc:
+            raise ConversionManifestError(
+                f"invalid conversion manifest JSON: {exc}"
+            ) from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def read_json(cls, path: str | Path) -> ConversionManifest:
+        try:
+            payload = read_bounded_regular_text(path, MAX_METADATA_ARTIFACT_BYTES)
+        except ArtifactReadError as exc:
+            raise ConversionManifestError(
+                f"invalid conversion manifest file: {exc}"
+            ) from exc
+        return cls.from_json(payload)

--- a/llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-control-manifest-template-v1.json
+++ b/llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-control-manifest-template-v1.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "1",
+  "lab_id": "qwen3-8b-m5-control-v1",
+  "model": {
+    "official_id": "Qwen/Qwen3-8B",
+    "official_revision": "b968826d9c46dd6066d109eabc6255188de91218",
+    "repository_id": "local-self-converted/qwen3-8b-mlx-q4g64",
+    "license": "Apache-2.0",
+    "quantization": "MLX affine 4-bit, group size 64 (self-converted, not byte-equivalent to any third-party conversion)",
+    "converter": "mlx-lm",
+    "converter_revision": "ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
+    "model_family": "qwen3",
+    "sources": [
+      "https://huggingface.co/Qwen/Qwen3-8B/tree/b968826d9c46dd6066d109eabc6255188de91218",
+      "https://github.com/ml-explore/mlx-lm/tree/ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd"
+    ]
+  },
+  "runtime": {
+    "name": "mlx-lm",
+    "version": "0.31.3",
+    "mlx_version": "0.32.2",
+    "mlx_lm_version": "0.31.3",
+    "transformers_version": "5.16.1",
+    "prefill_step_size": 2048
+  },
+  "generation": {
+    "max_output_tokens": 96,
+    "seed": 20260831,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "enable_thinking": false
+  },
+  "repetitions": {
+    "warmup_per_tier": 1,
+    "measured_per_workload": 2
+  },
+  "cooperative_timeout_seconds": 600,
+  "safety": {
+    "required_chip": "Apple M5 Pro",
+    "required_total_memory_bytes": 25769803776,
+    "minimum_free_disk_after_download_bytes": 21474836480,
+    "minimum_memory_free_percent": 25,
+    "maximum_peak_memory_bytes": 8589934592,
+    "maximum_swap_used_bytes": 12884901888,
+    "stop_on_any_failed_row": true
+  },
+  "artifacts": {
+    "workspace": ".cache/llmtracefx/qwen3-8b-m5-control-v1",
+    "model_cache": ".cache/models/qwen3-8b-mlx-q4g64-b968826",
+    "shareable_example_dir": "examples/optimizer/qwen3-8b-m5-control",
+    "commit_raw_artifacts": false
+  },
+  "environment_capture": [
+    "os_name",
+    "os_release",
+    "architecture",
+    "python_implementation",
+    "python_version",
+    "cpu_count",
+    "total_memory_gb",
+    "accelerator",
+    "package_versions"
+  ],
+  "context_tiers": [
+    {
+      "name": "2k",
+      "target_tokens": 2048,
+      "order": 1
+    },
+    {
+      "name": "8k",
+      "target_tokens": 8192,
+      "order": 2
+    },
+    {
+      "name": "16k",
+      "target_tokens": 16384,
+      "order": 3
+    }
+  ],
+  "workloads": [
+    {
+      "workload_id": "structured-json-profile-extraction",
+      "version": "1",
+      "prompt_hashes": {
+        "2k": "sha256:4a4a49e8368a99919fff1d1e68586466e279267d9de8d081ba8c08adac592fcd",
+        "8k": "sha256:5efe059227fd5eeeb07884207aaad68780b53c2198f4dc1bbfb03f409bb152dd",
+        "16k": "sha256:837d22b5c550cf616ea86e7d64a637c2d387b2b9fd00577f64186ae621804f99"
+      }
+    },
+    {
+      "workload_id": "prose-reasoning-two-train-gap",
+      "version": "1",
+      "prompt_hashes": {
+        "2k": "sha256:f583af51b9a3e6cb49cd53a71d0737924329492701508af226515734c4f9f568",
+        "8k": "sha256:954c0e8c1e0060c34e954e107c8b812926fcbfb5d3f5ca7e8904f0dba2d0e3c9",
+        "16k": "sha256:4ddc616d1772e3ead314a5247729778b21bec55376465a276ab805bcde29ce41"
+      }
+    }
+  ]
+}

--- a/llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-conversion-manifest-v1.json
+++ b/llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-conversion-manifest-v1.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1",
+  "conversion_id": "qwen3-8b-mlx-q4g64-self-convert-v1",
+  "source": {
+    "official_id": "Qwen/Qwen3-8B",
+    "official_revision": "b968826d9c46dd6066d109eabc6255188de91218",
+    "repository_id": "Qwen/Qwen3-8B",
+    "license": "Apache-2.0",
+    "expected_source_bytes": 16397461266,
+    "files": [
+      {
+        "path": ".gitattributes",
+        "size_bytes": 1570,
+        "sha256": "34448b82c17d60fec9b65b1f093c115ddbaadc04beb1b0140b6bfed2e012a930"
+      },
+      {
+        "path": "LICENSE",
+        "size_bytes": 11343,
+        "sha256": "832dd9e00a68dd83b3c3fb9f5588dad7dcf337a0db50f7d9483f310cd292e92e"
+      },
+      {
+        "path": "README.md",
+        "size_bytes": 16660,
+        "sha256": "0f36caaff9c2516411a7738db384606263ba653c1e63e61d72f511606164d5a6"
+      },
+      {
+        "path": "config.json",
+        "size_bytes": 728,
+        "sha256": "f7c4eadfbbf522470667b797a3c89be2524832d2d599797248dc304fff447c30"
+      },
+      {
+        "path": "generation_config.json",
+        "size_bytes": 239,
+        "sha256": "2325da0f15bb848e018c5ae071b7943332e9f871d6b60e2ed22ca97d4cb993d2"
+      },
+      {
+        "path": "merges.txt",
+        "size_bytes": 1671853,
+        "sha256": "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5"
+      },
+      {
+        "path": "model-00001-of-00005.safetensors",
+        "size_bytes": 3996250744,
+        "sha256": "31d6a825ae35f11fb85b195b4c42c146c051e446433125a215336abdf95cbf5f"
+      },
+      {
+        "path": "model-00002-of-00005.safetensors",
+        "size_bytes": 3993160032,
+        "sha256": "5991236cea6fe21f3d43cab0f0e84448734fbbe0789816202989f2ddc9d18282"
+      },
+      {
+        "path": "model-00003-of-00005.safetensors",
+        "size_bytes": 3959604768,
+        "sha256": "c5185c4794be2d8a9784d5753c9922db38df478ce11f9ed0b415b7304d896836"
+      },
+      {
+        "path": "model-00004-of-00005.safetensors",
+        "size_bytes": 3187841392,
+        "sha256": "b5ee7de71fbf17db3d5704e0c8f2bc7d005ca9e1d7ca2aeb19827b0cfcaa917a"
+      },
+      {
+        "path": "model-00005-of-00005.safetensors",
+        "size_bytes": 1244659840,
+        "sha256": "20c2d6366ab85c90786ccdd829cd2b9e7d30ef3b2ebbb998280e7e4014b542ff"
+      },
+      {
+        "path": "model.safetensors.index.json",
+        "size_bytes": 32878,
+        "sha256": "f9fdbcb91c23971c13ec5d5f2573d2349e8f61f2f049371ec699281748fdb1bc"
+      },
+      {
+        "path": "tokenizer.json",
+        "size_bytes": 11422654,
+        "sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
+      },
+      {
+        "path": "tokenizer_config.json",
+        "size_bytes": 9732,
+        "sha256": "d5d09f07b48c3086c508b30d1c9114bd1189145b74e982a265350c923acd8101"
+      },
+      {
+        "path": "vocab.json",
+        "size_bytes": 2776833,
+        "sha256": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910"
+      }
+    ],
+    "sources": [
+      "https://huggingface.co/Qwen/Qwen3-8B/tree/b968826d9c46dd6066d109eabc6255188de91218"
+    ]
+  },
+  "converter": {
+    "package": "mlx-lm",
+    "version": "0.31.3",
+    "git_repository": "https://github.com/ml-explore/mlx-lm",
+    "git_revision": "ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
+    "entrypoint": "python -m mlx_lm convert"
+  },
+  "parameters": {
+    "quantize": true,
+    "q_group_size": 64,
+    "q_bits": 4,
+    "q_mode": "affine",
+    "dtype": null,
+    "quant_predicate": null,
+    "dequantize": false,
+    "trust_remote_code": false,
+    "upload_repo": null
+  },
+  "expected_output_bytes": 4623784971,
+  "safety": {
+    "required_chip": "Apple M5 Pro",
+    "required_total_memory_bytes": 25769803776,
+    "minimum_residual_free_disk_bytes": 107374182400,
+    "minimum_memory_free_percent": 40,
+    "maximum_swap_used_bytes": 12884901888
+  },
+  "timeout_seconds": 5400,
+  "cleanup_grace_seconds": 30,
+  "max_journal_bytes": 262144,
+  "artifacts": {
+    "source_cache": ".cache/models/qwen3-8b-source-b968826",
+    "output_cache": ".cache/models/qwen3-8b-mlx-q4g64-b968826",
+    "workspace": ".cache/llmtracefx/qwen3-8b-conversion-v1"
+  }
+}

--- a/llmtracefx/optimizer/lab/qwen3_8b/report.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/report.py
@@ -1,0 +1,460 @@
+"""Report/evidence tooling for the Qwen3-8B M5 Pro control.
+
+Reuses ``lab.core``'s report machinery almost entirely unmodified: the
+per-row manifest-binding checks (``_record_matches_manifest``), the
+environment-drift checks (``_environment_errors``), state scoping
+(``_current_state_scope``), tier aggregation (``_tier_summary``),
+sanitized-report enforcement (``assert_shareable``), self-contained HTML
+rendering (``render_lab_report_html``), and the tune/compare layers are
+all the exact functions the packaged 27B lab uses.
+
+Only the top-level report assembly differs, and only where it must:
+this control's "model" section describes a self-converted checkpoint
+(so it never repeats the 27B report's disclaimer about not binding a
+source revision -- this control *does* bind one), and its "limitations"
+explicitly says the results are not comparable to the 27B lab's.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ...collectors._shared import atomic_write_text
+from ...compare.compare import compare
+from ...compare.policy import CompareConstraints, CompareObjective, ComparePolicy
+from ...compare.report_html import render_compare_report_html
+from ...schema import ExperimentRecord, MetricProvenance
+from ...tune.policy import TuneConstraints, TuneObjective, TunePolicy
+from ...tune.report_html import render_tune_report_html
+from ...tune.tuner import tune
+from ...workloads.verify import RowStatus, RowVerification
+from ..core import (
+    LabError,
+    _current_state_scope,
+    _environment_errors,
+    _materialize_current_results,
+    _measurement,
+    _record_matches_manifest,
+    _stale_result_run_ids,
+    _tier_summary,
+    assert_shareable,
+    render_lab_report_html,
+    verify_catalog,
+    verify_evidence,
+)
+from ..manifest import LabManifest
+
+CONTROL_REPORT_SCHEMA_VERSION = "1"
+
+#: ``verify_evidence`` is fully manifest-driven already (no 27B-specific
+#: literal anywhere in it); reused verbatim.
+verify_control_evidence = verify_evidence
+
+
+def _tier_with_tokens(
+    manifest: LabManifest,
+    name: str,
+    rows: list[tuple[RowVerification, ExperimentRecord]],
+) -> dict[str, Any]:
+    summary = _tier_summary(name, rows)
+    evaluated_actual = [
+        record.tokens.input_tokens
+        for verification, record in rows
+        if record.tokens.input_tokens is not None
+        and verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED)
+    ]
+    summary["requested_tokens"] = manifest.tier(name).target_tokens
+    summary["mean_actual_input_tokens"] = (
+        sum(evaluated_actual) / len(evaluated_actual) if evaluated_actual else None
+    )
+    return summary
+
+
+def build_control_report(manifest: LabManifest, *, workspace: Path) -> dict[str, Any]:
+    state_path = workspace / "state.json"
+    state = (
+        json.loads(state_path.read_text(encoding="utf-8"))
+        if state_path.exists()
+        else {}
+    )
+    if state.get("status") == "running":
+        raise LabError(
+            "current benchmark run is incomplete; report generation is refused"
+        )
+    allowed_tiers, measured_run_ids, warmup_run_ids = _current_state_scope(
+        manifest, state
+    )
+    environment: dict[str, Any] | None = None
+    rows_by_tier: dict[str, list[tuple[RowVerification, ExperimentRecord]]] = {}
+    runs_dir = workspace / "results" / "runs"
+    if runs_dir.is_dir():
+        for verification_path in sorted(runs_dir.glob("*/verification.json")):
+            verification = RowVerification.read_json(verification_path)
+            if (
+                verification.final_record_path is None
+                or verification.run_id not in measured_run_ids
+            ):
+                continue
+            record = ExperimentRecord.read_json(
+                verification_path.parent / "final_record.json"
+            )
+            if not _record_matches_manifest(
+                manifest,
+                verification,
+                record,
+                warmup=False,
+                allowed_tiers=allowed_tiers,
+            ):
+                continue
+            environment_path = (
+                verification_path.parent / "collection" / "environment.json"
+            )
+            if _environment_errors(manifest, environment_path):
+                continue
+            if environment is None and environment_path.is_file():
+                raw_environment = json.loads(
+                    environment_path.read_text(encoding="utf-8")
+                )
+                environment = {
+                    "os_name": raw_environment.get("os_name"),
+                    "os_release": raw_environment.get("os_release"),
+                    "architecture": raw_environment.get("architecture"),
+                    "python_implementation": raw_environment.get(
+                        "python_implementation"
+                    ),
+                    "python_version": raw_environment.get("python_version"),
+                    "cpu_count": raw_environment.get("cpu_count"),
+                    "total_memory_gb": raw_environment.get("total_memory_gb"),
+                    "accelerator": record.platform.accelerator,
+                    "package_versions": raw_environment.get("package_versions", {}),
+                }
+            rows_by_tier.setdefault(verification.context_tier, []).append(
+                (verification, record)
+            )
+    tier_order = {tier.name: tier.order for tier in manifest.context_tiers}
+    tiers = [
+        _tier_with_tokens(manifest, name, rows)
+        for name, rows in sorted(
+            rows_by_tier.items(), key=lambda item: tier_order[item[0]]
+        )
+    ]
+    failed_attempts: list[dict[str, Any]] = []
+    warmups_dir = workspace / "warmups"
+    if warmups_dir.is_dir():
+        for verification_path in sorted(warmups_dir.glob("*/runs/*/verification.json")):
+            verification = RowVerification.read_json(verification_path)
+            if verification.run_id not in warmup_run_ids:
+                continue
+            record_path = verification_path.parent / "final_record.json"
+            failed_record = (
+                ExperimentRecord.read_json(record_path)
+                if verification.final_record_path is not None and record_path.is_file()
+                else None
+            )
+            if failed_record is not None and not _record_matches_manifest(
+                manifest,
+                verification,
+                failed_record,
+                warmup=True,
+                allowed_tiers=allowed_tiers,
+            ):
+                continue
+            if failed_record is not None and _environment_errors(
+                manifest, verification_path.parent / "collection" / "environment.json"
+            ):
+                continue
+            if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED):
+                continue
+            failed_attempts.append(
+                {
+                    "run_id": verification.run_id,
+                    "tier": verification.context_tier,
+                    "phase": "warmup",
+                    "status": verification.status.value,
+                    "reason": verification.reason,
+                    "input_tokens": (
+                        failed_record.tokens.input_tokens
+                        if failed_record is not None
+                        else None
+                    ),
+                    "total_ms": (
+                        _measurement(failed_record, "total")
+                        if failed_record is not None
+                        else None
+                    ),
+                    "peak_memory_bytes": (
+                        failed_record.memory.peak.value
+                        if failed_record is not None
+                        and failed_record.memory.peak is not None
+                        else None
+                    ),
+                }
+            )
+    for tier_rows in rows_by_tier.values():
+        for verification, record in tier_rows:
+            if verification.status in (RowStatus.COMPLETED, RowStatus.SKIPPED):
+                continue
+            failed_attempts.append(
+                {
+                    "run_id": verification.run_id,
+                    "tier": verification.context_tier,
+                    "phase": "measured",
+                    "status": verification.status.value,
+                    "reason": verification.reason,
+                    "input_tokens": record.tokens.input_tokens,
+                    "total_ms": _measurement(record, "total"),
+                    "peak_memory_bytes": (
+                        record.memory.peak.value
+                        if record.memory.peak is not None
+                        else None
+                    ),
+                }
+            )
+    stop_reasons = state.get("stop_reasons", [])
+    if failed_attempts:
+        stop_reasons = [
+            attempt["reason"]
+            for attempt in failed_attempts
+            if attempt["reason"] is not None
+        ]
+    stopped_during = state.get("stopped_during")
+    if stopped_during is None and failed_attempts:
+        stopped_during = {
+            "tier": failed_attempts[0]["tier"],
+            "phase": failed_attempts[0]["phase"],
+        }
+    unattempted_tiers = state.get("unattempted_tiers")
+    if not isinstance(unattempted_tiers, list) and stopped_during is not None:
+        stopped_tier = manifest.tier(stopped_during["tier"])
+        unattempted_tiers = [
+            tier.name
+            for tier in manifest.context_tiers
+            if tier.order > stopped_tier.order
+        ]
+    stopped_before_tier = (
+        state.get("stopped_before_tier") if stopped_during is None else None
+    )
+    requested_max_tier = state.get("requested_max_tier")
+    not_executed_tiers = [
+        tier.name for tier in manifest.context_tiers if tier.name not in allowed_tiers
+    ]
+    preflight_snapshot = state.get("preflight", {}).get("snapshot", {})
+    tier_states = state.get("tiers", [])
+    last_postflight = (
+        tier_states[-1].get("postflight", {}).get("snapshot", {})
+        if tier_states and isinstance(tier_states[-1], dict)
+        else {}
+    )
+    report = {
+        "schema_version": CONTROL_REPORT_SCHEMA_VERSION,
+        "lab_id": manifest.lab_id,
+        "generated_at": state.get("ended_at"),
+        "run_mode": state.get("run_mode"),
+        "clean_boot_confirmed": state.get("clean_boot_confirmed"),
+        "model": {
+            "official_id": manifest.model.official_id,
+            "official_revision": manifest.model.official_revision,
+            "repository_id": manifest.model.repository_id,
+            "revision": manifest.model.revision,
+            "license": manifest.model.license,
+            "quantization": manifest.model.quantization,
+            "converter": manifest.model.converter,
+            "converter_revision": manifest.model.converter_revision,
+            "output_total_bytes": manifest.model.expected_download_bytes,
+            "sources": list(manifest.model.sources),
+        },
+        "self_conversion": {
+            "provenance": (
+                "self-converted locally with this repository's pinned "
+                "mlx-lm from the official upstream Qwen3-8B revision; "
+                "never claims byte-equivalence with any third-party "
+                "conversion (e.g. mlx-community)"
+            ),
+            "official_revision": manifest.model.official_revision,
+            "converter": manifest.model.converter,
+            "converter_revision": manifest.model.converter_revision,
+            "quantization": manifest.model.quantization,
+            "binding_revision": manifest.model.revision,
+            "binding_revision_provenance": (
+                "a deterministic fingerprint of the conversion identity "
+                "(source revision, converter revision, quantization "
+                "parameters, output file hashes), not an upstream git "
+                "commit"
+            ),
+        },
+        "environment": environment,
+        "runtime_contract": {
+            "name": manifest.runtime.name,
+            "version": manifest.runtime.version,
+            "mlx_version": manifest.runtime.mlx_version,
+            "mlx_lm_version": manifest.runtime.mlx_lm_version,
+            "transformers_version": manifest.runtime.transformers_version,
+            "prefill_step_size": manifest.runtime.prefill_step_size,
+        },
+        "generation": {
+            "max_output_tokens": manifest.generation.max_output_tokens,
+            "seed": manifest.generation.seed,
+            "temperature": manifest.generation.temperature,
+            "top_p": manifest.generation.top_p,
+            "enable_thinking": manifest.generation.enable_thinking,
+        },
+        "repetitions": {
+            "warmup_per_tier": manifest.repetitions.warmup_per_tier,
+            "measured_per_workload": manifest.repetitions.measured_per_workload,
+        },
+        "cooperative_timeout_seconds": manifest.cooperative_timeout_seconds,
+        "safety": {
+            "required_chip": manifest.safety.required_chip,
+            "required_total_memory_bytes": manifest.safety.required_total_memory_bytes,
+            "minimum_memory_free_percent": manifest.safety.minimum_memory_free_percent,
+            "maximum_peak_memory_bytes": manifest.safety.maximum_peak_memory_bytes,
+            "maximum_swap_used_bytes": manifest.safety.maximum_swap_used_bytes,
+            "stop_on_any_failed_row": manifest.safety.stop_on_any_failed_row,
+        },
+        "safety_observations": {
+            "provenance": "macOS memory_pressure and sysctl",
+            "preflight_memory_free_percent": preflight_snapshot.get(
+                "memory_free_percent"
+            ),
+            "preflight_swap_used_bytes": preflight_snapshot.get("swap_used_bytes"),
+            "postflight_memory_free_percent": last_postflight.get(
+                "memory_free_percent"
+            ),
+            "postflight_swap_used_bytes": last_postflight.get("swap_used_bytes"),
+        },
+        "tiers": tiers,
+        "failed_attempts": failed_attempts,
+        "stopped_before_tier": stopped_before_tier,
+        "stopped_during": stopped_during,
+        "requested_max_tier": requested_max_tier,
+        "unattempted_tiers": unattempted_tiers or [],
+        "not_executed_tiers": not_executed_tiers,
+        "stop_reasons": stop_reasons,
+        "limitations": [
+            "This is a self-converted Qwen3-8B positive control, not the "
+            "packaged Qwen3.8-27B lab; the two are different models, "
+            "different quantized checkpoints, and different memory/timing "
+            "envelopes, and are never directly comparable.",
+            "Results apply only to the pinned official source revision, "
+            "this repository's pinned mlx-lm converter revision, the "
+            "exact recorded quantization parameters, and this M5 Pro "
+            "configuration; they say nothing about any other conversion "
+            "of Qwen3-8B, including third-party ones.",
+            "This report only shows completion under the host state "
+            "actually observed during the run; it is not a claim about "
+            "peak achievable throughput or about any other machine.",
+            "The workload catalog's context tiers target an approximate, "
+            "model-independent token count; the checkpoint's own mlx-lm "
+            "chat template and tokenizer generally produce a different "
+            "*actual* input token count than that *requested* target -- "
+            "each tier reports both, never conflated.",
+            "Total, prefill, and decode durations are host wall-clock "
+            "boundaries measured by a fresh, isolated subprocess per row; "
+            "they are not kernel timings.",
+            "Peak memory is MLX allocator peak memory when available, "
+            "not whole-system resident memory.",
+            "Decode token rate is derived from measured generated tokens "
+            "and decode wall time.",
+            "The per-row timeout is a parent-enforced subprocess wall-"
+            "clock bound with TERM->KILL cleanup; it is not a claim about "
+            "any cooperative in-process timeout being sufficient alone.",
+            "No GPU utilization, bandwidth, power, energy, or kernel "
+            "timing is measured or inferred.",
+        ],
+    }
+    assert_shareable(report)
+    return report
+
+
+def write_control_reports(
+    manifest: LabManifest, *, workspace: Path, shareable_dir: Path | None = None
+) -> dict[str, Any]:
+    verify_catalog(manifest)
+    evidence_verification = verify_control_evidence(manifest, workspace=workspace)
+    if not evidence_verification["verified"]:
+        raise LabError(
+            "report generation refused unverified current-run evidence: "
+            + "; ".join(evidence_verification["failures"])
+        )
+    stale = _stale_result_run_ids(manifest, workspace=workspace)
+    if stale:
+        raise LabError(
+            "report generation refused stale or mismatched run evidence: "
+            + ", ".join(stale)
+        )
+    report = build_control_report(manifest, workspace=workspace)
+    reports_dir = workspace / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        reports_dir / "control-report.json",
+        json.dumps(report, indent=2, sort_keys=False) + "\n",
+    )
+    atomic_write_text(
+        reports_dir / "control-report.html", render_lab_report_html(report)
+    )
+
+    results_dir = _materialize_current_results(manifest, workspace=workspace)
+    tune_policy = TunePolicy(
+        name="Qwen3-8B M5 Pro self-converted control",
+        description=(
+            "Rank only repetitions that pass deterministic evaluation, remain "
+            "under the configured MLX peak-memory ceiling, and share identity."
+        ),
+        objective=TuneObjective.MAX_CORRECT_CASES_PER_MINUTE,
+        constraints=TuneConstraints(
+            min_pass_rate=1.0,
+            max_peak_memory_bytes=float(manifest.safety.maximum_peak_memory_bytes),
+            allowed_provenances=frozenset(
+                {MetricProvenance.MEASURED_WALL_CLOCK, MetricProvenance.MEASURED_NATIVE}
+            ),
+            min_measured_repetitions=manifest.repetitions.measured_per_workload,
+        ),
+    )
+    tune_report = tune(results_dirs=(results_dir,), policy=tune_policy)
+    atomic_write_text(reports_dir / "tune-report.json", tune_report.to_json() + "\n")
+    atomic_write_text(
+        reports_dir / "tune-report.html",
+        render_tune_report_html(tune_report, redact_paths=True),
+    )
+
+    compare_policy = ComparePolicy(
+        name="Pinned self-converted local-system evidence",
+        description=(
+            "Apply the same deterministic pass-rate and repetition bar "
+            "through the merged comparison layer; no hosted systems are "
+            "included."
+        ),
+        objective=CompareObjective.MAX_CORRECT_CASES_PER_MINUTE,
+        constraints=CompareConstraints(
+            min_pass_rate=1.0,
+            allowed_provenances=frozenset({MetricProvenance.MEASURED_WALL_CLOCK}),
+            min_measured_repetitions=manifest.repetitions.measured_per_workload,
+        ),
+    )
+    compare_report = compare(results_dirs=(results_dir,), policy=compare_policy)
+    atomic_write_text(
+        reports_dir / "compare-report.json", compare_report.to_json() + "\n"
+    )
+    atomic_write_text(
+        reports_dir / "compare-report.html",
+        render_compare_report_html(compare_report, redact_paths=True),
+    )
+
+    if shareable_dir is not None:
+        shareable_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(
+            shareable_dir / "evidence-summary.json",
+            json.dumps(report, indent=2, sort_keys=False) + "\n",
+        )
+        atomic_write_text(shareable_dir / "report.html", render_lab_report_html(report))
+    return report
+
+
+__all__ = [
+    "CONTROL_REPORT_SCHEMA_VERSION",
+    "build_control_report",
+    "verify_control_evidence",
+    "write_control_reports",
+]

--- a/llmtracefx/optimizer/lab/qwen3_8b/runtime.py
+++ b/llmtracefx/optimizer/lab/qwen3_8b/runtime.py
@@ -1,0 +1,119 @@
+"""MLX-LM chat-template runtime adapter for the Qwen3-8B control.
+
+``collectors.mlx.MLXLMRuntime`` tokenizes a prompt verbatim; it applies
+no chat template because most of its existing callers (autopsy probes,
+tuning fixtures) intentionally exercise the tokenizer directly. This
+control instead needs every prompt to go through the checkpoint's own
+mlx-lm chat template with ``enable_thinking=False`` (as pinned by
+``manifest.generation.enable_thinking``), exactly like a real chat
+completion. Rather than edit the shared, already-tested
+``MLXLMRuntime``, this module wraps one by composition and overrides
+only ``encode``, so every other collector-facing behavior (model
+loading, seeding, memory snapshots, generation) is the identical,
+already-covered code path the rest of the project relies on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from ...collectors.mlx import (
+    MLXCollectorError,
+    MLXGenerationResponse,
+    MLXLMRuntime,
+    MLXMemorySnapshot,
+)
+
+
+class Qwen3ChatMLXLMRuntime:
+    """Adapts ``MLXLMRuntime`` to tokenize through the checkpoint's own
+    mlx-lm chat template instead of the raw prompt text."""
+
+    def __init__(
+        self,
+        *,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        enable_thinking: bool = False,
+    ) -> None:
+        self._delegate = MLXLMRuntime(temperature=temperature, top_p=top_p)
+        self._enable_thinking = enable_thinking
+
+    @property
+    def mlx_version(self) -> str | None:
+        return self._delegate.mlx_version
+
+    @property
+    def mlx_lm_version(self) -> str | None:
+        return self._delegate.mlx_lm_version
+
+    @property
+    def runtime_name(self) -> str:
+        return self._delegate.runtime_name
+
+    @property
+    def runtime_version(self) -> str | None:
+        return self._delegate.runtime_version
+
+    def load_model(self, path: Path) -> tuple[Any, Any]:
+        return self._delegate.load_model(path)
+
+    def encode(self, tokenizer: Any, prompt: str) -> list[int]:
+        apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+        if apply_chat_template is None:
+            raise MLXCollectorError(
+                "this mlx-lm tokenizer does not expose apply_chat_template; "
+                "the Qwen3-8B control requires a chat-template-capable "
+                "checkpoint"
+            )
+        encoded = apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=self._enable_thinking,
+        )
+        if not isinstance(encoded, list):
+            raise MLXCollectorError(
+                "mlx-lm chat template did not return a token-id list for a "
+                "text-only run"
+            )
+        return [int(token) for token in encoded]
+
+    def seed(self, seed: int) -> None:
+        self._delegate.seed(seed)
+
+    def synchronize(self) -> None:
+        self._delegate.synchronize()
+
+    def reset_peak_memory(self) -> None:
+        self._delegate.reset_peak_memory()
+
+    def memory_snapshot(self) -> MLXMemorySnapshot:
+        return self._delegate.memory_snapshot()
+
+    def accelerator_name(self) -> str | None:
+        return self._delegate.accelerator_name()
+
+    def stream_generate(
+        self,
+        model: Any,
+        tokenizer: Any,
+        prompt_tokens: list[int],
+        *,
+        max_tokens: int,
+        draft_model: Any | None,
+        num_draft_tokens: int,
+    ) -> Iterator[MLXGenerationResponse]:
+        return self._delegate.stream_generate(
+            model,
+            tokenizer,
+            prompt_tokens,
+            max_tokens=max_tokens,
+            draft_model=draft_model,
+            num_draft_tokens=num_draft_tokens,
+        )
+
+
+__all__ = ["Qwen3ChatMLXLMRuntime"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ llmtracefx-optimizer = "llmtracefx.optimizer.cli:main"
 llmtracefx-deploy = "llmtracefx.deploy.cli:main"
 llmtracefx-m5-lab = "llmtracefx.optimizer.lab.cli:main"
 llmtracefx-m5-frontier = "llmtracefx.optimizer.lab.frontier:main"
+llmtracefx-m5-control = "llmtracefx.optimizer.lab.qwen3_8b.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -108,6 +109,7 @@ llmtracefx = [
     "test_traces/*.json",
     "*.md",
     "optimizer/lab/data/*.json",
+    "optimizer/lab/qwen3_8b/data/*.json",
 ]
 
 # Black configuration

--- a/tests/optimizer/test_m5_qwen3_8b_control.py
+++ b/tests/optimizer/test_m5_qwen3_8b_control.py
@@ -1,0 +1,1210 @@
+"""Offline tests for the Qwen3-8B M5 Pro control: manifests, namespace
+separation, the subprocess-isolated benchmark runner, reports, and the
+CLI. No test in this module loads real model weights or spawns a real
+MLX runtime; a monkeypatched fake stands in for the checkpoint so the
+resume, safety-gate, tokenizer-count, and subprocess-isolation logic
+can be verified deterministically and offline.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.collectors.mlx import MLXMemorySnapshot
+from llmtracefx.optimizer.lab.core import HostSnapshot, LabError, SafetyDecision
+from llmtracefx.optimizer.lab.manifest import LabManifest
+from llmtracefx.optimizer.lab.qwen3_8b import benchmark as bm
+from llmtracefx.optimizer.lab.qwen3_8b import cli as qcli
+from llmtracefx.optimizer.lab.qwen3_8b.control_manifest import (
+    ControlManifestError,
+    ControlManifestTemplate,
+    bind_control_manifest,
+)
+from llmtracefx.optimizer.lab.qwen3_8b.conversion import (
+    ConversionReceipt,
+    conversion_manifest_hash,
+)
+from llmtracefx.optimizer.lab.qwen3_8b.conversion_manifest import ConversionManifest
+from llmtracefx.optimizer.lab.qwen3_8b.report import (
+    build_control_report,
+    write_control_reports,
+)
+from llmtracefx.optimizer.manifest import EnvironmentManifest
+from llmtracefx.optimizer.schema import PlatformInfo
+from llmtracefx.optimizer.workloads.schema import ContextTier
+from llmtracefx.optimizer.workloads.verify import (
+    RowResult,
+    RowStatus,
+    RowVerification,
+)
+
+TWENTY_SEVEN_B_MANIFEST_PATH = Path(
+    "llmtracefx/optimizer/lab/data/lab-manifest-v1.json"
+)
+FRONTIER_MANIFEST_PATH = Path(
+    "llmtracefx/optimizer/lab/data/fit-frontier-manifest-v1.json"
+)
+AUTOPSY_MANIFEST_PATH = Path("llmtracefx/optimizer/lab/data/autopsy-manifest-v1.json")
+CONTROL_TEMPLATE_PATH = Path(
+    "llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-control-manifest-template-v1.json"
+)
+CONVERSION_MANIFEST_PATH = Path(
+    "llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-conversion-manifest-v1.json"
+)
+
+
+@pytest.fixture(autouse=True)
+def stable_m5_platform(monkeypatch):
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.mlx.record_platform",
+        lambda accelerator: PlatformInfo(
+            os_name="Darwin",
+            os_version="25.6.0",
+            architecture="arm64",
+            cpu_cores=18,
+            total_memory_gb=24.0,
+            accelerator=accelerator,
+        ),
+    )
+    monkeypatch.setattr(
+        "llmtracefx.optimizer.collectors.mlx.collect_environment_manifest",
+        lambda **kwargs: EnvironmentManifest(
+            schema_version="1",
+            collected_at="2026-08-31T00:00:00.000000Z",
+            os_name="Darwin",
+            os_release="25.6.0",
+            architecture="arm64",
+            python_implementation="CPython",
+            python_version="3.13.15",
+            cpu_count=18,
+            total_memory_gb=24.0,
+            package_versions={
+                "mlx": "0.32.2",
+                "mlx-lm": "0.31.3",
+                "transformers": "5.16.1",
+            },
+        ),
+    )
+
+
+def _conversion_manifest() -> ConversionManifest:
+    return ConversionManifest.read_json(CONVERSION_MANIFEST_PATH)
+
+
+def _fabricated_receipt(**overrides) -> ConversionReceipt:
+    """A receipt whose identity fields match the packaged conversion spec
+    exactly by default, so ``bind_control_manifest``'s provenance
+    cross-check succeeds unless a test deliberately overrides a field to
+    exercise a mismatch refusal."""
+    values = {
+        "schema_version": "1",
+        "conversion_id": "qwen3-8b-mlx-q4g64-self-convert-v1",
+        "conversion_manifest_hash": conversion_manifest_hash(_conversion_manifest()),
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T01:00:00Z",
+        "source": {
+            "official_id": "Qwen/Qwen3-8B",
+            "official_revision": "b968826d9c46dd6066d109eabc6255188de91218",
+            "license": "Apache-2.0",
+        },
+        "converter": {
+            "package": "mlx-lm",
+            "version": "0.31.3",
+            "git_revision": "ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
+        },
+        "parameters": {
+            "quantize": True,
+            "q_group_size": 64,
+            "q_bits": 4,
+            "q_mode": "affine",
+            "dtype": None,
+            "quant_predicate": None,
+            "dequantize": False,
+            "trust_remote_code": False,
+            "upload_repo": None,
+        },
+        "argv": ("mlx_lm", "convert"),
+        "output_files": (
+            {"path": "config.json", "size_bytes": 10, "sha256": "a" * 64},
+            {"path": "model.safetensors", "size_bytes": 20, "sha256": "b" * 64},
+        ),
+        "output_total_bytes": 30,
+        "host": {"os_name": "Darwin"},
+    }
+    values.update(overrides)
+    return ConversionReceipt(**values)
+
+
+def _bound_manifest(
+    tmp_path: Path, *, receipt: ConversionReceipt | None = None
+) -> tuple[LabManifest, Path]:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    receipt = receipt or _fabricated_receipt()
+    bound = bind_control_manifest(
+        template, receipt, conversion_manifest=_conversion_manifest()
+    )
+    payload = template.to_dict()
+    payload["model"] = {
+        **payload["model"],
+        "files": [
+            {"path": pin.path, "size_bytes": pin.size_bytes, "sha256": pin.sha256}
+            for pin in bound.model.files
+        ],
+        "expected_download_bytes": bound.model.expected_download_bytes,
+        "revision": bound.model.revision,
+    }
+    manifest_path = tmp_path / "control-manifest.bound.json"
+    manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return LabManifest.read_json(manifest_path), manifest_path
+
+
+def _safe_decision() -> SafetyDecision:
+    return SafetyDecision(
+        safe=True,
+        blockers=(),
+        snapshot=HostSnapshot(
+            collected_at="2026-09-01T00:00:00.000000Z",
+            os_name="Darwin",
+            os_release="25.6.0",
+            architecture="arm64",
+            python_implementation="CPython",
+            python_version="3.13.15",
+            cpu_count=18,
+            chip="Apple M5 Pro",
+            total_memory_bytes=24 * 1024**3,
+            memory_free_percent=50.0,
+            swap_used_bytes=0,
+            disk_free_bytes=500 * 1024**3,
+            package_versions={
+                "mlx": "0.32.2",
+                "mlx-lm": "0.31.3",
+                "transformers": "5.16.1",
+            },
+        ),
+    )
+
+
+@dataclass
+class FakeResponse:
+    text: str
+    from_draft: bool = False
+    prompt_tokens: int = 5
+    generation_tokens: int = 1
+    finish_reason: str | None = None
+
+
+class FakeChatTokenizer:
+    bos_token = None
+
+    def apply_chat_template(
+        self, messages, tokenize=True, add_generation_prompt=True, enable_thinking=False
+    ):
+        assert enable_thinking is False
+        assert tokenize is True
+        assert add_generation_prompt is True
+        return [1, 2, 3, 4, 5]
+
+
+class FakeRuntime:
+    mlx_version = "0.32.2"
+    mlx_lm_version = "0.31.3"
+    runtime_name = "mlx-lm"
+    runtime_version = "0.31.3"
+    generate_calls = 0
+    peak_bytes = 1024**3
+    fail_generation = False
+    wrong_answer = False
+
+    def __init__(self, **kwargs):
+        self.prompt = ""
+        self._kwargs = kwargs
+
+    def load_model(self, path):
+        return object(), FakeChatTokenizer()
+
+    def encode(self, tokenizer, prompt):
+        self.prompt = prompt
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=self._kwargs.get("enable_thinking", False),
+        )
+
+    def seed(self, seed):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def reset_peak_memory(self):
+        pass
+
+    def memory_snapshot(self):
+        return MLXMemorySnapshot(
+            active_bytes=512 * 1024**2,
+            cache_bytes=128 * 1024**2,
+            peak_bytes=type(self).peak_bytes,
+        )
+
+    def accelerator_name(self):
+        return "Apple M5 Pro"
+
+    def stream_generate(
+        self,
+        model,
+        tokenizer,
+        prompt_tokens,
+        *,
+        max_tokens,
+        draft_model,
+        num_draft_tokens,
+    ):
+        type(self).generate_calls += 1
+        if type(self).fail_generation:
+            raise RuntimeError("simulated failure")
+        if type(self).wrong_answer:
+            text = "this response satisfies neither evaluator's expected format"
+        else:
+            text = (
+                '{"name":"Priya","age":34,"is_active":true}'
+                if "Priya Nakamura" in self.prompt
+                else "3 hours. The combined closing speed is 70 miles per hour."
+            )
+        yield FakeResponse(text=text, prompt_tokens=len(prompt_tokens))
+
+
+def _in_process_launcher(manifest: LabManifest):
+    """A ``launcher`` that runs the exact child-row code path in-process
+    (bypassing a real subprocess spawn) so tests can assert on the tier
+    loop/safety-gate/resume logic without any process overhead."""
+
+    def launch(
+        *,
+        manifest_path,
+        workload_id,
+        tier,
+        repetition_index,
+        warmup,
+        model_path,
+        output_dir,
+        resume,
+        timeout_seconds,
+        cleanup_grace_seconds,
+    ):
+        bm.run_child_row(
+            manifest,
+            workload_id=workload_id,
+            tier=tier,
+            repetition_index=repetition_index,
+            warmup=warmup,
+            model_path=model_path,
+            output_dir=output_dir,
+            manifest_dir=manifest_path.parent,
+            resume=resume,
+            hardware_fingerprint="fixed-test-fingerprint",
+        )
+        return bm.ChildLaunchResult(
+            exit_code=0, timed_out=False, descendants_cleaned=True
+        )
+
+    return launch
+
+
+def _prepare(monkeypatch):
+    monkeypatch.setattr(bm, "verify_model", lambda *args, **kwargs: {"verified": True})
+    monkeypatch.setattr(bm, "assess_safety", lambda *args, **kwargs: _safe_decision())
+    monkeypatch.setattr(bm, "Qwen3ChatMLXLMRuntime", FakeRuntime)
+    FakeRuntime.generate_calls = 0
+    FakeRuntime.peak_bytes = 1024**3
+    FakeRuntime.fail_generation = False
+    FakeRuntime.wrong_answer = False
+
+
+# ---------------------------------------------------------------------------
+# Control manifest template / bind
+# ---------------------------------------------------------------------------
+
+
+def test_control_template_parses_without_precommitted_model_identity() -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    raw = template.to_dict()
+    assert "files" not in raw["model"]
+    assert "expected_download_bytes" not in raw["model"]
+    assert "revision" not in raw["model"]
+    assert raw["model"]["model_family"] == "qwen3"
+    assert raw["generation"]["enable_thinking"] is False
+    assert raw["repetitions"]["warmup_per_tier"] == 1
+    assert raw["repetitions"]["measured_per_workload"] == 2
+
+
+def test_control_template_rejects_precommitted_files_field() -> None:
+    payload = json.loads(CONTROL_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    payload["model"]["files"] = [{"path": "x", "size_bytes": 1, "sha256": "0" * 64}]
+    with pytest.raises(ControlManifestError, match="must not pre-commit"):
+        ControlManifestTemplate.from_dict(payload)
+
+
+def test_bind_control_manifest_is_deterministic_and_never_fabricated(tmp_path) -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt()
+    first = bind_control_manifest(
+        template, receipt, conversion_manifest=conversion_manifest
+    )
+    second = bind_control_manifest(
+        template, receipt, conversion_manifest=conversion_manifest
+    )
+    assert first.model.revision == second.model.revision
+    assert len(first.model.revision) == 40
+    assert all(c in "0123456789abcdef" for c in first.model.revision)
+    assert first.model.expected_download_bytes == 30
+    assert first.model.model_family == "qwen3"
+    # Changing the receipt's output hashes must change the binding.
+    different = bind_control_manifest(
+        template,
+        _fabricated_receipt(
+            output_files=(
+                {"path": "config.json", "size_bytes": 10, "sha256": "c" * 64},
+            ),
+            output_total_bytes=10,
+        ),
+        conversion_manifest=conversion_manifest,
+    )
+    assert different.model.revision != first.model.revision
+
+
+def test_bind_refuses_a_non_completed_receipt() -> None:
+    from dataclasses import replace
+
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    completed = bind_control_manifest(
+        template, _fabricated_receipt(), conversion_manifest=conversion_manifest
+    )
+    assert completed.model.model_family == "qwen3"
+    # bind_control_manifest's own guard rejects a hand-built non-completed
+    # receipt (``ConversionReceipt.from_dict`` already enforces this on any
+    # receipt read back from disk; this exercises the belt-and-braces
+    # in-memory guard directly).
+    stale_receipt = replace(_fabricated_receipt(), status="failed")
+    with pytest.raises(ControlManifestError, match="non-completed"):
+        bind_control_manifest(
+            template, stale_receipt, conversion_manifest=conversion_manifest
+        )
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value", "expected_substring"),
+    [
+        ("official_id", "Qwen/Qwen3.8-27B", "source.official_id"),
+        ("official_revision", "0" * 40, "source.official_revision"),
+        ("license", "MIT", "source.license"),
+    ],
+)
+def test_bind_refuses_receipt_with_mismatched_source_identity(
+    override_key, override_value, expected_substring
+) -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt(
+        source={**_fabricated_receipt().source, override_key: override_value}
+    )
+    with pytest.raises(ControlManifestError, match=expected_substring):
+        bind_control_manifest(
+            template, receipt, conversion_manifest=conversion_manifest
+        )
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value", "expected_substring"),
+    [
+        ("package", "mlx-vlm", "converter.package"),
+        ("version", "0.0.0", "converter.version"),
+        ("git_revision", "1" * 40, "converter.git_revision"),
+    ],
+)
+def test_bind_refuses_receipt_with_mismatched_converter_identity(
+    override_key, override_value, expected_substring
+) -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt(
+        converter={**_fabricated_receipt().converter, override_key: override_value}
+    )
+    with pytest.raises(ControlManifestError, match=expected_substring):
+        bind_control_manifest(
+            template, receipt, conversion_manifest=conversion_manifest
+        )
+
+
+def test_bind_refuses_receipt_with_mismatched_conversion_id() -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt(conversion_id="some-other-conversion")
+    with pytest.raises(ControlManifestError, match="conversion_id"):
+        bind_control_manifest(
+            template, receipt, conversion_manifest=conversion_manifest
+        )
+
+
+def test_bind_refuses_receipt_with_mismatched_quantization_parameters() -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt(
+        parameters={**_fabricated_receipt().parameters, "q_bits": 8}
+    )
+    with pytest.raises(ControlManifestError, match="parameters"):
+        bind_control_manifest(
+            template, receipt, conversion_manifest=conversion_manifest
+        )
+
+
+def test_bind_refuses_receipt_with_mismatched_manifest_hash() -> None:
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    conversion_manifest = _conversion_manifest()
+    receipt = _fabricated_receipt(conversion_manifest_hash="sha256:" + "f" * 64)
+    with pytest.raises(ControlManifestError, match="conversion_manifest_hash"):
+        bind_control_manifest(
+            template, receipt, conversion_manifest=conversion_manifest
+        )
+
+
+# ---------------------------------------------------------------------------
+# Namespace separation from the packaged 27B lab
+# ---------------------------------------------------------------------------
+
+
+def test_namespace_fully_separate_from_27b_lab_paths() -> None:
+    control_template = json.loads(CONTROL_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    conversion_manifest = json.loads(
+        CONVERSION_MANIFEST_PATH.read_text(encoding="utf-8")
+    )
+    lab_27b = json.loads(TWENTY_SEVEN_B_MANIFEST_PATH.read_text(encoding="utf-8"))
+    frontier_27b = json.loads(FRONTIER_MANIFEST_PATH.read_text(encoding="utf-8"))
+    autopsy_27b = json.loads(AUTOPSY_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    control_paths = {
+        control_template["artifacts"]["workspace"],
+        control_template["artifacts"]["model_cache"],
+        control_template["artifacts"]["shareable_example_dir"],
+        conversion_manifest["artifacts"]["source_cache"],
+        conversion_manifest["artifacts"]["output_cache"],
+        conversion_manifest["artifacts"]["workspace"],
+    }
+    existing_27b_paths = {
+        lab_27b["artifacts"]["workspace"],
+        lab_27b["artifacts"]["model_cache"],
+        lab_27b["artifacts"]["shareable_example_dir"],
+        frontier_27b["artifacts"]["workspace"],
+        frontier_27b["artifacts"]["shareable_example_dir"],
+        autopsy_27b["artifacts"]["workspace"],
+    }
+    assert control_paths.isdisjoint(existing_27b_paths)
+    # None of the new paths is a parent/child directory of an existing one.
+    for new_path in control_paths:
+        for old_path in existing_27b_paths:
+            new_parts = Path(new_path).parts
+            old_parts = Path(old_path).parts
+            shorter, longer = sorted((new_parts, old_parts), key=len)
+            assert longer[: len(shorter)] != shorter, (new_path, old_path)
+    assert control_template["lab_id"] != lab_27b["lab_id"]
+    assert (
+        control_template["model"]["repository_id"] != lab_27b["model"]["repository_id"]
+    )
+
+
+def test_control_manifest_leaves_27b_manifests_byte_identical_on_disk() -> None:
+    # Guards against any accidental in-place edit of the packaged 27B
+    # artifacts while adding this control (only additive fields with
+    # backward-compatible defaults were introduced in manifest.py/core.py).
+    for path, expected_lab_id in (
+        (TWENTY_SEVEN_B_MANIFEST_PATH, "m5-pro-qwen3.8-27b-v1"),
+        (FRONTIER_MANIFEST_PATH, None),
+        (AUTOPSY_MANIFEST_PATH, None),
+    ):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if expected_lab_id is not None:
+            assert payload["lab_id"] == expected_lab_id
+        assert "model_family" not in payload.get("model", {})
+
+
+def test_prompt_hashes_reused_from_catalog_are_model_independent() -> None:
+    """Prompt materialization never depends on which model executes it,
+    so the control manifest can (and does) pin the exact same prompt
+    hashes the 27B lab pins for the same (workload, tier) pair."""
+    from llmtracefx.optimizer.lab.core import verify_catalog
+
+    template = ControlManifestTemplate.read_json(CONTROL_TEMPLATE_PATH)
+    bound_in_memory = bind_control_manifest(
+        template, _fabricated_receipt(), conversion_manifest=_conversion_manifest()
+    )
+    verify_catalog(bound_in_memory)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner: run mode, subprocess isolation, safety, resume
+# ---------------------------------------------------------------------------
+
+
+def test_run_mode_defaults_exploratory_and_publication_requires_clean_boot(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    with pytest.raises(LabError, match="operator assertion"):
+        bm.run_benchmark(
+            manifest,
+            manifest_path=manifest_path,
+            workspace=tmp_path / "ws1",
+            model_path=tmp_path / "model",
+            max_tier="2k",
+            run_mode="publication",
+            clean_boot_confirmed=False,
+            launcher=_in_process_launcher(manifest),
+        )
+    with pytest.raises(LabError, match="only valid in publication mode"):
+        bm.run_benchmark(
+            manifest,
+            manifest_path=manifest_path,
+            workspace=tmp_path / "ws2",
+            model_path=tmp_path / "model",
+            max_tier="2k",
+            run_mode="exploratory",
+            clean_boot_confirmed=True,
+            launcher=_in_process_launcher(manifest),
+        )
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "ws3",
+        model_path=tmp_path / "model",
+        max_tier="2k",
+    )
+    assert state["run_mode"] == "exploratory"
+    assert state["clean_boot_confirmed"] is False
+
+
+def test_subprocess_launcher_uses_new_session_and_no_shell(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    captured = {}
+
+    class FakeProcess:
+        pid = 12345
+        returncode = 0
+
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+
+        def wait(self, timeout=None):
+            return 0
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(bm.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(bm, "_clean_process_group", lambda *args: True)
+    result = bm.launch_row_subprocess(
+        manifest_path=manifest_path,
+        workload_id="structured-json-profile-extraction",
+        tier=ContextTier.TIER_2K,
+        repetition_index=0,
+        warmup=False,
+        model_path=tmp_path / "model",
+        output_dir=tmp_path / "output",
+        resume=True,
+        timeout_seconds=10,
+        cleanup_grace_seconds=1,
+    )
+    assert captured["argv"][1:4] == [
+        "-m",
+        "llmtracefx.optimizer.lab.qwen3_8b.benchmark",
+    ][: len(["-m", "llmtracefx.optimizer.lab.qwen3_8b.benchmark"])] or captured["argv"][
+        1:4
+    ] == [
+        "-m",
+        "llmtracefx.optimizer.lab.qwen3_8b.benchmark",
+        "_child",
+    ]
+    assert captured["kwargs"]["start_new_session"] is True
+    assert captured["kwargs"]["shell"] is False
+    assert result.descendants_cleaned is True
+
+
+def test_row_timeout_escalates_before_declaring_cleaned(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+
+    class FakeProcess:
+        pid = 999
+        returncode = -15
+
+        def __init__(self, argv, **kwargs):
+            self._waits = 0
+
+        def wait(self, timeout=None):
+            self._waits += 1
+            if self._waits == 1:
+                raise bm.subprocess.TimeoutExpired("child", timeout)
+            return self.returncode
+
+        def poll(self):
+            return self.returncode
+
+    cleaned_polled_at = []
+    monkeypatch.setattr(bm.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(
+        bm,
+        "_clean_process_group",
+        lambda process, group, grace: cleaned_polled_at.append(process.poll()) or True,
+    )
+    result = bm.launch_row_subprocess(
+        manifest_path=manifest_path,
+        workload_id="structured-json-profile-extraction",
+        tier=ContextTier.TIER_2K,
+        repetition_index=0,
+        warmup=False,
+        model_path=tmp_path / "model",
+        output_dir=tmp_path / "output",
+        resume=True,
+        timeout_seconds=0.01,
+        cleanup_grace_seconds=0.01,
+    )
+    assert result.timed_out is True
+    assert result.descendants_cleaned is True
+    assert cleaned_polled_at == [-15]
+
+
+def test_stop_on_first_failed_row_preserves_lower_tier_evidence(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+
+    def launcher(**kwargs):
+        if kwargs["tier"].value == "8k" and not kwargs["warmup"]:
+            FakeRuntime.fail_generation = True
+        else:
+            FakeRuntime.fail_generation = False
+        return _in_process_launcher(manifest)(**kwargs)
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        max_tier="16k",
+        launcher=launcher,
+    )
+    statuses = [tier["status"] for tier in state["tiers"]]
+    assert statuses[0] == "passed"
+    assert "16k" not in [tier["tier"] for tier in state["tiers"]]
+    assert state["unattempted_tiers"] == ["16k"]
+    assert state["status"] == "stopped"
+    # Tier 2k's evidence remains on disk, unaffected by the later failure.
+    assert (
+        tmp_path
+        / "workspace"
+        / "results"
+        / "runs"
+        / "structured-json-profile-extraction-2k-rep-01"
+        / "verification.json"
+    ).is_file()
+
+
+def test_evaluator_failure_stops_immediately_in_measured_rows(
+    tmp_path, monkeypatch
+) -> None:
+    """RowStatus.COMPLETED with outcome_success=False is an evaluator
+    failure (the model executed cleanly but got the task wrong); it must
+    stop immediately, exactly like an infrastructure failure, and never
+    let the tier or a later tier pass."""
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+
+    def launcher(**kwargs):
+        FakeRuntime.wrong_answer = not kwargs["warmup"]
+        return _in_process_launcher(manifest)(**kwargs)
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        max_tier="8k",
+        launcher=launcher,
+    )
+    assert state["status"] == "stopped"
+    assert state["tiers"][0]["status"] == "failed"
+    assert any(
+        "evaluator reported outcome_success=False" in reason
+        for reason in state["stop_reasons"]
+    )
+    assert "8k" not in [tier["tier"] for tier in state["tiers"]]
+    assert state["unattempted_tiers"] == ["8k"]
+    # The row itself really did complete (collector succeeded); only the
+    # evaluator's task-quality verdict failed.
+    run_dir = (
+        tmp_path
+        / "workspace"
+        / "results"
+        / "runs"
+        / "structured-json-profile-extraction-2k-rep-01"
+    )
+    verification = RowVerification.read_json(run_dir / "verification.json")
+    assert verification.status == RowStatus.COMPLETED
+    assert verification.outcome_success is False
+
+
+def test_evaluator_failure_stops_immediately_in_warmup(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    FakeRuntime.wrong_answer = True
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=_in_process_launcher(manifest),
+    )
+    assert state["status"] == "stopped"
+    assert state["tiers"][0]["status"] == "failed_warmup"
+    assert any(
+        "evaluator reported outcome_success=False" in reason
+        for reason in state["stop_reasons"]
+    )
+    # No measured row ever ran once the warmup's evaluator failed.
+    assert not (tmp_path / "workspace" / "results").exists()
+
+
+def test_parent_never_trusts_disk_artifact_after_nonzero_child_exit(
+    tmp_path, monkeypatch
+) -> None:
+    """A non-zero child exit code must never be overridden by whatever
+    verification.json happens to already exist at that row's path (e.g.
+    stale evidence from an unrelated earlier attempt)."""
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+
+    # Plant a stale, otherwise well-formed "completed" verification.json at
+    # the exact path the first warmup row would use.
+    stale_run_dir = (
+        workspace
+        / "warmups"
+        / "2k"
+        / "runs"
+        / "structured-json-profile-extraction-2k-warmup-01"
+    )
+    stale_run_dir.mkdir(parents=True, exist_ok=True)
+    stale_verification = RowVerification(
+        schema_version="2",
+        run_id="structured-json-profile-extraction-2k-warmup-01",
+        workload_id="structured-json-profile-extraction",
+        workload_version="1",
+        category="structured_json",
+        context_tier="2k",
+        decode_mode="autoregressive",
+        status=RowStatus.COMPLETED,
+        reason=None,
+        recorded_prompt_hash="sha256:" + "0" * 64,
+        verified_prompt_hash="sha256:" + "0" * 64,
+        run_binding_hash="sha256:" + "1" * 64,
+        resumed=False,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1.0,
+        started_at="2026-01-01T00:00:00Z",
+        ended_at="2026-01-01T00:00:01Z",
+        final_record_path=None,
+        collection_dir=None,
+    )
+    (stale_run_dir / "verification.json").write_text(
+        stale_verification.to_json(), encoding="utf-8"
+    )
+
+    def crashing_launcher(**kwargs):
+        return bm.ChildLaunchResult(
+            exit_code=1, timed_out=False, descendants_cleaned=True
+        )
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=crashing_launcher,
+    )
+    assert state["status"] == "stopped"
+    assert state["tiers"][0]["status"] == "failed_warmup"
+    assert any(
+        "never trusted after a crash" in reason for reason in state["stop_reasons"]
+    )
+
+
+def test_parent_never_advances_on_mismatched_child_artifact(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    wrong_verification = RowVerification(
+        schema_version="2",
+        run_id="wrong-run-id",
+        workload_id="structured-json-profile-extraction",
+        workload_version="1",
+        category="structured_json",
+        context_tier="2k",
+        decode_mode="autoregressive",
+        status=RowStatus.COMPLETED,
+        reason=None,
+        recorded_prompt_hash="sha256:" + "0" * 64,
+        verified_prompt_hash="sha256:" + "0" * 64,
+        run_binding_hash="sha256:" + "1" * 64,
+        resumed=False,
+        outcome_success=True,
+        quality_score=1.0,
+        total_ms=1.0,
+        started_at="2026-01-01T00:00:00Z",
+        ended_at="2026-01-01T00:00:01Z",
+        final_record_path=None,
+        collection_dir=None,
+    )
+    monkeypatch.setattr(
+        bm,
+        "_row_result_from_disk",
+        lambda *args, **kwargs: RowResult(
+            entry=object(), verification=wrong_verification, final_record=None
+        ),
+    )
+
+    result = bm._run_row_isolated(
+        manifest,
+        manifest_path=manifest_path,
+        workload_id="structured-json-profile-extraction",
+        tier=ContextTier.TIER_2K,
+        repetition_index=0,
+        warmup=True,
+        model_path=tmp_path / "model",
+        output_dir=tmp_path / "output",
+        resume=False,
+        timeout_seconds=1,
+        cleanup_grace_seconds=1,
+        launcher=lambda **kwargs: bm.ChildLaunchResult(
+            exit_code=0, timed_out=False, descendants_cleaned=True
+        ),
+    )
+
+    assert result.verification.status is RowStatus.FAILED
+    assert "artifact identity is stale or mismatched" in (
+        result.verification.reason or ""
+    )
+
+
+def test_missing_supported_evidence_after_exit_synthesizes_failure_and_stops(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+
+    def launcher(**kwargs):
+        # Exits "successfully" without ever writing verification.json.
+        return bm.ChildLaunchResult(
+            exit_code=0, timed_out=False, descendants_cleaned=True
+        )
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "workspace",
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=launcher,
+    )
+    assert state["status"] == "stopped"
+    assert state["tiers"][0]["status"] == "failed_warmup"
+    assert any(
+        "without writing supported evidence" in reason
+        for reason in state["stop_reasons"]
+    )
+
+
+def test_timeout_and_cleanup_failure_stop_without_advancing(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+
+    def timeout_launcher(**kwargs):
+        return bm.ChildLaunchResult(
+            exit_code=None, timed_out=True, descendants_cleaned=True
+        )
+
+    state = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "ws-timeout",
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=timeout_launcher,
+    )
+    assert state["status"] == "stopped"
+    assert any("timeout" in reason for reason in state["stop_reasons"])
+
+    def cleanup_failure_launcher(**kwargs):
+        return bm.ChildLaunchResult(
+            exit_code=1, timed_out=False, descendants_cleaned=False
+        )
+
+    state2 = bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=tmp_path / "ws-cleanup",
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=cleanup_failure_launcher,
+    )
+    assert state2["status"] == "stopped"
+    assert any("cleanup failed" in reason for reason in state2["stop_reasons"])
+
+
+def test_resume_reuses_only_verified_matching_evidence(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+    launcher = _in_process_launcher(manifest)
+
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        resume=True,
+        launcher=launcher,
+    )
+    first_calls = FakeRuntime.generate_calls
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        resume=True,
+        launcher=launcher,
+    )
+    assert FakeRuntime.generate_calls == first_calls + 1  # only the warmup reran
+
+    statuses = [
+        RowVerification.read_json(path).status
+        for path in (workspace / "results" / "runs").glob("*/verification.json")
+    ]
+    assert statuses and set(statuses) == {RowStatus.SKIPPED}
+
+
+def test_stale_evidence_is_never_trusted_on_resume(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+    launcher = _in_process_launcher(manifest)
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        resume=True,
+        launcher=launcher,
+    )
+    record_path = next((workspace / "results" / "runs").glob("*/final_record.json"))
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    payload["command"]["config_hash"] = "sha256:" + "0" * 64
+    record_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    from llmtracefx.optimizer.lab.qwen3_8b.report import verify_control_evidence
+
+    result = verify_control_evidence(manifest, workspace=workspace)
+    assert result["verified"] is False
+    assert any(
+        "current manifest binding mismatch" in failure for failure in result["failures"]
+    )
+
+
+def test_tokenizer_requested_and_actual_token_counts_are_reported_separately(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=_in_process_launcher(manifest),
+    )
+    report = build_control_report(manifest, workspace=workspace)
+    tier = report["tiers"][0]
+    assert tier["requested_tokens"] == 2048
+    assert tier["mean_actual_input_tokens"] == 5.0
+    assert tier["requested_tokens"] != tier["mean_actual_input_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# Reports: differs-from-27B language, determinism, privacy/integrity
+# ---------------------------------------------------------------------------
+
+
+def test_report_states_it_differs_from_27b_and_never_repeats_its_disclaimer(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=_in_process_launcher(manifest),
+    )
+    report = build_control_report(manifest, workspace=workspace)
+    joined_limitations = " ".join(report["limitations"])
+    assert "not the packaged Qwen3.8-27B lab" in joined_limitations
+    assert "never directly comparable" in joined_limitations
+    # The 27B report's inaccurate-for-us disclaimer must never appear here:
+    # this control *does* cryptographically bind its source revision.
+    assert "does not cryptographically bind" not in joined_limitations
+    assert report["self_conversion"]["official_revision"] == (
+        "b968826d9c46dd6066d109eabc6255188de91218"
+    )
+
+
+def test_report_is_deterministic_sanitized_json_and_html(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "private-user-name" / "workspace"
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=_in_process_launcher(manifest),
+    )
+    report = build_control_report(manifest, workspace=workspace)
+    from llmtracefx.optimizer.lab.core import render_lab_report_html
+
+    first = render_lab_report_html(report)
+    second = render_lab_report_html(report)
+    assert first == second
+    assert str(tmp_path) not in json.dumps(report)
+    assert str(tmp_path) not in first
+
+    shareable = tmp_path / "shareable"
+    written = write_control_reports(
+        manifest, workspace=workspace, shareable_dir=shareable
+    )
+    assert written == report
+    assert (workspace / "reports" / "tune-report.json").is_file()
+    assert (workspace / "reports" / "compare-report.json").is_file()
+    assert (shareable / "evidence-summary.json").is_file()
+    assert (shareable / "report.html").read_text(encoding="utf-8") == first
+
+
+def test_write_control_reports_refuses_tampered_evidence(tmp_path, monkeypatch) -> None:
+    manifest, manifest_path = _bound_manifest(tmp_path)
+    _prepare(monkeypatch)
+    (tmp_path / "model").mkdir(exist_ok=True)
+    workspace = tmp_path / "workspace"
+    bm.run_benchmark(
+        manifest,
+        manifest_path=manifest_path,
+        workspace=workspace,
+        model_path=tmp_path / "model",
+        max_tier="2k",
+        launcher=_in_process_launcher(manifest),
+    )
+    record_path = next((workspace / "results" / "runs").glob("*/final_record.json"))
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    payload["command"]["config_hash"] = "sha256:" + "1" * 64
+    record_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(LabError, match="unverified current-run evidence"):
+        write_control_reports(manifest, workspace=workspace)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_default_action_is_no_download_plan(monkeypatch, capsys) -> None:
+    from llmtracefx.optimizer.lab.qwen3_8b.conversion import ConversionSafetyDecision
+
+    monkeypatch.setattr(
+        qcli,
+        "assess_conversion_safety",
+        lambda *args, **kwargs: ConversionSafetyDecision(
+            safe=True,
+            blockers=(),
+            snapshot=_safe_decision().snapshot,
+            required_free_disk_bytes=128395428637,
+        ),
+    )
+    assert qcli.main([]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["no_spend"] is True
+    assert payload["downloads_performed"] is False
+    assert payload["conversion_manifest"].startswith("package:")
+    assert payload["required_free_disk_bytes"] == 128395428637
+
+
+def test_cli_bind_materializes_manifest_from_receipt(tmp_path) -> None:
+    receipt = _fabricated_receipt()
+    receipt_path = tmp_path / "conversion-receipt.json"
+    receipt_path.write_text(json.dumps(receipt.to_dict()), encoding="utf-8")
+    output_path = tmp_path / "control-manifest.bound.json"
+    exit_code = qcli.main(
+        ["bind", "--receipt", str(receipt_path), "--output", str(output_path)]
+    )
+    assert exit_code == 0
+    bound = LabManifest.read_json(output_path)
+    assert bound.model.model_family == "qwen3"
+    assert len(bound.model.revision) == 40
+
+
+def test_cli_run_requires_manifest_or_receipt(tmp_path) -> None:
+    exit_code = qcli.main(["run", "--workspace", str(tmp_path / "ws")])
+    assert exit_code == 1
+
+
+def test_packaged_resources_load_from_external_cwd(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    conversion, conversion_source = qcli._load_conversion_manifest(None)
+    template, template_source = qcli._load_control_template(None)
+    assert conversion_source.startswith("package:llmtracefx.optimizer.lab.qwen3_8b/")
+    assert template_source.startswith("package:llmtracefx.optimizer.lab.qwen3_8b/")
+    assert conversion.source.official_id == "Qwen/Qwen3-8B"
+    assert template.to_dict()["model"]["model_family"] == "qwen3"

--- a/tests/optimizer/test_m5_qwen3_8b_conversion.py
+++ b/tests/optimizer/test_m5_qwen3_8b_conversion.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import sys
+import types
 from dataclasses import replace
 from pathlib import Path
 
@@ -90,14 +91,15 @@ def _patch_source_hash(
 def _forbid_network_download(monkeypatch) -> None:
     """Any test that reaches this guard while expecting an offline path
     has a bug in its fixture, not a legitimate reason to download."""
-    import huggingface_hub
 
     def fail(*args, **kwargs):
         raise AssertionError(
             "snapshot_download must never be called in an offline test"
         )
 
-    monkeypatch.setattr(huggingface_hub, "snapshot_download", fail)
+    module = types.ModuleType("huggingface_hub")
+    module.snapshot_download = fail
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
 
 
 def test_packaged_conversion_manifest_pins_exact_provenance() -> None:
@@ -260,9 +262,9 @@ def test_acquire_source_downloads_only_when_cache_is_absent(
         _populate_sparse_source(manifest, Path(local_dir))
         return str(local_dir)
 
-    import huggingface_hub
-
-    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_download)
+    module = types.ModuleType("huggingface_hub")
+    module.snapshot_download = fake_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
     _patch_source_hash(monkeypatch, manifest, source_path)
 
     result = conv.acquire_source(manifest, source_path=source_path, workspace=workspace)

--- a/tests/optimizer/test_m5_qwen3_8b_conversion.py
+++ b/tests/optimizer/test_m5_qwen3_8b_conversion.py
@@ -1,0 +1,936 @@
+"""Offline tests for the Qwen3-8B self-conversion runner.
+
+No test in this module downloads model weights or executes a real
+model conversion: every filesystem/subprocess boundary is monkeypatched
+so the exact conversion-parameter argv, subprocess isolation, timeout
+escalation, and output-inventory logic can be verified deterministically
+and offline.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from llmtracefx.optimizer.lab.core import HostSnapshot
+from llmtracefx.optimizer.lab.qwen3_8b import conversion as conv
+from llmtracefx.optimizer.lab.qwen3_8b.conversion_manifest import (
+    ConversionManifest,
+    ConversionManifestError,
+)
+
+CONVERSION_MANIFEST_PATH = Path(
+    "llmtracefx/optimizer/lab/qwen3_8b/data/qwen3-8b-conversion-manifest-v1.json"
+)
+
+
+def _manifest() -> ConversionManifest:
+    return ConversionManifest.read_json(CONVERSION_MANIFEST_PATH)
+
+
+def _snapshot(**overrides) -> HostSnapshot:
+    manifest = _manifest()
+    values = {
+        "collected_at": "2026-09-01T00:00:00.000000Z",
+        "os_name": "Darwin",
+        "os_release": "25.6.0",
+        "architecture": "arm64",
+        "python_implementation": "CPython",
+        "python_version": "3.13.15",
+        "cpu_count": 18,
+        "chip": manifest.safety.required_chip,
+        "total_memory_bytes": manifest.safety.required_total_memory_bytes,
+        "memory_free_percent": 50.0,
+        "swap_used_bytes": 0,
+        "disk_free_bytes": 500 * 1024**3,
+        "package_versions": {"mlx-lm": manifest.converter.version},
+    }
+    values.update(overrides)
+    return HostSnapshot(**values)
+
+
+def _populate_sparse_source(manifest: ConversionManifest, source_path: Path) -> None:
+    """Create exact-size (sparse) files for every pinned source file.
+
+    Never writes real content; the real bytes are irrelevant here
+    because tests monkeypatch ``conv._sha256_file`` to return the
+    pinned digest for anything under ``source_path``.
+    """
+    for pin in manifest.source.files:
+        path = source_path / pin.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as handle:
+            if pin.size_bytes:
+                handle.truncate(pin.size_bytes)
+
+
+def _patch_source_hash(
+    monkeypatch, manifest: ConversionManifest, source_path: Path
+) -> None:
+    real_sha256_file = conv._sha256_file
+
+    def fake(path: Path) -> str:
+        path = Path(path)
+        try:
+            relative = path.relative_to(source_path)
+        except ValueError:
+            return real_sha256_file(path)
+        for pin in manifest.source.files:
+            if pin.path == str(relative):
+                return pin.sha256
+        raise AssertionError(f"unexpected source path in test fixture: {path}")
+
+    monkeypatch.setattr(conv, "_sha256_file", fake)
+
+
+def _forbid_network_download(monkeypatch) -> None:
+    """Any test that reaches this guard while expecting an offline path
+    has a bug in its fixture, not a legitimate reason to download."""
+    import huggingface_hub
+
+    def fail(*args, **kwargs):
+        raise AssertionError(
+            "snapshot_download must never be called in an offline test"
+        )
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fail)
+
+
+def test_packaged_conversion_manifest_pins_exact_provenance() -> None:
+    manifest = _manifest()
+    assert manifest.source.official_id == "Qwen/Qwen3-8B"
+    assert manifest.source.official_revision == (
+        "b968826d9c46dd6066d109eabc6255188de91218"
+    )
+    assert manifest.source.license == "Apache-2.0"
+    assert manifest.source.expected_source_bytes == 16397461266
+    assert manifest.source.fully_pinned is True
+    assert sum(pin.size_bytes for pin in manifest.source.files) == (
+        manifest.source.expected_source_bytes
+    )
+    assert manifest.converter.package == "mlx-lm"
+    assert manifest.converter.version == "0.31.3"
+    assert manifest.converter.git_revision == "ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd"
+    assert manifest.parameters.quantize is True
+    assert manifest.parameters.q_group_size == 64
+    assert manifest.parameters.q_bits == 4
+    assert manifest.parameters.dequantize is False
+    assert manifest.parameters.upload_repo is None
+    assert manifest.parameters.trust_remote_code is False
+
+
+def test_conversion_manifest_rejects_dequantize() -> None:
+    payload = json.loads(CONVERSION_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["parameters"]["dequantize"] = True
+    with pytest.raises(ConversionManifestError, match="dequantize"):
+        ConversionManifest.from_dict(payload)
+
+
+def test_conversion_manifest_rejects_upload_repo() -> None:
+    payload = json.loads(CONVERSION_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["parameters"]["upload_repo"] = "someone/somewhere"
+    with pytest.raises(ConversionManifestError, match="upload_repo"):
+        ConversionManifest.from_dict(payload)
+
+
+def test_conversion_manifest_rejects_unpinned_official_revision_format() -> None:
+    payload = json.loads(CONVERSION_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["source"]["official_revision"] = "main"
+    with pytest.raises(ConversionManifestError, match="git revision"):
+        ConversionManifest.from_dict(payload)
+
+
+def test_conversion_manifest_rejects_source_file_without_sha256() -> None:
+    payload = json.loads(CONVERSION_MANIFEST_PATH.read_text(encoding="utf-8"))
+    payload["source"]["files"][0]["sha256"] = None
+    with pytest.raises(ConversionManifestError, match="sha256"):
+        ConversionManifest.from_dict(payload)
+
+
+def test_conversion_manifest_hash_binds_every_source_file_digest() -> None:
+    manifest = _manifest()
+    first = manifest.source.files[0]
+    changed = replace(
+        manifest,
+        source=replace(
+            manifest.source,
+            files=(replace(first, sha256="f" * 64), *manifest.source.files[1:]),
+        ),
+    )
+    assert conv.conversion_manifest_hash(changed) != conv.conversion_manifest_hash(
+        manifest
+    )
+
+
+def test_argv_is_the_exact_deterministic_mlx_lm_convert_invocation() -> None:
+    manifest = _manifest()
+    argv = manifest.parameters.argv(hf_path="/src", mlx_path="/out")
+    assert argv == (
+        "convert",
+        "--hf-path",
+        "/src",
+        "--mlx-path",
+        "/out",
+        "--quantize",
+        "--q-group-size",
+        "64",
+        "--q-bits",
+        "4",
+        "--q-mode",
+        "affine",
+    )
+
+
+def test_source_verification_rejects_unpinned_root_entry(tmp_path, monkeypatch) -> None:
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    _populate_sparse_source(manifest, source_path)
+    _patch_source_hash(monkeypatch, manifest, source_path)
+    (source_path / "stale-extra-file.bin").write_bytes(b"x")
+    with pytest.raises(conv.ConversionError, match="unpinned source-root entry"):
+        conv.verify_source(manifest, source_path)
+
+
+def test_source_verification_rejects_symlinked_file(tmp_path, monkeypatch) -> None:
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    _populate_sparse_source(manifest, source_path)
+    _patch_source_hash(monkeypatch, manifest, source_path)
+    real_file = source_path / manifest.source.files[0].path
+    real_file.unlink()
+    (source_path / "elsewhere.bin").write_bytes(b"x")
+    real_file.symlink_to(source_path / "elsewhere.bin")
+    with pytest.raises(conv.ConversionError, match="missing regular source file"):
+        conv.verify_source(manifest, source_path)
+
+
+def test_acquire_source_reuses_verified_cache_without_any_network_call(
+    tmp_path, monkeypatch
+) -> None:
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    workspace = tmp_path / "workspace"
+    _populate_sparse_source(manifest, source_path)
+    _patch_source_hash(monkeypatch, manifest, source_path)
+    _forbid_network_download(monkeypatch)
+
+    result = conv.acquire_source(manifest, source_path=source_path, workspace=workspace)
+    assert result["verified"] is True
+    assert result["fully_pinned"] is True
+
+
+def test_acquire_source_refuses_existing_invalid_cache_without_downloading(
+    tmp_path, monkeypatch
+) -> None:
+    """Per item 4: if source_path already has content that fails
+    verification, this refuses rather than falling through to a network
+    write into a possibly corrupt or stale cache."""
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    workspace = tmp_path / "workspace"
+    _populate_sparse_source(manifest, source_path)
+    # Corrupt exactly one file's size so verification fails.
+    corrupted = source_path / manifest.source.files[0].path
+    corrupted.write_bytes(b"short")
+    _patch_source_hash(monkeypatch, manifest, source_path)
+    _forbid_network_download(monkeypatch)
+
+    with pytest.raises(conv.ConversionError, match="size"):
+        conv.acquire_source(manifest, source_path=source_path, workspace=workspace)
+    # The corrupt file must remain exactly as it was; never overwritten.
+    assert corrupted.read_bytes() == b"short"
+
+
+def test_acquire_source_downloads_only_when_cache_is_absent(
+    tmp_path, monkeypatch
+) -> None:
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    workspace = tmp_path / "workspace"
+    assert not source_path.exists()
+
+    calls = []
+
+    def fake_download(*, repo_id, revision, local_dir, allow_patterns):
+        calls.append((repo_id, revision))
+        _populate_sparse_source(manifest, Path(local_dir))
+        return str(local_dir)
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_download)
+    _patch_source_hash(monkeypatch, manifest, source_path)
+
+    result = conv.acquire_source(manifest, source_path=source_path, workspace=workspace)
+    assert calls == [(manifest.source.repository_id, manifest.source.official_revision)]
+    assert result["verified"] is True
+
+
+def test_conversion_safety_blocks_on_mismatched_installed_converter_version(
+    tmp_path, monkeypatch
+) -> None:
+    manifest = _manifest()
+    monkeypatch.setattr(
+        conv,
+        "collect_host_snapshot",
+        lambda path: _snapshot(package_versions={"mlx-lm": "0.0.0"}),
+    )
+    decision = conv.assess_conversion_safety(
+        manifest, tmp_path, include_source_download=False
+    )
+    assert decision.safe is False
+    assert any("installed mlx-lm is 0.0.0" in blocker for blocker in decision.blockers)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_substring"),
+    [
+        ({"memory_free_percent": 39.0}, "memory free 39% is below 40%"),
+        ({"swap_used_bytes": 12884901889}, "swap used 12884901889 bytes exceeds"),
+        ({"disk_free_bytes": 111997967370}, "disk free 111997967370 bytes is below"),
+    ],
+)
+def test_conversion_safety_blocks_on_each_conservative_threshold(
+    overrides, expected_substring
+) -> None:
+    manifest = _manifest()
+    decision = conv.ConversionSafetyDecision(
+        safe=True,
+        blockers=(),
+        snapshot=_snapshot(**overrides),
+        required_free_disk_bytes=0,
+    )
+    # Re-run the real assessment against the overridden snapshot so this
+    # exercises the exact production code path, not a hand-built decision.
+    import llmtracefx.optimizer.lab.qwen3_8b.conversion as conv_module
+
+    original = conv_module.collect_host_snapshot
+    try:
+        conv_module.collect_host_snapshot = lambda path: decision.snapshot
+        result = conv.assess_conversion_safety(
+            manifest, Path("."), include_source_download=True
+        )
+    finally:
+        conv_module.collect_host_snapshot = original
+    assert result.safe is False
+    assert any(expected_substring in blocker for blocker in result.blockers)
+
+
+def test_required_free_disk_bytes_matches_exact_conservative_policy() -> None:
+    manifest = _manifest()
+    assert manifest.source.expected_source_bytes == 16397461266
+    assert manifest.expected_output_bytes == 4623784971
+    assert manifest.safety.minimum_residual_free_disk_bytes == 107374182400
+    assert manifest.safety.minimum_memory_free_percent == 40.0
+    assert manifest.safety.maximum_swap_used_bytes == 12 * 1024**3
+
+    decision_with_download = conv.assess_conversion_safety(
+        manifest, Path("."), include_source_download=True
+    )
+    assert decision_with_download.required_free_disk_bytes == 128395428637
+
+    decision_without_download = conv.assess_conversion_safety(
+        manifest, Path("."), include_source_download=False
+    )
+    assert decision_without_download.required_free_disk_bytes == 111997967371
+
+
+def test_run_conversion_refuses_before_any_download_or_subprocess_on_low_memory(
+    tmp_path, monkeypatch
+) -> None:
+    """The exact scenario this hardening pass fixes: a live safety-gate
+    refusal must precede any network/download/subprocess activity, write
+    a bounded pre_conversion_safety failure record, and never touch the
+    source/output paths."""
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    output_path = tmp_path / "output"
+    workspace = tmp_path / "workspace"
+
+    def refused_snapshot(path):
+        return _snapshot(
+            memory_free_percent=39.0,
+            swap_used_bytes=10148705730,
+            disk_free_bytes=721039908864,
+        )
+
+    monkeypatch.setattr(conv, "collect_host_snapshot", refused_snapshot)
+    _forbid_network_download(monkeypatch)
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("must never launch a subprocess after a safety refusal")
+
+    monkeypatch.setattr(conv.subprocess, "Popen", fail_popen)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+
+    assert journal["status"] == "safety_blocked"
+    assert journal["phase"] == "pre_conversion_safety"
+    assert journal["downloads_performed"] is False
+    assert journal["conversion_process_started"] is False
+    assert journal["retried"] is False
+    assert any("memory free 39%" in blocker for blocker in journal["blockers"])
+    assert journal["required_free_disk_bytes"] == 128395428637
+    assert not source_path.exists()
+    assert not output_path.exists()
+    failure_path = workspace / "conversion-failure.json"
+    assert failure_path.is_file()
+    assert json.loads(failure_path.read_text(encoding="utf-8")) == journal
+    # Bounded, privacy-safe: no repository-relative or user paths leaked.
+    assert str(tmp_path) not in json.dumps(journal)
+
+
+def test_cli_convert_surfaces_status_2_not_1_for_safety_refusal(
+    tmp_path, monkeypatch
+) -> None:
+    from llmtracefx.optimizer.lab.qwen3_8b import cli as qcli
+
+    def refused_snapshot(path):
+        return _snapshot(memory_free_percent=39.0)
+
+    monkeypatch.setattr(conv, "collect_host_snapshot", refused_snapshot)
+    exit_code = qcli.main(
+        [
+            "convert",
+            "--source-path",
+            str(tmp_path / "source"),
+            "--output-path",
+            str(tmp_path / "output"),
+            "--conversion-workspace",
+            str(tmp_path / "ws"),
+        ]
+    )
+    assert exit_code == 2
+
+
+def _prepare_offline_conversion(tmp_path, monkeypatch):
+    manifest = _manifest()
+    source_path = tmp_path / "source"
+    workspace = tmp_path / "workspace"
+    _populate_sparse_source(manifest, source_path)
+    _patch_source_hash(monkeypatch, manifest, source_path)
+    _forbid_network_download(monkeypatch)
+    monkeypatch.setattr(conv, "collect_host_snapshot", lambda path: _snapshot())
+    return manifest, source_path, workspace
+
+
+def test_run_conversion_launches_fresh_process_group_no_shell(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+    captured = {}
+
+    class FakeProcess:
+        pid = 4242
+        returncode = 0
+
+        def __init__(self, argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+
+        def wait(self, timeout=None):
+            output_path.mkdir(parents=True, exist_ok=True)
+            (output_path / "model.safetensors").write_bytes(b"abc")
+            return 0
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: True)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+
+    assert journal["status"] == "completed"
+    assert captured["kwargs"]["start_new_session"] is True
+    assert captured["kwargs"]["shell"] is False
+    assert captured["argv"][0] == sys.executable
+    assert captured["argv"][1:4] == ["-m", "mlx_lm", "convert"]
+    assert "--quantize" in captured["argv"]
+    assert (workspace / "conversion-receipt.json").is_file()
+    receipt = conv.ConversionReceipt.read_json(workspace / "conversion-receipt.json")
+    assert receipt.output_total_bytes == 3
+    assert receipt.converter["git_revision"] == manifest.converter.git_revision
+
+
+def test_run_conversion_timeout_escalates_to_kill_and_writes_failure(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+
+    class FakeProcess:
+        pid = 4242
+        returncode = -9
+
+        def __init__(self, argv, **kwargs):
+            self._waits = 0
+
+        def wait(self, timeout=None):
+            self._waits += 1
+            if self._waits == 1:
+                raise conv.subprocess.TimeoutExpired("child", timeout)
+            return self.returncode
+
+        def poll(self):
+            return self.returncode
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: True)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+    assert journal["status"] == "timeout"
+    assert journal["timed_out"] is True
+    assert (workspace / "conversion-failure.json").is_file()
+    assert not (workspace / "conversion-receipt.json").exists()
+
+
+def test_run_conversion_cleanup_failure_is_a_distinct_status(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+
+    class FakeProcess:
+        pid = 1
+        returncode = None
+
+        def __init__(self, argv, **kwargs):
+            pass
+
+        def wait(self, timeout=None):
+            return None
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: False)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+    assert journal["status"] == "cleanup_failed"
+    assert not (workspace / "conversion-receipt.json").exists()
+
+
+def test_run_conversion_nonzero_exit_writes_failure_not_receipt(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+
+    class FakeProcess:
+        pid = 2
+        returncode = 1
+
+        def __init__(self, argv, **kwargs):
+            pass
+
+        def wait(self, timeout=None):
+            return 1
+
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: True)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+    assert journal["status"] == "failed"
+    assert journal["exit_code"] == 1
+    assert (workspace / "conversion-failure.json").is_file()
+    assert not (workspace / "conversion-receipt.json").exists()
+
+
+def test_run_conversion_rejects_symlinked_output_as_failure_record(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+
+    class FakeProcess:
+        pid = 3
+        returncode = 0
+
+        def __init__(self, argv, **kwargs):
+            pass
+
+        def wait(self, timeout=None):
+            output_path.mkdir(parents=True, exist_ok=True)
+            (output_path / "real.bin").write_bytes(b"data")
+            (output_path / "link.bin").symlink_to(output_path / "real.bin")
+            return 0
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: True)
+
+    journal = conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+    assert journal["status"] == "unsafe_output"
+    assert not (workspace / "conversion-receipt.json").exists()
+    assert (workspace / "conversion-failure.json").is_file()
+
+
+def test_run_conversion_refuses_preexisting_output_without_deleting_it(
+    tmp_path, monkeypatch
+) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+    output_path.mkdir()
+    (output_path / "keep-me.bin").write_bytes(b"user data")
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError(
+            "must never launch a subprocess over an existing output path"
+        )
+
+    monkeypatch.setattr(conv.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(conv.ConversionError, match="already exists"):
+        conv.run_conversion(
+            manifest,
+            source_path=source_path,
+            output_path=output_path,
+            workspace=workspace,
+        )
+    assert (output_path / "keep-me.bin").read_bytes() == b"user data"
+
+
+def test_run_conversion_never_retries_automatically(tmp_path, monkeypatch) -> None:
+    manifest, source_path, workspace = _prepare_offline_conversion(
+        tmp_path, monkeypatch
+    )
+    output_path = tmp_path / "output"
+    popen_calls = []
+
+    class FakeProcess:
+        pid = 5
+        returncode = 1
+
+        def __init__(self, argv, **kwargs):
+            popen_calls.append(argv)
+
+        def wait(self, timeout=None):
+            return 1
+
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(conv.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(conv, "_clean_process_group", lambda *args: True)
+
+    conv.run_conversion(
+        manifest, source_path=source_path, output_path=output_path, workspace=workspace
+    )
+    assert len(popen_calls) == 1  # exactly one attempt; no internal retry loop
+
+
+def test_bounded_journal_tail_truncates_to_max_journal_bytes() -> None:
+    text = "x" * 5000
+    truncated = conv._bounded_tail(text, 100)
+    assert len(truncated.encode("utf-8")) == 100
+    assert conv._bounded_tail("short", 100) == "short"
+
+
+def test_conversion_receipt_rejects_incomplete_status() -> None:
+    with pytest.raises(conv.ConversionError, match="completed"):
+        conv.ConversionReceipt.from_dict(
+            {
+                "schema_version": "1",
+                "conversion_id": "x",
+                "status": "failed",
+                "started_at": "a",
+                "ended_at": "b",
+                "source": {},
+                "converter": {},
+                "parameters": {},
+                "argv": [],
+                "output_files": [{"path": "a", "size_bytes": 1, "sha256": "0" * 64}],
+                "output_total_bytes": 1,
+                "host": {},
+            }
+        )
+
+
+def _valid_receipt_payload() -> dict:
+    return {
+        "schema_version": "1",
+        "conversion_id": "qwen3-8b-mlx-q4g64-self-convert-v1",
+        "conversion_manifest_hash": "sha256:" + "a" * 64,
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T01:00:00Z",
+        "source": {
+            "official_id": "Qwen/Qwen3-8B",
+            "official_revision": "b968826d9c46dd6066d109eabc6255188de91218",
+            "license": "Apache-2.0",
+        },
+        "converter": {
+            "package": "mlx-lm",
+            "version": "0.31.3",
+            "git_revision": "ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
+        },
+        "parameters": {
+            "quantize": True,
+            "q_group_size": 64,
+            "q_bits": 4,
+            "q_mode": "affine",
+            "dtype": None,
+            "quant_predicate": None,
+            "dequantize": False,
+            "trust_remote_code": False,
+            "upload_repo": None,
+        },
+        "argv": ["mlx_lm", "convert"],
+        "output_files": [
+            {"path": "config.json", "size_bytes": 10, "sha256": "b" * 64},
+            {"path": "model.safetensors", "size_bytes": 20, "sha256": "c" * 64},
+        ],
+        "output_total_bytes": 30,
+        "host": {"os_name": "Darwin"},
+    }
+
+
+def test_conversion_receipt_parses_a_fully_valid_payload() -> None:
+    receipt = conv.ConversionReceipt.from_dict(_valid_receipt_payload())
+    assert receipt.output_total_bytes == 30
+    assert len(receipt.output_files) == 2
+    assert receipt.conversion_manifest_hash == "sha256:" + "a" * 64
+
+
+def test_conversion_receipt_rejects_duplicate_output_paths() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_files"] = [
+        {"path": "config.json", "size_bytes": 10, "sha256": "b" * 64},
+        {"path": "config.json", "size_bytes": 20, "sha256": "c" * 64},
+    ]
+    with pytest.raises(conv.ConversionError, match="unique"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_unsafe_output_path() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_files"][0]["path"] = "../escape.bin"
+    with pytest.raises(conv.ConversionError, match="safe relative path"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_absolute_output_path() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_files"][0]["path"] = "/etc/passwd"
+    with pytest.raises(conv.ConversionError, match="safe relative path"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_non_positive_size() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_files"][0]["size_bytes"] = 0
+    with pytest.raises(conv.ConversionError, match="positive integer"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_uppercase_sha256() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_files"][0]["sha256"] = "B" * 64
+    with pytest.raises(conv.ConversionError, match="lowercase SHA-256"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_total_bytes_mismatch() -> None:
+    payload = _valid_receipt_payload()
+    payload["output_total_bytes"] = 999
+    with pytest.raises(conv.ConversionError, match="does not equal the sum"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "a" * 64, "sha256:" + "A" * 64, "sha256:short"],
+)
+def test_conversion_receipt_requires_manifest_hash(value) -> None:
+    payload = _valid_receipt_payload()
+    payload["conversion_manifest_hash"] = value
+    with pytest.raises(conv.ConversionError, match="conversion_manifest_hash"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    ("section", "key"),
+    [
+        ("source", "official_id"),
+        ("source", "official_revision"),
+        ("source", "license"),
+        ("converter", "package"),
+        ("converter", "version"),
+        ("converter", "git_revision"),
+    ],
+)
+def test_conversion_receipt_rejects_missing_identity_key(section, key) -> None:
+    payload = _valid_receipt_payload()
+    del payload[section][key]
+    with pytest.raises(conv.ConversionError):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+def test_conversion_receipt_rejects_missing_parameter_key() -> None:
+    payload = _valid_receipt_payload()
+    del payload["parameters"]["q_group_size"]
+    with pytest.raises(conv.ConversionError, match="missing"):
+        conv.ConversionReceipt.from_dict(payload)
+
+
+EXAMPLE_REFUSAL_PATH = Path(
+    "examples/optimizer/qwen3-8b-m5-control/conversion-preflight-refusal-example.json"
+)
+
+
+def test_committed_refusal_example_is_named_and_shaped_as_a_refusal_not_evidence() -> (
+    None
+):
+    example = json.loads(EXAMPLE_REFUSAL_PATH.read_text(encoding="utf-8"))
+    assert example["artifact_type"] == "conversion_preflight_refusal"
+    assert example["phase"] == "pre_conversion_safety"
+    assert example["status"] == "safety_blocked"
+    assert example["downloads_performed"] is False
+    assert example["conversion_process_started"] is False
+    assert example["retried"] is False
+    assert example["cache_modified"] is False
+    assert any("not benchmark evidence" in note for note in example["limitations"])
+    assert any("memory_pressure" in note for note in example["limitations"])
+
+
+def test_committed_refusal_example_contains_no_private_data() -> None:
+    from llmtracefx.optimizer.lab.core import assert_shareable
+
+    example = json.loads(EXAMPLE_REFUSAL_PATH.read_text(encoding="utf-8"))
+    assert_shareable(example)  # raises LabError if any private pattern is found
+    serialized = json.dumps(example)
+    for forbidden in ("/Users/", "/home/", "generated_at", "collected_at"):
+        assert forbidden not in serialized
+
+
+def test_committed_refusal_example_matches_the_real_safety_gate_output(
+    monkeypatch,
+) -> None:
+    """Hash/integrity check: replaying the exact observed host state
+    recorded in the committed example through the real
+    ``assess_conversion_safety`` code path must reproduce the same single
+    blocker the example claims -- no drift between the committed example
+    and the code that actually produces refusals."""
+    example = json.loads(EXAMPLE_REFUSAL_PATH.read_text(encoding="utf-8"))
+    manifest = _manifest()
+    assert example["safety_thresholds"]["required_free_disk_bytes"] == (
+        manifest.source.expected_source_bytes
+        + manifest.expected_output_bytes
+        + manifest.safety.minimum_residual_free_disk_bytes
+    )
+    assert example["safety_thresholds"]["minimum_memory_free_percent"] == (
+        manifest.safety.minimum_memory_free_percent
+    )
+    assert example["safety_thresholds"]["maximum_swap_used_bytes"] == (
+        manifest.safety.maximum_swap_used_bytes
+    )
+    assert example["safety_thresholds"]["required_total_memory_bytes"] == (
+        manifest.safety.required_total_memory_bytes
+    )
+
+    observed = example["observed"]
+    monkeypatch.setattr(
+        conv,
+        "collect_host_snapshot",
+        lambda path: _snapshot(
+            chip=observed["chip"],
+            os_name=observed["os_name"],
+            architecture=observed["architecture"],
+            total_memory_bytes=observed["total_memory_bytes"],
+            memory_free_percent=observed["memory_free_percent"],
+            swap_used_bytes=observed["swap_used_bytes"],
+            disk_free_bytes=observed["disk_free_bytes"],
+            package_versions={"mlx-lm": manifest.converter.version},
+        ),
+    )
+    decision = conv.assess_conversion_safety(
+        manifest, Path("."), include_source_download=True
+    )
+    assert decision.safe is False
+    assert list(decision.blockers) == example["blockers"]
+    assert decision.required_free_disk_bytes == (
+        example["safety_thresholds"]["required_free_disk_bytes"]
+    )
+
+
+def test_committed_refusal_example_reproduces_via_run_conversion(
+    tmp_path, monkeypatch
+) -> None:
+    """End-to-end: feeding the example's exact observed host state
+    through ``run_conversion`` must refuse before any download or
+    subprocess and produce a journal whose blockers match the committed
+    example exactly."""
+    example = json.loads(EXAMPLE_REFUSAL_PATH.read_text(encoding="utf-8"))
+    manifest = _manifest()
+    observed = example["observed"]
+
+    monkeypatch.setattr(
+        conv,
+        "collect_host_snapshot",
+        lambda path: _snapshot(
+            chip=observed["chip"],
+            os_name=observed["os_name"],
+            architecture=observed["architecture"],
+            total_memory_bytes=observed["total_memory_bytes"],
+            memory_free_percent=observed["memory_free_percent"],
+            swap_used_bytes=observed["swap_used_bytes"],
+            disk_free_bytes=observed["disk_free_bytes"],
+            package_versions={"mlx-lm": manifest.converter.version},
+        ),
+    )
+    _forbid_network_download(monkeypatch)
+    monkeypatch.setattr(
+        conv.subprocess,
+        "Popen",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must never launch a subprocess after a safety refusal")
+        ),
+    )
+
+    journal = conv.run_conversion(
+        manifest,
+        source_path=tmp_path / "source",
+        output_path=tmp_path / "output",
+        workspace=tmp_path / "ws",
+    )
+    assert journal["status"] == "safety_blocked"
+    assert journal["phase"] == "pre_conversion_safety"
+    assert journal["blockers"] == example["blockers"]
+    assert not (tmp_path / "source").exists()
+    assert not (tmp_path / "output").exists()


### PR DESCRIPTION
## Summary

- add an offline-first, namespace-separated Qwen3-8B self-conversion/control workflow that reuses the existing M5 lab, safe evaluators, process isolation, evidence lifecycle, and reporting surfaces
- pin the official public Apache-2.0 source `Qwen/Qwen3-8B@b968826d9c46dd6066d109eabc6255188de91218` and converter `mlx-lm 0.31.3@ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd`
- record explicit affine 4-bit/group-size-64 conversion parameters, exact source inventory, strict receipt/output binding, no-overwrite caches, and pre-download memory/swap/disk gates
- add offline tests plus installed-wheel/external-CWD coverage without network or model execution

## Execution status

This is a **preparatory PR, not a positive-control result**. No model was downloaded, converted, or benchmarked. The live pre-conversion gate refused at 39% free memory against the conservative 40% threshold; the sanitized refusal artifact records that outcome and contains no benchmark metrics. Execution remains blocked pending a clean reboot and a passing safety preflight.

The workflow does not use or claim byte equivalence with any public `mlx-community` checkpoint. A future successful conversion will bind its own output inventory and hashes.

## Validation

- targeted M5 lab/frontier/autopsy/control tests: 203 passed
- full pytest: 3,254 passed
- clean Linux/Python 3.12 control suite: 87 passed
- changed-file quality ratchet: ruff, black, isort, mypy passed
- wheel build/import and `llmtracefx-m5-control plan` from an external CWD passed
- GitHub CI: macOS 3.10/3.13 and Ubuntu 3.10/3.11/3.12/3.13 passed
- GitHub wheel, quality-ratchet, CodeQL, and Python analysis jobs passed
- independent exact-head review of `2519bc8da309656d2e2ce2a7063f19b0dfb4c9ed`: no material findings

## Safety boundaries

- default action is a no-download plan
- conversion safety gates run before network access or subprocess launch
- no automatic retry, cache deletion, hosted inference, paid API, or model substitution
- prior Qwen3.8-27B manifests and artifacts remain unchanged