### PR TITLE
Fix CloudRift vLLM truth-runner preflight

### DIFF
--- a/containers/vllm-kv-truth/Containerfile
+++ b/containers/vllm-kv-truth/Containerfile
@@ -5,6 +5,10 @@ ARG RUNNER_COMMIT
 LABEL org.opencontainers.image.source="https://github.com/Siddhant-K-code/LLMTraceFX"
 LABEL org.opencontainers.image.revision="${RUNNER_COMMIT}"
 LABEL org.llmtracefx.protocol="qwen3-8b-vllm-kv-truth-v1"
+LABEL org.llmtracefx.downloader.package="huggingface-hub"
+LABEL org.llmtracefx.downloader.version="1.13.0"
+LABEL org.llmtracefx.downloader.interface="huggingface_hub.snapshot_download"
+LABEL org.llmtracefx.downloader.source="vllm/vllm-openai:v0.28.0@sha256:2286e8533ca8b6bc777594bae30524f1426ba46ca21797524e06df6a94b06635"
 
 COPY . /opt/llmtracefx/source
 

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -244,7 +244,8 @@ from OS state or from the application list-rate ledger.
 
 The authorized attempt at repository head
 `2720134ca6f285d06ae2b42f4fc3d260bda3c45d` stopped in preflight because the
-old probe treated a host `huggingface-cli` executable as mandatory under
-`set -e`. Teardown succeeded. No model download, image pull/build, canary,
-pair, eviction, or GPU workload occurred, so that attempt created no
-scientific evidence claim.
+old probe emitted no absolute `HF_CLI` path and the local verifier required
+one. The vanilla CloudRift Ubuntu 24.04 host did not provide that executable,
+so the marker set was rejected. Teardown succeeded. No model download, image
+pull/build, canary, pair, eviction, or GPU workload occurred, so that attempt
+created no scientific evidence claim.

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -56,6 +56,9 @@ Before GO, perform only the coordinator-approved read-only preflight: boot
 time, UTC clock, one GPU, GPU name/memory/driver/compute capability, zero GPU
 processes, zero containers, zero swap, RAM, disk, Python 3.12, Docker, and
 noninteractive sudo. Do not download the model or image during preflight.
+The vanilla host does **not** need `huggingface-cli`, `hf`, `pip`, or `uv`.
+Model acquisition is deliberately unavailable until the derived image has
+passed its downloader attestation.
 
 ## 3. Write protected execution config
 
@@ -86,6 +89,9 @@ The authorization must bind:
 - the exact merged repository head and `sha256:<archive digest>`;
 - protocol, digest-pinned base image, vLLM commit/version, immutable model
   revision and committed inventory digest;
+- authorization schema `2` and the exact downloader package
+  `huggingface-hub==1.13.0`, interface
+  `huggingface_hub.snapshot_download`, and digest-pinned base-image source;
 - one RTX 4090 and exact driver/memory expectations;
 - boot/billing timestamp, list rate, total cap, explicit operational cutoff,
   cleanup reserve of at least 35 minutes, authorization time/expiry, nonce;
@@ -103,6 +109,25 @@ Require both:
 now + all remaining stage allowances <= operational cutoff + cleanup reserve
 operational cutoff + cleanup reserve <= boot-derived absolute cap
 ```
+
+The fixed 210-minute reserve ledger is evaluated by stage identity in this
+order:
+
+| Stage | Allowance | Reserve at start |
+|---|---:|---:|
+| Preflight/planning reserve | 15 min | 210 min |
+| SSH identity and checked source transfer | 5 min | 195 min |
+| Image pull/build/inspect/downloader attestation | 20 min | 190 min |
+| In-image model acquisition and host inventory verification | 40 min | 170 min |
+| Event-bearing no-warmup canary | 15 min | 130 min |
+| Four fresh A/B lifecycle pairs | 60 min | 115 min |
+| Fixed eviction lane | 10 min | 55 min |
+| Private verify/redact/report/export | 10 min | 45 min |
+| Transfer verification, cleanup, key removal, shutdown | 35 min | 35 min |
+
+Reordering image preparation ahead of acquisition does not reduce or
+reallocate any allowance: the total remains 210 minutes, the stop-new-work
+point remains 175 minutes, and teardown retains its full 35-minute reserve.
 
 Set `authorization_expiry` no earlier than the end of cleanup. Calculate
 `authorization_sha256` with
@@ -123,12 +148,72 @@ llmtracefx-vllm-kv-truth run \
 ```
 
 There are zero retries and zero replacement runs. The command performs its
-own read-only preflight, exact model acquisition and verification, pinned
-image pull/build/inspection, event canary, four AB/BA/BA/AB lifecycle pairs,
-eviction lane, evidence transfer, local verification/redaction, scoped
-cleanup, and OS shutdown.
+own read-only preflight, SSH identity and checked source transfer, pinned image
+pull/build/inspection and downloader attestation, exact in-image model
+acquisition and host-side verification, event canary, four AB/BA/BA/AB
+lifecycle pairs, eviction lane, evidence transfer, local
+verification/redaction, scoped cleanup, temporary-key removal, and OS
+shutdown.
 
-## 6. Evidence and termination
+The model-download container is bound to the inspected derived image ID,
+labeled with the run nonce, and mounts only the run-scoped model destination
+and HF scratch directory. It is the only runtime container with networking
+enabled (`bridge`). Its checked Python module calls `snapshot_download` with
+the exact model ID and revision, an exact 15-file allowlist, and `token=False`.
+Scratch and Hugging Face local metadata are removed before a host-side
+15-file/16,397,461,266-byte SHA-256 verification. No GPU container can start
+until that verification succeeds. Canary, pair, and eviction containers all
+use `--network none` plus the fixed offline environment.
+
+Before the one command above, confirm only this checklist:
+
+1. The source archive is from the exact clean, tested, merged `origin/main`.
+2. Authorization schema 2 seals that head, archive digest, runtime/model/image
+   pins, downloader identity, budget, nonce, and zero-retry policy.
+3. The protected config names a fresh key, dedicated known-hosts file, and
+   empty local evidence destination.
+4. The coordinator has issued GO and the full 210-minute reserve gate passes.
+
+## 6. Private failure diagnostics
+
+Each command operation appends a mode-`0600`
+`private-operation-receipts.jsonl` record under the protected local evidence
+directory. This file is private and is not part of the public evidence schema.
+Each schema-1 record contains only:
+
+```text
+stage, substage, command_description, return_code, timed_out,
+stderr_category, stderr_message, reason_code, reserved_minutes
+```
+
+No argv, host, user, IP, key/known-hosts path, credential, remote/model path,
+prompt/token content, or raw stderr is retained. Failure text is selected from
+a bounded allowlist. Current reason codes are:
+
+```text
+operation_timeout, operation_start_failed,
+preflight_missing_linux, preflight_missing_nvidia_smi,
+preflight_missing_docker, preflight_missing_sudo,
+preflight_missing_python3, preflight_probe_failed,
+identity_gate_failed, source_transfer_failed, image_preparation_failed,
+model_download_interface_missing, model_download_version_mismatch,
+model_download_failed, model_inventory_mismatch, canary_failed,
+pair_lane_failed, eviction_lane_failed, evidence_archive_failed,
+evidence_digest_failed, evidence_download_failed,
+teardown_cleanup_failed, teardown_shutdown_failed
+```
+
+Successful acquisition also writes a private schema-1
+`private-model-acquisition-receipt.json` binding the authorization, inspected
+image ID, explicit network mode, run label, downloader package/version/
+interface/source, exact model revision, and verified inventory totals.
+
+The terminal reports `stage/substage`, reason code, and the corresponding safe
+message. Teardown still runs after any failure. `SAFE TO TERMINATE INSTANCE
+NOW` retains its existing meaning and is emitted only after scoped cleanup,
+temporary-key removal, zero-residual checks, and shutdown issuance succeed.
+
+## 7. Evidence and termination
 
 Keep the transferred private bundle private. Verify the public-redacted
 bundle offline:
@@ -148,3 +233,12 @@ That message proves only host cleanup checks and shutdown issuance. The
 coordinator must separately terminate the reservation in the provider
 console and preserve provider confirmation. Never claim provider deletion
 from OS state or from the application list-rate ledger.
+
+## 8. Failed-attempt provenance
+
+The authorized attempt at repository head
+`2720134ca6f285d06ae2b42f4fc3d260bda3c45d` stopped in preflight because the
+old probe treated a host `huggingface-cli` executable as mandatory under
+`set -e`. Teardown succeeded. No model download, image pull/build, canary,
+pair, eviction, or GPU workload occurred, so that attempt created no
+scientific evidence claim.

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -200,7 +200,7 @@ model_download_interface_missing, model_download_version_mismatch,
 model_download_failed, model_inventory_mismatch, canary_failed,
 pair_lane_failed, eviction_lane_failed, evidence_archive_failed,
 evidence_digest_failed, evidence_download_failed,
-teardown_cleanup_failed, teardown_shutdown_failed
+run_interrupted, teardown_cleanup_failed, teardown_shutdown_failed
 ```
 
 Successful acquisition also writes a private schema-1
@@ -209,9 +209,15 @@ image ID, explicit network mode, run label, downloader package/version/
 interface/source, exact model revision, and verified inventory totals.
 
 The terminal reports `stage/substage`, reason code, and the corresponding safe
-message. Teardown still runs after any failure. `SAFE TO TERMINATE INSTANCE
+message. Once trusted configuration and authorization have been loaded and
+lifecycle execution begins, teardown still runs after any stage failure or
+SIGTERM/SIGHUP. Input or signature rejection happens before all remote
+activity and therefore before lifecycle teardown. `SAFE TO TERMINATE INSTANCE
 NOW` retains its existing meaning and is emitted only after scoped cleanup,
 temporary-key removal, zero-residual checks, and shutdown issuance succeed.
+Shutdown is scheduled from the same authenticated SSH session that removes
+the temporary key, so key removal cannot prevent the shutdown command from
+being issued.
 
 ## 7. Evidence and termination
 

--- a/tests/deploy/test_vllm_kv_truth_cli.py
+++ b/tests/deploy/test_vllm_kv_truth_cli.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import json
 import stat
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from vllm_kv_truth import cli as cli_module
 from vllm_kv_truth import evidence
 from vllm_kv_truth.cli import _build_parser, main
+from vllm_kv_truth.lifecycle import HostOrchestrationError
 
 
 class TestArgumentParser:
@@ -176,3 +179,49 @@ class TestRunCommandRejectsBadInputs:
         assert exit_code == 1
         captured = capsys.readouterr()
         assert "x" not in captured.out
+
+    def test_run_reports_safe_failed_substage_and_reason(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        authorization = SimpleNamespace(signature_path=None)
+        monkeypatch.setattr(
+            cli_module.ProtectedExecutionConfig,
+            "load",
+            lambda _path: SimpleNamespace(local_evidence_dir=Path("unused")),
+        )
+        monkeypatch.setattr(
+            cli_module.RunAuthorization,
+            "read",
+            lambda _path: authorization,
+        )
+
+        class RefusingOrchestrator:
+            def __init__(self, **_kwargs: object) -> None:
+                pass
+
+            def run(self, **_kwargs: object) -> tuple[object, ...]:
+                raise HostOrchestrationError(
+                    "the remote host does not provide Docker",
+                    stage="preflight",
+                    substage="host_probe",
+                    reason_code="preflight_missing_docker",
+                )
+
+        monkeypatch.setattr(cli_module, "SubprocessCommandRunner", lambda: object())
+        monkeypatch.setattr(cli_module, "RemoteOrchestrator", RefusingOrchestrator)
+        exit_code = main(
+            [
+                "run",
+                "--execution-config",
+                "protected.json",
+                "--authorization",
+                "authorization.json",
+            ]
+        )
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert (
+            "preflight/host_probe: preflight_missing_docker: "
+            "the remote host does not provide Docker"
+        ) in captured.err

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -911,7 +911,11 @@ class FakeCommandRunner:
             local_path.write_bytes(self.scp_download_target_bytes)
             return lifecycle.CommandResult(returncode=0, stdout="", stderr="")
         if description == "stage_teardown_cleanup":
-            stdout = "RESIDUAL_CONTAINERS=0\nRESIDUAL_GPU_PROCESSES=0\n"
+            stdout = (
+                "RESIDUAL_CONTAINERS=0\n"
+                "RESIDUAL_GPU_PROCESSES=0\n"
+                "SHUTDOWN_ISSUED=1\n"
+            )
             return lifecycle.CommandResult(returncode=0, stdout=stdout, stderr="")
         return lifecycle.CommandResult(returncode=0, stdout="", stderr="")
 
@@ -970,7 +974,6 @@ class TestRemoteOrchestratorFullRun:
         assert "stage_eviction_lane" in descriptions
         assert "stage_transfer_evidence_archive" in descriptions
         assert "stage_teardown_cleanup" in descriptions
-        assert "stage_teardown_shutdown" in descriptions
 
         # The private/public evidence bundle wiring actually ran: a private
         # bundle with a real teardown receipt and a portably-verifiable
@@ -1237,9 +1240,50 @@ class TestRemoteOrchestratorFullRun:
         assert "-f containers/vllm-kv-truth/Containerfile" in script
         assert f"--build-arg RUNNER_COMMIT={VALID_HEAD}" in script
         assert "--network none" in script
+        authorized_archive_digest = (
+            orchestrator.authorization.derived_image_source_digest.removeprefix(
+                "sha256:"
+            )
+        )
+        assert authorized_archive_digest in script
         assert "COPY" not in script
         assert f"{orchestrator.paths.model_dir}:/model" not in script
         assert orchestrator.derived_image_id == DERIVED_IMAGE_ID
+
+    def test_image_build_rechecks_remote_archive_against_authorization_digest(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        config = _config(tmp_path)
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=config,
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_identity_gate()
+        config.local_runner_archive.write_bytes(
+            config.local_runner_archive.read_bytes() + b"replaced-after-upload"
+        )
+        replaced_digest = hashlib.sha256(
+            config.local_runner_archive.read_bytes()
+        ).hexdigest()
+
+        orchestrator.stage_image_preparation()
+
+        image_call = next(
+            call
+            for call in runner.calls
+            if call.description == "stage_image_preparation"
+        )
+        script = image_call.input_text or ""
+        authorized_digest = (
+            orchestrator.authorization.derived_image_source_digest.removeprefix(
+                "sha256:"
+            )
+        )
+        assert authorized_digest in script
+        assert replaced_digest not in script
 
     def test_teardown_only_targets_run_scoped_label(self, tmp_path: Path) -> None:
         runner = FakeCommandRunner()
@@ -1265,6 +1309,10 @@ class TestRemoteOrchestratorFullRun:
         assert f"rm -rf {orchestrator.paths.hf_scratch_dir}" in script
         assert f"rm -rf {orchestrator.paths.repo_dir}" in script
         assert f"rm -f {orchestrator.paths.source_archive_remote_path}" in script
+        assert "sudo -n shutdown -h +1" in script
+        assert script.index("authorized_keys") < script.index(
+            "sudo -n shutdown -h +1", script.index("authorized_keys")
+        )
         assert (
             "docker ps -q" not in script.replace("docker ps -q --filter", "PLACEHOLDER")
             or "--filter" in script
@@ -1382,7 +1430,6 @@ class TestRemoteOrchestratorFullRun:
         assert failed_receipt["reserved_minutes"] >= 35
         descriptions = [call.description for call in runner.calls]
         assert "stage_teardown_cleanup" in descriptions
-        assert "stage_teardown_shutdown" in descriptions
         cleanup = next(
             call
             for call in runner.calls
@@ -1406,9 +1453,8 @@ class TestRemoteOrchestratorFullRun:
             orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
         descriptions = {call.description for call in runner.calls}
         assert "stage_teardown_cleanup" in descriptions
-        assert "stage_teardown_shutdown" in descriptions
 
-    def test_teardown_attempts_shutdown_when_cleanup_fails(
+    def test_teardown_attempts_shutdown_in_same_session_when_cleanup_fails(
         self, tmp_path: Path
     ) -> None:
         runner = FakeCommandRunner(fail_stages=frozenset({"stage_teardown_cleanup"}))
@@ -1422,8 +1468,69 @@ class TestRemoteOrchestratorFullRun:
             orchestrator.stage_teardown(tmp_path / "bundle")
         descriptions = {call.description for call in runner.calls}
         assert "stage_teardown_cleanup" in descriptions
-        assert "stage_teardown_shutdown" in descriptions
+        cleanup = next(
+            call
+            for call in runner.calls
+            if call.description == "stage_teardown_cleanup"
+        )
+        assert "finish_teardown" in (cleanup.input_text or "")
+        assert "sudo -n shutdown -h +1" in (cleanup.input_text or "")
         assert orchestrator.state == lifecycle.OrchestratorState.TEARDOWN
+
+    def test_teardown_reports_shutdown_failure_from_same_session(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_teardown_cleanup": lifecycle.CommandResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="LLMTRACEFX_REASON=teardown_shutdown_failed\n",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_shutdown_failed",
+        ):
+            orchestrator.stage_teardown(tmp_path / "bundle")
+
+    def test_teardown_refuses_missing_shutdown_marker_with_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_teardown_cleanup": lifecycle.CommandResult(
+                    returncode=0,
+                    stdout="RESIDUAL_CONTAINERS=0\nRESIDUAL_GPU_PROCESSES=0\n",
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_shutdown_failed",
+        ):
+            orchestrator.stage_teardown(tmp_path / "bundle")
+        receipt = json.loads(
+            orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()[-1]
+        )
+        assert receipt["substage"] == "verify_cleanup_shutdown"
+        assert receipt["reason_code"] == "teardown_shutdown_failed"
 
     def test_teardown_still_runs_on_keyboard_interrupt(self, tmp_path: Path) -> None:
         class _InterruptingRunner(FakeCommandRunner):
@@ -1453,6 +1560,51 @@ class TestRemoteOrchestratorFullRun:
         )
         with pytest.raises(KeyboardInterrupt):
             orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        descriptions = {call.description for call in runner.calls}
+        assert "stage_teardown_cleanup" in descriptions
+
+    def test_teardown_still_runs_on_sigterm(self, tmp_path: Path) -> None:
+        installed_handlers: dict[int, object] = {}
+
+        def fake_signal(signum: int, handler: object) -> object:
+            installed_handlers[signum] = handler
+            return lifecycle.signal.SIG_DFL
+
+        class _TerminatingRunner(FakeCommandRunner):
+            def run(
+                self,
+                argv: Sequence[str],
+                *,
+                description: str,
+                timeout: float,
+                input_text: str | None = None,
+            ) -> lifecycle.CommandResult:
+                if description == "stage_canary":
+                    handler = installed_handlers[lifecycle.signal.SIGTERM]
+                    assert callable(handler)
+                    handler(lifecycle.signal.SIGTERM, None)
+                return super().run(
+                    argv,
+                    description=description,
+                    timeout=timeout,
+                    input_text=input_text,
+                )
+
+        runner = _TerminatingRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(lifecycle.signal, "getsignal", lambda _signum: None)
+            monkeypatch.setattr(lifecycle.signal, "signal", fake_signal)
+            with pytest.raises(
+                lifecycle.HostOrchestrationError,
+                match="run/signal: run_interrupted",
+            ):
+                orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
         descriptions = {call.description for call in runner.calls}
         assert "stage_teardown_cleanup" in descriptions
 
@@ -1805,7 +1957,10 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="does not match"):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="evidence_download_failed",
+        ):
             orchestrator.stage_transfer_evidence(tmp_path / "bundle")
 
     def test_transfer_evidence_rejects_tampered_lane_receipt(
@@ -1836,7 +1991,8 @@ class TestRemoteOrchestratorFullRun:
             now_fn=lambda: BILLING_STARTED_AT,
         )
         with pytest.raises(
-            lifecycle.HostOrchestrationError, match="failed local verification"
+            lifecycle.HostOrchestrationError,
+            match="evidence_download_failed",
         ):
             orchestrator.stage_transfer_evidence(tmp_path / "bundle")
 
@@ -1862,7 +2018,8 @@ class TestRemoteOrchestratorFullRun:
             now_fn=lambda: BILLING_STARTED_AT,
         )
         with pytest.raises(
-            lifecycle.HostOrchestrationError, match="failed local verification"
+            lifecycle.HostOrchestrationError,
+            match="evidence_download_failed",
         ):
             orchestrator.stage_transfer_evidence(tmp_path / "bundle")
 
@@ -1882,8 +2039,42 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="unsafe member"):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="evidence_download_failed",
+        ):
             orchestrator.stage_transfer_evidence(tmp_path / "bundle")
+
+    def test_transfer_evidence_rejects_empty_digest_with_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_transfer_evidence_digest": lifecycle.CommandResult(
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="evidence_digest_failed",
+        ):
+            orchestrator.stage_transfer_evidence(tmp_path / "bundle")
+        receipt = json.loads(
+            orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()[-1]
+        )
+        assert receipt["substage"] == "verify_remote_digest"
+        assert receipt["reason_code"] == "evidence_digest_failed"
 
     def test_teardown_skips_finalization_when_transfer_never_ran(
         self, tmp_path: Path
@@ -1909,7 +2100,11 @@ class TestRemoteOrchestratorFullRun:
             responses={
                 "stage_teardown_cleanup": lifecycle.CommandResult(
                     returncode=0,
-                    stdout="RESIDUAL_CONTAINERS=1\nRESIDUAL_GPU_PROCESSES=0\n",
+                    stdout=(
+                        "RESIDUAL_CONTAINERS=1\n"
+                        "RESIDUAL_GPU_PROCESSES=0\n"
+                        "SHUTDOWN_ISSUED=1\n"
+                    ),
                     stderr="",
                 )
             }
@@ -1920,7 +2115,10 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="residual"):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_cleanup_failed",
+        ):
             orchestrator.stage_teardown(tmp_path / "bundle")
 
     def test_a_failed_remote_stage_raises_without_leaking_stderr(

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -370,6 +370,10 @@ def _authorization_payload(**overrides: Any) -> dict[str, Any]:
         "model_id": lifecycle.MODEL_ID,
         "model_revision": lifecycle.MODEL_REVISION,
         "model_inventory_sha256": _model_inventory_sha256(),
+        "model_download_package": lifecycle.DOWNLOADER_PACKAGE,
+        "model_download_version": lifecycle.DOWNLOADER_VERSION,
+        "model_download_interface": lifecycle.DOWNLOADER_INTERFACE,
+        "model_download_source": lifecycle.DOWNLOADER_SOURCE,
         "gpu_expected_count": 1,
         "gpu_expected_name": lifecycle.EXPECTED_GPU_NAME,
         "gpu_expected_driver": lifecycle.EXPECTED_DRIVER,
@@ -783,6 +787,7 @@ class RecordedCall:
 
 def _preflight_stdout(**overrides: str) -> str:
     values = {
+        "OS_NAME": "Linux",
         "NOW_EPOCH": str(int(BILLING_STARTED_AT.timestamp())),
         "BOOT_EPOCH": str(int(BILLING_STARTED_AT.timestamp())),
         "GPU_COUNT": "1",
@@ -799,10 +804,37 @@ def _preflight_stdout(**overrides: str) -> str:
         "SWAP_USED_BYTES": "0",
         "PYTHON_VERSION": "3.12.3",
         "DOCKER_VERSION": "29.6.1",
-        "HF_CLI": "/usr/local/bin/huggingface-cli",
     }
     values.update(overrides)
     return "\n".join(f"{key}={value}" for key, value in values.items())
+
+
+def _image_preparation_stdout(**overrides: str) -> str:
+    expected_digest = lifecycle.BASE_IMAGE_REFERENCE.split("@", 1)[-1]
+    markers = {
+        "BASE_REPODIGESTS": f'["vllm/vllm-openai@{expected_digest}"]',
+        "BASE_IMAGE_ID": "sha256:" + "1" * 64,
+        "EXPECTED_HEAD": VALID_HEAD,
+        "DERIVED_IMAGE_ID": DERIVED_IMAGE_ID,
+        "DOWNLOADER_PACKAGE": lifecycle.DOWNLOADER_PACKAGE,
+        "DOWNLOADER_VERSION": lifecycle.DOWNLOADER_VERSION,
+        "DOWNLOADER_INTERFACE": lifecycle.DOWNLOADER_INTERFACE,
+        "DOWNLOADER_SOURCE": lifecycle.DOWNLOADER_SOURCE,
+    }
+    markers.update(overrides)
+    downloader = {
+        "schema_version": "1",
+        "package": markers["DOWNLOADER_PACKAGE"],
+        "version": markers["DOWNLOADER_VERSION"],
+        "interface": markers["DOWNLOADER_INTERFACE"],
+        "source": markers["DOWNLOADER_SOURCE"],
+    }
+    return "\n".join(
+        [
+            *(f"{key}={value}" for key, value in markers.items()),
+            json.dumps(downloader, sort_keys=True, separators=(",", ":")),
+        ]
+    )
 
 
 @dataclass
@@ -849,16 +881,23 @@ class FakeCommandRunner:
             stdout = _preflight_stdout()
             return lifecycle.CommandResult(returncode=0, stdout=stdout, stderr="")
         if description == "stage_image_preparation":
-            expected_digest = lifecycle.BASE_IMAGE_REFERENCE.split("@", 1)[-1]
-            stdout = "\n".join(
-                [
-                    f'BASE_REPODIGESTS=["vllm/vllm-openai@{expected_digest}"]',
-                    "BASE_IMAGE_ID=sha256:" + "1" * 64,
-                    f"EXPECTED_HEAD={VALID_HEAD}",
-                    f"DERIVED_IMAGE_ID={DERIVED_IMAGE_ID}",
-                ]
-            )
+            stdout = _image_preparation_stdout()
             return lifecycle.CommandResult(returncode=0, stdout=stdout, stderr="")
+        if description == "stage_model_acquisition_download":
+            payload = {
+                "schema_version": "1",
+                "package": lifecycle.DOWNLOADER_PACKAGE,
+                "version": lifecycle.DOWNLOADER_VERSION,
+                "interface": lifecycle.DOWNLOADER_INTERFACE,
+                "source": lifecycle.DOWNLOADER_SOURCE,
+                "model_id": lifecycle.MODEL_ID,
+                "model_revision": lifecycle.MODEL_REVISION,
+            }
+            return lifecycle.CommandResult(
+                returncode=0,
+                stdout=json.dumps(payload, sort_keys=True, separators=(",", ":")),
+                stderr="",
+            )
         if description == "stage_transfer_evidence_digest":
             digest = hashlib.sha256(self.scp_download_target_bytes).hexdigest()
             return lifecycle.CommandResult(
@@ -921,9 +960,10 @@ class TestRemoteOrchestratorFullRun:
         descriptions = {call.description for call in runner.calls}
         assert "stage_preflight" in descriptions
         assert "stage_identity_gate" in descriptions
+        assert "stage_identity_source_upload" in descriptions
+        assert "stage_image_preparation" in descriptions
         assert "stage_model_acquisition_download" in descriptions
         assert "stage_model_acquisition_verify" in descriptions
-        assert "stage_image_preparation" in descriptions
         assert "stage_canary" in descriptions
         assert any(d.startswith("stage_four_ab_pairs[pair1") for d in descriptions)
         assert any(d.startswith("stage_four_ab_pairs[pair4") for d in descriptions)
@@ -958,6 +998,159 @@ class TestRemoteOrchestratorFullRun:
         assert public.to_dict()["run_mode"] == evidence.RUN_MODE_REAL_RUN
         evidence.assert_publication_safe(public.to_dict())
 
+    def test_full_run_uses_the_reordered_stage_and_reserve_sequence(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        descriptions = [call.description for call in runner.calls]
+        assert descriptions.index("stage_identity_source_upload") < descriptions.index(
+            "stage_image_preparation"
+        )
+        assert descriptions.index("stage_image_preparation") < descriptions.index(
+            "stage_model_acquisition_download"
+        )
+        assert descriptions.index(
+            "stage_model_acquisition_verify"
+        ) < descriptions.index("stage_canary")
+
+        receipts = [
+            json.loads(line)
+            for line in orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        first_by_stage = {
+            receipt["stage"]: receipt["reserved_minutes"] for receipt in receipts
+        }
+        assert first_by_stage["preflight"] == 210
+        assert first_by_stage["identity_source_transfer"] == 195
+        assert first_by_stage["image_preparation"] == 190
+        assert first_by_stage["model_acquisition"] == 170
+        assert first_by_stage["canary"] == 130
+        assert first_by_stage["four_ab_pairs"] == 115
+        assert first_by_stage["eviction_lane"] == 55
+        assert first_by_stage["evidence_transfer"] == 45
+        assert first_by_stage["teardown"] == 35
+
+    def test_vanilla_host_preflight_has_no_host_downloader_dependency(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        outcome = orchestrator.stage_preflight()
+        script = runner.calls[-1].input_text or ""
+        assert outcome.ok
+        assert "HF_CLI" not in script
+        assert "command -v huggingface-cli" not in script
+
+    def test_model_acquisition_uses_only_labeled_digest_bound_container_mounts(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        auth = _authorization()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=auth,
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_identity_gate()
+        orchestrator.stage_image_preparation()
+        orchestrator.stage_model_acquisition()
+        call = next(
+            item
+            for item in runner.calls
+            if item.description == "stage_model_acquisition_download"
+        )
+        script = call.input_text or ""
+        assert "huggingface-cli" not in script
+        assert "--network bridge" in script
+        assert lifecycle.docker_run_label(auth.nonce) in script
+        assert DERIVED_IMAGE_ID in script
+        assert script.count(" -v ") == 2
+        assert f"{orchestrator.paths.model_dir}:/model" in script
+        assert f"{orchestrator.paths.hf_scratch_dir}:/hf" in script
+        assert "cleanup_download_scratch" in script
+        receipt = json.loads(
+            (
+                _config(tmp_path).local_evidence_dir
+                / "private-model-acquisition-receipt.json"
+            ).read_text(encoding="utf-8")
+        )
+        assert receipt["downloader"]["version"] == lifecycle.DOWNLOADER_VERSION
+        assert receipt["downloader"]["source"] == lifecycle.DOWNLOADER_SOURCE
+        assert receipt["verified_file_count"] == 15
+        assert receipt["verified_total_bytes"] == 16_397_461_266
+
+    @pytest.mark.parametrize(
+        ("marker", "reason"),
+        [
+            ("DOWNLOADER_PACKAGE", "model_download_interface_missing"),
+            ("DOWNLOADER_VERSION", "model_download_version_mismatch"),
+        ],
+    )
+    def test_image_attestation_refuses_missing_or_wrong_downloader(
+        self, tmp_path: Path, marker: str, reason: str
+    ) -> None:
+        value = "" if marker == "DOWNLOADER_PACKAGE" else "0.0.0"
+        runner = FakeCommandRunner(
+            responses={
+                "stage_image_preparation": lifecycle.CommandResult(
+                    returncode=0,
+                    stdout=_image_preparation_stdout(**{marker: value}),
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_identity_gate()
+        with pytest.raises(lifecycle.HostOrchestrationError, match=reason):
+            orchestrator.stage_image_preparation()
+        assert not any(
+            call.description == "stage_model_acquisition_download"
+            for call in runner.calls
+        )
+
+    def test_model_inventory_mismatch_refuses_before_any_gpu_container(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            fail_stages=frozenset({"stage_model_acquisition_verify"})
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="model_inventory_mismatch"
+        ):
+            orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        assert not any(
+            call.description == "stage_canary"
+            or call.description.startswith("stage_four_ab_pairs")
+            or call.description == "stage_eviction_lane"
+            for call in runner.calls
+        )
+
     def test_ab_pairs_use_the_fixed_ab_ba_ba_ab_order(self, tmp_path: Path) -> None:
         runner = FakeCommandRunner()
         orchestrator = lifecycle.RemoteOrchestrator(
@@ -968,8 +1161,8 @@ class TestRemoteOrchestratorFullRun:
         )
         orchestrator.stage_preflight()
         orchestrator.stage_identity_gate()
-        orchestrator.stage_model_acquisition()
         orchestrator.stage_image_preparation()
+        orchestrator.stage_model_acquisition()
         orchestrator.stage_canary()
         orchestrator.stage_four_ab_pairs()
         tags = [
@@ -993,8 +1186,8 @@ class TestRemoteOrchestratorFullRun:
         )
         orchestrator.stage_preflight()
         orchestrator.stage_identity_gate()
-        orchestrator.stage_model_acquisition()
         orchestrator.stage_image_preparation()
+        orchestrator.stage_model_acquisition()
         orchestrator.stage_canary()
         orchestrator.stage_four_ab_pairs()
         orchestrator.stage_eviction_lane()
@@ -1033,6 +1226,7 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
+        orchestrator.stage_identity_gate()
         orchestrator.stage_image_preparation()
         call = next(
             call
@@ -1042,7 +1236,9 @@ class TestRemoteOrchestratorFullRun:
         script = call.input_text or ""
         assert "-f containers/vllm-kv-truth/Containerfile" in script
         assert f"--build-arg RUNNER_COMMIT={VALID_HEAD}" in script
+        assert "--network none" in script
         assert "COPY" not in script
+        assert f"{orchestrator.paths.model_dir}:/model" not in script
         assert orchestrator.derived_image_id == DERIVED_IMAGE_ID
 
     def test_teardown_only_targets_run_scoped_label(self, tmp_path: Path) -> None:
@@ -1065,6 +1261,10 @@ class TestRemoteOrchestratorFullRun:
             f"if [ -d {orchestrator.config.remote_workspace} ]; then "
             f"rmdir {orchestrator.config.remote_workspace}; fi"
         ) in script
+        assert f"rm -rf {orchestrator.paths.model_dir}" in script
+        assert f"rm -rf {orchestrator.paths.hf_scratch_dir}" in script
+        assert f"rm -rf {orchestrator.paths.repo_dir}" in script
+        assert f"rm -f {orchestrator.paths.source_archive_remote_path}" in script
         assert (
             "docker ps -q" not in script.replace("docker ps -q --filter", "PLACEHOLDER")
             or "--filter" in script
@@ -1122,6 +1322,75 @@ class TestRemoteOrchestratorFullRun:
         descriptions = {call.description for call in runner.calls}
         assert "stage_teardown_cleanup" in descriptions
         assert orchestrator.state == lifecycle.OrchestratorState.COMPLETE
+
+    @pytest.mark.parametrize(
+        "failed_description",
+        [
+            "stage_preflight",
+            "stage_identity_gate",
+            "stage_identity_source_upload",
+            "stage_image_preparation",
+            "stage_model_acquisition_download",
+            "stage_model_acquisition_verify",
+            "stage_canary",
+            "stage_four_ab_pairs[pair1-slot1-a]",
+            "stage_four_ab_pairs[pair1-slot2-b]",
+            "stage_four_ab_pairs[pair2-slot1-b]",
+            "stage_four_ab_pairs[pair2-slot2-a]",
+            "stage_four_ab_pairs[pair3-slot1-b]",
+            "stage_four_ab_pairs[pair3-slot2-a]",
+            "stage_four_ab_pairs[pair4-slot1-a]",
+            "stage_four_ab_pairs[pair4-slot2-b]",
+            "stage_eviction_lane",
+            "stage_transfer_evidence_archive",
+            "stage_transfer_evidence_digest",
+            "stage_transfer_evidence_download",
+        ],
+    )
+    def test_every_substage_failure_is_receipted_and_tears_down_safely(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        failed_description: str,
+    ) -> None:
+        runner = FakeCommandRunner(fail_stages=frozenset({failed_description}))
+        config = _config(tmp_path)
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=config,
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(lifecycle.HostOrchestrationError):
+            orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        receipts = [
+            json.loads(line)
+            for line in orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        failed_receipt = next(
+            receipt
+            for receipt in receipts
+            if receipt["command_description"] == failed_description
+        )
+        assert failed_receipt["return_code"] == 1
+        assert failed_receipt["timed_out"] is False
+        assert failed_receipt["reason_code"] in lifecycle._SAFE_REASON_MESSAGES
+        assert failed_receipt["stderr_message"] != "denied"
+        assert len(failed_receipt["stderr_message"]) <= 160
+        assert failed_receipt["reserved_minutes"] >= 35
+        descriptions = [call.description for call in runner.calls]
+        assert "stage_teardown_cleanup" in descriptions
+        assert "stage_teardown_shutdown" in descriptions
+        cleanup = next(
+            call
+            for call in runner.calls
+            if call.description == "stage_teardown_cleanup"
+        )
+        assert "authorized_keys" in (cleanup.input_text or "")
+        assert config.authorized_key_marker in (cleanup.input_text or "")
+        assert "SAFE TO TERMINATE INSTANCE NOW" in capsys.readouterr().out
 
     def test_teardown_reaches_shutdown_when_preflight_fails(
         self, tmp_path: Path
@@ -1235,7 +1504,9 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="GPU name"):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="preflight_probe_failed"
+        ):
             orchestrator.stage_preflight()
 
     def test_preflight_rejects_wrong_gpu_count(self, tmp_path: Path) -> None:
@@ -1254,8 +1525,37 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="GPU count"):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="preflight_probe_failed"
+        ):
             orchestrator.stage_preflight()
+
+    def test_preflight_surfaces_allowlisted_missing_docker_reason(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_preflight": lifecycle.CommandResult(
+                    returncode=1,
+                    stdout="",
+                    stderr=(
+                        "private host detail\n"
+                        "LLMTRACEFX_REASON=preflight_missing_docker\n"
+                    ),
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="preflight_missing_docker"
+        ) as excinfo:
+            orchestrator.stage_preflight()
+        assert "private host detail" not in str(excinfo.value)
 
     @pytest.mark.parametrize(
         ("marker", "value", "message"),
@@ -1285,7 +1585,9 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match=message):
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="preflight_probe_failed"
+        ):
             orchestrator.stage_preflight()
 
     def test_image_preparation_rejects_wrong_base_digest(self, tmp_path: Path) -> None:
@@ -1313,7 +1615,10 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="RepoDigests"):
+        orchestrator.stage_identity_gate()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="image_preparation_failed"
+        ):
             orchestrator.stage_image_preparation()
 
     def test_image_preparation_rejects_wrong_derived_image_id(
@@ -1342,7 +1647,10 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="derived image id"):
+        orchestrator.stage_identity_gate()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="image_preparation_failed"
+        ):
             orchestrator.stage_image_preparation()
 
     def test_image_preparation_rejects_archive_with_wrong_embedded_commit(
@@ -1362,8 +1670,10 @@ class TestRemoteOrchestratorFullRun:
             runner=FakeCommandRunner(),
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="repository_head"):
-            orchestrator.stage_image_preparation()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="source_transfer_failed"
+        ):
+            orchestrator.stage_identity_gate()
 
     def test_image_preparation_rejects_archive_digest_not_authorized(
         self, tmp_path: Path
@@ -1377,9 +1687,9 @@ class TestRemoteOrchestratorFullRun:
             now_fn=lambda: BILLING_STARTED_AT,
         )
         with pytest.raises(
-            lifecycle.HostOrchestrationError, match="derived_image_source_digest"
+            lifecycle.HostOrchestrationError, match="source_transfer_failed"
         ):
-            orchestrator.stage_image_preparation()
+            orchestrator.stage_identity_gate()
 
     def test_image_preparation_rejects_remote_confirmed_wrong_head(
         self, tmp_path: Path
@@ -1410,7 +1720,10 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="repository_head"):
+        orchestrator.stage_identity_gate()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="image_preparation_failed"
+        ):
             orchestrator.stage_image_preparation()
 
     def test_image_preparation_rejects_archive_with_unsafe_member_path(
@@ -1433,8 +1746,10 @@ class TestRemoteOrchestratorFullRun:
             runner=FakeCommandRunner(),
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        with pytest.raises(lifecycle.HostOrchestrationError, match="unsafe member"):
-            orchestrator.stage_image_preparation()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="source_transfer_failed"
+        ):
+            orchestrator.stage_identity_gate()
 
     def test_image_preparation_rejects_archive_missing_commit_marker(
         self, tmp_path: Path
@@ -1454,9 +1769,9 @@ class TestRemoteOrchestratorFullRun:
             now_fn=lambda: BILLING_STARTED_AT,
         )
         with pytest.raises(
-            lifecycle.HostOrchestrationError, match="COMMIT_HEAD marker"
+            lifecycle.HostOrchestrationError, match="source_transfer_failed"
         ):
-            orchestrator.stage_image_preparation()
+            orchestrator.stage_identity_gate()
 
     def test_image_preparation_uploads_the_checked_source_archive(
         self, tmp_path: Path
@@ -1468,11 +1783,11 @@ class TestRemoteOrchestratorFullRun:
             runner=runner,
             now_fn=lambda: BILLING_STARTED_AT,
         )
-        orchestrator.stage_image_preparation()
+        orchestrator.stage_identity_gate()
         upload_calls = [
             call
             for call in runner.calls
-            if call.description == "stage_image_preparation_upload_source"
+            if call.description == "stage_identity_source_upload"
         ]
         assert len(upload_calls) == 1
         assert upload_calls[0].argv[0] == "scp"
@@ -1621,6 +1936,41 @@ class TestRemoteOrchestratorFullRun:
         with pytest.raises(lifecycle.HostOrchestrationError) as excinfo:
             orchestrator.stage_preflight()
         assert "denied" not in str(excinfo.value)
+
+    def test_timeout_receipt_is_bounded_and_contains_no_raw_stderr(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_preflight": lifecycle.CommandResult(
+                    returncode=-1,
+                    stdout="",
+                    stderr="private-host.example /secret/key TOKEN=value",
+                    timed_out=True,
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(lifecycle.HostOrchestrationError, match="operation_timeout"):
+            orchestrator.stage_preflight()
+        receipt = json.loads(
+            orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()[-1]
+        )
+        serialized = json.dumps(receipt)
+        assert receipt["timed_out"] is True
+        assert receipt["return_code"] == -1
+        assert receipt["stderr_category"] == "timeout"
+        assert receipt["stderr_message"] == "the operation timed out"
+        assert "private-host" not in serialized
+        assert "/secret/key" not in serialized
+        assert "TOKEN=value" not in serialized
 
 
 class TestNoNetworkOrProcessSpawned:

--- a/tests/deploy/test_vllm_kv_truth_model_download.py
+++ b/tests/deploy/test_vllm_kv_truth_model_download.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.metadata
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm_kv_truth import model_download
+
+
+def test_downloader_attestation_binds_exact_package_interface_and_source() -> None:
+    module = SimpleNamespace(snapshot_download=lambda **kwargs: kwargs)
+    receipt = model_download.downloader_attestation(
+        version_fn=lambda package: model_download.DOWNLOADER_VERSION,
+        import_module_fn=lambda module_name: module,
+    )
+    assert receipt == {
+        "schema_version": "1",
+        "package": "huggingface-hub",
+        "version": model_download.DOWNLOADER_VERSION,
+        "interface": "huggingface_hub.snapshot_download",
+        "source": model_download.DOWNLOADER_SOURCE,
+    }
+
+
+def test_downloader_attestation_refuses_absent_package() -> None:
+    def missing(_package: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    with pytest.raises(
+        model_download.ModelDownloadRefusal,
+        match="authorized downloader interface",
+    ) as excinfo:
+        model_download.downloader_attestation(version_fn=missing)
+    assert excinfo.value.reason_code == "model_download_interface_missing"
+
+
+def test_downloader_attestation_refuses_version_mismatch() -> None:
+    with pytest.raises(
+        model_download.ModelDownloadRefusal,
+        match="version does not match",
+    ) as excinfo:
+        model_download.downloader_attestation(version_fn=lambda _package: "0.0.0")
+    assert excinfo.value.reason_code == "model_download_version_mismatch"
+
+
+def test_downloader_attestation_refuses_noncallable_interface() -> None:
+    module = SimpleNamespace(snapshot_download=None)
+    with pytest.raises(model_download.ModelDownloadRefusal) as excinfo:
+        model_download.downloader_attestation(
+            version_fn=lambda _package: model_download.DOWNLOADER_VERSION,
+            import_module_fn=lambda _module_name: module,
+        )
+    assert excinfo.value.reason_code == "model_download_interface_missing"
+
+
+def test_download_uses_exact_pins_allowlist_and_sanitized_scratch_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "model"
+    scratch = tmp_path / "hf-scratch"
+    destination.mkdir()
+    scratch.mkdir()
+    observed: dict[str, Any] = {}
+
+    def snapshot_download(**kwargs: Any) -> None:
+        observed["kwargs"] = kwargs
+        observed["environment"] = dict(os.environ)
+
+    module = SimpleNamespace(snapshot_download=snapshot_download)
+    monkeypatch.setenv("HF_TOKEN", "must-not-reach-downloader")
+    receipt = model_download.download_model(
+        destination,
+        scratch,
+        version_fn=lambda _package: model_download.DOWNLOADER_VERSION,
+        import_module_fn=lambda _module_name: module,
+    )
+
+    kwargs = observed["kwargs"]
+    environment = observed["environment"]
+    assert kwargs["repo_id"] == model_download.MODEL_ID
+    assert kwargs["revision"] == model_download.MODEL_REVISION
+    assert kwargs["token"] is False
+    assert len(kwargs["allow_patterns"]) == 15
+    assert environment["HF_HOME"] == str(scratch)
+    assert environment["HF_HUB_CACHE"] == str(scratch / "hub")
+    assert environment["HF_ASSETS_CACHE"] == str(scratch / "assets")
+    assert environment["XDG_CACHE_HOME"] == str(scratch / "xdg")
+    assert "HF_TOKEN" not in environment
+    assert os.environ["HF_TOKEN"] == "must-not-reach-downloader"
+    assert receipt["version"] == model_download.DOWNLOADER_VERSION
+
+
+@pytest.mark.parametrize("python_minor", ["3.10", "3.11", "3.12", "3.13"])
+def test_attestation_logic_is_python_minor_and_platform_independent(
+    python_minor: str,
+) -> None:
+    calls: list[str] = []
+
+    def version(package: str) -> str:
+        calls.append(f"{python_minor}:{package}")
+        return model_download.DOWNLOADER_VERSION
+
+    module = SimpleNamespace(snapshot_download=lambda **_kwargs: None)
+    receipt = model_download.downloader_attestation(
+        version_fn=version,
+        import_module_fn=lambda _module_name: module,
+    )
+    assert receipt["version"] == model_download.DOWNLOADER_VERSION
+    assert calls == [f"{python_minor}:{model_download.DOWNLOADER_PACKAGE}"]
+
+
+def test_failure_cli_emits_only_allowlisted_reason(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def refuse(**_kwargs: Any) -> dict[str, str]:
+        raise model_download.ModelDownloadRefusal("model_download_interface_missing")
+
+    monkeypatch.setattr(model_download, "downloader_attestation", refuse)
+    assert model_download.main(["attest"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "LLMTRACEFX_REASON=model_download_interface_missing\n"

--- a/tests/optimizer/test_kv_truth_container.py
+++ b/tests/optimizer/test_kv_truth_container.py
@@ -23,6 +23,12 @@ def test_containerfile_is_bound_to_the_exact_offline_runtime() -> None:
     assert "COPY . /opt/llmtracefx/source" in text
     assert "--no-build-isolation" in text
     assert 'org.llmtracefx.protocol="qwen3-8b-vllm-kv-truth-v1"' in text
+    assert 'org.llmtracefx.downloader.package="huggingface-hub"' in text
+    assert 'org.llmtracefx.downloader.version="1.13.0"' in text
+    assert (
+        'org.llmtracefx.downloader.interface="huggingface_hub.snapshot_download"'
+        in text
+    )
 
 
 def test_containerfile_has_no_download_or_public_service_step() -> None:
@@ -32,7 +38,6 @@ def test_containerfile_has_no_download_or_public_service_step() -> None:
         "wget ",
         "apt-get",
         "git clone",
-        "snapshot_download",
         "huggingface-cli",
         "expose ",
     ):

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -42,10 +42,10 @@ the delegated task's hard requirements):
 5. Every GPU-lane container runs with ``--network none``, the fixed offline
    environment, and a run-scoped Docker label so teardown can find and stop
    *only* this run's containers -- never every container on the host.
-6. Teardown always runs, in a fixed order, transferring and locally
-   verifying evidence *before* any remote deletion, and never issues an
-   unscoped ``rm -rf`` or ``docker rm``/``docker stop`` against unvalidated
-   input.
+6. Once lifecycle execution begins, teardown runs in a fixed order,
+   transferring and locally verifying evidence *before* any remote deletion,
+   and never issues an unscoped ``rm -rf`` or ``docker rm``/``docker stop``
+   against unvalidated input.
 
 The in-container runner generates its own identity receipt and runtime
 attestation from installed package/source/model/GPU state. This host module
@@ -62,6 +62,7 @@ import json
 import os
 import re
 import shlex
+import signal
 import stat
 import subprocess
 import tarfile
@@ -1163,6 +1164,10 @@ _SAFE_REASON_MESSAGES: dict[str, tuple[str, str]] = {
         "evidence_transfer",
         "the evidence archive transfer failed",
     ),
+    "run_interrupted": (
+        "interruption",
+        "the coordinator received a termination signal",
+    ),
     "teardown_cleanup_failed": (
         "teardown",
         "scoped remote cleanup or key removal failed",
@@ -1819,6 +1824,8 @@ class RemoteOrchestrator:
                 input_text=input_text,
             )
         except HostOrchestrationError as exc:
+            if exc.reason_code == "run_interrupted":
+                raise
             result = CommandResult(
                 returncode=-1,
                 stdout="",
@@ -1869,20 +1876,25 @@ class RemoteOrchestrator:
         substage: str,
         description: str,
         reason_code: str,
-        reserve_stage: str,
+        reserve_stage: str | None,
     ) -> NoReturn:
         category, message = _SAFE_REASON_MESSAGES[reason_code]
+        reserved_minutes = (
+            CLEANUP_RESERVE_MINUTES
+            if reserve_stage is None
+            else remaining_reserve_minutes(stage_index(reserve_stage))
+        )
         self.operation_receipts.append(
             OperationReceipt(
                 stage=stage,
                 substage=substage,
                 command_description=description,
-                return_code=0,
+                return_code=-1,
                 timed_out=False,
                 stderr_category=category,
                 stderr_message=message,
                 reason_code=reason_code,
-                reserved_minutes=remaining_reserve_minutes(stage_index(reserve_stage)),
+                reserved_minutes=reserved_minutes,
             )
         )
         self._persist_operation_receipts()
@@ -2189,10 +2201,9 @@ class RemoteOrchestrator:
                 reason_code="image_preparation_failed",
                 reserve_stage=reserve_stage,
             )
-        archive_bytes, _ = read_runner_archive_commit_marker(
-            self.config.local_runner_archive
-        )
-        local_archive_digest = hashlib.sha256(archive_bytes).hexdigest()
+        authorized_archive_digest = self.authorization.derived_image_source_digest[
+            len("sha256:") :
+        ]
 
         script = "\n".join(
             [
@@ -2207,7 +2218,7 @@ class RemoteOrchestrator:
                 f"echo BASE_IMAGE_ID=$(docker image inspect "
                 f"{_quote(BASE_IMAGE_REFERENCE)} "
                 '--format "{{.Id}}")',
-                f"echo {_quote(local_archive_digest)}  "
+                f"echo {_quote(authorized_archive_digest)}  "
                 f"{_quote(self.paths.source_archive_remote_path)} | sha256sum -c -",
                 f"rm -rf {_quote(self.paths.repo_dir)}",
                 f"mkdir -p {_quote(self.paths.repo_dir)}",
@@ -2776,10 +2787,23 @@ class RemoteOrchestrator:
             reserve_stage="private_verify_redact_report_export",
             input_text=None,
         )
-        remote_digest = digest_result.stdout.split()[0].strip()
+        digest_fields = digest_result.stdout.split()
+        if not digest_fields:
+            self._local_failure(
+                stage="evidence_transfer",
+                substage="verify_remote_digest",
+                description="stage_transfer_evidence_digest_verify",
+                reason_code="evidence_digest_failed",
+                reserve_stage="private_verify_redact_report_export",
+            )
+        remote_digest = digest_fields[0].strip()
         if _SHA256_HEX.fullmatch(remote_digest) is None:
-            raise HostOrchestrationError(
-                "remote evidence archive digest output was malformed"
+            self._local_failure(
+                stage="evidence_transfer",
+                substage="verify_remote_digest",
+                description="stage_transfer_evidence_digest_verify",
+                reason_code="evidence_digest_failed",
+                reserve_stage="private_verify_redact_report_export",
             )
         local_bundle_dir.mkdir(parents=True, exist_ok=True)
         local_tar = local_bundle_dir / "evidence.tar"
@@ -2793,18 +2817,42 @@ class RemoteOrchestrator:
             reserve_stage="private_verify_redact_report_export",
             input_text=None,
         )
-        local_bytes = local_tar.read_bytes()
+        try:
+            local_bytes = read_bounded_regular_bytes(
+                local_tar,
+                MAX_SOURCE_ARCHIVE_BYTES,
+            )
+        except (ArtifactReadError, OSError):
+            self._local_failure(
+                stage="evidence_transfer",
+                substage="read_downloaded_archive",
+                description="stage_transfer_evidence_local_read",
+                reason_code="evidence_download_failed",
+                reserve_stage="private_verify_redact_report_export",
+            )
         local_digest = hashlib.sha256(local_bytes).hexdigest()
         if local_digest != remote_digest:
-            raise HostOrchestrationError(
-                "locally verified evidence archive digest does not match the "
-                "digest computed on the remote host before transfer"
+            self._local_failure(
+                stage="evidence_transfer",
+                substage="verify_downloaded_digest",
+                description="stage_transfer_evidence_local_digest_verify",
+                reason_code="evidence_download_failed",
+                reserve_stage="private_verify_redact_report_export",
             )
         raw_evidence_dir = local_bundle_dir / "raw_evidence"
-        extract_safe_tar(local_bytes, raw_evidence_dir)
-        claim_matrix, lane_receipts = self._build_claim_matrix_and_lane_receipts(
-            raw_evidence_dir / "evidence"
-        )
+        try:
+            extract_safe_tar(local_bytes, raw_evidence_dir)
+            claim_matrix, lane_receipts = self._build_claim_matrix_and_lane_receipts(
+                raw_evidence_dir / "evidence"
+            )
+        except (ArtifactReadError, HostOrchestrationError, OSError, tarfile.TarError):
+            self._local_failure(
+                stage="evidence_transfer",
+                substage="verify_downloaded_archive",
+                description="stage_transfer_evidence_local_archive_verify",
+                reason_code="evidence_download_failed",
+                reserve_stage="private_verify_redact_report_export",
+            )
         private_bundle = evidence.PrivateEvidenceBundle(
             run_mode=evidence.RUN_MODE_REAL_RUN,
             experiment_nonce=self.authorization.nonce,
@@ -2870,6 +2918,26 @@ class RemoteOrchestrator:
         script = "\n".join(
             [
                 "set -eu",
+                "reason=teardown_cleanup_failed",
+                "shutdown_attempted=0",
+                "finish_teardown() {",
+                "  status=$?",
+                "  trap - EXIT",
+                '  if [ "$shutdown_attempted" -eq 0 ]; then',
+                "    shutdown_attempted=1",
+                "    if sudo -n shutdown -h +1; then",
+                '      echo "SHUTDOWN_ISSUED=1"',
+                "    else",
+                '      echo "LLMTRACEFX_REASON=teardown_shutdown_failed" >&2',
+                "      exit 1",
+                "    fi",
+                "  fi",
+                '  if [ "$status" -ne 0 ]; then',
+                '    echo "LLMTRACEFX_REASON=$reason" >&2',
+                "  fi",
+                '  exit "$status"',
+                "}",
+                "trap finish_teardown EXIT",
                 f"docker ps -q --filter {_quote(label_filter)} | "
                 "xargs -r docker stop",
                 f"docker ps -aq --filter {_quote(label_filter)} | "
@@ -2901,46 +2969,40 @@ class RemoteOrchestrator:
                 '2>/dev/null | sed "/^[[:space:]]*$/d" | wc -l)"',
                 f"if [ -d {_quote(self.config.remote_workspace)} ]; then "
                 f"rmdir {_quote(self.config.remote_workspace)}; fi",
+                "reason=teardown_shutdown_failed",
+                "shutdown_attempted=1",
+                "sudo -n shutdown -h +1",
+                'echo "SHUTDOWN_ISSUED=1"',
+                "trap - EXIT",
             ]
         )
-        cleanup_error: BaseException | None = None
-        residual_containers = 0
-        residual_gpu_processes = 0
+        result = self._checked(
+            self.ssh_options.ssh_command("bash -s"),
+            stage="teardown",
+            substage="cleanup_key_removal_shutdown",
+            description="stage_teardown_cleanup",
+            timeout=300,
+            default_reason="teardown_cleanup_failed",
+            reserve_stage=None,
+            input_text=script,
+        )
         try:
-            result = self._checked(
-                self.ssh_options.ssh_command("bash -s"),
-                stage="teardown",
-                substage="cleanup_key_removal",
-                description="stage_teardown_cleanup",
-                timeout=300,
-                default_reason="teardown_cleanup_failed",
-                reserve_stage=None,
-                input_text=script,
-            )
             residual_containers, residual_gpu_processes = self._verify_teardown_output(
                 result.stdout
             )
-        except BaseException as exc:
-            cleanup_error = exc
-        try:
-            self._checked(
-                self.ssh_options.ssh_command("sudo -n shutdown -h now"),
-                stage="teardown",
-                substage="shutdown",
-                description="stage_teardown_shutdown",
-                timeout=30,
-                default_reason="teardown_shutdown_failed",
-                reserve_stage=None,
-                input_text=None,
+        except (HostOrchestrationError, ValueError):
+            reason_code = (
+                "teardown_shutdown_failed"
+                if "SHUTDOWN_ISSUED=1" not in result.stdout.splitlines()
+                else "teardown_cleanup_failed"
             )
-        except BaseException as exc:
-            if cleanup_error is not None:
-                raise HostOrchestrationError(
-                    "teardown cleanup failed and shutdown could not be issued"
-                ) from exc
-            raise
-        if cleanup_error is not None:
-            raise cleanup_error
+            self._local_failure(
+                stage="teardown",
+                substage="verify_cleanup_shutdown",
+                description="stage_teardown_verify",
+                reason_code=reason_code,
+                reserve_stage=None,
+            )
         self._finalize_evidence_bundle(
             local_bundle_dir,
             residual_containers=residual_containers,
@@ -2957,11 +3019,16 @@ class RemoteOrchestrator:
             for line in stdout.splitlines()
             if "=" in line
             and line.split("=", 1)[0]
-            in {"RESIDUAL_CONTAINERS", "RESIDUAL_GPU_PROCESSES"}
+            in {
+                "RESIDUAL_CONTAINERS",
+                "RESIDUAL_GPU_PROCESSES",
+                "SHUTDOWN_ISSUED",
+            }
         )
         if (
             "RESIDUAL_CONTAINERS" not in markers
             or "RESIDUAL_GPU_PROCESSES" not in markers
+            or markers.get("SHUTDOWN_ISSUED") != "1"
         ):
             raise HostOrchestrationError(
                 "teardown residual-state check produced no parsable markers"
@@ -2984,6 +3051,26 @@ class RemoteOrchestrator:
         """Execute every stage in order; teardown always runs in ``finally``,
         even if an earlier stage raised or the process is interrupted."""
 
+        installed_handlers: dict[int, Any] = {}
+
+        def handle_termination(signum: int, _frame: Any) -> NoReturn:
+            raise HostOrchestrationError(
+                "the coordinator received a termination signal",
+                stage="run",
+                substage="signal",
+                reason_code="run_interrupted",
+            )
+
+        for signal_name in ("SIGTERM", "SIGHUP"):
+            signum = getattr(signal, signal_name, None)
+            if signum is None:
+                continue
+            try:
+                installed_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, handle_termination)
+            except (OSError, ValueError):
+                installed_handlers.pop(signum, None)
+
         try:
             self.stage_preflight()
             self.stage_identity_gate()
@@ -3000,5 +3087,11 @@ class RemoteOrchestrator:
             self._record("run", False, detail=type(exc).__name__)
             raise
         finally:
-            self.stage_teardown(local_evidence_bundle_dir)
+            for signum in installed_handlers:
+                signal.signal(signum, signal.SIG_IGN)
+            try:
+                self.stage_teardown(local_evidence_bundle_dir)
+            finally:
+                for signum, previous_handler in installed_handlers.items():
+                    signal.signal(signum, previous_handler)
         return tuple(self.outcomes)

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -31,13 +31,18 @@ the delegated task's hard requirements):
    absolute timestamp from the plan's already-terminated VM is hardcoded
    anywhere in this module; every cutoff is computed from the
    caller-supplied boot time, rate, cap, and explicit operational cutoff.
-3. Model acquisition is verified file-by-file against the already-committed
-   15-file/16,397,461,266-byte SHA-256 inventory
+3. Checked source and the digest-pinned image are staged before acquisition.
+   The image must attest the exact ``huggingface_hub.snapshot_download``
+   package/version/interface/source; only then may one labeled, explicitly
+   networked, non-GPU container acquire the model. The vanilla host never
+   needs a Hugging Face CLI or Python package.
+4. Model acquisition is verified file-by-file on the host against the
+   already-committed 15-file/16,397,461,266-byte SHA-256 inventory
    (``qwen3-8b-conversion-manifest-v1.json``), not just a count/byte total.
-4. Every GPU-lane container runs with ``--network none``, the fixed offline
+5. Every GPU-lane container runs with ``--network none``, the fixed offline
    environment, and a run-scoped Docker label so teardown can find and stop
    *only* this run's containers -- never every container on the host.
-5. Teardown always runs, in a fixed order, transferring and locally
+6. Teardown always runs, in a fixed order, transferring and locally
    verifying evidence *before* any remote deletion, and never issues an
    unscoped ``rm -rf`` or ``docker rm``/``docker stop`` against unvalidated
    input.
@@ -66,7 +71,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import ROUND_FLOOR, ROUND_HALF_EVEN, Decimal, InvalidOperation
 from enum import Enum
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, NoReturn, Protocol
 
 from llmtracefx.cache_audit.adapters.vllm import (
     REQUIRED_VLLM_COMMIT,
@@ -96,6 +101,12 @@ from vllm_kv_truth.runner import (
 )
 
 from . import evidence
+from .model_download import (
+    DOWNLOADER_INTERFACE,
+    DOWNLOADER_PACKAGE,
+    DOWNLOADER_SOURCE,
+    DOWNLOADER_VERSION,
+)
 
 MAX_CONFIG_ARTIFACT_BYTES = 64 * 1024
 MAX_AUTHORIZATION_ARTIFACT_BYTES = 64 * 1024
@@ -128,6 +139,21 @@ MODEL_CONVERSION_MANIFEST_PATH = (
 
 class HostOrchestrationError(DeploymentPlanError):
     """Raised whenever a config/authorization/stage invariant is violated."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stage: str | None = None,
+        substage: str | None = None,
+        reason_code: str | None = None,
+    ) -> None:
+        self.stage = stage
+        self.substage = substage
+        self.reason_code = reason_code
+        if stage is not None and substage is not None and reason_code is not None:
+            message = f"{stage}/{substage}: {reason_code}: {message}"
+        super().__init__(message)
 
 
 def canonical_json(value: Any) -> str:
@@ -421,9 +447,9 @@ class BudgetStage:
 #: boot time, rate, and cap independently impose an absolute ceiling.
 BUDGET_STAGES: tuple[BudgetStage, ...] = (
     BudgetStage("existing_preflight_planning_reserve", 15),
-    BudgetStage("approval_handoff_ssh_identity_gate", 5),
-    BudgetStage("model_acquisition_verification", 40),
+    BudgetStage("approval_handoff_ssh_identity_source_transfer", 5),
     BudgetStage("image_pull_rebuild_inspect_attestation", 20),
+    BudgetStage("model_acquisition_verification", 40),
     BudgetStage("no_warmup_canary_event_feasibility_gate", 15),
     BudgetStage("four_fresh_ab_lifecycle_pairs", 60),
     BudgetStage("fixed_eviction_lane", 10),
@@ -534,9 +560,9 @@ def list_rate_cost_usd(elapsed_minutes: Decimal, rate_usd_per_hour: Decimal) -> 
 # Explicit, self-sealed run authorization.
 # ---------------------------------------------------------------------------
 
-AUTHORIZATION_SCHEMA_VERSION = "1"
+AUTHORIZATION_SCHEMA_VERSION = "2"
 AUTHORIZATION_SIGNER_IDENTITY = "vllm-kv-truth-coordinator"
-AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v1"
+AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v2"
 
 _AUTHORIZATION_REQUIRED_KEYS = frozenset(
     {
@@ -550,6 +576,10 @@ _AUTHORIZATION_REQUIRED_KEYS = frozenset(
         "model_id",
         "model_revision",
         "model_inventory_sha256",
+        "model_download_package",
+        "model_download_version",
+        "model_download_interface",
+        "model_download_source",
         "gpu_expected_count",
         "gpu_expected_name",
         "gpu_expected_driver",
@@ -639,6 +669,10 @@ class RunAuthorization:
             "model_id": MODEL_ID,
             "model_revision": MODEL_REVISION,
             "model_inventory_sha256": self.model_inventory_sha256,
+            "model_download_package": DOWNLOADER_PACKAGE,
+            "model_download_version": DOWNLOADER_VERSION,
+            "model_download_interface": DOWNLOADER_INTERFACE,
+            "model_download_source": DOWNLOADER_SOURCE,
             "gpu_expected_count": self.gpu_expected_count,
             "gpu_expected_name": EXPECTED_GPU_NAME,
             "gpu_expected_driver": EXPECTED_DRIVER,
@@ -686,6 +720,10 @@ class RunAuthorization:
             "vllm_commit": REQUIRED_VLLM_COMMIT,
             "model_id": MODEL_ID,
             "model_revision": MODEL_REVISION,
+            "model_download_package": DOWNLOADER_PACKAGE,
+            "model_download_version": DOWNLOADER_VERSION,
+            "model_download_interface": DOWNLOADER_INTERFACE,
+            "model_download_source": DOWNLOADER_SOURCE,
             "gpu_expected_name": EXPECTED_GPU_NAME,
             "gpu_expected_driver": EXPECTED_DRIVER,
             "gpu_expected_memory_mib": EXPECTED_MEMORY_MIB,
@@ -962,6 +1000,8 @@ class CommandResult:
     returncode: int
     stdout: str
     stderr: str
+    timed_out: bool = False
+    start_failed: bool = False
 
     @property
     def ok(self) -> bool:
@@ -1008,12 +1048,20 @@ class SubprocessCommandRunner:
                 env={"PATH": _SAFE_EXECUTION_PATH, "LANG": "C", "LC_ALL": "C"},
                 check=False,
             )
-        except subprocess.TimeoutExpired as exc:
-            raise HostOrchestrationError(f"{description} timed out") from exc
-        except OSError as exc:
-            raise HostOrchestrationError(
-                f"{description} could not start: {exc}"
-            ) from exc
+        except subprocess.TimeoutExpired:
+            return CommandResult(
+                returncode=-1,
+                stdout="",
+                stderr="",
+                timed_out=True,
+            )
+        except OSError:
+            return CommandResult(
+                returncode=-1,
+                stdout="",
+                stderr="",
+                start_failed=True,
+            )
         return CommandResult(
             returncode=completed.returncode,
             stdout=completed.stdout,
@@ -1043,6 +1091,134 @@ def checked(
     if not result.ok:
         raise HostOrchestrationError(f"stage failed: {description}")
     return result
+
+
+_SAFE_REASON_MESSAGES: dict[str, tuple[str, str]] = {
+    "operation_timeout": ("timeout", "the operation timed out"),
+    "operation_start_failed": ("local_start", "the operation could not start"),
+    "preflight_missing_linux": (
+        "host_prerequisite",
+        "the remote host did not identify as Linux",
+    ),
+    "preflight_missing_nvidia_smi": (
+        "host_prerequisite",
+        "the remote host does not provide nvidia-smi",
+    ),
+    "preflight_missing_docker": (
+        "host_prerequisite",
+        "the remote host does not provide Docker",
+    ),
+    "preflight_missing_sudo": (
+        "host_prerequisite",
+        "the remote host does not provide noninteractive sudo",
+    ),
+    "preflight_missing_python3": (
+        "host_prerequisite",
+        "the remote host does not provide Python 3",
+    ),
+    "preflight_probe_failed": (
+        "remote_command",
+        "the vanilla-host preflight probe failed",
+    ),
+    "identity_gate_failed": (
+        "remote_command",
+        "the SSH identity gate failed",
+    ),
+    "source_transfer_failed": (
+        "transfer",
+        "the checked source transfer failed",
+    ),
+    "image_preparation_failed": (
+        "container_image",
+        "the pinned image preparation or attestation failed",
+    ),
+    "model_download_interface_missing": (
+        "downloader_attestation",
+        "the pinned image lacks the authorized downloader interface",
+    ),
+    "model_download_version_mismatch": (
+        "downloader_attestation",
+        "the pinned image downloader version does not match authorization",
+    ),
+    "model_download_failed": (
+        "model_acquisition",
+        "the in-container model download failed",
+    ),
+    "model_inventory_mismatch": (
+        "model_inventory",
+        "the downloaded model inventory does not match the exact manifest",
+    ),
+    "canary_failed": ("gpu_lane", "the event-bearing canary failed"),
+    "pair_lane_failed": ("gpu_lane", "a fixed pair lane failed"),
+    "eviction_lane_failed": ("gpu_lane", "the fixed eviction lane failed"),
+    "evidence_archive_failed": (
+        "evidence_transfer",
+        "the remote evidence archive could not be prepared",
+    ),
+    "evidence_digest_failed": (
+        "evidence_transfer",
+        "the remote evidence digest could not be computed",
+    ),
+    "evidence_download_failed": (
+        "evidence_transfer",
+        "the evidence archive transfer failed",
+    ),
+    "teardown_cleanup_failed": (
+        "teardown",
+        "scoped remote cleanup or key removal failed",
+    ),
+    "teardown_shutdown_failed": (
+        "teardown",
+        "the remote shutdown command failed",
+    ),
+}
+_SAFE_REASON_MARKER = re.compile(r"^LLMTRACEFX_REASON=([a-z0-9_]{1,80})$")
+_MAX_SAFE_FAILURE_MESSAGE_LENGTH = 160
+
+
+@dataclass(frozen=True)
+class OperationReceipt:
+    """Private, path-free result for one local or remote operation."""
+
+    stage: str
+    substage: str
+    command_description: str
+    return_code: int
+    timed_out: bool
+    stderr_category: str
+    stderr_message: str
+    reason_code: str | None
+    reserved_minutes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "1",
+            "stage": self.stage,
+            "substage": self.substage,
+            "command_description": self.command_description,
+            "return_code": self.return_code,
+            "timed_out": self.timed_out,
+            "stderr_category": self.stderr_category,
+            "stderr_message": self.stderr_message,
+            "reason_code": self.reason_code,
+            "reserved_minutes": self.reserved_minutes,
+        }
+
+
+def _safe_failure(result: CommandResult, default_reason: str) -> tuple[str, str, str]:
+    if result.timed_out:
+        reason = "operation_timeout"
+    elif result.start_failed:
+        reason = "operation_start_failed"
+    else:
+        reason = default_reason
+        for line in result.stderr.splitlines():
+            match = _SAFE_REASON_MARKER.fullmatch(line.strip())
+            if match is not None and match.group(1) in _SAFE_REASON_MESSAGES:
+                reason = match.group(1)
+                break
+    category, message = _SAFE_REASON_MESSAGES[reason]
+    return reason, category, message[:_MAX_SAFE_FAILURE_MESSAGE_LENGTH]
 
 
 # ---------------------------------------------------------------------------
@@ -1204,6 +1380,10 @@ class RunPaths:
     @property
     def receipts_dir(self) -> str:
         return f"{self.remote_workspace}/receipts"
+
+    @property
+    def hf_scratch_dir(self) -> str:
+        return f"{self.remote_workspace}/hf-scratch"
 
     @property
     def source_archive_remote_path(self) -> str:
@@ -1482,6 +1662,44 @@ def build_docker_run_argv(
     )
 
 
+def build_model_download_argv(
+    *,
+    authorization: RunAuthorization,
+    paths: RunPaths,
+    derived_image_id: str,
+) -> tuple[str, ...]:
+    """Build the only network-enabled container command in the protocol."""
+
+    return (
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        "bridge",
+        "--label",
+        docker_run_label(authorization.nonce),
+        "--name",
+        container_name(authorization.nonce, "model-download"),
+        "-e",
+        "HF_HOME=/hf",
+        "-e",
+        "HF_HUB_DISABLE_TELEMETRY=1",
+        "-v",
+        f"{paths.model_dir}:/model",
+        "-v",
+        f"{paths.hf_scratch_dir}:/hf",
+        _require_pattern(derived_image_id, _SHA256_REF, field_name="derived_image_id"),
+        "python3",
+        "-m",
+        "vllm_kv_truth.model_download",
+        "download",
+        "--destination",
+        "/model",
+        "--scratch",
+        "/hf",
+    )
+
+
 def container_name(nonce: str, tag: str) -> str:
     return _require_label(f"kv-truth-{nonce}-{tag}"[:128], field_name="container_name")
 
@@ -1492,8 +1710,8 @@ class OrchestratorState(str, Enum):
     PENDING = "pending"
     PREFLIGHT = "preflight"
     IDENTITY_GATE = "identity_gate"
-    MODEL_ACQUISITION = "model_acquisition"
     IMAGE_PREPARATION = "image_preparation"
+    MODEL_ACQUISITION = "model_acquisition"
     CANARY = "canary"
     AB_PAIRS = "ab_pairs"
     EVICTION_LANE = "eviction_lane"
@@ -1542,6 +1760,138 @@ class RemoteOrchestrator:
         self.outcomes: list[StageOutcome] = []
         self.derived_image_id: str | None = None
         self.expected_runner_source_digest: str | None = None
+        self.downloader_attestation: dict[str, str] | None = None
+        self.operation_receipts: list[OperationReceipt] = []
+
+    @property
+    def operation_receipt_path(self) -> Path:
+        return self.config.local_evidence_dir / "private-operation-receipts.jsonl"
+
+    def _persist_operation_receipts(self) -> None:
+        directory = self.config.local_evidence_dir
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if directory.is_symlink():
+            raise HostOrchestrationError(
+                "local evidence directory must not be a symlink"
+            )
+        text = "".join(
+            canonical_json(receipt.to_dict()) + "\n"
+            for receipt in self.operation_receipts
+        )
+        temporary = directory / f".operation-receipts.{os.getpid()}.tmp"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(temporary, flags, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.operation_receipt_path)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    def _checked(
+        self,
+        argv: Sequence[str],
+        *,
+        stage: str,
+        substage: str,
+        description: str,
+        timeout: float,
+        default_reason: str,
+        reserve_stage: str | None,
+        input_text: str | None = None,
+    ) -> CommandResult:
+        reserved_minutes = (
+            CLEANUP_RESERVE_MINUTES
+            if reserve_stage is None
+            else remaining_reserve_minutes(stage_index(reserve_stage))
+        )
+        try:
+            result = self.runner.run(
+                argv,
+                description=description,
+                timeout=timeout,
+                input_text=input_text,
+            )
+        except HostOrchestrationError as exc:
+            result = CommandResult(
+                returncode=-1,
+                stdout="",
+                stderr="",
+                timed_out="timed out" in str(exc).lower(),
+                start_failed="timed out" not in str(exc).lower(),
+            )
+        if result.ok:
+            receipt = OperationReceipt(
+                stage=stage,
+                substage=substage,
+                command_description=description,
+                return_code=result.returncode,
+                timed_out=False,
+                stderr_category="none",
+                stderr_message="",
+                reason_code=None,
+                reserved_minutes=reserved_minutes,
+            )
+        else:
+            reason, category, message = _safe_failure(result, default_reason)
+            receipt = OperationReceipt(
+                stage=stage,
+                substage=substage,
+                command_description=description,
+                return_code=result.returncode,
+                timed_out=result.timed_out,
+                stderr_category=category,
+                stderr_message=message,
+                reason_code=reason,
+                reserved_minutes=reserved_minutes,
+            )
+        self.operation_receipts.append(receipt)
+        self._persist_operation_receipts()
+        if not result.ok:
+            raise HostOrchestrationError(
+                receipt.stderr_message,
+                stage=stage,
+                substage=substage,
+                reason_code=receipt.reason_code,
+            )
+        return result
+
+    def _local_failure(
+        self,
+        *,
+        stage: str,
+        substage: str,
+        description: str,
+        reason_code: str,
+        reserve_stage: str,
+    ) -> NoReturn:
+        category, message = _SAFE_REASON_MESSAGES[reason_code]
+        self.operation_receipts.append(
+            OperationReceipt(
+                stage=stage,
+                substage=substage,
+                command_description=description,
+                return_code=0,
+                timed_out=False,
+                stderr_category=category,
+                stderr_message=message,
+                reason_code=reason_code,
+                reserved_minutes=remaining_reserve_minutes(stage_index(reserve_stage)),
+            )
+        )
+        self._persist_operation_receipts()
+        raise HostOrchestrationError(
+            message,
+            stage=stage,
+            substage=substage,
+            reason_code=reason_code,
+        )
 
     def _require_derived_image_id(self) -> str:
         if self.derived_image_id is None:
@@ -1598,6 +1948,23 @@ class RemoteOrchestrator:
         script = "\n".join(
             [
                 "set -eu",
+                "command -v uname >/dev/null 2>&1 || "
+                "{ echo LLMTRACEFX_REASON=preflight_missing_linux >&2; exit 1; }",
+                'test "$(uname -s)" = Linux || '
+                "{ echo LLMTRACEFX_REASON=preflight_missing_linux >&2; exit 1; }",
+                "command -v nvidia-smi >/dev/null 2>&1 || "
+                "{ echo LLMTRACEFX_REASON=preflight_missing_nvidia_smi >&2; exit 1; }",
+                "command -v docker >/dev/null 2>&1 || "
+                "{ echo LLMTRACEFX_REASON=preflight_missing_docker >&2; exit 1; }",
+                "command -v sudo >/dev/null 2>&1 || "
+                "{ echo LLMTRACEFX_REASON=preflight_missing_sudo >&2; exit 1; }",
+                "command -v python3 >/dev/null 2>&1 || "
+                "{ echo LLMTRACEFX_REASON=preflight_missing_python3 >&2; exit 1; }",
+                "for tool in date uptime df free awk sed wc; do "
+                'command -v "$tool" >/dev/null 2>&1 || '
+                "{ echo LLMTRACEFX_REASON=preflight_probe_failed >&2; exit 1; }; "
+                "done",
+                'echo "OS_NAME=$(uname -s)"',
                 'echo "NOW_EPOCH=$(date -u +%s)"',
                 'echo "BOOT_EPOCH=$(date -u -d "$(uptime -s)" +%s)"',
                 'echo "GPU_COUNT=$(nvidia-smi --list-gpus | wc -l)"',
@@ -1619,17 +1986,28 @@ class RemoteOrchestrator:
                 ')"',
                 'echo "DOCKER_VERSION=$(docker version '
                 "--format '{{.Server.Version}}')\"",
-                'echo "HF_CLI=$(command -v huggingface-cli)"',
             ]
         )
-        result = checked(
-            self.runner,
+        result = self._checked(
             self.ssh_options.ssh_command("bash -s"),
+            stage="preflight",
+            substage="host_probe",
             description="stage_preflight",
             timeout=60,
+            default_reason="preflight_probe_failed",
+            reserve_stage="existing_preflight_planning_reserve",
             input_text=script,
         )
-        self._verify_preflight_output(result.stdout)
+        try:
+            self._verify_preflight_output(result.stdout)
+        except (HostOrchestrationError, ValueError):
+            self._local_failure(
+                stage="preflight",
+                substage="validate_markers",
+                description="stage_preflight_validate",
+                reason_code="preflight_probe_failed",
+                reserve_stage="existing_preflight_planning_reserve",
+            )
         self._record("preflight", True)
         return self.outcomes[-1]
 
@@ -1641,6 +2019,7 @@ class RemoteOrchestrator:
                 markers[key.strip()] = value.strip()
         required = {
             "NOW_EPOCH",
+            "OS_NAME",
             "BOOT_EPOCH",
             "GPU_COUNT",
             "GPU",
@@ -1652,12 +2031,13 @@ class RemoteOrchestrator:
             "SWAP_USED_BYTES",
             "PYTHON_VERSION",
             "DOCKER_VERSION",
-            "HF_CLI",
         }
         if set(markers) != required:
             raise HostOrchestrationError(
                 "preflight output markers differ from the exact required set"
             )
+        if markers["OS_NAME"] != "Linux":
+            raise HostOrchestrationError("preflight host operating system is not Linux")
         parts = [part.strip() for part in markers["GPU"].split(",")]
         if len(parts) != 4:
             raise HostOrchestrationError("preflight GPU inventory line is malformed")
@@ -1701,10 +2081,6 @@ class RemoteOrchestrator:
             raise HostOrchestrationError("preflight Python version is not 3.12.x")
         if not markers["DOCKER_VERSION"]:
             raise HostOrchestrationError("preflight Docker version is empty")
-        if not markers["HF_CLI"].startswith("/"):
-            raise HostOrchestrationError(
-                "preflight did not find an absolute huggingface-cli executable"
-            )
         now = datetime.fromtimestamp(int(markers["NOW_EPOCH"]), tz=timezone.utc)
         boot = datetime.fromtimestamp(int(markers["BOOT_EPOCH"]), tz=timezone.utc)
         if abs((boot - self.authorization.billing_started_at).total_seconds()) > 2:
@@ -1716,11 +2092,48 @@ class RemoteOrchestrator:
                 "preflight remote clock differs from the coordinator clock"
             )
 
-    # -- stage 2: approval handoff / ssh identity gate ---------------------
+    # -- stage 2: approval handoff / identity and source transfer -----------
 
     def stage_identity_gate(self) -> StageOutcome:
-        self._require_budget("approval_handoff_ssh_identity_gate")
+        reserve_stage = "approval_handoff_ssh_identity_source_transfer"
+        self._require_budget(reserve_stage)
         self.state = OrchestratorState.IDENTITY_GATE
+        try:
+            archive_bytes, archive_commit = read_runner_archive_commit_marker(
+                self.config.local_runner_archive
+            )
+        except HostOrchestrationError:
+            self._local_failure(
+                stage="identity_source_transfer",
+                substage="validate_source_archive",
+                description="stage_identity_source_validate",
+                reason_code="source_transfer_failed",
+                reserve_stage=reserve_stage,
+            )
+        if archive_commit != self.authorization.repository_head:
+            self._local_failure(
+                stage="identity_source_transfer",
+                substage="validate_source_archive",
+                description="stage_identity_source_validate",
+                reason_code="source_transfer_failed",
+                reserve_stage=reserve_stage,
+            )
+        local_archive_digest = hashlib.sha256(archive_bytes).hexdigest()
+        if (
+            f"sha256:{local_archive_digest}"
+            != self.authorization.derived_image_source_digest
+        ):
+            self._local_failure(
+                stage="identity_source_transfer",
+                substage="validate_source_archive",
+                description="stage_identity_source_validate",
+                reason_code="source_transfer_failed",
+                reserve_stage=reserve_stage,
+            )
+        self.expected_runner_source_digest = runner_source_digest_from_archive(
+            archive_bytes
+        )
+
         script = "\n".join(
             [
                 "set -eu",
@@ -1736,101 +2149,57 @@ class RemoteOrchestrator:
                 '"$AUTHORIZED_KEYS")" = "1"',
             ]
         )
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.ssh_command("bash -s"),
+            stage="identity_source_transfer",
+            substage="identity_gate",
             description="stage_identity_gate",
-            timeout=30,
+            timeout=20,
+            default_reason="identity_gate_failed",
+            reserve_stage=reserve_stage,
             input_text=script,
         )
-        self._record("identity_gate", True)
-        return self.outcomes[-1]
-
-    # -- stage 3: model acquisition and per-file verification ---------------
-
-    def stage_model_acquisition(self) -> StageOutcome:
-        self._require_budget("model_acquisition_verification")
-        self.state = OrchestratorState.MODEL_ACQUISITION
-        download_script = "\n".join(
-            [
-                "set -eu",
-                f"rm -rf {_quote(self.paths.model_dir)}",
-                f"mkdir -p {_quote(self.paths.model_dir)}",
-                f"rm -rf {_quote(self.paths.remote_workspace + '/hf-home')}",
-                "env -i PATH=/usr/local/bin:/usr/bin:/bin "
-                f"HOME={_quote(self.paths.remote_workspace)} "
-                f"HF_HOME={_quote(self.paths.remote_workspace + '/hf-home')} "
-                "HF_HUB_DISABLE_TELEMETRY=1 "
-                "huggingface-cli download "
-                f"{_quote(MODEL_ID)} --revision {_quote(MODEL_REVISION)} "
-                f"--local-dir {_quote(self.paths.model_dir)}",
-                f"rm -rf {_quote(self.paths.remote_workspace + '/hf-home')}",
-                f"rm -rf {_quote(self.paths.model_dir + '/.cache')}",
-            ]
-        )
-        checked(
-            self.runner,
-            self.ssh_options.ssh_command("bash -s"),
-            description="stage_model_acquisition_download",
-            timeout=1800,
-            input_text=download_script,
-        )
-        verification_script = build_model_inventory_verification_script(self.paths)
-        checked(
-            self.runner,
-            self.ssh_options.ssh_command("bash -s"),
-            description="stage_model_acquisition_verify",
-            timeout=600,
-            input_text=verification_script,
-        )
-        self._record("model_acquisition", True)
-        return self.outcomes[-1]
-
-    # -- stage 4: checked source staging, image pull/build, inspection ------
-
-    def stage_image_preparation(self) -> StageOutcome:
-        self._require_budget("image_pull_rebuild_inspect_attestation")
-        self.state = OrchestratorState.IMAGE_PREPARATION
-
-        # Verify the checked source archive's embedded commit purely
-        # locally (no network, no live `git fetch` against any remote)
-        # before it is ever staged onto the host.
-        archive_bytes, archive_commit = read_runner_archive_commit_marker(
-            self.config.local_runner_archive
-        )
-        if archive_commit != self.authorization.repository_head:
-            raise HostOrchestrationError(
-                "checked source archive's embedded commit does not match the "
-                "authorization's repository_head "
-                f"({archive_commit} != {self.authorization.repository_head})"
-            )
-        local_archive_digest = hashlib.sha256(archive_bytes).hexdigest()
-        if (
-            f"sha256:{local_archive_digest}"
-            != self.authorization.derived_image_source_digest
-        ):
-            raise HostOrchestrationError(
-                "checked source archive digest does not match the authorization's "
-                "derived_image_source_digest"
-            )
-        self.expected_runner_source_digest = runner_source_digest_from_archive(
-            archive_bytes
-        )
-
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.scp_upload_command(
                 self.config.local_runner_archive,
                 self.paths.source_archive_remote_path,
             ),
-            description="stage_image_preparation_upload_source",
-            timeout=600,
+            stage="identity_source_transfer",
+            substage="source_upload",
+            description="stage_identity_source_upload",
+            timeout=280,
+            default_reason="source_transfer_failed",
+            reserve_stage=reserve_stage,
             input_text=None,
         )
+        self._record("identity_source_transfer", True)
+        return self.outcomes[-1]
+
+    # -- stage 3: pinned image pull/build/inspection/downloader attestation --
+
+    def stage_image_preparation(self) -> StageOutcome:
+        reserve_stage = "image_pull_rebuild_inspect_attestation"
+        self._require_budget(reserve_stage)
+        self.state = OrchestratorState.IMAGE_PREPARATION
+        if self.expected_runner_source_digest is None:
+            self._local_failure(
+                stage="image_preparation",
+                substage="source_binding",
+                description="stage_image_preparation_source_binding",
+                reason_code="image_preparation_failed",
+                reserve_stage=reserve_stage,
+            )
+        archive_bytes, _ = read_runner_archive_commit_marker(
+            self.config.local_runner_archive
+        )
+        local_archive_digest = hashlib.sha256(archive_bytes).hexdigest()
 
         script = "\n".join(
             [
                 "set -eu",
+                "reason=image_preparation_failed",
+                'trap \'status=$?; if [ "$status" -ne 0 ]; then '
+                'echo "LLMTRACEFX_REASON=$reason" >&2; fi\' EXIT',
                 f"docker pull {_quote(BASE_IMAGE_REFERENCE)}",
                 f"echo BASE_REPODIGESTS=$(docker image inspect "
                 f"{_quote(BASE_IMAGE_REFERENCE)} "
@@ -1851,6 +2220,7 @@ class RemoteOrchestrator:
                 f"test \"$(sed -n '1p' containers/vllm-kv-truth/Containerfile)\" "
                 f"= {_quote('FROM ' + BASE_IMAGE_REFERENCE)}",
                 "docker build -q "
+                "--network none "
                 f"--label {_quote(docker_run_label(self.authorization.nonce))} "
                 f"--build-arg RUNNER_COMMIT={_quote(self.authorization.repository_head)} "
                 "-f containers/vllm-kv-truth/Containerfile "
@@ -1858,20 +2228,63 @@ class RemoteOrchestrator:
                 "echo DERIVED_IMAGE_ID=$(docker image inspect "
                 f"kv-truth-derived-{_quote(self.authorization.nonce)} "
                 '--format "{{.Id}}")',
+                "echo DOWNLOADER_PACKAGE=$(docker image inspect "
+                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
+                "--format '{{ index .Config.Labels "
+                '"org.llmtracefx.downloader.package" }}\')',
+                "echo DOWNLOADER_VERSION=$(docker image inspect "
+                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
+                "--format '{{ index .Config.Labels "
+                '"org.llmtracefx.downloader.version" }}\')',
+                "echo DOWNLOADER_INTERFACE=$(docker image inspect "
+                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
+                "--format '{{ index .Config.Labels "
+                '"org.llmtracefx.downloader.interface" }}\')',
+                "echo DOWNLOADER_SOURCE=$(docker image inspect "
+                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
+                "--format '{{ index .Config.Labels "
+                '"org.llmtracefx.downloader.source" }}\')',
+                f"docker run --rm --network none --label "
+                f"{_quote(docker_run_label(self.authorization.nonce))} "
+                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
+                "python3 -m vllm_kv_truth.model_download attest",
+                "trap - EXIT",
             ]
         )
-        result = checked(
-            self.runner,
+        result = self._checked(
             self.ssh_options.ssh_command("bash -s"),
+            stage="image_preparation",
+            substage="pull_build_inspect_attest",
             description="stage_image_preparation",
-            timeout=1800,
+            timeout=1200,
+            default_reason="image_preparation_failed",
+            reserve_stage=reserve_stage,
             input_text=script,
         )
-        self.derived_image_id = self._verify_image_preparation_output(result.stdout)
+        try:
+            (
+                self.derived_image_id,
+                self.downloader_attestation,
+            ) = self._verify_image_preparation_output(result.stdout)
+        except HostOrchestrationError as exc:
+            reason = (
+                exc.reason_code
+                if exc.reason_code in _SAFE_REASON_MESSAGES
+                else "image_preparation_failed"
+            )
+            self._local_failure(
+                stage="image_preparation",
+                substage="verify_attestation",
+                description="stage_image_preparation_verify",
+                reason_code=reason,
+                reserve_stage=reserve_stage,
+            )
         self._record("image_preparation", True)
         return self.outcomes[-1]
 
-    def _verify_image_preparation_output(self, stdout: str) -> str:
+    def _verify_image_preparation_output(
+        self, stdout: str
+    ) -> tuple[str, dict[str, str]]:
         markers = dict(
             line.strip().split("=", 1)
             for line in stdout.splitlines()
@@ -1882,6 +2295,10 @@ class RemoteOrchestrator:
                 "BASE_IMAGE_ID",
                 "EXPECTED_HEAD",
                 "DERIVED_IMAGE_ID",
+                "DOWNLOADER_PACKAGE",
+                "DOWNLOADER_VERSION",
+                "DOWNLOADER_INTERFACE",
+                "DOWNLOADER_SOURCE",
             }
         )
         if "BASE_REPODIGESTS" not in markers:
@@ -1924,7 +2341,194 @@ class RemoteOrchestrator:
             raise HostOrchestrationError(
                 "derived image id is malformed or identical to the base image id"
             )
-        return derived_id
+        expected_downloader = {
+            "package": DOWNLOADER_PACKAGE,
+            "version": DOWNLOADER_VERSION,
+            "interface": DOWNLOADER_INTERFACE,
+            "source": DOWNLOADER_SOURCE,
+        }
+        label_attestation = {
+            key.removeprefix("DOWNLOADER_").lower(): markers.get(key, "")
+            for key in (
+                "DOWNLOADER_PACKAGE",
+                "DOWNLOADER_VERSION",
+                "DOWNLOADER_INTERFACE",
+                "DOWNLOADER_SOURCE",
+            )
+        }
+        if label_attestation != expected_downloader:
+            reason = (
+                "model_download_version_mismatch"
+                if all(
+                    label_attestation.get(key) == expected_downloader[key]
+                    for key in ("package", "interface", "source")
+                )
+                else "model_download_interface_missing"
+            )
+            raise HostOrchestrationError(
+                _SAFE_REASON_MESSAGES[reason][1],
+                reason_code=reason,
+            )
+        runtime_lines = [
+            line.strip()
+            for line in stdout.splitlines()
+            if line.strip().startswith("{") and '"package"' in line
+        ]
+        if len(runtime_lines) != 1:
+            raise HostOrchestrationError(
+                _SAFE_REASON_MESSAGES["model_download_interface_missing"][1],
+                reason_code="model_download_interface_missing",
+            )
+        try:
+            runtime_attestation = json.loads(runtime_lines[0])
+        except ValueError as exc:
+            raise HostOrchestrationError(
+                _SAFE_REASON_MESSAGES["model_download_interface_missing"][1],
+                reason_code="model_download_interface_missing",
+            ) from exc
+        if runtime_attestation != {"schema_version": "1", **expected_downloader}:
+            reason = (
+                "model_download_version_mismatch"
+                if runtime_attestation.get("version") != DOWNLOADER_VERSION
+                else "model_download_interface_missing"
+            )
+            raise HostOrchestrationError(
+                _SAFE_REASON_MESSAGES[reason][1],
+                reason_code=reason,
+            )
+        return derived_id, expected_downloader
+
+    # -- stage 4: in-image model acquisition and host inventory verification
+
+    def _persist_model_acquisition_receipt(
+        self,
+        *,
+        download_attestation: Mapping[str, Any],
+    ) -> None:
+        payload = {
+            "schema_version": "1",
+            "protocol_id": PROTOCOL_ID,
+            "authorization_sha256": self.authorization.authorization_sha256,
+            "derived_image_id": self._require_derived_image_id(),
+            "base_image_reference": BASE_IMAGE_REFERENCE,
+            "network_mode": "bridge",
+            "container_label": docker_run_label(self.authorization.nonce),
+            "downloader": dict(download_attestation),
+            "model_id": MODEL_ID,
+            "model_revision": MODEL_REVISION,
+            "model_inventory_sha256": self.authorization.model_inventory_sha256,
+            "verified_file_count": EXPECTED_MODEL_FILE_COUNT,
+            "verified_total_bytes": EXPECTED_MODEL_BYTES,
+        }
+        directory = self.config.local_evidence_dir
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target = directory / "private-model-acquisition-receipt.json"
+        temporary = directory / f".model-acquisition-receipt.{os.getpid()}.tmp"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(temporary, flags, 0o600)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(canonical_json(payload) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, target)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+
+    def stage_model_acquisition(self) -> StageOutcome:
+        reserve_stage = "model_acquisition_verification"
+        self._require_budget(reserve_stage)
+        self.state = OrchestratorState.MODEL_ACQUISITION
+        derived_image_id = self._require_derived_image_id()
+        if self.downloader_attestation is None:
+            self._local_failure(
+                stage="model_acquisition",
+                substage="downloader_binding",
+                description="stage_model_acquisition_binding",
+                reason_code="model_download_interface_missing",
+                reserve_stage=reserve_stage,
+            )
+        download_argv = build_model_download_argv(
+            authorization=self.authorization,
+            paths=self.paths,
+            derived_image_id=derived_image_id,
+        )
+        download_script = "\n".join(
+            [
+                "set -eu",
+                f"rm -rf {_quote(self.paths.model_dir)} "
+                f"{_quote(self.paths.hf_scratch_dir)}",
+                f"mkdir -p {_quote(self.paths.model_dir)} "
+                f"{_quote(self.paths.hf_scratch_dir)}",
+                "cleanup_download_scratch() { "
+                f"rm -rf {_quote(self.paths.hf_scratch_dir)} "
+                f"{_quote(self.paths.model_dir + '/.cache')}; "
+                "}",
+                "trap cleanup_download_scratch EXIT HUP INT TERM",
+                " ".join(_quote(part) for part in download_argv),
+                "cleanup_download_scratch",
+                "trap - EXIT HUP INT TERM",
+            ]
+        )
+        result = self._checked(
+            self.ssh_options.ssh_command("bash -s"),
+            stage="model_acquisition",
+            substage="container_download",
+            description="stage_model_acquisition_download",
+            timeout=1800,
+            default_reason="model_download_failed",
+            reserve_stage=reserve_stage,
+            input_text=download_script,
+        )
+        receipt_lines = [
+            line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip().startswith("{") and '"model_revision"' in line
+        ]
+        try:
+            download_attestation = json.loads(receipt_lines[-1])
+        except (IndexError, ValueError):
+            self._local_failure(
+                stage="model_acquisition",
+                substage="download_receipt",
+                description="stage_model_acquisition_receipt",
+                reason_code="model_download_failed",
+                reserve_stage=reserve_stage,
+            )
+        expected_download_attestation = {
+            "schema_version": "1",
+            **self.downloader_attestation,
+            "model_id": MODEL_ID,
+            "model_revision": MODEL_REVISION,
+        }
+        if download_attestation != expected_download_attestation:
+            self._local_failure(
+                stage="model_acquisition",
+                substage="download_receipt",
+                description="stage_model_acquisition_receipt",
+                reason_code="model_download_interface_missing",
+                reserve_stage=reserve_stage,
+            )
+        verification_script = build_model_inventory_verification_script(self.paths)
+        self._checked(
+            self.ssh_options.ssh_command("bash -s"),
+            stage="model_acquisition",
+            substage="inventory_verify",
+            description="stage_model_acquisition_verify",
+            timeout=600,
+            default_reason="model_inventory_mismatch",
+            reserve_stage=reserve_stage,
+            input_text=verification_script,
+        )
+        self._persist_model_acquisition_receipt(
+            download_attestation=download_attestation
+        )
+        self._record("model_acquisition", True)
+        return self.outcomes[-1]
 
     # -- stage 5: no-warmup canary -----------------------------------------
 
@@ -1942,11 +2546,14 @@ class RemoteOrchestrator:
             invocation=invocation,
             derived_image_id=self._require_derived_image_id(),
         )
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.ssh_command(" ".join(_quote(part) for part in argv)),
+            stage="canary",
+            substage="event_feasibility",
             description="stage_canary",
             timeout=900,
+            default_reason="canary_failed",
+            reserve_stage="no_warmup_canary_event_feasibility_gate",
             input_text=None,
         )
         self._record("canary", True)
@@ -1972,13 +2579,16 @@ class RemoteOrchestrator:
                     invocation=invocation,
                     derived_image_id=self._require_derived_image_id(),
                 )
-                checked(
-                    self.runner,
+                self._checked(
                     self.ssh_options.ssh_command(
                         " ".join(_quote(part) for part in argv)
                     ),
+                    stage="four_ab_pairs",
+                    substage=tag,
                     description=f"stage_four_ab_pairs[{tag}]",
                     timeout=900,
+                    default_reason="pair_lane_failed",
+                    reserve_stage="four_fresh_ab_lifecycle_pairs",
                     input_text=None,
                 )
                 self._record(tag, True)
@@ -2001,11 +2611,14 @@ class RemoteOrchestrator:
             invocation=invocation,
             derived_image_id=self._require_derived_image_id(),
         )
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.ssh_command(" ".join(_quote(part) for part in argv)),
+            stage="eviction_lane",
+            substage="fixed_eviction",
             description="stage_eviction_lane",
             timeout=900,
+            default_reason="eviction_lane_failed",
+            reserve_stage="fixed_eviction_lane",
             input_text=None,
         )
         self._record("eviction_lane", True)
@@ -2096,7 +2709,14 @@ class RemoteOrchestrator:
             raise HostOrchestrationError(
                 f"lane receipt {tag!r} has no valid measured KV-event boundary"
             )
-        return receipt.to_dict()
+        payload = receipt.to_dict()
+        if not isinstance(payload, dict) or not all(
+            isinstance(key, str) for key in payload
+        ):
+            raise HostOrchestrationError(
+                f"lane receipt {tag!r} did not serialize to a string-keyed object"
+            )
+        return {key: value for key, value in payload.items() if isinstance(key, str)}
 
     def _build_claim_matrix_and_lane_receipts(
         self, evidence_dir: Path
@@ -2133,21 +2753,27 @@ class RemoteOrchestrator:
         self._require_budget("private_verify_redact_report_export")
         self.state = OrchestratorState.EVIDENCE_EXPORT
         remote_tar = f"{self.config.remote_workspace}/evidence.tar"
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.ssh_command(
                 f"tar -cf {_quote(remote_tar)} -C "
                 f"{_quote(self.config.remote_workspace)} evidence receipts"
             ),
+            stage="evidence_transfer",
+            substage="archive",
             description="stage_transfer_evidence_archive",
             timeout=300,
+            default_reason="evidence_archive_failed",
+            reserve_stage="private_verify_redact_report_export",
             input_text=None,
         )
-        digest_result = checked(
-            self.runner,
+        digest_result = self._checked(
             self.ssh_options.ssh_command(f"sha256sum {_quote(remote_tar)}"),
+            stage="evidence_transfer",
+            substage="digest",
             description="stage_transfer_evidence_digest",
             timeout=60,
+            default_reason="evidence_digest_failed",
+            reserve_stage="private_verify_redact_report_export",
             input_text=None,
         )
         remote_digest = digest_result.stdout.split()[0].strip()
@@ -2157,11 +2783,14 @@ class RemoteOrchestrator:
             )
         local_bundle_dir.mkdir(parents=True, exist_ok=True)
         local_tar = local_bundle_dir / "evidence.tar"
-        checked(
-            self.runner,
+        self._checked(
             self.ssh_options.scp_download_command(remote_tar, local_tar),
+            stage="evidence_transfer",
+            substage="download",
             description="stage_transfer_evidence_download",
             timeout=300,
+            default_reason="evidence_download_failed",
+            reserve_stage="private_verify_redact_report_export",
             input_text=None,
         )
         local_bytes = local_tar.read_bytes()
@@ -2252,7 +2881,7 @@ class RemoteOrchestrator:
                 f"rm -rf {_quote(self.paths.repo_dir)}",
                 f"rm -rf {_quote(self.paths.evidence_dir)}",
                 f"rm -rf {_quote(self.paths.receipts_dir)}",
-                f"rm -rf {_quote(self.config.remote_workspace + '/hf-home')}",
+                f"rm -rf {_quote(self.paths.hf_scratch_dir)}",
                 f"rm -f {_quote(self.paths.source_archive_remote_path)}",
                 f"rm -f {_quote(self.config.remote_workspace + '/evidence.tar')}",
                 'AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"',
@@ -2278,11 +2907,14 @@ class RemoteOrchestrator:
         residual_containers = 0
         residual_gpu_processes = 0
         try:
-            result = checked(
-                self.runner,
+            result = self._checked(
                 self.ssh_options.ssh_command("bash -s"),
+                stage="teardown",
+                substage="cleanup_key_removal",
                 description="stage_teardown_cleanup",
                 timeout=300,
+                default_reason="teardown_cleanup_failed",
+                reserve_stage=None,
                 input_text=script,
             )
             residual_containers, residual_gpu_processes = self._verify_teardown_output(
@@ -2291,11 +2923,14 @@ class RemoteOrchestrator:
         except BaseException as exc:
             cleanup_error = exc
         try:
-            checked(
-                self.runner,
+            self._checked(
                 self.ssh_options.ssh_command("sudo -n shutdown -h now"),
+                stage="teardown",
+                substage="shutdown",
                 description="stage_teardown_shutdown",
                 timeout=30,
+                default_reason="teardown_shutdown_failed",
+                reserve_stage=None,
                 input_text=None,
             )
         except BaseException as exc:
@@ -2352,8 +2987,8 @@ class RemoteOrchestrator:
         try:
             self.stage_preflight()
             self.stage_identity_gate()
-            self.stage_model_acquisition()
             self.stage_image_preparation()
+            self.stage_model_acquisition()
             self.stage_canary()
             self.stage_four_ab_pairs()
             self.stage_eviction_lane()

--- a/vllm_kv_truth/model_download.py
+++ b/vllm_kv_truth/model_download.py
@@ -1,0 +1,181 @@
+"""Fail-closed Qwen3-8B acquisition inside the pinned runtime image."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import os
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from llmtracefx.optimizer.lab.qwen3_8b.vllm_compile import MODEL_ID, MODEL_REVISION
+
+from .runner import BASE_IMAGE_REFERENCE
+
+DOWNLOADER_PACKAGE = "huggingface-hub"
+DOWNLOADER_VERSION = "1.13.0"
+DOWNLOADER_INTERFACE = "huggingface_hub.snapshot_download"
+DOWNLOADER_SOURCE = BASE_IMAGE_REFERENCE
+
+_SAFE_FAILURE_MESSAGES = {
+    "model_download_interface_missing": (
+        "the pinned runtime image does not provide the authorized downloader interface"
+    ),
+    "model_download_version_mismatch": (
+        "the pinned runtime image downloader version does not match authorization"
+    ),
+    "model_download_failed": "the in-container model download failed",
+}
+
+
+class ModelDownloadRefusal(RuntimeError):
+    """A safe, allowlisted acquisition refusal."""
+
+    def __init__(self, reason_code: str) -> None:
+        if reason_code not in _SAFE_FAILURE_MESSAGES:
+            raise ValueError("unknown model download refusal code")
+        self.reason_code = reason_code
+        super().__init__(_SAFE_FAILURE_MESSAGES[reason_code])
+
+
+def downloader_attestation(
+    *,
+    version_fn: Callable[[str], str] | None = None,
+    import_module_fn: Callable[[str], Any] | None = None,
+) -> dict[str, str]:
+    """Verify the exact installed package and callable used for acquisition."""
+
+    version_fn = version_fn or importlib.metadata.version
+    import_module_fn = import_module_fn or importlib.import_module
+    try:
+        version = version_fn(DOWNLOADER_PACKAGE)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ModelDownloadRefusal("model_download_interface_missing") from exc
+    if version != DOWNLOADER_VERSION:
+        raise ModelDownloadRefusal("model_download_version_mismatch")
+    try:
+        module = import_module_fn("huggingface_hub")
+        interface = module.snapshot_download
+    except (ImportError, AttributeError) as exc:
+        raise ModelDownloadRefusal("model_download_interface_missing") from exc
+    if not callable(interface):
+        raise ModelDownloadRefusal("model_download_interface_missing")
+    return {
+        "schema_version": "1",
+        "package": DOWNLOADER_PACKAGE,
+        "version": version,
+        "interface": DOWNLOADER_INTERFACE,
+        "source": DOWNLOADER_SOURCE,
+    }
+
+
+def _manifest_allow_patterns() -> list[str]:
+    manifest_path = (
+        Path(__file__).resolve().parents[1]
+        / "llmtracefx"
+        / "optimizer"
+        / "lab"
+        / "qwen3_8b"
+        / "data"
+        / "qwen3-8b-conversion-manifest-v1.json"
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    files = payload["source"]["files"]
+    return [str(item["path"]) for item in files]
+
+
+def download_model(
+    destination: Path,
+    scratch: Path,
+    *,
+    version_fn: Callable[[str], str] | None = None,
+    import_module_fn: Callable[[str], Any] | None = None,
+) -> dict[str, str]:
+    """Download only the pinned model files through the attested interface."""
+
+    import_module_fn = import_module_fn or importlib.import_module
+    if not destination.is_absolute() or not scratch.is_absolute():
+        raise ModelDownloadRefusal("model_download_failed")
+    if (
+        destination == scratch
+        or destination in scratch.parents
+        or scratch in destination.parents
+    ):
+        raise ModelDownloadRefusal("model_download_failed")
+    if destination.is_symlink() or scratch.is_symlink():
+        raise ModelDownloadRefusal("model_download_failed")
+
+    original_environment = dict(os.environ)
+    try:
+        os.environ.clear()
+        os.environ.update(
+            {
+                "HOME": str(scratch),
+                "HF_HOME": str(scratch),
+                "HF_HUB_CACHE": str(scratch / "hub"),
+                "HF_ASSETS_CACHE": str(scratch / "assets"),
+                "XDG_CACHE_HOME": str(scratch / "xdg"),
+                "HF_HUB_DISABLE_TELEMETRY": "1",
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": "/usr/local/bin:/usr/bin:/bin",
+            }
+        )
+        attestation = downloader_attestation(
+            version_fn=version_fn,
+            import_module_fn=import_module_fn,
+        )
+        module = import_module_fn("huggingface_hub")
+        snapshot_download = module.snapshot_download
+        snapshot_download(
+            repo_id=MODEL_ID,
+            revision=MODEL_REVISION,
+            local_dir=str(destination),
+            allow_patterns=_manifest_allow_patterns(),
+            token=False,
+        )
+    except ModelDownloadRefusal:
+        raise
+    except Exception as exc:
+        raise ModelDownloadRefusal("model_download_failed") from exc
+    finally:
+        os.environ.clear()
+        os.environ.update(original_environment)
+    return {
+        **attestation,
+        "model_id": MODEL_ID,
+        "model_revision": MODEL_REVISION,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("attest")
+    download = subparsers.add_parser("download")
+    download.add_argument("--destination", required=True, type=Path)
+    download.add_argument("--scratch", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        payload = (
+            downloader_attestation()
+            if args.command == "attest"
+            else download_model(args.destination, args.scratch)
+        )
+    except ModelDownloadRefusal as exc:
+        print(f"LLMTRACEFX_REASON={exc.reason_code}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- remove the bare-host `huggingface-cli` prerequisite so vanilla CloudRift Ubuntu 24.04 preflight checks only key-only SSH, Linux/GPU/RAM/swap/disk/Python/Docker/sudo
- reorder the lifecycle to prepare and attest the digest-pinned image before model acquisition, preserving the 210-minute budget and 35-minute teardown reserve
- acquire exact Qwen3-8B with pinned `huggingface_hub.snapshot_download` inside the inspected derived image, then verify the exact 15-file / 16,397,461,266-byte inventory before any GPU container
- add private, sanitized substage operation receipts and safe CLI reason codes without leaking host/user/IP/key paths, credentials, argv, model paths, prompts, tokens, or arbitrary stderr
- harden source authorization binding, interruption handling, scoped partial-stage cleanup, temporary-key removal, and same-session shutdown

## Stage order and reserve

| Stage | Reserve at start |
|---|---:|
| Preflight | 210 min |
| Identity/source transfer | 195 min |
| Image pull/build/inspect/attest | 190 min |
| Model acquisition/verify | 170 min |
| Event-bearing canary | 130 min |
| Four A/B pairs | 115 min |
| Eviction lane | 55 min |
| Evidence transfer/verification | 45 min |
| Teardown | 35 min |

## Validation

- full repository: 4,586 passed, 2 skipped
- focused lifecycle/downloader/container/CLI: 132 passed
- expanded affected runner/evidence suite: 286 passed
- exact changed-file quality ratchet passed
- scoped changed-module mypy passed
- offline sdist/wheel build and isolated wheel CLI passed
- historical evidence catalog tests passed with 11 entries and 7 edges
- independent exact-head code, security/privacy, methodology/evidence, and operations/runbook reviews: no findings

## Safety

No VM was provisioned and no SSH, provider, model download, image pull/build, GPU work, or spend occurred while developing or validating this hotfix. The failed authorized attempt at base `2720134ca6f285d06ae2b42f4fc3d260bda3c45d` remains preflight-only and creates no scientific evidence claim.