### PR TITLE
Add explicit Docker execution modes for KV truth runs

### DIFF
--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -424,8 +424,16 @@ model_download_interface_missing, model_download_version_mismatch,
 model_download_failed, model_inventory_mismatch, canary_failed,
 pair_lane_failed, eviction_lane_failed, evidence_archive_failed,
 evidence_digest_failed, evidence_download_failed,
-run_interrupted, teardown_cleanup_failed, teardown_shutdown_failed
+run_interrupted, teardown_cleanup_failed, teardown_shutdown_failed,
+teardown_cleanup_and_shutdown_failed, teardown_outcome_unknown
 ```
+
+`teardown_cleanup_failed` means shutdown was issued but scoped cleanup was not
+fully proved. `teardown_shutdown_failed` and
+`teardown_cleanup_and_shutdown_failed` mean shutdown was not successfully
+proved. `teardown_outcome_unknown`, `operation_timeout`, or
+`operation_start_failed` during teardown means shutdown was not proved. Every
+unproved or failed shutdown requires immediate provider-console termination.
 
 Successful acquisition also writes a private schema-2
 `private-model-acquisition-receipt.json` binding the authorization, inspected

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -70,7 +70,8 @@ user:
 ```bash
 docker ps -q >/dev/null &&
 docker info >/dev/null &&
-docker version --format '{{.Server.Version}}'
+docker version --format '{{.Server.Version}}' &&
+sudo -n true
 ```
 
 For `sudo_noninteractive`, run this exact read-only provider-console probe as
@@ -79,13 +80,25 @@ the eventual SSH user:
 ```bash
 sudo -n -- docker ps -q >/dev/null &&
 sudo -n -- docker info >/dev/null &&
-sudo -n -- docker version --format '{{.Server.Version}}'
+sudo -n -- docker version --format '{{.Server.Version}}' &&
+sudo -n true
 ```
 
-Record only the mode whose complete three-command probe succeeds. A password
+Record only the mode whose complete probe succeeds. A password
 prompt, permission denial, missing executable, empty version, or partial pass
 is a refusal. The orchestrator never falls back between modes: every Docker
-operation, including teardown, uses the preregistered prefix.
+operation, including teardown, uses the preregistered prefix. Container
+quiescence is scoped to the Docker daemon reached by that exact prefix; do not
+claim or rely on a second rootless daemon or Docker context. The independent
+`sudo -n true` gate is also mandatory because teardown schedules OS shutdown
+through noninteractive sudo.
+
+During orchestrator preflight, `DOCKER_EXECUTION_MODE` and
+`DOCKER_EXECUTION_CONFIG_SHA256` are coordinator-sealed binding markers, not
+facts discovered from the host. Host capability is proved only when `ps`,
+`info`, and server `version` all succeed through the exact selected prefix;
+those successful commands attest that the selected command can reach the
+daemon without an interactive password.
 
 ## 3. Write protected execution config
 
@@ -393,7 +406,7 @@ Each schema-2 record contains only:
 ```text
 stage, substage, command_description, return_code, timed_out,
 stderr_category, stderr_message, reason_code, reserved_minutes,
-docker_execution_mode
+docker_execution_mode, docker_execution_config_sha256
 ```
 
 No argv, host, user, IP, key/known-hosts path, credential, remote/model path,
@@ -414,11 +427,12 @@ evidence_digest_failed, evidence_download_failed,
 run_interrupted, teardown_cleanup_failed, teardown_shutdown_failed
 ```
 
-Successful acquisition also writes a private schema-1
+Successful acquisition also writes a private schema-2
 `private-model-acquisition-receipt.json` binding the authorization, inspected
-image ID, explicit Docker execution mode and network mode, run label,
-downloader package/version/interface/source, exact model revision, and
-verified inventory totals.
+image ID, explicit Docker execution mode and
+`docker_execution_config_sha256`, network mode, run label, downloader
+package/version/interface/source, exact model revision, and verified inventory
+totals.
 
 The terminal reports `stage/substage`, reason code, and the corresponding safe
 message. Once trusted configuration and authorization have been loaded and
@@ -503,16 +517,17 @@ scientific evidence.
 
 The next CloudRift reservation at merged repository head
 `74c9856aaaafb9deb8a2553ea99ad1c559ba6e3d` passed the offline clean-bootstrap
-preflight and independently matched the preregistered RTX 4090, driver,
-memory, compute-capability, boot-time, and zero-GPU-process facts. Its
-read-only provider-console probe then found that the standard `riftuser`
-account could not access `/var/run/docker.sock`: direct `docker ps -q` and
-`docker info` failed with permission denied. The runner never started and no
-SSH lifecycle, image/model action, GPU workload, or scientific stage
-occurred. The temporary key was removed, the provider reservation was
-terminated and confirmed, and all one-attempt local credentials were
-destroyed. This `preflight_probe_failed` event is operational provenance only,
-not scientific evidence.
+preflight. Separate read-only provider-console observations, not runner
+attestations, matched the preregistered RTX 4090, driver, memory,
+compute-capability, boot-time, and zero-GPU-process facts. That same manual
+provider-console probe found that the standard `riftuser` account could not
+access `/var/run/docker.sock`: direct `docker ps -q` and `docker info` failed
+with permission denied. The runner never started, so no operation receipt or
+runner reason code was emitted and no SSH lifecycle, image/model action, GPU
+workload, or scientific stage occurred. The temporary key was removed, the
+provider reservation was terminated and confirmed, and all one-attempt local
+credentials were destroyed. This manual pre-GO refusal is operational
+provenance only, not scientific evidence.
 
 Do not provision a new VM for the next attempt until the clean-bootstrap
 change is merged, its exact merged head passes CI and CodeQL, the wheel-installed

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -60,15 +60,44 @@ The vanilla host does **not** need `huggingface-cli`, `hf`, `pip`, or `uv`.
 Model acquisition is deliberately unavailable until the derived image has
 passed its downloader attestation.
 
+Select exactly one Docker execution mode before writing the protected config
+or authorization. Do not configure fallback behavior and do not change group
+membership, socket permissions, aliases, wrappers, or `PATH`.
+
+For `direct`, run this read-only provider-console probe as the eventual SSH
+user:
+
+```bash
+docker ps -q >/dev/null &&
+docker info >/dev/null &&
+docker version --format '{{.Server.Version}}'
+```
+
+For `sudo_noninteractive`, run this exact read-only provider-console probe as
+the eventual SSH user:
+
+```bash
+sudo -n -- docker ps -q >/dev/null &&
+sudo -n -- docker info >/dev/null &&
+sudo -n -- docker version --format '{{.Server.Version}}'
+```
+
+Record only the mode whose complete three-command probe succeeds. A password
+prompt, permission denial, missing executable, empty version, or partial pass
+is a refusal. The orchestrator never falls back between modes: every Docker
+operation, including teardown, uses the preregistered prefix.
+
 ## 3. Write protected execution config
 
 Write a `0600` JSON file with exactly these keys:
 
 ```json
 {
+  "schema_version": "2",
   "host": "provider-supplied-host-or-ip",
   "port": 22,
   "user": "provider-supplied-user",
+  "docker_execution_mode": "direct",
   "private_key_path": "/protected/path/to/new-key",
   "known_hosts_path": "/protected/path/to/dedicated-known-hosts",
   "remote_workspace": "/home/provider-user/llmtracefx-kv-truth",
@@ -77,6 +106,10 @@ Write a `0600` JSON file with exactly these keys:
   "local_runner_archive": "/absolute/path/to/the-checked-source.tar"
 }
 ```
+
+`docker_execution_mode` must be exactly `direct` or `sudo_noninteractive`.
+There is no default and schema-1 configs are rejected, so an old protected
+config cannot silently acquire elevated Docker behavior.
 
 The SSH port belongs only in this protected file. Never place the target,
 user, port, key path, or known-hosts path in shell arguments, logs, evidence,
@@ -89,7 +122,8 @@ The authorization must bind:
 - the exact merged repository head and `sha256:<archive digest>`;
 - protocol, digest-pinned base image, vLLM commit/version, immutable model
   revision and committed inventory digest;
-- authorization schema `2` and the exact downloader package
+- authorization schema `3`, the exact preregistered Docker execution mode,
+  its schema-2 Docker execution-policy SHA-256, and the exact downloader package
   `huggingface-hub==1.13.0`, interface
   `huggingface_hub.snapshot_download`, and digest-pinned base-image source;
 - one RTX 4090 and exact driver/memory expectations;
@@ -339,10 +373,12 @@ Before the one command above, confirm only this checklist:
 0. The clean-bootstrap change is merged and that exact merged head has passed
    CI and CodeQL. No new VM exists before this gate passes.
 1. The source archive is from the exact clean, tested, merged `origin/main`.
-2. Authorization schema 2 seals that head, archive digest, runtime/model/image
-   pins, downloader identity, budget, nonce, and zero-retry policy.
-3. The protected config names a fresh key, dedicated known-hosts file, and
-   the same empty output directory passed to the bootstrap.
+2. Authorization schema 3 seals that head, archive digest, Docker execution
+   mode and execution-policy digest, runtime/model/image pins, downloader
+   identity, budget, nonce, and zero-retry policy.
+3. Protected-config schema 2 names the same Docker execution mode, a fresh
+   key, dedicated known-hosts file, and the same empty output directory passed
+   to the bootstrap.
 4. The externally recorded trusted-manifest SHA-256 still matches and the
    wheel/environment clean preflight succeeds.
 5. The coordinator has issued GO and the full 210-minute reserve gate passes.
@@ -352,11 +388,12 @@ Before the one command above, confirm only this checklist:
 Each command operation appends a mode-`0600`
 `private-operation-receipts.jsonl` record under the protected local evidence
 directory. This file is private and is not part of the public evidence schema.
-Each schema-1 record contains only:
+Each schema-2 record contains only:
 
 ```text
 stage, substage, command_description, return_code, timed_out,
-stderr_category, stderr_message, reason_code, reserved_minutes
+stderr_category, stderr_message, reason_code, reserved_minutes,
+docker_execution_mode
 ```
 
 No argv, host, user, IP, key/known-hosts path, credential, remote/model path,
@@ -366,7 +403,8 @@ a bounded allowlist. Current reason codes are:
 ```text
 operation_timeout, operation_start_failed,
 preflight_missing_linux, preflight_missing_nvidia_smi,
-preflight_missing_docker, preflight_missing_sudo,
+preflight_missing_docker, preflight_docker_execution_denied,
+preflight_missing_sudo,
 preflight_missing_python3, preflight_probe_failed,
 identity_gate_failed, source_transfer_failed, image_preparation_failed,
 model_download_interface_missing, model_download_version_mismatch,
@@ -378,8 +416,9 @@ run_interrupted, teardown_cleanup_failed, teardown_shutdown_failed
 
 Successful acquisition also writes a private schema-1
 `private-model-acquisition-receipt.json` binding the authorization, inspected
-image ID, explicit network mode, run label, downloader package/version/
-interface/source, exact model revision, and verified inventory totals.
+image ID, explicit Docker execution mode and network mode, run label,
+downloader package/version/interface/source, exact model revision, and
+verified inventory totals.
 
 The terminal reports `stage/substage`, reason code, and the corresponding safe
 message. Once trusted configuration and authorization have been loaded and
@@ -462,7 +501,22 @@ OS, and the operator confirmed provider-console termination. The inferred
 cost was approximately `$0.058434`; it is operational provenance, not
 scientific evidence.
 
+The next CloudRift reservation at merged repository head
+`74c9856aaaafb9deb8a2553ea99ad1c559ba6e3d` passed the offline clean-bootstrap
+preflight and independently matched the preregistered RTX 4090, driver,
+memory, compute-capability, boot-time, and zero-GPU-process facts. Its
+read-only provider-console probe then found that the standard `riftuser`
+account could not access `/var/run/docker.sock`: direct `docker ps -q` and
+`docker info` failed with permission denied. The runner never started and no
+SSH lifecycle, image/model action, GPU workload, or scientific stage
+occurred. The temporary key was removed, the provider reservation was
+terminated and confirmed, and all one-attempt local credentials were
+destroyed. This `preflight_probe_failed` event is operational provenance only,
+not scientific evidence.
+
 Do not provision a new VM for the next attempt until the clean-bootstrap
 change is merged, its exact merged head passes CI and CodeQL, the wheel-installed
-bootstrap preflight passes from the contaminated operator shell, and a new
-authorization binds the resulting exact source archive.
+bootstrap preflight passes from the contaminated operator shell, the selected
+Docker execution mode passes its exact read-only provider-console probe, and a
+new schema-3 authorization binds both that mode and the resulting exact source
+archive.

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -68,7 +68,7 @@ For `direct`, run this read-only provider-console probe as the eventual SSH
 user:
 
 ```bash
-docker ps -q >/dev/null &&
+docker ps -aq >/dev/null &&
 docker info >/dev/null &&
 docker version --format '{{.Server.Version}}' &&
 sudo -n true
@@ -78,7 +78,7 @@ For `sudo_noninteractive`, run this exact read-only provider-console probe as
 the eventual SSH user:
 
 ```bash
-sudo -n -- docker ps -q >/dev/null &&
+sudo -n -- docker ps -aq >/dev/null &&
 sudo -n -- docker info >/dev/null &&
 sudo -n -- docker version --format '{{.Server.Version}}' &&
 sudo -n true
@@ -440,7 +440,8 @@ lifecycle execution begins, teardown still runs after any stage failure or
 SIGTERM/SIGHUP. Input or signature rejection happens before all remote
 activity and therefore before lifecycle teardown. `SAFE TO TERMINATE INSTANCE
 NOW` retains its existing meaning and is emitted only after scoped cleanup,
-temporary-key removal, zero-residual checks, and shutdown issuance succeed.
+temporary-key removal, zero residual containers (running or stopped), zero
+GPU compute processes, and shutdown issuance succeed.
 Shutdown is scheduled from the same authenticated SSH session that removes
 the temporary key, so key removal cannot prevent the shutdown command from
 being issued.
@@ -490,9 +491,10 @@ If a run fails and `SAFE TO TERMINATE INSTANCE NOW` is absent, teardown is not
 proven. Do not infer provider termination and do not start another attempt.
 Use a separately approved, read-only recovery key path to inspect and perform
 the scoped cleanup, or use the provider console when that is the approved
-recovery route. Confirm zero run-scoped containers/GPU processes, remove the
-temporary key, issue shutdown, and separately confirm provider termination.
-Preserve the private failure receipt and recovery evidence.
+recovery route. Confirm zero containers in the selected Docker daemon
+(including stopped containers), no run-labeled images, and zero GPU processes;
+remove the temporary key, issue shutdown, and separately confirm provider
+termination. Preserve the private failure receipt and recovery evidence.
 
 ## 9. Failed-attempt provenance
 

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -380,6 +380,7 @@ def _authorization_payload(**overrides: Any) -> dict[str, Any]:
         "gpu_expected_name": lifecycle.EXPECTED_GPU_NAME,
         "gpu_expected_driver": lifecycle.EXPECTED_DRIVER,
         "gpu_expected_memory_mib": lifecycle.EXPECTED_MEMORY_MIB,
+        "docker_execution_mode": lifecycle.DockerExecutionMode.DIRECT.value,
         "rate_usd_per_hour": "0.500000",
         "total_cap_usd": "10.000000",
         "billing_started_at": lifecycle._canonical_timestamp(BILLING_STARTED_AT),
@@ -399,6 +400,15 @@ def _authorization_payload(**overrides: Any) -> dict[str, Any]:
         "nonce": VALID_NONCE,
     }
     payload.update(overrides)
+    if "docker_execution_config_sha256" not in payload:
+        try:
+            mode = lifecycle.DockerExecutionMode.parse(payload["docker_execution_mode"])
+        except lifecycle.HostOrchestrationError:
+            payload["docker_execution_config_sha256"] = "0" * 64
+        else:
+            payload["docker_execution_config_sha256"] = (
+                lifecycle.docker_execution_config_sha256(mode)
+            )
     seal_input = {k: v for k, v in payload.items() if k != "authorization_sha256"}
     payload["authorization_sha256"] = lifecycle.build_authorization_seal(seal_input)
     return payload
@@ -424,6 +434,32 @@ class TestRunAuthorization:
             {k: v for k, v in payload.items() if k != "authorization_sha256"}
         )
         with pytest.raises(lifecycle.HostOrchestrationError, match="protocol_id"):
+            lifecycle.RunAuthorization.from_dict(payload)
+
+    def test_rejects_tampered_docker_execution_mode(self) -> None:
+        payload = _authorization_payload()
+        payload["docker_execution_mode"] = (
+            lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE.value
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="docker_execution_config_sha256",
+        ):
+            lifecycle.RunAuthorization.from_dict(payload)
+
+    def test_rejects_unknown_docker_execution_mode_with_valid_seal(self) -> None:
+        payload = _authorization_payload(docker_execution_mode="auto")
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="docker_execution_mode"
+        ):
+            lifecycle.RunAuthorization.from_dict(payload)
+
+    def test_rejects_tampered_docker_execution_config_hash(self) -> None:
+        payload = _authorization_payload(docker_execution_config_sha256="0" * 64)
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="docker_execution_config_sha256",
+        ):
             lifecycle.RunAuthorization.from_dict(payload)
 
     def test_rejects_wrong_model_inventory_digest(self) -> None:
@@ -637,7 +673,12 @@ class TestProtectedExecutionConfig:
         path.write_text("example.com ssh-ed25519 AAAA", encoding="utf-8")
         os.chmod(path, mode)
 
-    def _payload(self, tmp_path: Path) -> dict[str, Any]:
+    def _payload(
+        self,
+        tmp_path: Path,
+        *,
+        docker_execution_mode: str = lifecycle.DockerExecutionMode.DIRECT.value,
+    ) -> dict[str, Any]:
         key_path = tmp_path / "id_ed25519"
         known_hosts = tmp_path / "known_hosts"
         self._write_key(key_path)
@@ -645,9 +686,11 @@ class TestProtectedExecutionConfig:
         archive = tmp_path / "runner.tar.gz"
         archive.write_bytes(b"fake archive")
         return {
+            "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
             "host": "198.51.100.10",
             "port": 57003,
             "user": "deploy",
+            "docker_execution_mode": docker_execution_mode,
             "private_key_path": str(key_path),
             "known_hosts_path": str(known_hosts),
             "remote_workspace": "/home/deploy/kv-truth-run",
@@ -664,8 +707,14 @@ class TestProtectedExecutionConfig:
         config = lifecycle.ProtectedExecutionConfig.load(config_path)
         assert config.host == "198.51.100.10"
         assert config.public_record() == {
-            "schema_version": "1",
+            "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
             "source": "protected_execution_config",
+            "docker_execution_mode": lifecycle.DockerExecutionMode.DIRECT.value,
+            "docker_execution_config_sha256": (
+                lifecycle.docker_execution_config_sha256(
+                    lifecycle.DockerExecutionMode.DIRECT
+                )
+            ),
         }
 
     def test_public_record_never_leaks_sensitive_fields(self, tmp_path: Path) -> None:
@@ -772,6 +821,29 @@ class TestProtectedExecutionConfig:
         with pytest.raises(lifecycle.HostOrchestrationError, match="required set"):
             lifecycle.ProtectedExecutionConfig.from_dict(payload)
 
+    @pytest.mark.parametrize("mode", ["", "sudo", "auto", 1, None])
+    def test_rejects_unexpected_docker_execution_mode(
+        self, tmp_path: Path, mode: Any
+    ) -> None:
+        payload = self._payload(tmp_path)
+        payload["docker_execution_mode"] = mode
+        with pytest.raises(
+            lifecycle.HostOrchestrationError, match="docker_execution_mode"
+        ):
+            lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+    def test_rejects_legacy_config_without_explicit_mode(self, tmp_path: Path) -> None:
+        payload = self._payload(tmp_path)
+        del payload["docker_execution_mode"]
+        with pytest.raises(lifecycle.HostOrchestrationError, match="required set"):
+            lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+    def test_rejects_legacy_config_schema(self, tmp_path: Path) -> None:
+        payload = self._payload(tmp_path)
+        payload["schema_version"] = "1"
+        with pytest.raises(lifecycle.HostOrchestrationError, match="schema_version"):
+            lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
     def test_rejects_unsafe_remote_workspace(self, tmp_path: Path) -> None:
         payload = self._payload(tmp_path)
         payload["remote_workspace"] = "/home/deploy/../etc"
@@ -797,9 +869,11 @@ class TestStrictSSHOptions:
         os.chmod(known_hosts, 0o600)
         return lifecycle.ProtectedExecutionConfig.from_dict(
             {
+                "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
                 "host": "203.0.113.5",
                 "port": 57003,
                 "user": "runner",
+                "docker_execution_mode": lifecycle.DockerExecutionMode.DIRECT.value,
                 "private_key_path": str(key),
                 "known_hosts_path": str(known_hosts),
                 "remote_workspace": "/srv/kv-truth",
@@ -879,6 +953,28 @@ class TestStrictSSHOptions:
         assert str(config.known_hosts_path) not in record_text
 
 
+class TestDockerCommand:
+    def test_direct_mode_builds_exact_argv(self) -> None:
+        docker = lifecycle.DockerCommand(lifecycle.DockerExecutionMode.DIRECT)
+        assert docker.argv("ps", "-q") == ("docker", "ps", "-q")
+        assert docker.shell("ps", "-q") == "docker ps -q"
+
+    def test_sudo_mode_builds_exact_noninteractive_argv(self) -> None:
+        docker = lifecycle.DockerCommand(
+            lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+        )
+        assert docker.argv("ps", "-q") == (
+            "sudo",
+            "-n",
+            "--",
+            "docker",
+            "ps",
+            "-q",
+        )
+        assert docker.shell("ps", "-q") == "sudo -n -- docker ps -q"
+        assert docker.xargs_shell("rm", "-f") == ("xargs -r sudo -n -- docker rm -f")
+
+
 @dataclass
 class RecordedCall:
     argv: tuple[str, ...]
@@ -899,6 +995,12 @@ def _preflight_stdout(**overrides: str) -> str:
             f"{lifecycle.EXPECTED_GPU_COMPUTE_CAPABILITY}"
         ),
         "GPU_PROCESS_COUNT": "0",
+        "DOCKER_EXECUTION_MODE": lifecycle.DockerExecutionMode.DIRECT.value,
+        "DOCKER_EXECUTION_CONFIG_SHA256": (
+            lifecycle.docker_execution_config_sha256(
+                lifecycle.DockerExecutionMode.DIRECT
+            )
+        ),
         "CONTAINER_COUNT": "0",
         "SUDO_NONINTERACTIVE": "1",
         "DISK_FREE_BYTES": str(lifecycle.MINIMUM_DISK_FREE_BYTES),
@@ -1022,7 +1124,13 @@ class FakeCommandRunner:
         return lifecycle.CommandResult(returncode=0, stdout="", stderr="")
 
 
-def _config(tmp_path: Path) -> lifecycle.ProtectedExecutionConfig:
+def _config(
+    tmp_path: Path,
+    *,
+    docker_execution_mode: lifecycle.DockerExecutionMode = (
+        lifecycle.DockerExecutionMode.DIRECT
+    ),
+) -> lifecycle.ProtectedExecutionConfig:
     key = tmp_path / "key"
     key.write_text("x", encoding="utf-8")
     os.chmod(key, 0o600)
@@ -1034,9 +1142,11 @@ def _config(tmp_path: Path) -> lifecycle.ProtectedExecutionConfig:
         _write_source_archive(archive)
     return lifecycle.ProtectedExecutionConfig.from_dict(
         {
+            "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
             "host": "203.0.113.5",
             "port": 57003,
             "user": "runner",
+            "docker_execution_mode": docker_execution_mode.value,
             "private_key_path": str(key),
             "known_hosts_path": str(known_hosts),
             "remote_workspace": "/srv/kv-truth",
@@ -1048,6 +1158,21 @@ def _config(tmp_path: Path) -> lifecycle.ProtectedExecutionConfig:
 
 
 class TestRemoteOrchestratorFullRun:
+    @staticmethod
+    def _remote_docker_lines(runner: FakeCommandRunner) -> list[str]:
+        lines: list[str] = []
+        for call in runner.calls:
+            texts = [call.input_text or ""]
+            if call.argv and call.argv[0] == "ssh":
+                texts.append(call.argv[-1])
+            for text in texts:
+                lines.extend(
+                    line.strip()
+                    for line in text.splitlines()
+                    if "docker" in line and "command -v docker" not in line
+                )
+        return lines
+
     def test_full_run_never_touches_network_or_gpu_and_succeeds(
         self, tmp_path: Path
     ) -> None:
@@ -1159,6 +1284,138 @@ class TestRemoteOrchestratorFullRun:
         assert outcome.ok
         assert "HF_CLI" not in script
         assert "command -v huggingface-cli" not in script
+        assert "DOCKER_EXECUTION_MODE=direct" in script
+        assert "sudo -n -- docker" not in script
+
+    def test_sudo_noninteractive_mode_prefixes_every_docker_call(
+        self, tmp_path: Path
+    ) -> None:
+        mode = lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+        config = _config(tmp_path, docker_execution_mode=mode)
+        authorization = _authorization(docker_execution_mode=mode.value)
+        runner = FakeCommandRunner(
+            responses={
+                "stage_preflight": lifecycle.CommandResult(
+                    returncode=0,
+                    stdout=_preflight_stdout(
+                        DOCKER_EXECUTION_MODE=mode.value,
+                        DOCKER_EXECUTION_CONFIG_SHA256=(
+                            lifecycle.docker_execution_config_sha256(mode)
+                        ),
+                    ),
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=config,
+            authorization=authorization,
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        outcomes = orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        assert all(outcome.ok for outcome in outcomes)
+        docker_lines = self._remote_docker_lines(runner)
+        assert docker_lines
+        assert all("sudo -n -- docker" in line for line in docker_lines)
+        assert all(
+            line.replace("preflight_docker_execution_denied", "").count("docker")
+            == line.count("sudo -n -- docker")
+            for line in docker_lines
+        )
+        receipts = [
+            json.loads(line)
+            for line in orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        ]
+        assert receipts
+        assert {receipt["docker_execution_mode"] for receipt in receipts} == {
+            mode.value
+        }
+        assert {receipt["docker_execution_config_sha256"] for receipt in receipts} == {
+            lifecycle.docker_execution_config_sha256(mode)
+        }
+
+    def test_direct_mode_never_mixes_in_sudo_docker_calls(self, tmp_path: Path) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        outcomes = orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        assert all(outcome.ok for outcome in outcomes)
+        docker_lines = self._remote_docker_lines(runner)
+        assert docker_lines
+        assert all("sudo -n -- docker" not in line for line in docker_lines)
+        assert all("docker" in line for line in docker_lines)
+
+    def test_config_authorization_mode_mismatch_refuses_before_ssh(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="does not match authorization",
+        ):
+            lifecycle.RemoteOrchestrator(
+                config=_config(
+                    tmp_path,
+                    docker_execution_mode=(
+                        lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+                    ),
+                ),
+                authorization=_authorization(),
+                runner=runner,
+                now_fn=lambda: BILLING_STARTED_AT,
+            )
+        assert runner.calls == []
+
+    def test_denied_sudo_docker_refuses_before_image_or_gpu_work(
+        self, tmp_path: Path
+    ) -> None:
+        mode = lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+        runner = FakeCommandRunner(
+            responses={
+                "stage_preflight": lifecycle.CommandResult(
+                    returncode=1,
+                    stdout="",
+                    stderr=(
+                        "sudo: a password is required\n"
+                        "LLMTRACEFX_REASON=preflight_docker_execution_denied\n"
+                    ),
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path, docker_execution_mode=mode),
+            authorization=_authorization(docker_execution_mode=mode.value),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="preflight_docker_execution_denied",
+        ):
+            orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        descriptions = [call.description for call in runner.calls]
+        assert descriptions == ["stage_preflight", "stage_teardown_cleanup"]
+        assert not any(
+            description
+            in {
+                "stage_image_preparation",
+                "stage_model_acquisition_download",
+                "stage_canary",
+                "stage_eviction_lane",
+            }
+            or description.startswith("stage_four_ab_pairs")
+            for description in descriptions
+        )
+        teardown = runner.calls[-1].input_text or ""
+        assert "sudo -n -- docker" in teardown
+        assert "xargs -r sudo -n -- docker" in teardown
 
     def test_model_acquisition_uses_only_labeled_digest_bound_container_mounts(
         self, tmp_path: Path
@@ -1196,6 +1453,12 @@ class TestRemoteOrchestratorFullRun:
         )
         assert receipt["downloader"]["version"] == lifecycle.DOWNLOADER_VERSION
         assert receipt["downloader"]["source"] == lifecycle.DOWNLOADER_SOURCE
+        assert receipt["docker_execution_mode"] == "direct"
+        assert receipt["docker_execution_config_sha256"] == (
+            lifecycle.docker_execution_config_sha256(
+                lifecycle.DockerExecutionMode.DIRECT
+            )
+        )
         assert receipt["verified_file_count"] == 15
         assert receipt["verified_total_bytes"] == 16_397_461_266
 
@@ -1426,6 +1689,25 @@ class TestRemoteOrchestratorFullRun:
             ):
                 assert "--filter" in line
                 assert lifecycle.docker_run_label(auth.nonce) in line
+
+    def test_sudo_mode_teardown_uses_only_selected_docker_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        mode = lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path, docker_execution_mode=mode),
+            authorization=_authorization(docker_execution_mode=mode.value),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_teardown(tmp_path / "bundle")
+        script = runner.calls[-1].input_text or ""
+        docker_lines = [
+            line.strip() for line in script.splitlines() if "docker" in line
+        ]
+        assert docker_lines
+        assert all("sudo -n -- docker" in line for line in docker_lines)
 
     def test_teardown_emits_safe_to_terminate_message(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -1322,6 +1322,7 @@ class TestRemoteOrchestratorFullRun:
         marker, value = result.stdout.split("=", 1)
         assert marker == "CONTAINER_COUNT"
         assert value.strip() == expected_count
+        assert "CONTAINER_IDS=$(docker ps -aq)" in script
 
     def test_preflight_gpu_process_query_failure_cannot_report_zero(
         self, tmp_path: Path
@@ -1437,6 +1438,25 @@ class TestRemoteOrchestratorFullRun:
                 now_fn=lambda: BILLING_STARTED_AT,
             )
         assert runner.calls == []
+
+    def test_docker_execution_policy_cannot_be_reassigned_after_validation(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(AttributeError):
+            orchestrator.docker = lifecycle.DockerCommand(  # type: ignore[misc]
+                lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE
+            )
+        orchestrator.stage_preflight()
+        script = runner.calls[-1].input_text or ""
+        assert "CONTAINER_IDS=$(docker ps -aq)" in script
+        assert "sudo -n -- docker" not in script
 
     def test_denied_sudo_docker_refuses_before_image_or_gpu_work(
         self, tmp_path: Path
@@ -1753,8 +1773,13 @@ class TestRemoteOrchestratorFullRun:
         assert len(docker_listing_lines) == 3
         assert all(label_filter in line for line in docker_listing_lines[:2])
         assert docker_listing_lines[2].startswith(
-            "RESIDUAL_CONTAINER_IDS=$(docker ps -q)"
+            "RESIDUAL_CONTAINER_IDS=$(docker ps -aq)"
         )
+        image_listing_lines = [
+            line for line in script.splitlines() if "docker images" in line
+        ]
+        assert len(image_listing_lines) == 1
+        assert all(label_filter in line for line in image_listing_lines)
         assert (
             f"RUNNING_CONTAINERS=$(docker ps -q --filter "
             f"label={lifecycle.docker_run_label(auth.nonce)})"
@@ -1767,7 +1792,9 @@ class TestRemoteOrchestratorFullRun:
             f"LABELED_IMAGES=$(docker images -q --filter "
             f"label={lifecycle.docker_run_label(auth.nonce)})"
         ) in script
-        assert "RESIDUAL_CONTAINER_IDS=$(docker ps -q) ||" in script
+        assert "RESIDUAL_CONTAINER_IDS=$(docker ps -aq) ||" in script
+        assert "docker rmi -f; fi" in script
+        assert "docker rmi -f || true; fi" not in script
         assert script.count("LLMTRACEFX_REASON=teardown_cleanup_failed") >= 4
 
     @pytest.mark.parametrize(
@@ -2061,6 +2088,39 @@ class TestRemoteOrchestratorFullRun:
         ):
             orchestrator.stage_teardown(tmp_path / "bundle")
 
+    def test_teardown_shutdown_failure_takes_priority_over_cleanup_failure(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_teardown_cleanup": lifecycle.CommandResult(
+                    returncode=1,
+                    stdout="",
+                    stderr=(
+                        "LLMTRACEFX_REASON=teardown_cleanup_failed\n"
+                        "LLMTRACEFX_REASON=teardown_shutdown_failed\n"
+                    ),
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_shutdown_failed",
+        ):
+            orchestrator.stage_teardown(tmp_path / "bundle")
+        receipt = json.loads(
+            orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()[-1]
+        )
+        assert receipt["reason_code"] == "teardown_shutdown_failed"
+
     def test_teardown_refuses_missing_shutdown_marker_with_receipt(
         self, tmp_path: Path
     ) -> None:
@@ -2068,7 +2128,7 @@ class TestRemoteOrchestratorFullRun:
             responses={
                 "stage_teardown_cleanup": lifecycle.CommandResult(
                     returncode=0,
-                    stdout="RESIDUAL_CONTAINERS=0\nRESIDUAL_GPU_PROCESSES=0\n",
+                    stdout=("RESIDUAL_CONTAINERS=0\n" "RESIDUAL_GPU_PROCESSES=0\n"),
                     stderr="",
                 )
             }

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -1287,6 +1287,71 @@ class TestRemoteOrchestratorFullRun:
         assert "DOCKER_EXECUTION_MODE=direct" in script
         assert "sudo -n -- docker" not in script
 
+    @pytest.mark.parametrize(
+        ("container_ids", "expected_count"),
+        [
+            ("", "0"),
+            ("container-one", "1"),
+            ("container-one\ncontainer-two", "2"),
+        ],
+    )
+    def test_preflight_container_count_preserves_the_last_id(
+        self, tmp_path: Path, container_ids: str, expected_count: str
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_preflight()
+        script = runner.calls[-1].input_text or ""
+        count_line = next(
+            line
+            for line in script.splitlines()
+            if line.startswith('echo "CONTAINER_COUNT=')
+        )
+        result = subprocess.run(
+            ["bash", "-c", count_line],
+            env={"CONTAINER_IDS": container_ids},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        marker, value = result.stdout.split("=", 1)
+        assert marker == "CONTAINER_COUNT"
+        assert value.strip() == expected_count
+
+    def test_preflight_gpu_process_query_failure_cannot_report_zero(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_preflight()
+        script = runner.calls[-1].input_text or ""
+        lines = script.splitlines()
+        start = next(
+            index
+            for index, line in enumerate(lines)
+            if line.startswith("GPU_PROCESS_IDS=")
+        )
+        fragment = "\n".join(lines[start : start + 2])
+        result = subprocess.run(
+            ["bash", "-c", f"nvidia-smi() {{ return 42; }}\n{fragment}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "LLMTRACEFX_REASON=preflight_probe_failed" in result.stderr
+        assert "GPU_PROCESS_COUNT=" not in result.stdout
+
     def test_sudo_noninteractive_mode_prefixes_every_docker_call(
         self, tmp_path: Path
     ) -> None:
@@ -1451,6 +1516,7 @@ class TestRemoteOrchestratorFullRun:
                 / "private-model-acquisition-receipt.json"
             ).read_text(encoding="utf-8")
         )
+        assert receipt["schema_version"] == "2"
         assert receipt["downloader"]["version"] == lifecycle.DOWNLOADER_VERSION
         assert receipt["downloader"]["source"] == lifecycle.DOWNLOADER_SOURCE
         assert receipt["docker_execution_mode"] == "direct"
@@ -1678,17 +1744,127 @@ class TestRemoteOrchestratorFullRun:
         assert script.index("authorized_keys") < script.index(
             "sudo -n shutdown -h +1", script.index("authorized_keys")
         )
-        assert (
-            "docker ps -q" not in script.replace("docker ps -q --filter", "PLACEHOLDER")
-            or "--filter" in script
+        # Mutating discovery is label-scoped; the sole unfiltered query is the
+        # read-only final residual check.
+        label_filter = f"--filter label={lifecycle.docker_run_label(auth.nonce)}"
+        docker_listing_lines = [
+            line for line in script.splitlines() if "docker ps" in line
+        ]
+        assert len(docker_listing_lines) == 3
+        assert all(label_filter in line for line in docker_listing_lines[:2])
+        assert docker_listing_lines[2].startswith(
+            "RESIDUAL_CONTAINER_IDS=$(docker ps -q)"
         )
-        # Never a blanket, unfiltered container listing/removal.
-        for line in script.splitlines():
-            if line.strip().startswith("docker ps") or line.strip().startswith(
-                "docker images"
-            ):
-                assert "--filter" in line
-                assert lifecycle.docker_run_label(auth.nonce) in line
+        assert (
+            f"RUNNING_CONTAINERS=$(docker ps -q --filter "
+            f"label={lifecycle.docker_run_label(auth.nonce)})"
+        ) in script
+        assert (
+            f"ALL_RUN_CONTAINERS=$(docker ps -aq --filter "
+            f"label={lifecycle.docker_run_label(auth.nonce)})"
+        ) in script
+        assert (
+            f"LABELED_IMAGES=$(docker images -q --filter "
+            f"label={lifecycle.docker_run_label(auth.nonce)})"
+        ) in script
+        assert "RESIDUAL_CONTAINER_IDS=$(docker ps -q) ||" in script
+        assert script.count("LLMTRACEFX_REASON=teardown_cleanup_failed") >= 4
+
+    @pytest.mark.parametrize(
+        ("container_ids", "expected_count"),
+        [
+            ("", "0"),
+            ("container-one", "1"),
+            ("container-one\ncontainer-two", "2"),
+        ],
+    )
+    def test_teardown_residual_container_query_counts_exactly(
+        self, tmp_path: Path, container_ids: str, expected_count: str
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_teardown(tmp_path / "bundle")
+        script = runner.calls[-1].input_text or ""
+        lines = script.splitlines()
+        start = next(
+            index
+            for index, line in enumerate(lines)
+            if line.startswith("RESIDUAL_CONTAINER_IDS=")
+        )
+        fragment = "\n".join(lines[start : start + 2])
+        result = subprocess.run(
+            ["bash", "-c", f'docker() {{ printf %s "$DOCKER_OUTPUT"; }}\n{fragment}'],
+            env={"DOCKER_OUTPUT": container_ids},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        marker, value = result.stdout.split("=", 1)
+        assert marker == "RESIDUAL_CONTAINERS"
+        assert value.strip() == expected_count
+
+    def test_teardown_residual_container_query_failure_cannot_report_zero(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_teardown(tmp_path / "bundle")
+        script = runner.calls[-1].input_text or ""
+        lines = script.splitlines()
+        start = next(
+            index
+            for index, line in enumerate(lines)
+            if line.startswith("RESIDUAL_CONTAINER_IDS=")
+        )
+        fragment = "\n".join(lines[start : start + 2])
+        result = subprocess.run(
+            ["bash", "-c", f"docker() {{ return 42; }}\n{fragment}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "LLMTRACEFX_REASON=teardown_cleanup_failed" in result.stderr
+        assert "RESIDUAL_CONTAINERS=" not in result.stdout
+
+    def test_teardown_gpu_process_query_failure_cannot_report_zero(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_teardown(tmp_path / "bundle")
+        script = runner.calls[-1].input_text or ""
+        lines = script.splitlines()
+        start = next(
+            index
+            for index, line in enumerate(lines)
+            if line.startswith("RESIDUAL_GPU_PIDS=")
+        )
+        fragment = "\n".join(lines[start : start + 2])
+        result = subprocess.run(
+            ["bash", "-c", f"nvidia-smi() {{ return 42; }}\n{fragment}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "LLMTRACEFX_REASON=teardown_cleanup_failed" in result.stderr
+        assert "RESIDUAL_GPU_PROCESSES=" not in result.stdout
 
     def test_sudo_mode_teardown_uses_only_selected_docker_prefix(
         self, tmp_path: Path

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -1118,6 +1118,7 @@ class FakeCommandRunner:
             stdout = (
                 "RESIDUAL_CONTAINERS=0\n"
                 "RESIDUAL_GPU_PROCESSES=0\n"
+                "TEARDOWN_SCRIPT_COMPLETE=1\n"
                 "SHUTDOWN_ISSUED=1\n"
             )
             return lifecycle.CommandResult(returncode=0, stdout=stdout, stderr="")
@@ -1754,16 +1755,18 @@ class TestRemoteOrchestratorFullRun:
         script = cleanup_call.input_text or ""
         assert (
             f"if [ -d {orchestrator.config.remote_workspace} ]; then "
-            f"rmdir {orchestrator.config.remote_workspace}; fi"
+            f"rmdir {orchestrator.config.remote_workspace} "
+            "|| cleanup_failed=1; fi"
         ) in script
         assert f"rm -rf {orchestrator.paths.model_dir}" in script
         assert f"rm -rf {orchestrator.paths.hf_scratch_dir}" in script
         assert f"rm -rf {orchestrator.paths.repo_dir}" in script
         assert f"rm -f {orchestrator.paths.source_archive_remote_path}" in script
-        assert "sudo -n shutdown -h +1" in script
-        assert script.index("authorized_keys") < script.index(
-            "sudo -n shutdown -h +1", script.index("authorized_keys")
-        )
+        assert script.count("sudo -n shutdown -h +1") == 1
+        assert "trap finish_teardown EXIT" in script
+        assert script.index(
+            "remove_authorized_key || cleanup_failed=1"
+        ) < script.rindex("exit 0")
         # Mutating discovery is label-scoped; the sole unfiltered query is the
         # read-only final residual check.
         label_filter = f"--filter label={lifecycle.docker_run_label(auth.nonce)}"
@@ -1773,7 +1776,7 @@ class TestRemoteOrchestratorFullRun:
         assert len(docker_listing_lines) == 3
         assert all(label_filter in line for line in docker_listing_lines[:2])
         assert docker_listing_lines[2].startswith(
-            "RESIDUAL_CONTAINER_IDS=$(docker ps -aq)"
+            "if RESIDUAL_CONTAINER_IDS=$(docker ps -aq)"
         )
         image_listing_lines = [
             line for line in script.splitlines() if "docker images" in line
@@ -1792,10 +1795,16 @@ class TestRemoteOrchestratorFullRun:
             f"LABELED_IMAGES=$(docker images -q --filter "
             f"label={lifecycle.docker_run_label(auth.nonce)})"
         ) in script
-        assert "RESIDUAL_CONTAINER_IDS=$(docker ps -aq) ||" in script
-        assert "docker rmi -f; fi" in script
-        assert "docker rmi -f || true; fi" not in script
-        assert script.count("LLMTRACEFX_REASON=teardown_cleanup_failed") >= 4
+        assert "if RESIDUAL_CONTAINER_IDS=$(docker ps -aq); then" in script
+        assert "xargs -r docker rmi -f || cleanup_failed=1" in script
+        assert "xargs -r docker rmi -f || true" not in script
+        assert "LLMTRACEFX_REASON=teardown_cleanup_failed" in script
+        assert "LLMTRACEFX_REASON=teardown_shutdown_failed" in script
+        assert "LLMTRACEFX_REASON=teardown_cleanup_and_shutdown_failed" in script
+        for line in script.splitlines():
+            if line.startswith(("rm -rf ", "rm -f ")):
+                assert line.endswith("|| cleanup_failed=1")
+        assert script.count("else\n  cleanup_failed=1\nfi") >= 5
 
     @pytest.mark.parametrize(
         ("container_ids", "expected_count"),
@@ -1821,11 +1830,18 @@ class TestRemoteOrchestratorFullRun:
         start = next(
             index
             for index, line in enumerate(lines)
-            if line.startswith("RESIDUAL_CONTAINER_IDS=")
+            if line.startswith("if RESIDUAL_CONTAINER_IDS=")
         )
-        fragment = "\n".join(lines[start : start + 2])
+        fragment = "\n".join(lines[start : start + 5])
         result = subprocess.run(
-            ["bash", "-c", f'docker() {{ printf %s "$DOCKER_OUTPUT"; }}\n{fragment}'],
+            [
+                "bash",
+                "-c",
+                "cleanup_failed=0\n"
+                'docker() { printf %s "$DOCKER_OUTPUT"; }\n'
+                f"{fragment}\n"
+                'test "$cleanup_failed" -eq 0',
+            ],
             env={"DOCKER_OUTPUT": container_ids},
             check=True,
             capture_output=True,
@@ -1851,11 +1867,18 @@ class TestRemoteOrchestratorFullRun:
         start = next(
             index
             for index, line in enumerate(lines)
-            if line.startswith("RESIDUAL_CONTAINER_IDS=")
+            if line.startswith("if RESIDUAL_CONTAINER_IDS=")
         )
-        fragment = "\n".join(lines[start : start + 2])
+        fragment = "\n".join(lines[start : start + 5])
         result = subprocess.run(
-            ["bash", "-c", f"docker() {{ return 42; }}\n{fragment}"],
+            [
+                "bash",
+                "-c",
+                "cleanup_failed=0\n"
+                f"docker() {{ return 42; }}\n{fragment}\n"
+                'if [ "$cleanup_failed" -ne 0 ]; then '
+                "echo LLMTRACEFX_REASON=teardown_cleanup_failed >&2; exit 1; fi",
+            ],
             check=False,
             capture_output=True,
             text=True,
@@ -1880,11 +1903,18 @@ class TestRemoteOrchestratorFullRun:
         start = next(
             index
             for index, line in enumerate(lines)
-            if line.startswith("RESIDUAL_GPU_PIDS=")
+            if line.startswith("if RESIDUAL_GPU_PIDS=")
         )
-        fragment = "\n".join(lines[start : start + 2])
+        fragment = "\n".join(lines[start : start + 5])
         result = subprocess.run(
-            ["bash", "-c", f"nvidia-smi() {{ return 42; }}\n{fragment}"],
+            [
+                "bash",
+                "-c",
+                "cleanup_failed=0\n"
+                f"nvidia-smi() {{ return 42; }}\n{fragment}\n"
+                'if [ "$cleanup_failed" -ne 0 ]; then '
+                "echo LLMTRACEFX_REASON=teardown_cleanup_failed >&2; exit 1; fi",
+            ],
             check=False,
             capture_output=True,
             text=True,
@@ -1892,6 +1922,56 @@ class TestRemoteOrchestratorFullRun:
         assert result.returncode != 0
         assert "LLMTRACEFX_REASON=teardown_cleanup_failed" in result.stderr
         assert "RESIDUAL_GPU_PROCESSES=" not in result.stdout
+
+    def test_teardown_continues_key_removal_and_shutdown_after_cleanup_failure(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner()
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        orchestrator.stage_teardown(tmp_path / "bundle")
+        script = runner.calls[-1].input_text or ""
+        remote_workspace = tmp_path / "remote-workspace"
+        remote_workspace.mkdir()
+        script = script.replace(
+            orchestrator.config.remote_workspace, str(remote_workspace)
+        )
+        assert orchestrator.config.remote_workspace not in script
+        home = tmp_path / "home"
+        ssh_dir = home / ".ssh"
+        ssh_dir.mkdir(parents=True)
+        authorized_keys = ssh_dir / "authorized_keys"
+        authorized_keys.write_text("ssh-ed25519 AAAATEST marker\n", encoding="utf-8")
+        stubs = """
+docker() {
+  if [ "$1" = ps ] && [ "$2" = -q ] && [ "${3-}" = --filter ]; then
+    return 42
+  fi
+  return 0
+}
+nvidia-smi() { return 0; }
+sudo() { test "$1" = -n && test "$2" = shutdown; }
+chmod() { return 0; }
+xargs() { cat >/dev/null; }
+"""
+        result = subprocess.run(
+            ["bash", "-c", stubs + "\n" + script],
+            env={"HOME": str(home), "PATH": os.environ["PATH"]},
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "SHUTDOWN_ISSUED=1" in result.stdout
+        assert "RESIDUAL_CONTAINERS=" in result.stdout
+        assert "RESIDUAL_GPU_PROCESSES=" in result.stdout
+        assert "TEARDOWN_SCRIPT_COMPLETE=1" in result.stdout
+        assert "LLMTRACEFX_REASON=teardown_cleanup_failed" in result.stderr
+        assert "marker" not in authorized_keys.read_text(encoding="utf-8")
 
     def test_sudo_mode_teardown_uses_only_selected_docker_prefix(
         self, tmp_path: Path
@@ -2088,7 +2168,37 @@ class TestRemoteOrchestratorFullRun:
         ):
             orchestrator.stage_teardown(tmp_path / "bundle")
 
-    def test_teardown_shutdown_failure_takes_priority_over_cleanup_failure(
+    def test_teardown_unmarked_failure_reports_unknown_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_teardown_cleanup": lifecycle.CommandResult(
+                    returncode=255,
+                    stdout="",
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_outcome_unknown",
+        ):
+            orchestrator.stage_teardown(tmp_path / "bundle")
+        receipt = json.loads(
+            orchestrator.operation_receipt_path.read_text(
+                encoding="utf-8"
+            ).splitlines()[-1]
+        )
+        assert receipt["reason_code"] == "teardown_outcome_unknown"
+
+    def test_teardown_combined_failure_preserves_both_outcomes(
         self, tmp_path: Path
     ) -> None:
         runner = FakeCommandRunner(
@@ -2097,8 +2207,7 @@ class TestRemoteOrchestratorFullRun:
                     returncode=1,
                     stdout="",
                     stderr=(
-                        "LLMTRACEFX_REASON=teardown_cleanup_failed\n"
-                        "LLMTRACEFX_REASON=teardown_shutdown_failed\n"
+                        "LLMTRACEFX_REASON=" "teardown_cleanup_and_shutdown_failed\n"
                     ),
                 )
             }
@@ -2111,7 +2220,7 @@ class TestRemoteOrchestratorFullRun:
         )
         with pytest.raises(
             lifecycle.HostOrchestrationError,
-            match="teardown_shutdown_failed",
+            match="teardown_cleanup_and_shutdown_failed",
         ):
             orchestrator.stage_teardown(tmp_path / "bundle")
         receipt = json.loads(
@@ -2119,7 +2228,7 @@ class TestRemoteOrchestratorFullRun:
                 encoding="utf-8"
             ).splitlines()[-1]
         )
-        assert receipt["reason_code"] == "teardown_shutdown_failed"
+        assert receipt["reason_code"] == "teardown_cleanup_and_shutdown_failed"
 
     def test_teardown_refuses_missing_shutdown_marker_with_receipt(
         self, tmp_path: Path
@@ -2128,7 +2237,11 @@ class TestRemoteOrchestratorFullRun:
             responses={
                 "stage_teardown_cleanup": lifecycle.CommandResult(
                     returncode=0,
-                    stdout=("RESIDUAL_CONTAINERS=0\n" "RESIDUAL_GPU_PROCESSES=0\n"),
+                    stdout=(
+                        "RESIDUAL_CONTAINERS=0\n"
+                        "RESIDUAL_GPU_PROCESSES=0\n"
+                        "TEARDOWN_SCRIPT_COMPLETE=1\n"
+                    ),
                     stderr="",
                 )
             }
@@ -2151,6 +2264,34 @@ class TestRemoteOrchestratorFullRun:
         )
         assert receipt["substage"] == "verify_cleanup_shutdown"
         assert receipt["reason_code"] == "teardown_shutdown_failed"
+
+    def test_teardown_refuses_truncated_script_despite_shutdown_marker(
+        self, tmp_path: Path
+    ) -> None:
+        runner = FakeCommandRunner(
+            responses={
+                "stage_teardown_cleanup": lifecycle.CommandResult(
+                    returncode=0,
+                    stdout=(
+                        "RESIDUAL_CONTAINERS=0\n"
+                        "RESIDUAL_GPU_PROCESSES=0\n"
+                        "SHUTDOWN_ISSUED=1\n"
+                    ),
+                    stderr="",
+                )
+            }
+        )
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=_config(tmp_path),
+            authorization=_authorization(),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        with pytest.raises(
+            lifecycle.HostOrchestrationError,
+            match="teardown_cleanup_failed",
+        ):
+            orchestrator.stage_teardown(tmp_path / "bundle")
 
     def test_teardown_still_runs_on_keyboard_interrupt(self, tmp_path: Path) -> None:
         class _InterruptingRunner(FakeCommandRunner):
@@ -2812,6 +2953,7 @@ class TestRemoteOrchestratorFullRun:
                     stdout=(
                         "RESIDUAL_CONTAINERS=1\n"
                         "RESIDUAL_GPU_PROCESSES=0\n"
+                        "TEARDOWN_SCRIPT_COMPLETE=1\n"
                         "SHUTDOWN_ISSUED=1\n"
                     ),
                     stderr="",

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -2186,14 +2186,16 @@ class RemoteOrchestrator:
                 "nvidia-smi --query-gpu=name,driver_version,memory.total,"
                 "compute_cap --format=csv,noheader,nounits | "
                 "sed 's/^/GPU=/'",
-                'echo "GPU_PROCESS_COUNT=$(nvidia-smi '
-                "--query-compute-apps=pid --format=csv,noheader 2>/dev/null | "
+                "GPU_PROCESS_IDS=$(nvidia-smi "
+                "--query-compute-apps=pid --format=csv,noheader 2>/dev/null) || "
+                "{ echo LLMTRACEFX_REASON=preflight_probe_failed >&2; exit 1; }",
+                'echo "GPU_PROCESS_COUNT=$(printf \'%s\\n\' "$GPU_PROCESS_IDS" | '
                 'sed "/^[[:space:]]*$/d" | wc -l)"',
                 f'echo "DOCKER_EXECUTION_MODE={self.docker.mode.value}"',
                 "echo DOCKER_EXECUTION_CONFIG_SHA256="
                 + self.authorization.docker_execution_config_sha256,
                 f"CONTAINER_IDS=$({docker_ps}) || {docker_failure}",
-                'echo "CONTAINER_COUNT=$(printf %s "$CONTAINER_IDS" | '
+                'echo "CONTAINER_COUNT=$(printf \'%s\\n\' "$CONTAINER_IDS" | '
                 'sed "/^[[:space:]]*$/d" | wc -l)"',
                 f"{docker_info} >/dev/null || {docker_failure}",
                 "sudo -n true",
@@ -2687,7 +2689,7 @@ class RemoteOrchestrator:
         download_attestation: Mapping[str, Any],
     ) -> None:
         payload = {
-            "schema_version": "1",
+            "schema_version": "2",
             "protocol_id": PROTOCOL_ID,
             "authorization_sha256": self.authorization.authorization_sha256,
             "docker_execution_mode": self.docker.mode.value,
@@ -3201,6 +3203,9 @@ class RemoteOrchestrator:
         remove_images = self.docker.xargs_shell("rmi", "-f")
         remove_base_image = self.docker.shell("rmi", "-f", BASE_IMAGE_REFERENCE)
         residual_containers = self.docker.shell("ps", "-q")
+        docker_cleanup_failure = (
+            "{ echo LLMTRACEFX_REASON=teardown_cleanup_failed >&2; exit 1; }"
+        )
         script = "\n".join(
             [
                 "set -eu",
@@ -3224,9 +3229,20 @@ class RemoteOrchestrator:
                 '  exit "$status"',
                 "}",
                 "trap finish_teardown EXIT",
-                f"{running_containers} | {stop_containers}",
-                f"{all_containers} | {remove_containers}",
-                f"{labeled_images} | {remove_images} || true",
+                f"RUNNING_CONTAINERS=$({running_containers}) || "
+                f"{docker_cleanup_failure}",
+                'if [ -n "$RUNNING_CONTAINERS" ]; then '
+                "printf '%s\\n' \"$RUNNING_CONTAINERS\" | "
+                f"{stop_containers}; fi",
+                f"ALL_RUN_CONTAINERS=$({all_containers}) || "
+                f"{docker_cleanup_failure}",
+                'if [ -n "$ALL_RUN_CONTAINERS" ]; then '
+                "printf '%s\\n' \"$ALL_RUN_CONTAINERS\" | "
+                f"{remove_containers}; fi",
+                f"LABELED_IMAGES=$({labeled_images}) || {docker_cleanup_failure}",
+                'if [ -n "$LABELED_IMAGES" ]; then '
+                "printf '%s\\n' \"$LABELED_IMAGES\" | "
+                f"{remove_images} || true; fi",
                 f"{remove_base_image} || true",
                 f"rm -rf {_quote(self.paths.model_dir)}",
                 f"rm -rf {_quote(self.paths.repo_dir)}",
@@ -3246,10 +3262,17 @@ class RemoteOrchestrator:
                 'test "$(awk -v marker="$KEY_MARKER" '
                 "'$NF == marker { count++ } END { print count + 0 }' "
                 '"$AUTHORIZED_KEYS")" = "0"',
-                f'echo "RESIDUAL_CONTAINERS=$({residual_containers} | wc -l)"',
-                'echo "RESIDUAL_GPU_PROCESSES=$('
-                "nvidia-smi --query-compute-apps=pid --format=csv,noheader "
-                '2>/dev/null | sed "/^[[:space:]]*$/d" | wc -l)"',
+                f"RESIDUAL_CONTAINER_IDS=$({residual_containers}) || "
+                f"{docker_cleanup_failure}",
+                "echo \"RESIDUAL_CONTAINERS=$(printf '%s\\n' "
+                '"$RESIDUAL_CONTAINER_IDS" | '
+                'sed "/^[[:space:]]*$/d" | wc -l)"',
+                "RESIDUAL_GPU_PIDS=$(nvidia-smi "
+                "--query-compute-apps=pid --format=csv,noheader 2>/dev/null) || "
+                f"{docker_cleanup_failure}",
+                "echo \"RESIDUAL_GPU_PROCESSES=$(printf '%s\\n' "
+                '"$RESIDUAL_GPU_PIDS" | '
+                'sed "/^[[:space:]]*$/d" | wc -l)"',
                 f"if [ -d {_quote(self.config.remote_workspace)} ]; then "
                 f"rmdir {_quote(self.config.remote_workspace)}; fi",
                 "reason=teardown_shutdown_failed",

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -319,9 +319,11 @@ def _require_pattern(value: Any, pattern: re.Pattern[str], *, field_name: str) -
 
 _CONFIG_REQUIRED_KEYS = frozenset(
     {
+        "schema_version",
         "host",
         "port",
         "user",
+        "docker_execution_mode",
         "private_key_path",
         "known_hosts_path",
         "remote_workspace",
@@ -330,6 +332,37 @@ _CONFIG_REQUIRED_KEYS = frozenset(
         "local_runner_archive",
     }
 )
+
+PROTECTED_CONFIG_SCHEMA_VERSION = "2"
+
+
+class DockerExecutionMode(str, Enum):
+    """One preregistered, immutable way to invoke Docker on the remote host."""
+
+    DIRECT = "direct"
+    SUDO_NONINTERACTIVE = "sudo_noninteractive"
+
+    @classmethod
+    def parse(cls, value: Any) -> DockerExecutionMode:
+        if not isinstance(value, str):
+            raise HostOrchestrationError("docker_execution_mode must be a string")
+        try:
+            return cls(value)
+        except ValueError as exc:
+            raise HostOrchestrationError(
+                "docker_execution_mode must be 'direct' or 'sudo_noninteractive'"
+            ) from exc
+
+
+def docker_execution_config_sha256(mode: DockerExecutionMode) -> str:
+    """Hash the complete non-secret Docker execution policy in config schema 2."""
+
+    return sha256_json(
+        {
+            "schema_version": PROTECTED_CONFIG_SCHEMA_VERSION,
+            "docker_execution_mode": mode.value,
+        }
+    )
 
 
 @dataclass(frozen=True)
@@ -345,6 +378,7 @@ class ProtectedExecutionConfig:
     host: str = field(repr=False)
     port: int = field(repr=False)
     user: str = field(repr=False)
+    docker_execution_mode: DockerExecutionMode
     private_key_path: Path = field(repr=False)
     known_hosts_path: Path = field(repr=False)
     remote_workspace: str = field(repr=False)
@@ -389,9 +423,16 @@ class ProtectedExecutionConfig:
             raise HostOrchestrationError(
                 "protected execution config keys differ from the required set"
             )
+        if payload["schema_version"] != PROTECTED_CONFIG_SCHEMA_VERSION:
+            raise HostOrchestrationError(
+                "protected execution config schema_version is unsupported"
+            )
         host = payload["host"]
         user = payload["user"]
         port = payload["port"]
+        docker_execution_mode = DockerExecutionMode.parse(
+            payload["docker_execution_mode"]
+        )
         if not isinstance(host, str) or _SAFE_HOSTNAME_OR_IP.fullmatch(host) is None:
             raise HostOrchestrationError("host must be a safe hostname or IP literal")
         if (
@@ -438,6 +479,7 @@ class ProtectedExecutionConfig:
             host=host,
             port=port,
             user=user,
+            docker_execution_mode=docker_execution_mode,
             private_key_path=private_key_path,
             known_hosts_path=known_hosts_path,
             remote_workspace=remote_workspace,
@@ -449,7 +491,14 @@ class ProtectedExecutionConfig:
     def public_record(self) -> dict[str, Any]:
         """Publication/evidence-safe view: no host/user/key/known-hosts/paths."""
 
-        return {"schema_version": "1", "source": "protected_execution_config"}
+        return {
+            "schema_version": PROTECTED_CONFIG_SCHEMA_VERSION,
+            "source": "protected_execution_config",
+            "docker_execution_mode": self.docker_execution_mode.value,
+            "docker_execution_config_sha256": docker_execution_config_sha256(
+                self.docker_execution_mode
+            ),
+        }
 
 
 def _require_nonempty_str(value: Any, field_name: str) -> str:
@@ -591,9 +640,9 @@ def list_rate_cost_usd(elapsed_minutes: Decimal, rate_usd_per_hour: Decimal) -> 
 # Explicit, self-sealed run authorization.
 # ---------------------------------------------------------------------------
 
-AUTHORIZATION_SCHEMA_VERSION = "2"
+AUTHORIZATION_SCHEMA_VERSION = "3"
 AUTHORIZATION_SIGNER_IDENTITY = "vllm-kv-truth-coordinator"
-AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v2"
+AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v3"
 
 _AUTHORIZATION_REQUIRED_KEYS = frozenset(
     {
@@ -615,6 +664,8 @@ _AUTHORIZATION_REQUIRED_KEYS = frozenset(
         "gpu_expected_name",
         "gpu_expected_driver",
         "gpu_expected_memory_mib",
+        "docker_execution_mode",
+        "docker_execution_config_sha256",
         "rate_usd_per_hour",
         "total_cap_usd",
         "billing_started_at",
@@ -663,6 +714,8 @@ class RunAuthorization:
     derived_image_source_digest: str
     model_inventory_sha256: str
     gpu_expected_count: int
+    docker_execution_mode: DockerExecutionMode
+    docker_execution_config_sha256: str
     rate_usd_per_hour: Decimal
     total_cap_usd: Decimal
     billing_started_at: datetime
@@ -708,6 +761,8 @@ class RunAuthorization:
             "gpu_expected_name": EXPECTED_GPU_NAME,
             "gpu_expected_driver": EXPECTED_DRIVER,
             "gpu_expected_memory_mib": EXPECTED_MEMORY_MIB,
+            "docker_execution_mode": self.docker_execution_mode.value,
+            "docker_execution_config_sha256": self.docker_execution_config_sha256,
             "rate_usd_per_hour": _money_str(self.rate_usd_per_hour),
             "total_cap_usd": _money_str(self.total_cap_usd),
             "billing_started_at": _canonical_timestamp(self.billing_started_at),
@@ -797,6 +852,19 @@ class RunAuthorization:
             raise HostOrchestrationError(
                 "gpu_expected_count must be exactly 1 for this fixed protocol "
                 "(tensor_parallel_size=1, data_parallel_size=1)"
+            )
+        docker_execution_mode = DockerExecutionMode.parse(data["docker_execution_mode"])
+        docker_execution_config_digest = _require_pattern(
+            data["docker_execution_config_sha256"],
+            _SHA256_HEX,
+            field_name="docker_execution_config_sha256",
+        )
+        expected_docker_execution_config_digest = docker_execution_config_sha256(
+            docker_execution_mode
+        )
+        if docker_execution_config_digest != expected_docker_execution_config_digest:
+            raise HostOrchestrationError(
+                "docker_execution_config_sha256 does not match " "docker_execution_mode"
             )
         rate_usd_per_hour = _canonical_decimal(
             data["rate_usd_per_hour"], field_name="rate_usd_per_hour"
@@ -890,6 +958,8 @@ class RunAuthorization:
             derived_image_source_digest=derived_image_source_digest,
             model_inventory_sha256=model_inventory_sha256,
             gpu_expected_count=gpu_expected_count,
+            docker_execution_mode=docker_execution_mode,
+            docker_execution_config_sha256=docker_execution_config_digest,
             rate_usd_per_hour=rate_usd_per_hour,
             total_cap_usd=total_cap_usd,
             billing_started_at=billing_started_at,
@@ -1158,6 +1228,10 @@ _SAFE_REASON_MESSAGES: dict[str, tuple[str, str]] = {
         "host_prerequisite",
         "the remote host does not provide Docker",
     ),
+    "preflight_docker_execution_denied": (
+        "host_prerequisite",
+        "the preregistered Docker execution mode cannot access the daemon",
+    ),
     "preflight_missing_sudo": (
         "host_prerequisite",
         "the remote host does not provide noninteractive sudo",
@@ -1243,10 +1317,12 @@ class OperationReceipt:
     stderr_message: str
     reason_code: str | None
     reserved_minutes: int
+    docker_execution_mode: DockerExecutionMode
+    docker_execution_config_sha256: str
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "schema_version": "1",
+            "schema_version": "2",
             "stage": self.stage,
             "substage": self.substage,
             "command_description": self.command_description,
@@ -1256,6 +1332,8 @@ class OperationReceipt:
             "stderr_message": self.stderr_message,
             "reason_code": self.reason_code,
             "reserved_minutes": self.reserved_minutes,
+            "docker_execution_mode": self.docker_execution_mode.value,
+            "docker_execution_config_sha256": self.docker_execution_config_sha256,
         }
 
 
@@ -1427,6 +1505,32 @@ def _quote(value: str) -> str:
     values so a future refactor cannot silently reintroduce injection."""
 
     return shlex.quote(value)
+
+
+@dataclass(frozen=True)
+class DockerCommand:
+    """Render every Docker invocation from one preregistered execution mode."""
+
+    mode: DockerExecutionMode
+
+    @property
+    def prefix(self) -> tuple[str, ...]:
+        if self.mode is DockerExecutionMode.DIRECT:
+            return ("docker",)
+        if self.mode is DockerExecutionMode.SUDO_NONINTERACTIVE:
+            return ("sudo", "-n", "--", "docker")
+        raise HostOrchestrationError("unsupported Docker execution mode")
+
+    def argv(self, *arguments: str) -> tuple[str, ...]:
+        return (*self.prefix, *arguments)
+
+    def shell(self, *arguments: str) -> str:
+        return " ".join(_quote(part) for part in self.argv(*arguments))
+
+    def xargs_shell(self, *arguments: str) -> str:
+        return " ".join(
+            ("xargs", "-r", *(_quote(part) for part in self.argv(*arguments)))
+        )
 
 
 @dataclass(frozen=True)
@@ -1670,6 +1774,7 @@ class LaneInvocation:
 
 def build_docker_run_argv(
     *,
+    docker: DockerCommand,
     authorization: RunAuthorization,
     paths: RunPaths,
     invocation: LaneInvocation,
@@ -1700,8 +1805,7 @@ def build_docker_run_argv(
     for key, value in sorted(expected_identity_env.items()):
         env_pairs.extend(("-e", f"{key}={value}"))
 
-    return (
-        "docker",
+    return docker.argv(
         "run",
         "--rm",
         "--network",
@@ -1734,14 +1838,14 @@ def build_docker_run_argv(
 
 def build_model_download_argv(
     *,
+    docker: DockerCommand,
     authorization: RunAuthorization,
     paths: RunPaths,
     derived_image_id: str,
 ) -> tuple[str, ...]:
     """Build the only network-enabled container command in the protocol."""
 
-    return (
-        "docker",
+    return docker.argv(
         "run",
         "--rm",
         "--network",
@@ -1824,7 +1928,22 @@ class RemoteOrchestrator:
         self.authorization = authorization
         self.runner = runner
         self.now_fn = now_fn
+        if config.docker_execution_mode is not authorization.docker_execution_mode:
+            raise HostOrchestrationError(
+                "protected config Docker execution mode does not match authorization"
+            )
+        config_docker_execution_digest = docker_execution_config_sha256(
+            config.docker_execution_mode
+        )
+        if (
+            config_docker_execution_digest
+            != authorization.docker_execution_config_sha256
+        ):
+            raise HostOrchestrationError(
+                "protected config Docker execution hash does not match authorization"
+            )
         self.ssh_options = StrictSSHOptions(config)
+        self.docker = DockerCommand(config.docker_execution_mode)
         self.paths = RunPaths(config.remote_workspace)
         self.state = OrchestratorState.PENDING
         self.outcomes: list[StageOutcome] = []
@@ -1909,6 +2028,10 @@ class RemoteOrchestrator:
                 stderr_message="",
                 reason_code=None,
                 reserved_minutes=reserved_minutes,
+                docker_execution_mode=self.config.docker_execution_mode,
+                docker_execution_config_sha256=(
+                    self.authorization.docker_execution_config_sha256
+                ),
             )
         else:
             reason, category, message = _safe_failure(result, default_reason)
@@ -1922,6 +2045,10 @@ class RemoteOrchestrator:
                 stderr_message=message,
                 reason_code=reason,
                 reserved_minutes=reserved_minutes,
+                docker_execution_mode=self.config.docker_execution_mode,
+                docker_execution_config_sha256=(
+                    self.authorization.docker_execution_config_sha256
+                ),
             )
         self.operation_receipts.append(receipt)
         self._persist_operation_receipts()
@@ -1960,6 +2087,10 @@ class RemoteOrchestrator:
                 stderr_message=message,
                 reason_code=reason_code,
                 reserved_minutes=reserved_minutes,
+                docker_execution_mode=self.config.docker_execution_mode,
+                docker_execution_config_sha256=(
+                    self.authorization.docker_execution_config_sha256
+                ),
             )
         )
         self._persist_operation_receipts()
@@ -2022,6 +2153,13 @@ class RemoteOrchestrator:
     def stage_preflight(self) -> StageOutcome:
         self._require_budget("existing_preflight_planning_reserve")
         self.state = OrchestratorState.PREFLIGHT
+        docker_ps = self.docker.shell("ps", "-q")
+        docker_info = self.docker.shell("info")
+        docker_version = self.docker.shell("version", "--format", "{{.Server.Version}}")
+        docker_failure = (
+            "{ echo LLMTRACEFX_REASON=preflight_docker_execution_denied >&2; "
+            "exit 1; }"
+        )
         script = "\n".join(
             [
                 "set -eu",
@@ -2051,8 +2189,13 @@ class RemoteOrchestrator:
                 'echo "GPU_PROCESS_COUNT=$(nvidia-smi '
                 "--query-compute-apps=pid --format=csv,noheader 2>/dev/null | "
                 'sed "/^[[:space:]]*$/d" | wc -l)"',
-                'echo "CONTAINER_COUNT=$(docker ps -q | wc -l)"',
-                "docker info >/dev/null",
+                f'echo "DOCKER_EXECUTION_MODE={self.docker.mode.value}"',
+                "echo DOCKER_EXECUTION_CONFIG_SHA256="
+                + self.authorization.docker_execution_config_sha256,
+                f"CONTAINER_IDS=$({docker_ps}) || {docker_failure}",
+                'echo "CONTAINER_COUNT=$(printf %s "$CONTAINER_IDS" | '
+                'sed "/^[[:space:]]*$/d" | wc -l)"',
+                f"{docker_info} >/dev/null || {docker_failure}",
                 "sudo -n true",
                 'echo "SUDO_NONINTERACTIVE=1"',
                 'echo "DISK_FREE_BYTES=$(df -PB1 "$HOME" | awk \'NR==2 {print $4}\')"',
@@ -2061,8 +2204,8 @@ class RemoteOrchestrator:
                 'echo "PYTHON_VERSION=$(python3 -c '
                 "'import platform; print(platform.python_version())'"
                 ')"',
-                'echo "DOCKER_VERSION=$(docker version '
-                "--format '{{.Server.Version}}')\"",
+                f"DOCKER_VERSION=$({docker_version}) || {docker_failure}",
+                'echo "DOCKER_VERSION=$DOCKER_VERSION"',
             ]
         )
         result = self._checked(
@@ -2101,6 +2244,8 @@ class RemoteOrchestrator:
             "GPU_COUNT",
             "GPU",
             "GPU_PROCESS_COUNT",
+            "DOCKER_EXECUTION_MODE",
+            "DOCKER_EXECUTION_CONFIG_SHA256",
             "CONTAINER_COUNT",
             "SUDO_NONINTERACTIVE",
             "DISK_FREE_BYTES",
@@ -2115,6 +2260,17 @@ class RemoteOrchestrator:
             )
         if markers["OS_NAME"] != "Linux":
             raise HostOrchestrationError("preflight host operating system is not Linux")
+        if markers["DOCKER_EXECUTION_MODE"] != self.docker.mode.value:
+            raise HostOrchestrationError(
+                "preflight Docker execution mode does not match authorization"
+            )
+        if (
+            markers["DOCKER_EXECUTION_CONFIG_SHA256"]
+            != self.authorization.docker_execution_config_sha256
+        ):
+            raise HostOrchestrationError(
+                "preflight Docker execution hash does not match authorization"
+            )
         parts = [part.strip() for part in markers["GPU"].split(",")]
         if len(parts) != 4:
             raise HostOrchestrationError("preflight GPU inventory line is malformed")
@@ -2269,6 +2425,7 @@ class RemoteOrchestrator:
         authorized_archive_digest = self.authorization.derived_image_source_digest[
             len("sha256:") :
         ]
+        image_tag = f"kv-truth-derived-{self.authorization.nonce}"
 
         script = "\n".join(
             [
@@ -2276,13 +2433,21 @@ class RemoteOrchestrator:
                 "reason=image_preparation_failed",
                 'trap \'status=$?; if [ "$status" -ne 0 ]; then '
                 'echo "LLMTRACEFX_REASON=$reason" >&2; fi\' EXIT',
-                f"docker pull {_quote(BASE_IMAGE_REFERENCE)}",
-                f"echo BASE_REPODIGESTS=$(docker image inspect "
-                f"{_quote(BASE_IMAGE_REFERENCE)} "
-                '--format "{{json .RepoDigests}}")',
-                f"echo BASE_IMAGE_ID=$(docker image inspect "
-                f"{_quote(BASE_IMAGE_REFERENCE)} "
-                '--format "{{.Id}}")',
+                self.docker.shell("pull", BASE_IMAGE_REFERENCE),
+                "echo BASE_REPODIGESTS=$("
+                + self.docker.shell(
+                    "image",
+                    "inspect",
+                    BASE_IMAGE_REFERENCE,
+                    "--format",
+                    "{{json .RepoDigests}}",
+                )
+                + ")",
+                "echo BASE_IMAGE_ID=$("
+                + self.docker.shell(
+                    "image", "inspect", BASE_IMAGE_REFERENCE, "--format", "{{.Id}}"
+                )
+                + ")",
                 f"echo {_quote(authorized_archive_digest)}  "
                 f"{_quote(self.paths.source_archive_remote_path)} | sha256sum -c -",
                 f"rm -rf {_quote(self.paths.repo_dir)}",
@@ -2295,35 +2460,75 @@ class RemoteOrchestrator:
                 f"cd {_quote(self.paths.repo_dir)}",
                 f"test \"$(sed -n '1p' containers/vllm-kv-truth/Containerfile)\" "
                 f"= {_quote('FROM ' + BASE_IMAGE_REFERENCE)}",
-                "docker build -q "
-                "--network none "
-                f"--label {_quote(docker_run_label(self.authorization.nonce))} "
-                f"--build-arg RUNNER_COMMIT={_quote(self.authorization.repository_head)} "
-                "-f containers/vllm-kv-truth/Containerfile "
-                f"-t kv-truth-derived-{_quote(self.authorization.nonce)} .",
-                "echo DERIVED_IMAGE_ID=$(docker image inspect "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                '--format "{{.Id}}")',
-                "echo DOWNLOADER_PACKAGE=$(docker image inspect "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                "--format '{{ index .Config.Labels "
-                '"org.llmtracefx.downloader.package" }}\')',
-                "echo DOWNLOADER_VERSION=$(docker image inspect "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                "--format '{{ index .Config.Labels "
-                '"org.llmtracefx.downloader.version" }}\')',
-                "echo DOWNLOADER_INTERFACE=$(docker image inspect "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                "--format '{{ index .Config.Labels "
-                '"org.llmtracefx.downloader.interface" }}\')',
-                "echo DOWNLOADER_SOURCE=$(docker image inspect "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                "--format '{{ index .Config.Labels "
-                '"org.llmtracefx.downloader.source" }}\')',
-                f"docker run --rm --network none --label "
-                f"{_quote(docker_run_label(self.authorization.nonce))} "
-                f"kv-truth-derived-{_quote(self.authorization.nonce)} "
-                "python3 -m vllm_kv_truth.model_download attest",
+                self.docker.shell(
+                    "build",
+                    "-q",
+                    "--network",
+                    "none",
+                    "--label",
+                    docker_run_label(self.authorization.nonce),
+                    "--build-arg",
+                    f"RUNNER_COMMIT={self.authorization.repository_head}",
+                    "-f",
+                    "containers/vllm-kv-truth/Containerfile",
+                    "-t",
+                    image_tag,
+                    ".",
+                ),
+                "echo DERIVED_IMAGE_ID=$("
+                + self.docker.shell(
+                    "image", "inspect", image_tag, "--format", "{{.Id}}"
+                )
+                + ")",
+                "echo DOWNLOADER_PACKAGE=$("
+                + self.docker.shell(
+                    "image",
+                    "inspect",
+                    image_tag,
+                    "--format",
+                    '{{ index .Config.Labels "org.llmtracefx.downloader.package" }}',
+                )
+                + ")",
+                "echo DOWNLOADER_VERSION=$("
+                + self.docker.shell(
+                    "image",
+                    "inspect",
+                    image_tag,
+                    "--format",
+                    '{{ index .Config.Labels "org.llmtracefx.downloader.version" }}',
+                )
+                + ")",
+                "echo DOWNLOADER_INTERFACE=$("
+                + self.docker.shell(
+                    "image",
+                    "inspect",
+                    image_tag,
+                    "--format",
+                    '{{ index .Config.Labels "org.llmtracefx.downloader.interface" }}',
+                )
+                + ")",
+                "echo DOWNLOADER_SOURCE=$("
+                + self.docker.shell(
+                    "image",
+                    "inspect",
+                    image_tag,
+                    "--format",
+                    '{{ index .Config.Labels "org.llmtracefx.downloader.source" }}',
+                )
+                + ")",
+                self.docker.shell(
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    "--label",
+                    docker_run_label(self.authorization.nonce),
+                    image_tag,
+                    "python3",
+                    "-m",
+                    "vllm_kv_truth.model_download",
+                    "attest",
+                ),
                 "trap - EXIT",
             ]
         )
@@ -2485,6 +2690,10 @@ class RemoteOrchestrator:
             "schema_version": "1",
             "protocol_id": PROTOCOL_ID,
             "authorization_sha256": self.authorization.authorization_sha256,
+            "docker_execution_mode": self.docker.mode.value,
+            "docker_execution_config_sha256": (
+                self.authorization.docker_execution_config_sha256
+            ),
             "derived_image_id": self._require_derived_image_id(),
             "base_image_reference": BASE_IMAGE_REFERENCE,
             "network_mode": "bridge",
@@ -2529,6 +2738,7 @@ class RemoteOrchestrator:
                 reserve_stage=reserve_stage,
             )
         download_argv = build_model_download_argv(
+            docker=self.docker,
             authorization=self.authorization,
             paths=self.paths,
             derived_image_id=derived_image_id,
@@ -2617,6 +2827,7 @@ class RemoteOrchestrator:
             container_name=container_name(self.authorization.nonce, "canary"),
         )
         argv = build_docker_run_argv(
+            docker=self.docker,
             authorization=self.authorization,
             paths=self.paths,
             invocation=invocation,
@@ -2650,6 +2861,7 @@ class RemoteOrchestrator:
                     container_name=container_name(self.authorization.nonce, tag),
                 )
                 argv = build_docker_run_argv(
+                    docker=self.docker,
                     authorization=self.authorization,
                     paths=self.paths,
                     invocation=invocation,
@@ -2682,6 +2894,7 @@ class RemoteOrchestrator:
             container_name=container_name(self.authorization.nonce, "eviction"),
         )
         argv = build_docker_run_argv(
+            docker=self.docker,
             authorization=self.authorization,
             paths=self.paths,
             invocation=invocation,
@@ -2980,6 +3193,14 @@ class RemoteOrchestrator:
         self.state = OrchestratorState.TEARDOWN
         nonce = self.authorization.nonce
         label_filter = f"label={docker_run_label(nonce)}"
+        running_containers = self.docker.shell("ps", "-q", "--filter", label_filter)
+        all_containers = self.docker.shell("ps", "-aq", "--filter", label_filter)
+        labeled_images = self.docker.shell("images", "-q", "--filter", label_filter)
+        stop_containers = self.docker.xargs_shell("stop")
+        remove_containers = self.docker.xargs_shell("rm", "-f")
+        remove_images = self.docker.xargs_shell("rmi", "-f")
+        remove_base_image = self.docker.shell("rmi", "-f", BASE_IMAGE_REFERENCE)
+        residual_containers = self.docker.shell("ps", "-q")
         script = "\n".join(
             [
                 "set -eu",
@@ -3003,13 +3224,10 @@ class RemoteOrchestrator:
                 '  exit "$status"',
                 "}",
                 "trap finish_teardown EXIT",
-                f"docker ps -q --filter {_quote(label_filter)} | "
-                "xargs -r docker stop",
-                f"docker ps -aq --filter {_quote(label_filter)} | "
-                "xargs -r docker rm -f",
-                f"docker images -q --filter {_quote(label_filter)} | "
-                "xargs -r docker rmi -f || true",
-                f"docker rmi -f {_quote(BASE_IMAGE_REFERENCE)} || true",
+                f"{running_containers} | {stop_containers}",
+                f"{all_containers} | {remove_containers}",
+                f"{labeled_images} | {remove_images} || true",
+                f"{remove_base_image} || true",
                 f"rm -rf {_quote(self.paths.model_dir)}",
                 f"rm -rf {_quote(self.paths.repo_dir)}",
                 f"rm -rf {_quote(self.paths.evidence_dir)}",
@@ -3028,7 +3246,7 @@ class RemoteOrchestrator:
                 'test "$(awk -v marker="$KEY_MARKER" '
                 "'$NF == marker { count++ } END { print count + 0 }' "
                 '"$AUTHORIZED_KEYS")" = "0"',
-                'echo "RESIDUAL_CONTAINERS=$(' 'docker ps -q | wc -l)"',
+                f'echo "RESIDUAL_CONTAINERS=$({residual_containers} | wc -l)"',
                 'echo "RESIDUAL_GPU_PROCESSES=$('
                 "nvidia-smi --query-compute-apps=pid --format=csv,noheader "
                 '2>/dev/null | sed "/^[[:space:]]*$/d" | wc -l)"',

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -1299,6 +1299,14 @@ _SAFE_REASON_MESSAGES: dict[str, tuple[str, str]] = {
         "teardown",
         "the remote shutdown command failed",
     ),
+    "teardown_cleanup_and_shutdown_failed": (
+        "teardown",
+        "scoped remote cleanup or key removal and remote shutdown both failed",
+    ),
+    "teardown_outcome_unknown": (
+        "teardown",
+        "the remote teardown ended before cleanup and shutdown were proved",
+    ),
 }
 _SAFE_REASON_MARKER = re.compile(r"^LLMTRACEFX_REASON=([a-z0-9_]{1,80})$")
 _MAX_SAFE_FAILURE_MESSAGE_LENGTH = 160
@@ -1349,13 +1357,8 @@ def _safe_failure(result: CommandResult, default_reason: str) -> tuple[str, str,
             match = _SAFE_REASON_MARKER.fullmatch(line.strip())
             if match is not None and match.group(1) in _SAFE_REASON_MESSAGES:
                 marked_reasons.append(match.group(1))
-        if (
-            default_reason in {"teardown_cleanup_failed", "teardown_shutdown_failed"}
-            and "teardown_shutdown_failed" in marked_reasons
-        ):
-            reason = "teardown_shutdown_failed"
-        elif marked_reasons:
-            reason = marked_reasons[0]
+        if marked_reasons:
+            reason = marked_reasons[-1]
     category, message = _SAFE_REASON_MESSAGES[reason]
     return reason, category, message[:_MAX_SAFE_FAILURE_MESSAGE_LENGTH]
 
@@ -3216,84 +3219,116 @@ class RemoteOrchestrator:
         remove_images = self.docker.xargs_shell("rmi", "-f")
         remove_base_image = self.docker.shell("rmi", "-f", BASE_IMAGE_REFERENCE)
         residual_containers_command = self.docker.shell("ps", "-aq")
-        docker_cleanup_failure = (
-            "{ echo LLMTRACEFX_REASON=teardown_cleanup_failed >&2; exit 1; }"
-        )
         script = "\n".join(
             [
-                "set -eu",
-                "reason=teardown_cleanup_failed",
+                "set -u",
+                "cleanup_failed=0",
                 "shutdown_attempted=0",
                 "finish_teardown() {",
                 "  status=$?",
                 "  trap - EXIT",
+                '  if [ "$status" -ne 0 ]; then cleanup_failed=1; fi',
+                "  shutdown_failed=0",
                 '  if [ "$shutdown_attempted" -eq 0 ]; then',
                 "    shutdown_attempted=1",
                 "    if sudo -n shutdown -h +1; then",
                 '      echo "SHUTDOWN_ISSUED=1"',
                 "    else",
-                '      echo "LLMTRACEFX_REASON=teardown_shutdown_failed" >&2',
-                "      exit 1",
+                "      shutdown_failed=1",
                 "    fi",
                 "  fi",
-                '  if [ "$status" -ne 0 ]; then',
-                '    echo "LLMTRACEFX_REASON=$reason" >&2',
+                '  if [ "$cleanup_failed" -ne 0 ] && '
+                '[ "$shutdown_failed" -ne 0 ]; then',
+                "    echo "
+                '"LLMTRACEFX_REASON=teardown_cleanup_and_shutdown_failed" >&2',
+                "    exit 1",
                 "  fi",
-                '  exit "$status"',
+                '  if [ "$shutdown_failed" -ne 0 ]; then',
+                '    echo "LLMTRACEFX_REASON=teardown_shutdown_failed" >&2',
+                "    exit 1",
+                "  fi",
+                '  if [ "$cleanup_failed" -ne 0 ]; then',
+                '    echo "LLMTRACEFX_REASON=teardown_cleanup_failed" >&2',
+                "    exit 1",
+                "  fi",
+                "  exit 0",
                 "}",
                 "trap finish_teardown EXIT",
-                f"RUNNING_CONTAINERS=$({running_containers}) || "
-                f"{docker_cleanup_failure}",
-                'if [ -n "$RUNNING_CONTAINERS" ]; then '
-                "printf '%s\\n' \"$RUNNING_CONTAINERS\" | "
-                f"{stop_containers}; fi",
-                f"ALL_RUN_CONTAINERS=$({all_containers}) || "
-                f"{docker_cleanup_failure}",
-                'if [ -n "$ALL_RUN_CONTAINERS" ]; then '
-                "printf '%s\\n' \"$ALL_RUN_CONTAINERS\" | "
-                f"{remove_containers}; fi",
-                f"LABELED_IMAGES=$({labeled_images}) || {docker_cleanup_failure}",
-                'if [ -n "$LABELED_IMAGES" ]; then '
-                "printf '%s\\n' \"$LABELED_IMAGES\" | "
+                f"if RUNNING_CONTAINERS=$({running_containers}); then",
+                '  if [ -n "$RUNNING_CONTAINERS" ]; then',
+                "    printf '%s\\n' \"$RUNNING_CONTAINERS\" | "
+                f"{stop_containers} || cleanup_failed=1",
+                "  fi",
+                "else",
+                "  cleanup_failed=1",
+                "fi",
+                f"if ALL_RUN_CONTAINERS=$({all_containers}); then",
+                '  if [ -n "$ALL_RUN_CONTAINERS" ]; then',
+                "    printf '%s\\n' \"$ALL_RUN_CONTAINERS\" | "
+                f"{remove_containers} || cleanup_failed=1",
+                "  fi",
+                "else",
+                "  cleanup_failed=1",
+                "fi",
+                f"if LABELED_IMAGES=$({labeled_images}); then",
+                '  if [ -n "$LABELED_IMAGES" ]; then',
+                "    printf '%s\\n' \"$LABELED_IMAGES\" | "
                 "awk '!seen[$0]++' | "
-                f"{remove_images}; fi",
+                f"{remove_images} || cleanup_failed=1",
+                "  fi",
+                "else",
+                "  cleanup_failed=1",
+                "fi",
                 f"{remove_base_image} || true",
-                f"rm -rf {_quote(self.paths.model_dir)}",
-                f"rm -rf {_quote(self.paths.repo_dir)}",
-                f"rm -rf {_quote(self.paths.evidence_dir)}",
-                f"rm -rf {_quote(self.paths.receipts_dir)}",
-                f"rm -rf {_quote(self.paths.hf_scratch_dir)}",
-                f"rm -f {_quote(self.paths.source_archive_remote_path)}",
-                f"rm -f {_quote(self.config.remote_workspace + '/evidence.tar')}",
-                'AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"',
-                f"KEY_MARKER={_quote(self.config.authorized_key_marker)}",
-                'test -f "$AUTHORIZED_KEYS"',
-                'KEY_TMP=$(mktemp "$HOME/.ssh/authorized_keys.llmtracefx.XXXXXX")',
-                "awk -v marker=\"$KEY_MARKER\" '$NF != marker' "
-                '"$AUTHORIZED_KEYS" > "$KEY_TMP"',
-                'chmod --reference="$AUTHORIZED_KEYS" "$KEY_TMP"',
-                'mv "$KEY_TMP" "$AUTHORIZED_KEYS"',
-                'test "$(awk -v marker="$KEY_MARKER" '
+                f"rm -rf {_quote(self.paths.model_dir)} || cleanup_failed=1",
+                f"rm -rf {_quote(self.paths.repo_dir)} || cleanup_failed=1",
+                f"rm -rf {_quote(self.paths.evidence_dir)} || cleanup_failed=1",
+                f"rm -rf {_quote(self.paths.receipts_dir)} || cleanup_failed=1",
+                f"rm -rf {_quote(self.paths.hf_scratch_dir)} || cleanup_failed=1",
+                f"rm -f {_quote(self.paths.source_archive_remote_path)} "
+                "|| cleanup_failed=1",
+                f"rm -f {_quote(self.config.remote_workspace + '/evidence.tar')} "
+                "|| cleanup_failed=1",
+                "remove_authorized_key() {",
+                '  AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"',
+                f"  KEY_MARKER={_quote(self.config.authorized_key_marker)}",
+                '  test -f "$AUTHORIZED_KEYS" || return 1',
+                '  KEY_TMP=$(mktemp "$HOME/.ssh/authorized_keys.llmtracefx.XXXXXX") '
+                "|| return 1",
+                "  if ! awk -v marker=\"$KEY_MARKER\" '$NF != marker' "
+                '"$AUTHORIZED_KEYS" > "$KEY_TMP"; then',
+                '    rm -f "$KEY_TMP"',
+                "    return 1",
+                "  fi",
+                '  chmod --reference="$AUTHORIZED_KEYS" "$KEY_TMP" || '
+                '{ rm -f "$KEY_TMP"; return 1; }',
+                '  mv "$KEY_TMP" "$AUTHORIZED_KEYS" || '
+                '{ rm -f "$KEY_TMP"; return 1; }',
+                '  test "$(awk -v marker="$KEY_MARKER" '
                 "'$NF == marker { count++ } END { print count + 0 }' "
                 '"$AUTHORIZED_KEYS")" = "0"',
-                f"RESIDUAL_CONTAINER_IDS=$({residual_containers_command}) || "
-                f"{docker_cleanup_failure}",
-                "echo \"RESIDUAL_CONTAINERS=$(printf '%s\\n' "
+                "}",
+                "remove_authorized_key || cleanup_failed=1",
+                f"if RESIDUAL_CONTAINER_IDS=$({residual_containers_command}); then",
+                "  echo \"RESIDUAL_CONTAINERS=$(printf '%s\\n' "
                 '"$RESIDUAL_CONTAINER_IDS" | '
                 'sed "/^[[:space:]]*$/d" | wc -l)"',
-                "RESIDUAL_GPU_PIDS=$(nvidia-smi "
-                "--query-compute-apps=pid --format=csv,noheader 2>/dev/null) || "
-                f"{docker_cleanup_failure}",
-                "echo \"RESIDUAL_GPU_PROCESSES=$(printf '%s\\n' "
+                "else",
+                "  cleanup_failed=1",
+                "fi",
+                "if RESIDUAL_GPU_PIDS=$(nvidia-smi "
+                "--query-compute-apps=pid --format=csv,noheader 2>/dev/null); then",
+                "  echo \"RESIDUAL_GPU_PROCESSES=$(printf '%s\\n' "
                 '"$RESIDUAL_GPU_PIDS" | '
                 'sed "/^[[:space:]]*$/d" | wc -l)"',
+                "else",
+                "  cleanup_failed=1",
+                "fi",
                 f"if [ -d {_quote(self.config.remote_workspace)} ]; then "
-                f"rmdir {_quote(self.config.remote_workspace)}; fi",
-                "reason=teardown_shutdown_failed",
-                "shutdown_attempted=1",
-                "sudo -n shutdown -h +1",
-                'echo "SHUTDOWN_ISSUED=1"',
-                "trap - EXIT",
+                f"rmdir {_quote(self.config.remote_workspace)} "
+                "|| cleanup_failed=1; fi",
+                'echo "TEARDOWN_SCRIPT_COMPLETE=1"',
+                "exit 0",
             ]
         )
         result = self._checked(
@@ -3302,7 +3337,7 @@ class RemoteOrchestrator:
             substage="cleanup_key_removal_shutdown",
             description="stage_teardown_cleanup",
             timeout=300,
-            default_reason="teardown_cleanup_failed",
+            default_reason="teardown_outcome_unknown",
             reserve_stage=None,
             input_text=script,
         )
@@ -3343,12 +3378,14 @@ class RemoteOrchestrator:
                 "RESIDUAL_CONTAINERS",
                 "RESIDUAL_GPU_PROCESSES",
                 "SHUTDOWN_ISSUED",
+                "TEARDOWN_SCRIPT_COMPLETE",
             }
         )
         if (
             "RESIDUAL_CONTAINERS" not in markers
             or "RESIDUAL_GPU_PROCESSES" not in markers
             or markers.get("SHUTDOWN_ISSUED") != "1"
+            or markers.get("TEARDOWN_SCRIPT_COMPLETE") != "1"
         ):
             raise HostOrchestrationError(
                 "teardown residual-state check produced no parsable markers"

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -1344,11 +1344,18 @@ def _safe_failure(result: CommandResult, default_reason: str) -> tuple[str, str,
         reason = "operation_start_failed"
     else:
         reason = default_reason
+        marked_reasons: list[str] = []
         for line in result.stderr.splitlines():
             match = _SAFE_REASON_MARKER.fullmatch(line.strip())
             if match is not None and match.group(1) in _SAFE_REASON_MESSAGES:
-                reason = match.group(1)
-                break
+                marked_reasons.append(match.group(1))
+        if (
+            default_reason in {"teardown_cleanup_failed", "teardown_shutdown_failed"}
+            and "teardown_shutdown_failed" in marked_reasons
+        ):
+            reason = "teardown_shutdown_failed"
+        elif marked_reasons:
+            reason = marked_reasons[0]
     category, message = _SAFE_REASON_MESSAGES[reason]
     return reason, category, message[:_MAX_SAFE_FAILURE_MESSAGE_LENGTH]
 
@@ -1943,7 +1950,7 @@ class RemoteOrchestrator:
                 "protected config Docker execution hash does not match authorization"
             )
         self.ssh_options = StrictSSHOptions(config)
-        self.docker = DockerCommand(config.docker_execution_mode)
+        self._docker = DockerCommand(config.docker_execution_mode)
         self.paths = RunPaths(config.remote_workspace)
         self.state = OrchestratorState.PENDING
         self.outcomes: list[StageOutcome] = []
@@ -1955,6 +1962,12 @@ class RemoteOrchestrator:
     @property
     def operation_receipt_path(self) -> Path:
         return self.config.local_evidence_dir / "private-operation-receipts.jsonl"
+
+    @property
+    def docker(self) -> DockerCommand:
+        """The immutable Docker policy validated against sealed authorization."""
+
+        return self._docker
 
     def _persist_operation_receipts(self) -> None:
         directory = self.config.local_evidence_dir
@@ -2153,7 +2166,7 @@ class RemoteOrchestrator:
     def stage_preflight(self) -> StageOutcome:
         self._require_budget("existing_preflight_planning_reserve")
         self.state = OrchestratorState.PREFLIGHT
-        docker_ps = self.docker.shell("ps", "-q")
+        docker_ps = self.docker.shell("ps", "-aq")
         docker_info = self.docker.shell("info")
         docker_version = self.docker.shell("version", "--format", "{{.Server.Version}}")
         docker_failure = (
@@ -3202,7 +3215,7 @@ class RemoteOrchestrator:
         remove_containers = self.docker.xargs_shell("rm", "-f")
         remove_images = self.docker.xargs_shell("rmi", "-f")
         remove_base_image = self.docker.shell("rmi", "-f", BASE_IMAGE_REFERENCE)
-        residual_containers = self.docker.shell("ps", "-q")
+        residual_containers_command = self.docker.shell("ps", "-aq")
         docker_cleanup_failure = (
             "{ echo LLMTRACEFX_REASON=teardown_cleanup_failed >&2; exit 1; }"
         )
@@ -3242,7 +3255,8 @@ class RemoteOrchestrator:
                 f"LABELED_IMAGES=$({labeled_images}) || {docker_cleanup_failure}",
                 'if [ -n "$LABELED_IMAGES" ]; then '
                 "printf '%s\\n' \"$LABELED_IMAGES\" | "
-                f"{remove_images} || true; fi",
+                "awk '!seen[$0]++' | "
+                f"{remove_images}; fi",
                 f"{remove_base_image} || true",
                 f"rm -rf {_quote(self.paths.model_dir)}",
                 f"rm -rf {_quote(self.paths.repo_dir)}",
@@ -3262,7 +3276,7 @@ class RemoteOrchestrator:
                 'test "$(awk -v marker="$KEY_MARKER" '
                 "'$NF == marker { count++ } END { print count + 0 }' "
                 '"$AUTHORIZED_KEYS")" = "0"',
-                f"RESIDUAL_CONTAINER_IDS=$({residual_containers}) || "
+                f"RESIDUAL_CONTAINER_IDS=$({residual_containers_command}) || "
                 f"{docker_cleanup_failure}",
                 "echo \"RESIDUAL_CONTAINERS=$(printf '%s\\n' "
                 '"$RESIDUAL_CONTAINER_IDS" | '
@@ -3342,9 +3356,7 @@ class RemoteOrchestrator:
         residual_containers = int(markers["RESIDUAL_CONTAINERS"].strip())
         residual_gpu_processes = int(markers["RESIDUAL_GPU_PROCESSES"].strip())
         if residual_containers != 0:
-            raise HostOrchestrationError(
-                "residual experiment-scoped containers remain after teardown"
-            )
+            raise HostOrchestrationError("residual containers remain after teardown")
         if residual_gpu_processes != 0:
             raise HostOrchestrationError(
                 "residual GPU compute processes remain after teardown"


### PR DESCRIPTION
## Summary
- require protected-config schema 2 to preregister either direct Docker or exact noninteractive sudo Docker execution
- bind the selected mode and canonical execution-policy digest into authorization schema 3, preflight markers, and private receipts
- route every lifecycle Docker command, including teardown, through one centralized argv renderer
- fail closed before image/model/GPU work when the selected mode cannot access the daemon
- document provider-console mode selection and the non-scientific Sep 9 direct-socket refusal

## Validation
- 4,673 tests passed, 1 skipped
- targeted KV-truth suite: 257 passed, 1 skipped
- Ruff, Black, and isort checks passed on changed Python files
- wheel built with `--no-build-isolation`
- fresh Python 3.12 `--no-deps` wheel install, trust enrollment, native `/usr/bin/env -i` preflight, and clean-bootstrap integration passed

No CloudRift resource was provisioned or contacted for this change.