### PR TITLE
Add explicit evidence-labeled TOFU enrollment

### DIFF
--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -550,8 +550,9 @@ Before the one command above, confirm only this checklist:
    budget, nonce, zero-retry policy, and, for TOFU, every host-key trust
    binding.
 4. The protected config names the same Docker execution mode, a fresh client
-   key selected at rent time, dedicated known-hosts file, and the same empty
-   output directory passed to the bootstrap.
+   key installed by rent-time selection or the permitted independent
+   provider-console alternative (never password SSH), a dedicated known-hosts
+   file, and the same empty output directory passed to the bootstrap.
 5. The externally recorded trusted-manifest SHA-256 still matches and the
    wheel/environment clean preflight succeeds.
 6. The coordinator has issued GO and the full 210-minute reserve gate passes.

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -46,11 +46,48 @@ Do not rebuild or replace this archive after authorization is signed.
 Provision exactly one RTX 4090 host only after the PR is merged. Generate a
 new temporary SSH key with the exact comment
 `llmtracefx-kv-truth-authorized-key` (or another safe, unique marker recorded
-as `authorized_key_marker` below) and a dedicated known-hosts file. Install
-that one public-key line on the host. The orchestrator verifies there is
+as `authorized_key_marker` below) and a dedicated known-hosts file. Prefer
+adding that fresh public key to the CloudRift customer account and selecting
+it for the instance in the rent request. Do not use password SSH to install
+the key when rent-time public-key selection is available. Never store a
+provider token or password in the config, authorization, environment,
+receipt, command history, or evidence.
+
+If the provider UI does not offer rent-time key selection, a manual
+provider-console alternative is acceptable only when that console is
+independent of the SSH endpoint and can install the exact fresh public-key
+line without password SSH. CloudRift did not expose such a browser/web console
+in the September 10 workflow, so this alternative was unavailable there.
+
+The orchestrator verifies there is
 exactly one authorized-key line ending in the marker and atomically removes
 it during teardown. Verify the private key mode is `0600`; never reuse a key
 from an earlier VM.
+
+Choose exactly one host-key trust policy before enrollment:
+
+- `provider_pinned` is the existing strong path. Obtain the ED25519 host key
+  or fingerprint through a provider-authenticated channel independent of the
+  SSH endpoint, write the exact `[IP]:port ssh-ed25519 <base64>` line to the
+  dedicated mode-`0600` known-hosts file, and use protected-config schema 2
+  plus authorization schema 3 exactly as before. A key learned from the same
+  SSH connection is not provider-pinned.
+- `tofu_unverified` is an explicit weaker enrollment path. It observes one
+  ED25519 key unauthenticated from the preregistered literal IP and port. It
+  does not authenticate provider identity, resist an active MITM during
+  enrollment, prove secure provider provenance, or independently verify the
+  host key. It requires the clean-bootstrap enrollment operation,
+  protected-config schema 3, authorization schema 4, and the exact
+  acknowledgement shown below. There is no fallback or migration between
+  policies.
+
+CloudRift API OpenAPI v0.62.0
+(`https://api.cloudrift.ai/api-docs/openapi2.json`) exposes instance
+endpoint/login data and customer SSH public keys, but no VM SSH host public
+key or fingerprint field. The public CloudRift SSH and VM documentation also
+provides no independent host-key source. Therefore CloudRift cannot currently
+satisfy `provider_pinned` through those documented surfaces; use
+`tofu_unverified` only when its limitations are explicitly accepted.
 
 Before GO, perform only the coordinator-approved read-only preflight: boot
 time, UTC clock, one GPU, GPU name/memory/driver/compute capability, zero GPU
@@ -102,7 +139,8 @@ daemon without an interactive password.
 
 ## 3. Write protected execution config
 
-Write a `0600` JSON file with exactly these keys:
+For `provider_pinned`, write the existing `0600` schema-2 JSON file with
+exactly these keys:
 
 ```json
 {
@@ -127,6 +165,29 @@ config cannot silently acquire elevated Docker behavior.
 The SSH port belongs only in this protected file. Never place the target,
 user, port, key path, or known-hosts path in shell arguments, logs, evidence,
 or the authorization.
+
+For `tofu_unverified`, do not write or seal the final config until the
+enrollment in section 5 succeeds. Then write a `0600` schema-3 config with the
+schema-2 fields plus exactly:
+
+```json
+{
+  "schema_version": "3",
+  "host_key_trust_policy": "tofu_unverified",
+  "host_key_ed25519_base64": "<receipt host_key.base64>",
+  "host_key_fingerprint_sha256": "<receipt host_key.fingerprint_sha256>",
+  "known_hosts_sha256": "<receipt known_hosts.content_sha256>",
+  "tofu_enrollment_receipt_path": "/protected/path/to/tofu-enrollment-receipt.json",
+  "tofu_enrollment_receipt_sha256": "<receipt receipt_sha256>",
+  "tofu_unverified_acknowledgement": "I understand that provider identity was not independently authenticated and that TOFU enrollment does not resist an active MITM."
+}
+```
+
+This fragment supplements, rather than replaces, every common schema-2
+execution field. The loader verifies the receipt seal, endpoint, raw ED25519
+key, computed OpenSSH SHA-256 fingerprint, known-hosts bytes/digest/path, and
+acknowledgement before any authenticated SSH can be built. Schema 2 remains
+`provider_pinned`; it cannot consume a TOFU receipt.
 
 ## 4. Calculate and sign authorization
 
@@ -182,6 +243,25 @@ Set `authorization_expiry` no earlier than the end of cleanup. Calculate
 authorization object without `authorization_sha256`. Optional detached
 OpenSSH signing uses both `signature_path` and `authorized_signers_path`;
 supplying only one is invalid.
+
+For `provider_pinned`, authorization schema 3 is unchanged. For
+`tofu_unverified`, use authorization schema 4 and additionally bind:
+
+```text
+host_key_trust_policy=tofu_unverified
+host_key_ed25519_sha256=<SHA-256 hex of decoded OpenSSH key blob>
+host_key_fingerprint_sha256=<OpenSSH SHA256: fingerprint>
+known_hosts_sha256=<SHA-256 hex of exact canonical known-hosts bytes>
+tofu_enrollment_receipt_sha256=<receipt self-seal>
+host_key_trust_binding_sha256=<ProtectedExecutionConfig.host_key_trust_binding_sha256()>
+tofu_unverified_acknowledgement=<exact acknowledgement above>
+```
+
+The trust-binding digest commits to the literal endpoint, raw key,
+fingerprint, known-hosts digest, receipt digest, policy, and acknowledgement
+without publishing the endpoint. Compute the schema-4 authorization seal only
+after the schema-3 config loads successfully. A provider-pinned config cannot
+consume schema 4, and a TOFU config cannot consume schema 3.
 
 ## 5. Build, install, authorize, and preflight the clean bootstrap
 
@@ -313,7 +393,80 @@ bootstrap deliberately does not accept signature, signer, target, user, SSH
 key, known-hosts, or remote-workspace arguments.
 The public `llmtracefx-vllm-kv-truth` console script exposes only
 `verify-public-bundle`; `run` and `preflight` exist only in the internal
-dispatcher called by the bootstrap after trust verification.
+dispatcher called by the bootstrap after trust verification. `enroll-tofu`
+is likewise internal and cannot be reached through the public CLI.
+
+### Explicit TOFU enrollment
+
+Skip this subsection for `provider_pinned`. For `tofu_unverified`, create a
+new protected directory, an empty dedicated known-hosts file, and one
+mode-`0600` request. The directory must be current-user-owned mode `0700`;
+the known-hosts file must be a current-user-owned, non-symlink, empty regular
+file with exact mode `0600`; and the receipt path must not exist:
+
+```bash
+install -d -m 0700 /protected/path/tofu
+install -m 0600 /dev/null /protected/path/tofu/known_hosts
+```
+
+```json
+{
+  "schema_version": "1",
+  "host_key_trust_policy": "tofu_unverified",
+  "tofu_unverified_acknowledgement": "I understand that provider identity was not independently authenticated and that TOFU enrollment does not resist an active MITM.",
+  "host": "<canonical literal instance IP>",
+  "port": 22,
+  "known_hosts_path": "/protected/path/tofu/known_hosts",
+  "receipt_path": "/protected/path/tofu/tofu-enrollment-receipt.json"
+}
+```
+
+Write that object to
+`/protected/path/tofu/tofu-enrollment-request.json`, set mode `0600`, and run
+the single enrollment command:
+
+```bash
+/usr/bin/env -i PATH=/usr/bin:/bin:/usr/local/bin LANG=C LC_ALL=C \
+  /absolute/protected/kv-truth-venv/bin/python -I -S -B \
+  /absolute/protected/kv-truth-venv/bin/run-vllm-kv-truth-clean-env.py \
+  enroll-tofu \
+  --wheel /absolute/protected/build-output/llmtracefx-1.0.0-py3-none-any.whl \
+  --trusted-manifest /absolute/protected/kv-truth-launch-manifest.json \
+  --trusted-manifest-sha256 <RECORDED_64_HEX_MANIFEST_SHA256> \
+  --enrollment-request /protected/path/tofu/tofu-enrollment-request.json
+```
+
+After trust verification, the internal operation invokes exactly:
+
+```text
+/usr/bin/ssh-keyscan -T 5 -t ed25519 -p <port> <literal-IP>
+```
+
+The subprocess has a 10-second outer timeout and only
+`PATH=/usr/bin:/bin:/usr/local/bin`, `LANG=C`, and `LC_ALL=C`. No shell,
+DNS name, SSH config, proxy/jump, agent, password, global known-hosts file, or
+authenticated SSH is used. Enrollment accepts exactly one complete output
+line for exact `[IP]:port`, algorithm `ssh-ed25519`, and one structurally
+valid 32-byte ED25519 key. Zero lines, duplicates, multiple distinct keys,
+other algorithms, endpoint mismatch, malformed/truncated output, ambiguous
+stderr, timeout, nonzero exit, path substitution, or changed output files are
+hard refusals.
+
+The new mode-`0600` receipt canonically records `policy=tofu_unverified`, the
+statement that provider identity was not independently authenticated, the
+endpoint, raw ED25519 key, computed SHA-256 fingerprint, UTC observation
+time, absolute tool/argv/environment/timeout provenance, known-hosts
+path/content hash, and its own SHA-256 seal. Keep the request, receipt, and
+known-hosts file private. Return to sections 3 and 4 to write schema-3 config
+and schema-4 authorization from those exact bytes; never edit the enrolled
+file or receipt after sealing.
+
+If enrollment refuses, no authenticated SSH or workload has occurred. Remove
+the empty or partially written dedicated files and terminate any already
+created provider reservation through the provider control plane; preserve
+termination confirmation. Do not rerun against the same endpoint/key
+material, accept a second line, switch policy, or copy a key from a password
+SSH session.
 
 Run the offline environment preflight first:
 
@@ -386,15 +539,20 @@ Before the one command above, confirm only this checklist:
 0. The clean-bootstrap change is merged and that exact merged head has passed
    CI and CodeQL. No new VM exists before this gate passes.
 1. The source archive is from the exact clean, tested, merged `origin/main`.
-2. Authorization schema 3 seals that head, archive digest, Docker execution
-   mode and execution-policy digest, runtime/model/image pins, downloader
-   identity, budget, nonce, and zero-retry policy.
-3. Protected-config schema 2 names the same Docker execution mode, a fresh
-   key, dedicated known-hosts file, and the same empty output directory passed
-   to the bootstrap.
-4. The externally recorded trusted-manifest SHA-256 still matches and the
+2. The host-key policy is exactly one of: unchanged `provider_pinned` with
+   protected-config schema 2 and authorization schema 3; or explicit
+   `tofu_unverified` with a fresh clean-bootstrap receipt, protected-config
+   schema 3, and authorization schema 4. No fallback is configured.
+3. Authorization seals that head, archive digest, Docker execution mode and
+   execution-policy digest, runtime/model/image pins, downloader identity,
+   budget, nonce, zero-retry policy, and, for TOFU, every host-key trust
+   binding.
+4. The protected config names the same Docker execution mode, a fresh client
+   key selected at rent time, dedicated known-hosts file, and the same empty
+   output directory passed to the bootstrap.
+5. The externally recorded trusted-manifest SHA-256 still matches and the
    wheel/environment clean preflight succeeds.
-5. The coordinator has issued GO and the full 210-minute reserve gate passes.
+6. The coordinator has issued GO and the full 210-minute reserve gate passes.
 
 ## 7. Private failure diagnostics
 
@@ -465,6 +623,19 @@ bundle offline:
   --bundle-dir /protected/path/to/evidence-output/public
 ```
 
+When every workload, runtime, budget, transfer, and teardown verifier passes,
+scientific runtime/cache evidence may be evaluated under either host-key
+policy. A TOFU bundle explicitly records
+`host_key_trust_policy=tofu_unverified`,
+`provider_identity_independently_authenticated=false`, and false support for
+enrollment MITM resistance, secure provider provenance, and independent
+host-key verification. It redacts raw host-identity fields. Such a bundle
+must not support claims of provider-authenticated host identity, MITM
+resistance during enrollment, secure provider provenance, or independent
+host-key verification. Missing strong identity evidence is always
+unsupported; it is never inferred from successful SSH, workload output,
+runtime attestation, teardown, or provider endpoint reuse.
+
 Wait for the exact message:
 
 ```text
@@ -485,9 +656,16 @@ local material:
 ```bash
 /bin/rm -- \
   /protected/path/to/fresh-temporary-key \
+  /protected/path/to/dedicated-known-hosts \
+  /protected/path/to/tofu-enrollment-request.json \
+  /protected/path/to/tofu-enrollment-receipt.json \
   /protected/path/execution-config.json \
   /protected/path/run-authorization.json
 ```
+
+Omit the two TOFU files for `provider_pinned`. If any listed file is absent,
+remove only the files belonging to this one attempt; never broaden the cleanup
+with a wildcard.
 
 Repair or rebuild the dedicated environment, create a trust manifest at a new
 path (manifest creation deliberately refuses to overwrite), and repeat the
@@ -539,9 +717,21 @@ provider reservation was terminated and confirmed, and all one-attempt local
 credentials were destroyed. This manual pre-GO refusal is operational
 provenance only, not scientific evidence.
 
+On September 10, the subsequent prepared run correctly refused host identity
+because the only available host key had been learned through the same
+manually TOFU-accepted password SSH connection. That observation was not an
+independent provider pin and was not relabeled as one. No runner SSH,
+workload, image/model action, or GPU/scientific stage occurred. The
+reservation was terminated and its one-attempt key was cleaned. The
+nonsecret refusal receipt SHA-256 was
+`504c8be0fab8259d3d2e116831d8207570392895d684eb7a71b817d3b751d69e`.
+The inferred cost upper bound was `$0.204875`; official provider spend remains
+unknown. This is operational/non-scientific provenance and creates no result
+or evidence-catalog entry.
+
 Do not provision a new VM for the next attempt until the clean-bootstrap
 change is merged, its exact merged head passes CI and CodeQL, the wheel-installed
 bootstrap preflight passes from the contaminated operator shell, the selected
 Docker execution mode passes its exact read-only provider-console probe, and a
-new schema-3 authorization binds both that mode and the resulting exact source
-archive.
+new authorization of the policy-appropriate schema binds that mode, the
+resulting exact source archive, and all required host-key trust evidence.

--- a/docs/VLLM_KV_TRUTH_RUNBOOK.md
+++ b/docs/VLLM_KV_TRUTH_RUNBOOK.md
@@ -68,8 +68,9 @@ Choose exactly one host-key trust policy before enrollment:
 
 - `provider_pinned` is the existing strong path. Obtain the ED25519 host key
   or fingerprint through a provider-authenticated channel independent of the
-  SSH endpoint, write the exact `[IP]:port ssh-ed25519 <base64>` line to the
-  dedicated mode-`0600` known-hosts file, and use protected-config schema 2
+  SSH endpoint, write the exact OpenSSH host token (`IP` for port 22,
+  `[IP]:port` otherwise) followed by `ssh-ed25519 <base64>` to the dedicated
+  mode-`0600` known-hosts file, and use protected-config schema 2
   plus authorization schema 3 exactly as before. A key learned from the same
   SSH connection is not provider-pinned.
 - `tofu_unverified` is an explicit weaker enrollment path. It observes one
@@ -445,9 +446,10 @@ After trust verification, the internal operation invokes exactly:
 The subprocess has a 10-second outer timeout and only
 `PATH=/usr/bin:/bin:/usr/local/bin`, `LANG=C`, and `LC_ALL=C`. No shell,
 DNS name, SSH config, proxy/jump, agent, password, global known-hosts file, or
-authenticated SSH is used. Enrollment accepts exactly one complete output
-line for exact `[IP]:port`, algorithm `ssh-ed25519`, and one structurally
-valid 32-byte ED25519 key. Zero lines, duplicates, multiple distinct keys,
+authenticated SSH is used. enrollment accepts exactly one complete output key line for the canonical
+OpenSSH host token (`IP` for port 22, `[IP]:port` otherwise), algorithm
+`ssh-ed25519`, and one structurally valid 32-byte ED25519 key. Zero lines,
+duplicates, multiple distinct keys,
 other algorithms, endpoint mismatch, malformed/truncated output, ambiguous
 stderr, timeout, nonzero exit, path substitution, or changed output files are
 hard refusals.

--- a/scripts/run-vllm-kv-truth-clean-env.py
+++ b/scripts/run-vllm-kv-truth-clean-env.py
@@ -639,7 +639,12 @@ def _verify_wheel_install(wheel_bytes: bytes, root: Path, interpreter: Path) -> 
 
 
 def _parse_options(argv: list[str]) -> tuple[str, dict[str, str]]:
-    if not argv or argv[0] not in {"record-trust", "preflight", "run"}:
+    if not argv or argv[0] not in {
+        "record-trust",
+        "preflight",
+        "enroll-tofu",
+        "run",
+    }:
         _fail("usage error")
     command = argv[0]
     required = {
@@ -648,6 +653,12 @@ def _parse_options(argv: list[str]) -> tuple[str, dict[str, str]]:
             "--wheel",
             "--trusted-manifest",
             "--trusted-manifest-sha256",
+        },
+        "enroll-tofu": {
+            "--wheel",
+            "--trusted-manifest",
+            "--trusted-manifest-sha256",
+            "--enrollment-request",
         },
         "run": {
             "--wheel",
@@ -870,6 +881,15 @@ def main(argv: list[str] | None = None) -> int:
     cli_args: list[str]
     if command == "preflight":
         cli_args = ["preflight"]
+    elif command == "enroll-tofu":
+        request = _require_private_input(
+            values["--enrollment-request"], "TOFU enrollment request"
+        )
+        cli_args = [
+            "enroll-tofu",
+            "--enrollment-request",
+            str(request),
+        ]
     else:
         config = _require_private_input(
             values["--execution-config"], "execution config"

--- a/tests/deploy/test_vllm_kv_truth_clean_env_launcher.py
+++ b/tests/deploy/test_vllm_kv_truth_clean_env_launcher.py
@@ -75,6 +75,20 @@ def bootstrap_dispatch(argv):
     if args == ["preflight"]:
         print("clean environment preflight: ok")
         return 0
+    if args[0] == "enroll-tofu":
+        request = Path(args[args.index("--enrollment-request") + 1])
+        payload = json.loads(request.read_text(encoding="utf-8"))
+        Path(payload["receipt_path"]).write_text(
+            json.dumps(
+                {
+                    "environment": dict(os.environ),
+                    "operation": "enroll-tofu",
+                    "request_path": str(request),
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
     output = Path(args[args.index("--output-dir") + 1])
     auth = Path(args[args.index("--authorization") + 1])
     authorization = json.loads(auth.read_text(encoding="utf-8"))
@@ -111,7 +125,7 @@ def _write_wheel(path: Path, bootstrap: bytes, cli_source: str = FAKE_CLI) -> No
         "llmtracefx/__init__.py": b"",
         "vllm_kv_truth/__init__.py": b"",
         "vllm_kv_truth/cli.py": cli_source.encode(),
-        ("llmtracefx-1.0.0.data/scripts/" "run-vllm-kv-truth-clean-env.py"): bootstrap,
+        ("llmtracefx-1.0.0.data/scripts/run-vllm-kv-truth-clean-env.py"): bootstrap,
         "llmtracefx-1.0.0.dist-info/METADATA": (
             b"Metadata-Version: 2.1\nName: llmtracefx\nVersion: 1.0.0\n"
         ),
@@ -364,7 +378,12 @@ def test_real_setuptools_wheel_install_and_public_cli_split(tmp_path: Path) -> N
 
     public_cli = venv / "bin" / "llmtracefx-vllm-kv-truth"
     private_read_marker = tmp_path / "private-input-was-read"
-    for command in ("run", "preflight", "preflight-clean-environment"):
+    for command in (
+        "run",
+        "preflight",
+        "preflight-clean-environment",
+        "enroll-tofu",
+    ):
         refused = subprocess.run(
             [
                 "/usr/bin/env",
@@ -489,6 +508,45 @@ def test_native_env_strips_shell_hooks_and_ambient_state(tmp_path: Path) -> None
     assert set(child_environment).isdisjoint(CONTAMINATED_ENVIRONMENT)
     assert observation["lifecycle"] == "complete"
     assert (output / "cleanup").read_text() == "complete"
+    assert not (tmp_path / "should-never-run").exists()
+
+
+def test_native_clean_bootstrap_enrollment_strips_ambient_state(
+    tmp_path: Path,
+) -> None:
+    interpreter, bootstrap, wheel = _install_fake_environment(tmp_path)
+    manifest, digest = _record_trust(tmp_path, interpreter, bootstrap, wheel)
+    protected = tmp_path / "protected-enrollment"
+    protected.mkdir(mode=0o700)
+    receipt = protected / "receipt.json"
+    request = protected / "request.json"
+    request.write_text(json.dumps({"receipt_path": str(receipt)}), encoding="utf-8")
+    request.chmod(0o600)
+    completed = subprocess.run(
+        _native_command(
+            interpreter,
+            bootstrap,
+            "enroll-tofu",
+            *_trusted_args(wheel, manifest, digest),
+            "--enrollment-request",
+            str(request),
+        ),
+        env={**os.environ, **CONTAMINATED_ENVIRONMENT},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    observation = json.loads(receipt.read_text(encoding="utf-8"))
+    assert observation["operation"] == "enroll-tofu"
+    assert observation["request_path"] == str(request)
+    assert {
+        name: observation["environment"][name] for name in SAFE_ENVIRONMENT
+    } == SAFE_ENVIRONMENT
+    assert set(observation["environment"]) <= (
+        set(SAFE_ENVIRONMENT) | PLATFORM_ENVIRONMENT_NAMES
+    )
+    assert set(observation["environment"]).isdisjoint(CONTAMINATED_ENVIRONMENT)
     assert not (tmp_path / "should-never-run").exists()
 
 

--- a/tests/deploy/test_vllm_kv_truth_lifecycle.py
+++ b/tests/deploy/test_vllm_kv_truth_lifecycle.py
@@ -11,6 +11,7 @@ than a placeholder that always refuses.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
 import json
@@ -1131,30 +1132,126 @@ def _config(
     docker_execution_mode: lifecycle.DockerExecutionMode = (
         lifecycle.DockerExecutionMode.DIRECT
     ),
+    host_key_trust_policy: lifecycle.HostKeyTrustPolicy = (
+        lifecycle.HostKeyTrustPolicy.PROVIDER_PINNED
+    ),
 ) -> lifecycle.ProtectedExecutionConfig:
     key = tmp_path / "key"
     key.write_text("x", encoding="utf-8")
     os.chmod(key, 0o600)
     known_hosts = tmp_path / "known_hosts"
-    known_hosts.write_text("x", encoding="utf-8")
+    config_payload: dict[str, Any] = {
+        "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
+        "host": "203.0.113.5",
+        "port": 57003,
+        "user": "runner",
+        "docker_execution_mode": docker_execution_mode.value,
+        "private_key_path": str(key),
+        "known_hosts_path": str(known_hosts),
+        "remote_workspace": "/srv/kv-truth",
+        "authorized_key_marker": "marker",
+        "local_evidence_dir": str(tmp_path / "evidence"),
+        "local_runner_archive": str(tmp_path / "archive.tar"),
+    }
+    if host_key_trust_policy is lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED:
+        algorithm = b"ssh-ed25519"
+        key_blob = (
+            len(algorithm).to_bytes(4, "big")
+            + algorithm
+            + (32).to_bytes(4, "big")
+            + b"\x07" * 32
+        )
+        key_base64 = base64.b64encode(key_blob).decode("ascii")
+        known_hosts_content = (
+            f"[203.0.113.5]:57003 ssh-ed25519 {key_base64}\n"
+        ).encode("ascii")
+        known_hosts.write_bytes(known_hosts_content)
+        known_hosts_sha256 = hashlib.sha256(known_hosts_content).hexdigest()
+        receipt_path = tmp_path / "tofu-receipt.json"
+        receipt_unsealed = {
+            "schema_version": lifecycle.TOFU_ENROLLMENT_RECEIPT_SCHEMA_VERSION,
+            "policy": lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED.value,
+            "provider_identity_independently_authenticated": False,
+            "identity_statement": lifecycle.TOFU_IDENTITY_STATEMENT,
+            "endpoint": {"host": "203.0.113.5", "port": 57003},
+            "host_key": {
+                "algorithm": "ssh-ed25519",
+                "base64": key_base64,
+                "fingerprint_sha256": lifecycle.openssh_sha256_fingerprint(key_blob),
+            },
+            "observed_at": lifecycle._canonical_timestamp(BILLING_STARTED_AT),
+            "tool": {
+                "path": lifecycle.SSH_KEYSCAN_PATH,
+                "argv": [
+                    lifecycle.SSH_KEYSCAN_PATH,
+                    "-T",
+                    str(lifecycle.SSH_KEYSCAN_CONNECT_TIMEOUT_SECONDS),
+                    "-t",
+                    "ed25519",
+                    "-p",
+                    "57003",
+                    "203.0.113.5",
+                ],
+                "environment": lifecycle.SSH_KEYSCAN_ENVIRONMENT,
+                "process_timeout_seconds": (
+                    lifecycle.SSH_KEYSCAN_PROCESS_TIMEOUT_SECONDS
+                ),
+            },
+            "known_hosts": {
+                "path": str(known_hosts),
+                "content_sha256": known_hosts_sha256,
+            },
+        }
+        receipt = {
+            **receipt_unsealed,
+            "receipt_sha256": lifecycle.sha256_json(receipt_unsealed),
+        }
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        receipt_path.chmod(0o600)
+        config_payload.update(
+            {
+                "schema_version": lifecycle.TOFU_CONFIG_SCHEMA_VERSION,
+                "host_key_trust_policy": host_key_trust_policy.value,
+                "host_key_ed25519_base64": key_base64,
+                "host_key_fingerprint_sha256": (
+                    lifecycle.openssh_sha256_fingerprint(key_blob)
+                ),
+                "known_hosts_sha256": known_hosts_sha256,
+                "tofu_enrollment_receipt_path": str(receipt_path),
+                "tofu_enrollment_receipt_sha256": receipt["receipt_sha256"],
+                "tofu_unverified_acknowledgement": (
+                    lifecycle.TOFU_UNVERIFIED_ACKNOWLEDGEMENT
+                ),
+            }
+        )
+    else:
+        known_hosts.write_text("x", encoding="utf-8")
     os.chmod(known_hosts, 0o600)
     archive = tmp_path / "archive.tar"
     if not archive.exists():
         _write_source_archive(archive)
-    return lifecycle.ProtectedExecutionConfig.from_dict(
-        {
-            "schema_version": lifecycle.PROTECTED_CONFIG_SCHEMA_VERSION,
-            "host": "203.0.113.5",
-            "port": 57003,
-            "user": "runner",
-            "docker_execution_mode": docker_execution_mode.value,
-            "private_key_path": str(key),
-            "known_hosts_path": str(known_hosts),
-            "remote_workspace": "/srv/kv-truth",
-            "authorized_key_marker": "marker",
-            "local_evidence_dir": str(tmp_path / "evidence"),
-            "local_runner_archive": str(archive),
-        }
+    config_payload["local_runner_archive"] = str(archive)
+    return lifecycle.ProtectedExecutionConfig.from_dict(config_payload)
+
+
+def _authorization_for_config(
+    config: lifecycle.ProtectedExecutionConfig,
+) -> lifecycle.RunAuthorization:
+    if config.host_key_trust_policy is lifecycle.HostKeyTrustPolicy.PROVIDER_PINNED:
+        return _authorization(docker_execution_mode=config.docker_execution_mode.value)
+    assert config.host_key_ed25519_base64 is not None
+    return _authorization(
+        schema_version=lifecycle.TOFU_AUTHORIZATION_SCHEMA_VERSION,
+        docker_execution_mode=config.docker_execution_mode.value,
+        host_key_trust_policy=config.host_key_trust_policy.value,
+        host_key_ed25519_sha256=hashlib.sha256(
+            base64.b64decode(config.host_key_ed25519_base64)
+        ).hexdigest(),
+        host_key_fingerprint_sha256=config.host_key_fingerprint_sha256,
+        known_hosts_sha256=config.known_hosts_sha256,
+        tofu_enrollment_receipt_sha256=config.tofu_enrollment_receipt_sha256,
+        host_key_trust_binding_sha256=config.host_key_trust_binding_sha256(),
+        tofu_unverified_acknowledgement=(lifecycle.TOFU_UNVERIFIED_ACKNOWLEDGEMENT),
     )
 
 
@@ -1403,6 +1500,62 @@ class TestRemoteOrchestratorFullRun:
         assert {receipt["docker_execution_config_sha256"] for receipt in receipts} == {
             lifecycle.docker_execution_config_sha256(mode)
         }
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            lifecycle.DockerExecutionMode.DIRECT,
+            lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            lifecycle.HostKeyTrustPolicy.PROVIDER_PINNED,
+            lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED,
+        ],
+    )
+    def test_fake_remote_lifecycle_remains_valid_for_both_trust_policies(
+        self,
+        tmp_path: Path,
+        mode: lifecycle.DockerExecutionMode,
+        policy: lifecycle.HostKeyTrustPolicy,
+    ) -> None:
+        config = _config(
+            tmp_path,
+            docker_execution_mode=mode,
+            host_key_trust_policy=policy,
+        )
+        responses = {}
+        if mode is lifecycle.DockerExecutionMode.SUDO_NONINTERACTIVE:
+            responses["stage_preflight"] = lifecycle.CommandResult(
+                returncode=0,
+                stdout=_preflight_stdout(
+                    DOCKER_EXECUTION_MODE=mode.value,
+                    DOCKER_EXECUTION_CONFIG_SHA256=(
+                        lifecycle.docker_execution_config_sha256(mode)
+                    ),
+                ),
+                stderr="",
+            )
+        runner = FakeCommandRunner(responses=responses)
+        orchestrator = lifecycle.RemoteOrchestrator(
+            config=config,
+            authorization=_authorization_for_config(config),
+            runner=runner,
+            now_fn=lambda: BILLING_STARTED_AT,
+        )
+        outcomes = orchestrator.run(local_evidence_bundle_dir=tmp_path / "bundle")
+        assert all(outcome.ok for outcome in outcomes)
+        assert orchestrator.state is lifecycle.OrchestratorState.COMPLETE
+        ssh_record = evidence.PrivateEvidenceBundle.read(
+            tmp_path / "bundle" / "private_bundle.json"
+        ).ssh_options_public_record
+        if policy is lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            assert ssh_record["host_key_trust_policy"] == "tofu_unverified"
+            assert ssh_record["provider_identity_independently_authenticated"] is False
+        else:
+            assert "host_key_trust_policy" not in ssh_record
 
     def test_direct_mode_never_mixes_in_sudo_docker_calls(self, tmp_path: Path) -> None:
         runner = FakeCommandRunner()
@@ -2206,9 +2359,7 @@ xargs() { cat >/dev/null; }
                 "stage_teardown_cleanup": lifecycle.CommandResult(
                     returncode=1,
                     stdout="",
-                    stderr=(
-                        "LLMTRACEFX_REASON=" "teardown_cleanup_and_shutdown_failed\n"
-                    ),
+                    stderr=("LLMTRACEFX_REASON=teardown_cleanup_and_shutdown_failed\n"),
                 )
             }
         )

--- a/tests/deploy/test_vllm_kv_truth_tofu.py
+++ b/tests/deploy/test_vllm_kv_truth_tofu.py
@@ -1,0 +1,542 @@
+"""Explicit, evidence-labeled SSH trust-on-first-use enrollment tests."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vllm_kv_truth import lifecycle
+
+OBSERVED_AT = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+
+def _key_base64(fill: int = 7) -> str:
+    algorithm = b"ssh-ed25519"
+    raw = (
+        len(algorithm).to_bytes(4, "big")
+        + algorithm
+        + (32).to_bytes(4, "big")
+        + bytes([fill]) * 32
+    )
+    return base64.b64encode(raw).decode("ascii")
+
+
+@dataclass
+class FakeRunner:
+    result: lifecycle.CommandResult
+    calls: list[tuple[tuple[str, ...], str, float, str | None]] = field(
+        default_factory=list
+    )
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        description: str,
+        timeout: float,
+        input_text: str | None = None,
+    ) -> lifecycle.CommandResult:
+        self.calls.append((tuple(argv), description, timeout, input_text))
+        return self.result
+
+
+def _protected_dir(tmp_path: Path) -> Path:
+    protected = tmp_path / "protected"
+    protected.mkdir(mode=0o700)
+    return protected
+
+
+def _request(
+    protected: Path,
+    *,
+    host: str = "203.0.113.8",
+    port: int = 57003,
+) -> tuple[Path, Path, Path]:
+    known_hosts = protected / "known_hosts"
+    known_hosts.write_bytes(b"")
+    known_hosts.chmod(0o600)
+    receipt = protected / "tofu-enrollment-receipt.json"
+    request = protected / "tofu-enrollment-request.json"
+    request.write_text(
+        json.dumps(
+            {
+                "schema_version": lifecycle.TOFU_ENROLLMENT_REQUEST_SCHEMA_VERSION,
+                "host_key_trust_policy": (
+                    lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED.value
+                ),
+                "tofu_unverified_acknowledgement": (
+                    lifecycle.TOFU_UNVERIFIED_ACKNOWLEDGEMENT
+                ),
+                "host": host,
+                "port": port,
+                "known_hosts_path": str(known_hosts),
+                "receipt_path": str(receipt),
+            }
+        ),
+        encoding="utf-8",
+    )
+    request.chmod(0o600)
+    return request, known_hosts, receipt
+
+
+def _successful_runner(
+    *, host: str = "203.0.113.8", port: int = 57003, key: str | None = None
+) -> FakeRunner:
+    key = key or _key_base64()
+    return FakeRunner(
+        lifecycle.CommandResult(
+            returncode=0,
+            stdout=f"[{host}]:{port} ssh-ed25519 {key}\n",
+            stderr=f"# {host}:{port} SSH-2.0-test-server\n",
+        )
+    )
+
+
+def _enroll(
+    tmp_path: Path,
+) -> tuple[
+    Path,
+    Path,
+    lifecycle.TofuEnrollmentReceipt,
+    FakeRunner,
+]:
+    protected = _protected_dir(tmp_path)
+    request, known_hosts, receipt_path = _request(protected)
+    runner = _successful_runner()
+    receipt = lifecycle.enroll_tofu_host_key(
+        request, runner, now_fn=lambda: OBSERVED_AT
+    )
+    return known_hosts, receipt_path, receipt, runner
+
+
+def _config_payload(
+    tmp_path: Path,
+    known_hosts: Path,
+    receipt_path: Path,
+    receipt: lifecycle.TofuEnrollmentReceipt,
+) -> dict[str, Any]:
+    private_key = known_hosts.parent / "id_ed25519"
+    private_key.write_text("private", encoding="utf-8")
+    private_key.chmod(0o600)
+    archive = known_hosts.parent / "runner.tar"
+    archive.write_bytes(b"archive")
+    return {
+        "schema_version": lifecycle.TOFU_CONFIG_SCHEMA_VERSION,
+        "host": receipt.host,
+        "port": receipt.port,
+        "user": "runner",
+        "host_key_trust_policy": (lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED.value),
+        "host_key_ed25519_base64": receipt.host_key_ed25519_base64,
+        "host_key_fingerprint_sha256": receipt.host_key_fingerprint_sha256,
+        "known_hosts_sha256": receipt.known_hosts_sha256,
+        "tofu_enrollment_receipt_path": str(receipt_path),
+        "tofu_enrollment_receipt_sha256": receipt.receipt_sha256,
+        "tofu_unverified_acknowledgement": (lifecycle.TOFU_UNVERIFIED_ACKNOWLEDGEMENT),
+        "docker_execution_mode": lifecycle.DockerExecutionMode.DIRECT.value,
+        "private_key_path": str(private_key),
+        "known_hosts_path": str(known_hosts),
+        "remote_workspace": "/srv/kv-truth",
+        "authorized_key_marker": "marker",
+        "local_evidence_dir": str(tmp_path / "evidence"),
+        "local_runner_archive": str(archive),
+    }
+
+
+def _authorization_payload(
+    config: lifecycle.ProtectedExecutionConfig,
+    **overrides: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": lifecycle.TOFU_AUTHORIZATION_SCHEMA_VERSION,
+        "protocol_id": lifecycle.PROTOCOL_ID,
+        "repository_head": "a" * 40,
+        "base_image_reference": lifecycle.BASE_IMAGE_REFERENCE,
+        "derived_image_source_digest": "sha256:" + "b" * 64,
+        "vllm_version": lifecycle.REQUIRED_VLLM_VERSION,
+        "vllm_commit": lifecycle.REQUIRED_VLLM_COMMIT,
+        "model_id": lifecycle.MODEL_ID,
+        "model_revision": lifecycle.MODEL_REVISION,
+        "model_inventory_sha256": lifecycle._model_inventory_sha256(),
+        "model_download_package": lifecycle.DOWNLOADER_PACKAGE,
+        "model_download_version": lifecycle.DOWNLOADER_VERSION,
+        "model_download_interface": lifecycle.DOWNLOADER_INTERFACE,
+        "model_download_source": lifecycle.DOWNLOADER_SOURCE,
+        "gpu_expected_count": 1,
+        "gpu_expected_name": lifecycle.EXPECTED_GPU_NAME,
+        "gpu_expected_driver": lifecycle.EXPECTED_DRIVER,
+        "gpu_expected_memory_mib": lifecycle.EXPECTED_MEMORY_MIB,
+        "docker_execution_mode": lifecycle.DockerExecutionMode.DIRECT.value,
+        "docker_execution_config_sha256": (
+            lifecycle.docker_execution_config_sha256(
+                lifecycle.DockerExecutionMode.DIRECT
+            )
+        ),
+        "rate_usd_per_hour": "0.500000",
+        "total_cap_usd": "10.000000",
+        "billing_started_at": lifecycle._canonical_timestamp(OBSERVED_AT),
+        "operational_cutoff": lifecycle._canonical_timestamp(
+            OBSERVED_AT + timedelta(minutes=175)
+        ),
+        "cleanup_reserve_minutes": lifecycle.CLEANUP_RESERVE_MINUTES,
+        "authorized_at": lifecycle._canonical_timestamp(
+            OBSERVED_AT - timedelta(minutes=5)
+        ),
+        "authorization_expiry": lifecycle._canonical_timestamp(
+            OBSERVED_AT + timedelta(hours=6)
+        ),
+        "automatic_retries": 0,
+        "replacement_allowed": False,
+        "nonce": "c" * 40,
+        "host_key_trust_policy": (lifecycle.HostKeyTrustPolicy.TOFU_UNVERIFIED.value),
+        "host_key_ed25519_sha256": hashlib.sha256(
+            base64.b64decode(config.host_key_ed25519_base64 or "")
+        ).hexdigest(),
+        "host_key_fingerprint_sha256": config.host_key_fingerprint_sha256,
+        "known_hosts_sha256": config.known_hosts_sha256,
+        "tofu_enrollment_receipt_sha256": (config.tofu_enrollment_receipt_sha256),
+        "host_key_trust_binding_sha256": (config.host_key_trust_binding_sha256()),
+        "tofu_unverified_acknowledgement": (lifecycle.TOFU_UNVERIFIED_ACKNOWLEDGEMENT),
+    }
+    payload.update(overrides)
+    payload["authorization_sha256"] = lifecycle.build_authorization_seal(payload)
+    return payload
+
+
+def test_explicit_tofu_happy_path_has_exact_native_argv_and_receipt(
+    tmp_path: Path,
+) -> None:
+    known_hosts, receipt_path, receipt, runner = _enroll(tmp_path)
+    assert runner.calls == [
+        (
+            (
+                "/usr/bin/ssh-keyscan",
+                "-T",
+                "5",
+                "-t",
+                "ed25519",
+                "-p",
+                "57003",
+                "203.0.113.8",
+            ),
+            "enroll_tofu_host_key",
+            10,
+            None,
+        )
+    ]
+    assert "known_hosts" not in " ".join(runner.calls[0][0])
+    assert receipt.host_key_fingerprint_sha256.startswith("SHA256:")
+    assert receipt.observed_at == OBSERVED_AT
+    assert receipt_path.stat().st_mode & 0o777 == 0o600
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert payload["policy"] == "tofu_unverified"
+    assert payload["provider_identity_independently_authenticated"] is False
+    assert payload["identity_statement"] == lifecycle.TOFU_IDENTITY_STATEMENT
+    assert payload["tool"]["path"] == "/usr/bin/ssh-keyscan"
+    assert payload["tool"]["environment"] == lifecycle.SSH_KEYSCAN_ENVIRONMENT
+    assert hashlib.sha256(known_hosts.read_bytes()).hexdigest() == (
+        payload["known_hosts"]["content_sha256"]
+    )
+
+
+def test_tofu_subprocess_uses_only_fixed_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    protected = _protected_dir(tmp_path)
+    request, _known_hosts, _receipt = _request(protected)
+    observed: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed["argv"] = argv
+        observed.update(kwargs)
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(lifecycle.subprocess, "run", fake_run)
+    monkeypatch.setattr(lifecycle, "reject_credential_environment", lambda _env: None)
+    lifecycle.enroll_tofu_host_key(
+        request,
+        lifecycle.SubprocessCommandRunner(),
+        now_fn=lambda: OBSERVED_AT,
+    )
+    assert observed["argv"] == [
+        "/usr/bin/ssh-keyscan",
+        "-T",
+        "5",
+        "-t",
+        "ed25519",
+        "-p",
+        "57003",
+        "203.0.113.8",
+    ]
+    assert observed["env"] == lifecycle.SSH_KEYSCAN_ENVIRONMENT
+    assert observed.get("shell", False) is False
+    assert observed["timeout"] == 10
+    assert observed["check"] is False
+
+
+@pytest.mark.parametrize(
+    ("stdout", "stderr", "returncode", "timed_out", "expected"),
+    [
+        ("", "", 0, False, "truncated"),
+        ("\n", "", 0, False, "malformed"),
+        (
+            "[203.0.113.8]:57003 ssh-rsa AAAA\n",
+            "",
+            0,
+            False,
+            "algorithm",
+        ),
+        (
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n"
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n",
+            "",
+            0,
+            False,
+            "exactly one",
+        ),
+        (
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n"
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64(8)}\n",
+            "",
+            0,
+            False,
+            "exactly one",
+        ),
+        (
+            f"[203.0.113.9]:57003 ssh-ed25519 {_key_base64()}\n",
+            "",
+            0,
+            False,
+            "endpoint",
+        ),
+        (
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}",
+            "",
+            0,
+            False,
+            "truncated",
+        ),
+        ("malformed output\n", "", 0, False, "malformed"),
+        ("[203.0.113.8]:57003 ssh-ed25519 AAAA\n", "", 0, False, "truncated"),
+        (
+            f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n",
+            "unexpected warning\n",
+            0,
+            False,
+            "stderr",
+        ),
+        ("", "", 1, False, "nonzero"),
+        ("", "", -1, True, "timed out"),
+    ],
+)
+def test_tofu_refuses_ambiguous_or_invalid_keyscan_results(
+    tmp_path: Path,
+    stdout: str,
+    stderr: str,
+    returncode: int,
+    timed_out: bool,
+    expected: str,
+) -> None:
+    protected = _protected_dir(tmp_path)
+    request, known_hosts, receipt = _request(protected)
+    runner = FakeRunner(
+        lifecycle.CommandResult(
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=timed_out,
+        )
+    )
+    with pytest.raises(lifecycle.HostOrchestrationError, match=expected):
+        lifecycle.enroll_tofu_host_key(request, runner)
+    assert known_hosts.read_bytes() == b""
+    assert not receipt.exists()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ("nonempty", "fresh empty"),
+        ("symlink", "symlink"),
+        ("writable", "0600"),
+        ("unsafe-parent", "mode 0700"),
+    ],
+)
+def test_tofu_requires_fresh_protected_known_hosts(
+    tmp_path: Path, mutation: str, expected: str
+) -> None:
+    protected = _protected_dir(tmp_path)
+    request, known_hosts, _receipt = _request(protected)
+    if mutation == "nonempty":
+        known_hosts.write_text("existing", encoding="utf-8")
+    elif mutation == "symlink":
+        known_hosts.unlink()
+        target = protected / "target"
+        target.write_bytes(b"")
+        target.chmod(0o600)
+        known_hosts.symlink_to(target)
+    elif mutation == "writable":
+        known_hosts.chmod(0o666)
+    else:
+        protected.chmod(0o755)
+    with pytest.raises(lifecycle.HostOrchestrationError, match=expected):
+        lifecycle.enroll_tofu_host_key(request, _successful_runner())
+
+
+@pytest.mark.parametrize("host", ["example.com", "203.0.113.008", "2001:0db8::1"])
+def test_tofu_requires_canonical_direct_ip(tmp_path: Path, host: str) -> None:
+    protected = _protected_dir(tmp_path)
+    request, _known_hosts, _receipt = _request(protected, host=host)
+    with pytest.raises(lifecycle.HostOrchestrationError, match="IP literal|canonical"):
+        lifecycle.enroll_tofu_host_key(request, _successful_runner(host=host))
+
+
+@pytest.mark.parametrize("port", [0, 65536, True, "22"])
+def test_tofu_requires_valid_literal_port(tmp_path: Path, port: Any) -> None:
+    protected = _protected_dir(tmp_path)
+    request, _known_hosts, _receipt = _request(protected, port=port)
+    with pytest.raises(lifecycle.HostOrchestrationError, match="port"):
+        lifecycle.enroll_tofu_host_key(request, _successful_runner(port=22))
+
+
+def test_tofu_config_and_authorization_bind_every_trust_artifact(
+    tmp_path: Path,
+) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    config = lifecycle.ProtectedExecutionConfig.from_dict(
+        _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    )
+    authorization = lifecycle.RunAuthorization.from_dict(_authorization_payload(config))
+    runner = FakeRunner(lifecycle.CommandResult(0, "", ""))
+    orchestrator = lifecycle.RemoteOrchestrator(
+        config=config,
+        authorization=authorization,
+        runner=runner,
+        now_fn=lambda: OBSERVED_AT,
+    )
+    ssh = orchestrator.ssh_options.shared_options()
+    assert "StrictHostKeyChecking=yes" in ssh
+    assert "GlobalKnownHostsFile=/dev/null" in ssh
+    assert f"UserKnownHostsFile={known_hosts}" in ssh
+    assert (
+        orchestrator.ssh_options.public_record()["host_key_trust_policy"]
+        == "tofu_unverified"
+    )
+    assert (
+        orchestrator.ssh_options.public_record()[
+            "provider_identity_independently_authenticated"
+        ]
+        is False
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("host_key_ed25519_base64", _key_base64(8), "fingerprint"),
+        (
+            "host_key_fingerprint_sha256",
+            "SHA256:" + "A" * 43,
+            "fingerprint",
+        ),
+        ("known_hosts_sha256", "0" * 64, "known_hosts_sha256"),
+        ("tofu_enrollment_receipt_sha256", "0" * 64, "receipt digest"),
+        ("host_key_trust_policy", "provider_pinned", "schema 3"),
+        ("tofu_unverified_acknowledgement", "yes", "acknowledgement"),
+    ],
+)
+def test_tofu_config_tampering_refuses_before_ssh(
+    tmp_path: Path, field: str, value: str, expected: str
+) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    payload = _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    payload[field] = value
+    with pytest.raises(lifecycle.HostOrchestrationError, match=expected):
+        lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+
+def test_changed_known_hosts_or_receipt_refuses_before_ssh(tmp_path: Path) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    payload = _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    known_hosts.write_text(
+        f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64(9)}\n",
+        encoding="ascii",
+    )
+    with pytest.raises(lifecycle.HostOrchestrationError, match="known_hosts"):
+        lifecycle.ProtectedExecutionConfig.from_dict(payload)
+    known_hosts.write_text(
+        f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n",
+        encoding="ascii",
+    )
+    raw_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    raw_receipt["observed_at"] = "2031-01-01T00:00:00.000000Z"
+    receipt_path.write_text(json.dumps(raw_receipt), encoding="utf-8")
+    with pytest.raises(lifecycle.HostOrchestrationError, match="own content"):
+        lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+
+def test_policy_switch_and_authorization_mismatch_refuse_before_ssh(
+    tmp_path: Path,
+) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    config = lifecycle.ProtectedExecutionConfig.from_dict(
+        _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    )
+    payload = _authorization_payload(
+        config,
+        host_key_fingerprint_sha256="SHA256:" + "A" * 43,
+    )
+    authorization = lifecycle.RunAuthorization.from_dict(payload)
+    runner = FakeRunner(lifecycle.CommandResult(0, "", ""))
+    with pytest.raises(lifecycle.HostOrchestrationError, match="fingerprint"):
+        lifecycle.RemoteOrchestrator(
+            config=config, authorization=authorization, runner=runner
+        )
+    assert runner.calls == []
+
+
+def test_provider_pinned_schema_cannot_consume_tofu_receipt(tmp_path: Path) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    payload = _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    payload["schema_version"] = lifecycle.PROVIDER_PINNED_CONFIG_SCHEMA_VERSION
+    with pytest.raises(lifecycle.HostOrchestrationError, match="required set"):
+        lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+
+def test_provider_authorization_cannot_consume_tofu_fields(tmp_path: Path) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    config = lifecycle.ProtectedExecutionConfig.from_dict(
+        _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    )
+    payload = _authorization_payload(
+        config, schema_version=lifecycle.AUTHORIZATION_SCHEMA_VERSION
+    )
+    payload["authorization_sha256"] = lifecycle.build_authorization_seal(payload)
+    with pytest.raises(lifecycle.HostOrchestrationError, match="required set"):
+        lifecycle.RunAuthorization.from_dict(payload)
+
+
+def test_tofu_authorization_cannot_omit_receipt_binding(tmp_path: Path) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    config = lifecycle.ProtectedExecutionConfig.from_dict(
+        _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    )
+    payload = _authorization_payload(config)
+    del payload["tofu_enrollment_receipt_sha256"]
+    payload["authorization_sha256"] = lifecycle.build_authorization_seal(payload)
+    with pytest.raises(lifecycle.HostOrchestrationError, match="required set"):
+        lifecycle.RunAuthorization.from_dict(payload)

--- a/tests/deploy/test_vllm_kv_truth_tofu.py
+++ b/tests/deploy/test_vllm_kv_truth_tofu.py
@@ -95,8 +95,12 @@ def _successful_runner(
     return FakeRunner(
         lifecycle.CommandResult(
             returncode=0,
-            stdout=f"[{host}]:{port} ssh-ed25519 {key}\n",
-            stderr=f"# {host}:{port} SSH-2.0-test-server\n",
+            stdout=(
+                f"# {host}:{port} SSH-2.0-test-server\n"
+                f"{lifecycle.openssh_known_hosts_host_token(host, port)} "
+                f"ssh-ed25519 {key}\n"
+            ),
+            stderr="",
         )
     )
 
@@ -260,7 +264,10 @@ def test_tofu_subprocess_uses_only_fixed_environment(
         return subprocess.CompletedProcess(
             argv,
             0,
-            stdout=f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n",
+            stdout=(
+                "# 203.0.113.8:57003 SSH-2.0-test-server\n"
+                f"[203.0.113.8]:57003 ssh-ed25519 {_key_base64()}\n"
+            ),
             stderr="",
         )
 
@@ -396,6 +403,37 @@ def test_tofu_requires_fresh_protected_known_hosts(
         lifecycle.enroll_tofu_host_key(request, _successful_runner())
 
 
+@pytest.mark.parametrize("mutation", ["symlink-ancestor", "writable-ancestor"])
+def test_tofu_rejects_unsafe_higher_ancestry(tmp_path: Path, mutation: str) -> None:
+    protected = _protected_dir(tmp_path)
+    request, _unused_known_hosts, _unused_receipt = _request(protected)
+    if mutation == "symlink-ancestor":
+        actual = tmp_path / "actual"
+        actual.mkdir(mode=0o700)
+        leaf = actual / "leaf"
+        leaf.mkdir(mode=0o700)
+        ancestor = tmp_path / "ancestor-link"
+        ancestor.symlink_to(actual, target_is_directory=True)
+    else:
+        ancestor = tmp_path / "writable-ancestor"
+        ancestor.mkdir(mode=0o700)
+        ancestor.chmod(0o777)
+        leaf = ancestor / "leaf"
+        leaf.mkdir(mode=0o700)
+    known_hosts = ancestor / "leaf" / "known_hosts"
+    known_hosts.write_bytes(b"")
+    known_hosts.chmod(0o600)
+    raw = json.loads(request.read_text(encoding="utf-8"))
+    raw["known_hosts_path"] = str(known_hosts)
+    raw["receipt_path"] = str(ancestor / "leaf" / "receipt.json")
+    request.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(
+        lifecycle.HostOrchestrationError,
+        match="ancestry.*symlink|ancestry.*writable",
+    ):
+        lifecycle.enroll_tofu_host_key(request, _successful_runner())
+
+
 @pytest.mark.parametrize("host", ["example.com", "203.0.113.008", "2001:0db8::1"])
 def test_tofu_requires_canonical_direct_ip(tmp_path: Path, host: str) -> None:
     protected = _protected_dir(tmp_path)
@@ -410,6 +448,19 @@ def test_tofu_requires_valid_literal_port(tmp_path: Path, port: Any) -> None:
     request, _known_hosts, _receipt = _request(protected, port=port)
     with pytest.raises(lifecycle.HostOrchestrationError, match="port"):
         lifecycle.enroll_tofu_host_key(request, _successful_runner(port=22))
+
+
+def test_tofu_uses_native_default_port_known_hosts_token(tmp_path: Path) -> None:
+    protected = _protected_dir(tmp_path)
+    request, known_hosts, _receipt = _request(protected, port=22)
+    lifecycle.enroll_tofu_host_key(
+        request,
+        _successful_runner(port=22),
+        now_fn=lambda: OBSERVED_AT,
+    )
+    assert known_hosts.read_text(encoding="ascii") == (
+        f"203.0.113.8 ssh-ed25519 {_key_base64()}\n"
+    )
 
 
 def test_tofu_config_and_authorization_bind_every_trust_artifact(
@@ -486,6 +537,23 @@ def test_changed_known_hosts_or_receipt_refuses_before_ssh(tmp_path: Path) -> No
     raw_receipt["observed_at"] = "2031-01-01T00:00:00.000000Z"
     receipt_path.write_text(json.dumps(raw_receipt), encoding="utf-8")
     with pytest.raises(lifecycle.HostOrchestrationError, match="own content"):
+        lifecycle.ProtectedExecutionConfig.from_dict(payload)
+
+
+def test_tofu_config_rejects_private_key_with_symlinked_ancestor(
+    tmp_path: Path,
+) -> None:
+    known_hosts, receipt_path, receipt, _runner = _enroll(tmp_path)
+    payload = _config_payload(tmp_path, known_hosts, receipt_path, receipt)
+    actual = tmp_path / "actual-key-parent"
+    actual.mkdir(mode=0o700)
+    key = actual / "key"
+    key.write_text("private", encoding="utf-8")
+    key.chmod(0o600)
+    alias = tmp_path / "key-parent-alias"
+    alias.symlink_to(actual, target_is_directory=True)
+    payload["private_key_path"] = str(alias / "key")
+    with pytest.raises(lifecycle.HostOrchestrationError, match="ancestry.*symlink"):
         lifecycle.ProtectedExecutionConfig.from_dict(payload)
 
 

--- a/vllm_kv_truth/cli.py
+++ b/vllm_kv_truth/cli.py
@@ -19,6 +19,7 @@ from .lifecycle import (
     RemoteOrchestrator,
     RunAuthorization,
     SubprocessCommandRunner,
+    enroll_tofu_host_key,
     reject_credential_environment,
     verify_authorization_signature,
 )
@@ -57,6 +58,8 @@ def _build_bootstrap_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--execution-config", required=True, type=Path)
     run_parser.add_argument("--authorization", required=True, type=Path)
     run_parser.add_argument("--output-dir", required=True, type=Path)
+    enroll_parser = subparsers.add_parser("enroll-tofu")
+    enroll_parser.add_argument("--enrollment-request", required=True, type=Path)
     subparsers.add_parser("preflight")
     return parser
 
@@ -120,6 +123,14 @@ def _preflight_clean_environment() -> int:
     return 0
 
 
+def _enroll_tofu(args: argparse.Namespace) -> int:
+    _require_clean_parent_environment()
+    receipt = enroll_tofu_host_key(args.enrollment_request, SubprocessCommandRunner())
+    print(f"TOFU enrollment receipt SHA-256: {receipt.receipt_sha256}")
+    print("host identity: tofu_unverified (provider identity not authenticated)")
+    return 0
+
+
 def _verify_public_bundle(args: argparse.Namespace) -> int:
     bundle = evidence.verify_public_bundle_directory(args.bundle_dir)
     payload = bundle.to_dict()
@@ -156,6 +167,8 @@ def bootstrap_dispatch(argv: list[str]) -> int:
     try:
         if args.command == "preflight":
             return _preflight_clean_environment()
+        if args.command == "enroll-tofu":
+            return _enroll_tofu(args)
         return _run(args)
     except HostOrchestrationError as exc:
         print(f"{PROG}: error: {exc}", file=sys.stderr)

--- a/vllm_kv_truth/evidence.py
+++ b/vllm_kv_truth/evidence.py
@@ -610,6 +610,12 @@ _ALLOWED_KEY_NAMES_WITH_FORBIDDEN_FRAGMENTS = frozenset(
         "cache_salt_present",
         "kv_events_use_int_block_hashes",
         "strict_host_key_checking",
+        "host_key_trust_policy",
+        "host_key_trust_binding_sha256",
+        "host_identity_fields_redacted",
+        "independent_host_key_verification_supported",
+        "enrollment_mitm_resistance_supported",
+        "secure_provider_provenance_supported",
     }
 )
 

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -56,8 +56,11 @@ strings alone never establish runtime support.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import io
+import ipaddress
 import json
 import os
 import re
@@ -111,6 +114,7 @@ from .model_download import (
 
 MAX_CONFIG_ARTIFACT_BYTES = 64 * 1024
 MAX_AUTHORIZATION_ARTIFACT_BYTES = 64 * 1024
+MAX_TOFU_ARTIFACT_BYTES = 64 * 1024
 MAX_MANIFEST_ARTIFACT_BYTES = 4 * 1024 * 1024
 MAX_SOURCE_ARCHIVE_BYTES = 256 * 1024 * 1024
 
@@ -123,6 +127,7 @@ _SAFE_OPENSSH_LOCAL_PATH = re.compile(r"^/[A-Za-z0-9._/-]{1,4095}$")
 _SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SAFE_HOSTNAME_OR_IP = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.:-]{0,253}[A-Za-z0-9])?$")
 _SAFE_USER = re.compile(r"^[A-Za-z_][A-Za-z0-9._-]{0,31}$")
+_OPENSSH_SHA256_FINGERPRINT = re.compile(r"^SHA256:[A-Za-z0-9+/]{43}$")
 
 EXPECTED_GPU_COMPUTE_CAPABILITY = "8.9"
 MINIMUM_HOST_RAM_BYTES = 48_000_000_000
@@ -262,6 +267,74 @@ def _require_literal_openssh_path(value: str, *, label: str) -> Path:
     return path
 
 
+def _require_canonical_ip_literal(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise HostOrchestrationError(f"{field_name} must be an IP literal")
+    try:
+        parsed = ipaddress.ip_address(value)
+    except ValueError as exc:
+        raise HostOrchestrationError(
+            f"{field_name} must be an IP literal; DNS names are not allowed"
+        ) from exc
+    canonical = str(parsed)
+    if value != canonical:
+        raise HostOrchestrationError(
+            f"{field_name} must use the canonical IP literal spelling"
+        )
+    return canonical
+
+
+def _require_private_parent(path: Path, *, label: str) -> None:
+    parent = path.parent
+    try:
+        info = parent.lstat()
+    except OSError as exc:
+        raise HostOrchestrationError(
+            f"{label} parent directory could not be inspected: {exc}"
+        ) from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise HostOrchestrationError(f"{label} parent must be a non-symlink directory")
+    if info.st_uid != os.geteuid() or stat.S_IMODE(info.st_mode) != 0o700:
+        raise HostOrchestrationError(
+            f"{label} parent must be current-user-owned with mode 0700"
+        )
+
+
+def _decode_ed25519_public_key(key_base64: Any) -> bytes:
+    if not isinstance(key_base64, str) or not key_base64:
+        raise HostOrchestrationError("ED25519 public key must be non-empty base64")
+    try:
+        decoded = base64.b64decode(key_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HostOrchestrationError(
+            "ED25519 public key is not valid canonical base64"
+        ) from exc
+    if base64.b64encode(decoded).decode("ascii") != key_base64:
+        raise HostOrchestrationError("ED25519 public key is not valid canonical base64")
+    if len(decoded) < 4:
+        raise HostOrchestrationError("ED25519 public key is truncated")
+    algorithm_length = int.from_bytes(decoded[:4], "big")
+    algorithm_end = 4 + algorithm_length
+    if decoded[4:algorithm_end] != b"ssh-ed25519":
+        raise HostOrchestrationError(
+            "ED25519 public key blob does not identify ssh-ed25519"
+        )
+    if len(decoded) < algorithm_end + 4:
+        raise HostOrchestrationError("ED25519 public key is truncated")
+    key_length = int.from_bytes(decoded[algorithm_end : algorithm_end + 4], "big")
+    key = decoded[algorithm_end + 4 :]
+    if key_length != 32 or len(key) != 32:
+        raise HostOrchestrationError(
+            "ED25519 public key blob must contain exactly 32 key bytes"
+        )
+    return decoded
+
+
+def openssh_sha256_fingerprint(key_blob: bytes) -> str:
+    encoded = base64.b64encode(hashlib.sha256(key_blob).digest())
+    return "SHA256:" + encoded.rstrip(b"=").decode("ascii")
+
+
 def _require_private_key_permissions(path: Path, *, label: str) -> Path:
     """Require exactly ``0600`` (owner read/write only, no group/other bits)."""
 
@@ -269,7 +342,7 @@ def _require_private_key_permissions(path: Path, *, label: str) -> Path:
     mode = stat.S_IMODE(path.lstat().st_mode)
     if mode != 0o600:
         raise HostOrchestrationError(
-            f"{label} must be mode 0600 (owner read/write only); found " f"{oct(mode)}"
+            f"{label} must be mode 0600 (owner read/write only); found {oct(mode)}"
         )
     return path
 
@@ -281,8 +354,7 @@ def _require_not_group_or_world_readable(path: Path, *, label: str) -> Path:
     mode = stat.S_IMODE(path.lstat().st_mode)
     if mode & 0o077:
         raise HostOrchestrationError(
-            f"{label} must not be group- or world-readable/writable; found "
-            f"{oct(mode)}"
+            f"{label} must not be group- or world-readable/writable; found {oct(mode)}"
         )
     return path
 
@@ -313,11 +385,298 @@ def _require_pattern(value: Any, pattern: re.Pattern[str], *, field_name: str) -
 
 
 # ---------------------------------------------------------------------------
-# Protected execution config: the only place host/user/key/known-hosts and
-# remote-path facts may be read from, and never as individual CLI arguments.
+# Host-key trust enrollment and protected execution config.
 # ---------------------------------------------------------------------------
 
-_CONFIG_REQUIRED_KEYS = frozenset(
+PROVIDER_PINNED_CONFIG_SCHEMA_VERSION = "2"
+TOFU_CONFIG_SCHEMA_VERSION = "3"
+PROTECTED_CONFIG_SCHEMA_VERSION = PROVIDER_PINNED_CONFIG_SCHEMA_VERSION
+TOFU_ENROLLMENT_REQUEST_SCHEMA_VERSION = "1"
+TOFU_ENROLLMENT_RECEIPT_SCHEMA_VERSION = "1"
+TOFU_UNVERIFIED_ACKNOWLEDGEMENT = (
+    "I understand that provider identity was not independently authenticated "
+    "and that TOFU enrollment does not resist an active MITM."
+)
+TOFU_IDENTITY_STATEMENT = (
+    "Provider identity was not independently authenticated; this key was "
+    "observed unauthenticated from the preregistered endpoint."
+)
+SSH_KEYSCAN_PATH = "/usr/bin/ssh-keyscan"
+SSH_KEYSCAN_CONNECT_TIMEOUT_SECONDS = 5
+SSH_KEYSCAN_PROCESS_TIMEOUT_SECONDS = 10
+SSH_KEYSCAN_ENVIRONMENT = {
+    "PATH": "/usr/bin:/bin:/usr/local/bin",
+    "LANG": "C",
+    "LC_ALL": "C",
+}
+
+
+class HostKeyTrustPolicy(str, Enum):
+    PROVIDER_PINNED = "provider_pinned"
+    TOFU_UNVERIFIED = "tofu_unverified"
+
+    @classmethod
+    def parse(cls, value: Any) -> HostKeyTrustPolicy:
+        if not isinstance(value, str):
+            raise HostOrchestrationError("host_key_trust_policy must be a string")
+        try:
+            return cls(value)
+        except ValueError as exc:
+            raise HostOrchestrationError(
+                "host_key_trust_policy must be 'provider_pinned' or 'tofu_unverified'"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class TofuEnrollmentRequest:
+    host: str = field(repr=False)
+    port: int = field(repr=False)
+    known_hosts_path: Path = field(repr=False)
+    receipt_path: Path = field(repr=False)
+
+    @classmethod
+    def read(cls, path: Path) -> TofuEnrollmentRequest:
+        _require_private_parent(path, label="TOFU enrollment request")
+        _require_not_group_or_world_readable(path, label="TOFU enrollment request")
+        try:
+            raw = json.loads(
+                read_bounded_regular_text(path, MAX_TOFU_ARTIFACT_BYTES),
+                parse_constant=reject_non_finite_json_constant,
+            )
+        except (OSError, ArtifactReadError, ValueError, RecursionError) as exc:
+            raise HostOrchestrationError(
+                f"TOFU enrollment request could not be read safely: {exc}"
+            ) from exc
+        required = {
+            "schema_version",
+            "host_key_trust_policy",
+            "tofu_unverified_acknowledgement",
+            "host",
+            "port",
+            "known_hosts_path",
+            "receipt_path",
+        }
+        if not isinstance(raw, dict) or set(raw) != required:
+            raise HostOrchestrationError(
+                "TOFU enrollment request keys differ from the required set"
+            )
+        if raw["schema_version"] != TOFU_ENROLLMENT_REQUEST_SCHEMA_VERSION:
+            raise HostOrchestrationError(
+                "TOFU enrollment request schema_version is unsupported"
+            )
+        if (
+            HostKeyTrustPolicy.parse(raw["host_key_trust_policy"])
+            is not HostKeyTrustPolicy.TOFU_UNVERIFIED
+        ):
+            raise HostOrchestrationError(
+                "TOFU enrollment request must explicitly select tofu_unverified"
+            )
+        if raw["tofu_unverified_acknowledgement"] != TOFU_UNVERIFIED_ACKNOWLEDGEMENT:
+            raise HostOrchestrationError(
+                "TOFU enrollment request lacks the exact unverified acknowledgement"
+            )
+        host = _require_canonical_ip_literal(raw["host"], field_name="host")
+        port = raw["port"]
+        if (
+            not isinstance(port, int)
+            or isinstance(port, bool)
+            or not 1 <= port <= 65535
+        ):
+            raise HostOrchestrationError("port must be an integer from 1 through 65535")
+        known_hosts_path = _require_literal_openssh_path(
+            _require_nonempty_str(raw["known_hosts_path"], "known_hosts_path"),
+            label="known_hosts_path",
+        )
+        receipt_path = _require_unambiguous_absolute_local_path(
+            _require_nonempty_str(raw["receipt_path"], "receipt_path"),
+            label="receipt_path",
+        )
+        if known_hosts_path == receipt_path:
+            raise HostOrchestrationError(
+                "known_hosts_path and receipt_path must be different"
+            )
+        _require_private_parent(known_hosts_path, label="known_hosts_path")
+        _require_private_parent(receipt_path, label="receipt_path")
+        _require_private_key_permissions(known_hosts_path, label="known_hosts_path")
+        try:
+            if known_hosts_path.stat().st_size != 0:
+                raise HostOrchestrationError(
+                    "known_hosts_path must be a fresh empty file"
+                )
+        except OSError as exc:
+            raise HostOrchestrationError(
+                f"known_hosts_path could not be inspected: {exc}"
+            ) from exc
+        if receipt_path.exists() or receipt_path.is_symlink():
+            raise HostOrchestrationError(
+                "receipt_path must not already exist or be a symlink"
+            )
+        return cls(
+            host=host,
+            port=port,
+            known_hosts_path=known_hosts_path,
+            receipt_path=receipt_path,
+        )
+
+
+@dataclass(frozen=True)
+class TofuEnrollmentReceipt:
+    host: str = field(repr=False)
+    port: int = field(repr=False)
+    host_key_ed25519_base64: str = field(repr=False)
+    host_key_fingerprint_sha256: str
+    observed_at: datetime
+    known_hosts_path: Path = field(repr=False)
+    known_hosts_sha256: str
+    receipt_sha256: str
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> TofuEnrollmentReceipt:
+        required = {
+            "schema_version",
+            "policy",
+            "provider_identity_independently_authenticated",
+            "identity_statement",
+            "endpoint",
+            "host_key",
+            "observed_at",
+            "tool",
+            "known_hosts",
+            "receipt_sha256",
+        }
+        if not isinstance(raw, dict) or set(raw) != required:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt keys differ from the required set"
+            )
+        if raw["schema_version"] != TOFU_ENROLLMENT_RECEIPT_SCHEMA_VERSION:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt schema_version is unsupported"
+            )
+        if raw["policy"] != HostKeyTrustPolicy.TOFU_UNVERIFIED.value:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt policy must be tofu_unverified"
+            )
+        if raw["provider_identity_independently_authenticated"] is not False:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt must deny independent provider identity"
+            )
+        if raw["identity_statement"] != TOFU_IDENTITY_STATEMENT:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt identity statement is invalid"
+            )
+        endpoint = raw["endpoint"]
+        if not isinstance(endpoint, dict) or set(endpoint) != {"host", "port"}:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt endpoint is malformed"
+            )
+        host = _require_canonical_ip_literal(
+            endpoint["host"], field_name="endpoint.host"
+        )
+        port = endpoint["port"]
+        if (
+            not isinstance(port, int)
+            or isinstance(port, bool)
+            or not 1 <= port <= 65535
+        ):
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt endpoint port is invalid"
+            )
+        host_key = raw["host_key"]
+        if not isinstance(host_key, dict) or set(host_key) != {
+            "algorithm",
+            "base64",
+            "fingerprint_sha256",
+        }:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt host key is malformed"
+            )
+        if host_key["algorithm"] != "ssh-ed25519":
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt host key must be ssh-ed25519"
+            )
+        key_blob = _decode_ed25519_public_key(host_key["base64"])
+        fingerprint = openssh_sha256_fingerprint(key_blob)
+        if (
+            _OPENSSH_SHA256_FINGERPRINT.fullmatch(str(host_key["fingerprint_sha256"]))
+            is None
+            or host_key["fingerprint_sha256"] != fingerprint
+        ):
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt fingerprint does not match its key"
+            )
+        observed_at = _parse_utc(raw["observed_at"], field_name="observed_at")
+        tool = raw["tool"]
+        expected_argv = [
+            SSH_KEYSCAN_PATH,
+            "-T",
+            str(SSH_KEYSCAN_CONNECT_TIMEOUT_SECONDS),
+            "-t",
+            "ed25519",
+            "-p",
+            str(port),
+            host,
+        ]
+        if tool != {
+            "path": SSH_KEYSCAN_PATH,
+            "argv": expected_argv,
+            "environment": SSH_KEYSCAN_ENVIRONMENT,
+            "process_timeout_seconds": SSH_KEYSCAN_PROCESS_TIMEOUT_SECONDS,
+        }:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt tool provenance is invalid"
+            )
+        known_hosts = raw["known_hosts"]
+        if not isinstance(known_hosts, dict) or set(known_hosts) != {
+            "path",
+            "content_sha256",
+        }:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt known_hosts binding is malformed"
+            )
+        known_hosts_path = _require_literal_openssh_path(
+            _require_nonempty_str(known_hosts["path"], "known_hosts.path"),
+            label="known_hosts.path",
+        )
+        known_hosts_sha256 = _require_pattern(
+            known_hosts["content_sha256"],
+            _SHA256_HEX,
+            field_name="known_hosts.content_sha256",
+        )
+        unsealed = {key: value for key, value in raw.items() if key != "receipt_sha256"}
+        receipt_sha256 = _require_pattern(
+            raw["receipt_sha256"], _SHA256_HEX, field_name="receipt_sha256"
+        )
+        if sha256_json(unsealed) != receipt_sha256:
+            raise HostOrchestrationError(
+                "TOFU enrollment receipt does not verify against its own content"
+            )
+        return cls(
+            host=host,
+            port=port,
+            host_key_ed25519_base64=host_key["base64"],
+            host_key_fingerprint_sha256=fingerprint,
+            observed_at=observed_at,
+            known_hosts_path=known_hosts_path,
+            known_hosts_sha256=known_hosts_sha256,
+            receipt_sha256=receipt_sha256,
+        )
+
+    @classmethod
+    def read(cls, path: Path) -> TofuEnrollmentReceipt:
+        _require_not_group_or_world_readable(path, label="TOFU enrollment receipt")
+        try:
+            raw = json.loads(
+                read_bounded_regular_text(path, MAX_TOFU_ARTIFACT_BYTES),
+                parse_constant=reject_non_finite_json_constant,
+            )
+        except (OSError, ArtifactReadError, ValueError, RecursionError) as exc:
+            raise HostOrchestrationError(
+                f"TOFU enrollment receipt could not be read safely: {exc}"
+            ) from exc
+        return cls.from_dict(raw)
+
+
+_PROVIDER_PINNED_CONFIG_REQUIRED_KEYS = frozenset(
     {
         "schema_version",
         "host",
@@ -333,7 +692,18 @@ _CONFIG_REQUIRED_KEYS = frozenset(
     }
 )
 
-PROTECTED_CONFIG_SCHEMA_VERSION = "2"
+_TOFU_CONFIG_REQUIRED_KEYS = frozenset(
+    {
+        *_PROVIDER_PINNED_CONFIG_REQUIRED_KEYS,
+        "host_key_trust_policy",
+        "host_key_ed25519_base64",
+        "host_key_fingerprint_sha256",
+        "known_hosts_sha256",
+        "tofu_enrollment_receipt_path",
+        "tofu_enrollment_receipt_sha256",
+        "tofu_unverified_acknowledgement",
+    }
+)
 
 
 class DockerExecutionMode(str, Enum):
@@ -378,6 +748,7 @@ class ProtectedExecutionConfig:
     host: str = field(repr=False)
     port: int = field(repr=False)
     user: str = field(repr=False)
+    host_key_trust_policy: HostKeyTrustPolicy
     docker_execution_mode: DockerExecutionMode
     private_key_path: Path = field(repr=False)
     known_hosts_path: Path = field(repr=False)
@@ -385,6 +756,11 @@ class ProtectedExecutionConfig:
     authorized_key_marker: str = field(repr=False)
     local_evidence_dir: Path = field(repr=False)
     local_runner_archive: Path = field(repr=False)
+    host_key_ed25519_base64: str | None = field(default=None, repr=False)
+    host_key_fingerprint_sha256: str | None = field(default=None, repr=False)
+    known_hosts_sha256: str | None = field(default=None, repr=False)
+    tofu_enrollment_receipt_path: Path | None = field(default=None, repr=False)
+    tofu_enrollment_receipt_sha256: str | None = field(default=None, repr=False)
 
     @classmethod
     def load(cls, path: Path) -> ProtectedExecutionConfig:
@@ -408,9 +784,19 @@ class ProtectedExecutionConfig:
             ) from exc
         if not isinstance(payload, dict):
             raise HostOrchestrationError("protected execution config must be an object")
-        if set(payload) != _CONFIG_REQUIRED_KEYS:
-            missing = sorted(_CONFIG_REQUIRED_KEYS - set(payload))
-            extra = sorted(set(payload) - _CONFIG_REQUIRED_KEYS)
+        schema_version = payload.get("schema_version")
+        required_keys = (
+            _PROVIDER_PINNED_CONFIG_REQUIRED_KEYS
+            if schema_version == PROVIDER_PINNED_CONFIG_SCHEMA_VERSION
+            else (
+                _TOFU_CONFIG_REQUIRED_KEYS
+                if schema_version == TOFU_CONFIG_SCHEMA_VERSION
+                else frozenset()
+            )
+        )
+        if not required_keys or set(payload) != required_keys:
+            missing = sorted(required_keys - set(payload))
+            extra = sorted(set(payload) - required_keys)
             raise HostOrchestrationError(
                 "protected execution config keys differ from the required set "
                 f"(missing={missing}, extra={extra})"
@@ -419,13 +805,27 @@ class ProtectedExecutionConfig:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> ProtectedExecutionConfig:
-        if set(payload) != _CONFIG_REQUIRED_KEYS:
-            raise HostOrchestrationError(
-                "protected execution config keys differ from the required set"
+        schema_version = payload.get("schema_version")
+        if schema_version == PROVIDER_PINNED_CONFIG_SCHEMA_VERSION:
+            required_keys = _PROVIDER_PINNED_CONFIG_REQUIRED_KEYS
+            host_key_trust_policy = HostKeyTrustPolicy.PROVIDER_PINNED
+        elif schema_version == TOFU_CONFIG_SCHEMA_VERSION:
+            required_keys = _TOFU_CONFIG_REQUIRED_KEYS
+            host_key_trust_policy = HostKeyTrustPolicy.parse(
+                payload.get("host_key_trust_policy")
             )
-        if payload["schema_version"] != PROTECTED_CONFIG_SCHEMA_VERSION:
+            if host_key_trust_policy is not HostKeyTrustPolicy.TOFU_UNVERIFIED:
+                raise HostOrchestrationError(
+                    "protected execution config schema 3 is reserved for explicit "
+                    "tofu_unverified enrollment"
+                )
+        else:
             raise HostOrchestrationError(
                 "protected execution config schema_version is unsupported"
+            )
+        if set(payload) != required_keys:
+            raise HostOrchestrationError(
+                "protected execution config keys differ from the required set"
             )
         host = payload["host"]
         user = payload["user"]
@@ -475,10 +875,95 @@ class ProtectedExecutionConfig:
             )
         if local_evidence_dir.exists() and local_evidence_dir.is_symlink():
             raise HostOrchestrationError("local_evidence_dir must not be a symlink")
+
+        host_key_ed25519_base64: str | None = None
+        host_key_fingerprint_sha256: str | None = None
+        known_hosts_sha256: str | None = None
+        tofu_enrollment_receipt_path: Path | None = None
+        tofu_enrollment_receipt_sha256: str | None = None
+        if host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            if (
+                payload["tofu_unverified_acknowledgement"]
+                != TOFU_UNVERIFIED_ACKNOWLEDGEMENT
+            ):
+                raise HostOrchestrationError(
+                    "protected execution config lacks the exact TOFU unverified "
+                    "acknowledgement"
+                )
+            host = _require_canonical_ip_literal(host, field_name="host")
+            key_blob = _decode_ed25519_public_key(payload["host_key_ed25519_base64"])
+            host_key_ed25519_base64 = payload["host_key_ed25519_base64"]
+            host_key_fingerprint_sha256 = _require_pattern(
+                payload["host_key_fingerprint_sha256"],
+                _OPENSSH_SHA256_FINGERPRINT,
+                field_name="host_key_fingerprint_sha256",
+            )
+            if host_key_fingerprint_sha256 != openssh_sha256_fingerprint(key_blob):
+                raise HostOrchestrationError(
+                    "host_key_fingerprint_sha256 does not match the ED25519 key"
+                )
+            known_hosts_sha256 = _require_pattern(
+                payload["known_hosts_sha256"],
+                _SHA256_HEX,
+                field_name="known_hosts_sha256",
+            )
+            tofu_enrollment_receipt_path = _require_unambiguous_absolute_local_path(
+                _require_nonempty_str(
+                    payload["tofu_enrollment_receipt_path"],
+                    "tofu_enrollment_receipt_path",
+                ),
+                label="tofu_enrollment_receipt_path",
+            )
+            _require_private_parent(known_hosts_path, label="known_hosts_path")
+            _require_private_parent(
+                tofu_enrollment_receipt_path,
+                label="tofu_enrollment_receipt_path",
+            )
+            tofu_enrollment_receipt_sha256 = _require_pattern(
+                payload["tofu_enrollment_receipt_sha256"],
+                _SHA256_HEX,
+                field_name="tofu_enrollment_receipt_sha256",
+            )
+            receipt = TofuEnrollmentReceipt.read(tofu_enrollment_receipt_path)
+            expected_known_hosts = (
+                f"[{host}]:{port} ssh-ed25519 {host_key_ed25519_base64}\n"
+            ).encode("ascii")
+            try:
+                actual_known_hosts = read_bounded_regular_bytes(
+                    known_hosts_path, MAX_TOFU_ARTIFACT_BYTES
+                )
+            except (OSError, ArtifactReadError) as exc:
+                raise HostOrchestrationError(
+                    f"known_hosts_path could not be read safely: {exc}"
+                ) from exc
+            actual_known_hosts_sha256 = hashlib.sha256(actual_known_hosts).hexdigest()
+            mismatches = []
+            if actual_known_hosts != expected_known_hosts:
+                mismatches.append("known_hosts content")
+            if actual_known_hosts_sha256 != known_hosts_sha256:
+                mismatches.append("known_hosts_sha256")
+            if receipt.host != host or receipt.port != port:
+                mismatches.append("endpoint")
+            if receipt.known_hosts_path != known_hosts_path:
+                mismatches.append("known_hosts path")
+            if receipt.host_key_ed25519_base64 != host_key_ed25519_base64:
+                mismatches.append("ED25519 key")
+            if receipt.host_key_fingerprint_sha256 != host_key_fingerprint_sha256:
+                mismatches.append("fingerprint")
+            if receipt.known_hosts_sha256 != known_hosts_sha256:
+                mismatches.append("receipt known_hosts digest")
+            if receipt.receipt_sha256 != tofu_enrollment_receipt_sha256:
+                mismatches.append("receipt digest")
+            if mismatches:
+                raise HostOrchestrationError(
+                    "TOFU enrollment bindings do not match the protected config: "
+                    + ", ".join(mismatches)
+                )
         return cls(
             host=host,
             port=port,
             user=user,
+            host_key_trust_policy=host_key_trust_policy,
             docker_execution_mode=docker_execution_mode,
             private_key_path=private_key_path,
             known_hosts_path=known_hosts_path,
@@ -486,19 +971,60 @@ class ProtectedExecutionConfig:
             authorized_key_marker=authorized_key_marker,
             local_evidence_dir=local_evidence_dir,
             local_runner_archive=local_runner_archive,
+            host_key_ed25519_base64=host_key_ed25519_base64,
+            host_key_fingerprint_sha256=host_key_fingerprint_sha256,
+            known_hosts_sha256=known_hosts_sha256,
+            tofu_enrollment_receipt_path=tofu_enrollment_receipt_path,
+            tofu_enrollment_receipt_sha256=tofu_enrollment_receipt_sha256,
         )
 
     def public_record(self) -> dict[str, Any]:
         """Publication/evidence-safe view: no host/user/key/known-hosts/paths."""
 
-        return {
-            "schema_version": PROTECTED_CONFIG_SCHEMA_VERSION,
+        record: dict[str, Any] = {
+            "schema_version": (
+                TOFU_CONFIG_SCHEMA_VERSION
+                if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED
+                else PROVIDER_PINNED_CONFIG_SCHEMA_VERSION
+            ),
             "source": "protected_execution_config",
             "docker_execution_mode": self.docker_execution_mode.value,
             "docker_execution_config_sha256": docker_execution_config_sha256(
                 self.docker_execution_mode
             ),
         }
+        if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            record.update(
+                {
+                    "host_key_trust_policy": self.host_key_trust_policy.value,
+                    "provider_identity_independently_authenticated": False,
+                    "tofu_enrollment_receipt_sha256": (
+                        self.tofu_enrollment_receipt_sha256
+                    ),
+                }
+            )
+        return record
+
+    def host_key_trust_binding_sha256(self) -> str:
+        if self.host_key_trust_policy is HostKeyTrustPolicy.PROVIDER_PINNED:
+            return sha256_json(
+                {"host_key_trust_policy": HostKeyTrustPolicy.PROVIDER_PINNED.value}
+            )
+        assert self.host_key_ed25519_base64 is not None
+        assert self.host_key_fingerprint_sha256 is not None
+        assert self.known_hosts_sha256 is not None
+        assert self.tofu_enrollment_receipt_sha256 is not None
+        return sha256_json(
+            {
+                "host_key_trust_policy": self.host_key_trust_policy.value,
+                "endpoint": {"host": self.host, "port": self.port},
+                "host_key_ed25519_base64": self.host_key_ed25519_base64,
+                "host_key_fingerprint_sha256": self.host_key_fingerprint_sha256,
+                "known_hosts_sha256": self.known_hosts_sha256,
+                "tofu_enrollment_receipt_sha256": (self.tofu_enrollment_receipt_sha256),
+                "tofu_unverified_acknowledgement": TOFU_UNVERIFIED_ACKNOWLEDGEMENT,
+            }
+        )
 
 
 def _require_nonempty_str(value: Any, field_name: str) -> str:
@@ -641,8 +1167,10 @@ def list_rate_cost_usd(elapsed_minutes: Decimal, rate_usd_per_hour: Decimal) -> 
 # ---------------------------------------------------------------------------
 
 AUTHORIZATION_SCHEMA_VERSION = "3"
+TOFU_AUTHORIZATION_SCHEMA_VERSION = "4"
 AUTHORIZATION_SIGNER_IDENTITY = "vllm-kv-truth-coordinator"
 AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v3"
+TOFU_AUTHORIZATION_SIGNATURE_NAMESPACE = "llmtracefx-vllm-kv-truth-authorization-v4"
 
 _AUTHORIZATION_REQUIRED_KEYS = frozenset(
     {
@@ -681,6 +1209,18 @@ _AUTHORIZATION_REQUIRED_KEYS = frozenset(
 )
 _AUTHORIZATION_OPTIONAL_SIGNATURE_KEYS = frozenset(
     {"signature_path", "authorized_signers_path"}
+)
+_TOFU_AUTHORIZATION_REQUIRED_KEYS = frozenset(
+    {
+        *_AUTHORIZATION_REQUIRED_KEYS,
+        "host_key_trust_policy",
+        "host_key_ed25519_sha256",
+        "host_key_fingerprint_sha256",
+        "known_hosts_sha256",
+        "tofu_enrollment_receipt_sha256",
+        "host_key_trust_binding_sha256",
+        "tofu_unverified_acknowledgement",
+    }
 )
 
 
@@ -725,6 +1265,12 @@ class RunAuthorization:
     authorization_expiry: datetime
     nonce: str
     authorization_sha256: str
+    host_key_trust_policy: HostKeyTrustPolicy = HostKeyTrustPolicy.PROVIDER_PINNED
+    host_key_ed25519_sha256: str | None = field(default=None, repr=False)
+    host_key_fingerprint_sha256: str | None = field(default=None, repr=False)
+    known_hosts_sha256: str | None = field(default=None, repr=False)
+    tofu_enrollment_receipt_sha256: str | None = field(default=None, repr=False)
+    host_key_trust_binding_sha256: str | None = field(default=None, repr=False)
     signature_path: Path | None = field(default=None, repr=False)
     authorized_signers_path: Path | None = field(default=None, repr=False)
 
@@ -742,8 +1288,12 @@ class RunAuthorization:
         return self.authorized_at <= now <= self.authorization_expiry
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "schema_version": AUTHORIZATION_SCHEMA_VERSION,
+        payload = {
+            "schema_version": (
+                TOFU_AUTHORIZATION_SCHEMA_VERSION
+                if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED
+                else AUTHORIZATION_SCHEMA_VERSION
+            ),
             "protocol_id": PROTOCOL_ID,
             "repository_head": self.repository_head,
             "base_image_reference": BASE_IMAGE_REFERENCE,
@@ -775,6 +1325,25 @@ class RunAuthorization:
             "nonce": self.nonce,
             "authorization_sha256": self.authorization_sha256,
         }
+        if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            payload.update(
+                {
+                    "host_key_trust_policy": self.host_key_trust_policy.value,
+                    "host_key_ed25519_sha256": self.host_key_ed25519_sha256,
+                    "host_key_fingerprint_sha256": (self.host_key_fingerprint_sha256),
+                    "known_hosts_sha256": self.known_hosts_sha256,
+                    "tofu_enrollment_receipt_sha256": (
+                        self.tofu_enrollment_receipt_sha256
+                    ),
+                    "host_key_trust_binding_sha256": (
+                        self.host_key_trust_binding_sha256
+                    ),
+                    "tofu_unverified_acknowledgement": (
+                        TOFU_UNVERIFIED_ACKNOWLEDGEMENT
+                    ),
+                }
+            )
+        return payload
 
     @classmethod
     def from_dict(
@@ -782,12 +1351,31 @@ class RunAuthorization:
     ) -> RunAuthorization:
         if not isinstance(data, dict):
             raise HostOrchestrationError("authorization must be a JSON object")
+        schema_version = data.get("schema_version")
+        if schema_version == AUTHORIZATION_SCHEMA_VERSION:
+            required_keys = _AUTHORIZATION_REQUIRED_KEYS
+            host_key_trust_policy = HostKeyTrustPolicy.PROVIDER_PINNED
+        elif schema_version == TOFU_AUTHORIZATION_SCHEMA_VERSION:
+            required_keys = _TOFU_AUTHORIZATION_REQUIRED_KEYS
+            host_key_trust_policy = HostKeyTrustPolicy.parse(
+                data.get("host_key_trust_policy")
+            )
+            if host_key_trust_policy is not HostKeyTrustPolicy.TOFU_UNVERIFIED:
+                raise HostOrchestrationError(
+                    "authorization schema 4 is reserved for explicit "
+                    "tofu_unverified enrollment"
+                )
+        else:
+            raise HostOrchestrationError(
+                "authorization 'schema_version' does not match the approved "
+                "protocol envelope"
+            )
         observed_keys = set(data)
-        if observed_keys != _AUTHORIZATION_REQUIRED_KEYS:
-            signed_extra = observed_keys - _AUTHORIZATION_REQUIRED_KEYS
+        if observed_keys != required_keys:
+            signed_extra = observed_keys - required_keys
             if signed_extra and (
                 signed_extra != _AUTHORIZATION_OPTIONAL_SIGNATURE_KEYS
-                or observed_keys - signed_extra != _AUTHORIZATION_REQUIRED_KEYS
+                or observed_keys - signed_extra != required_keys
             ):
                 raise HostOrchestrationError(
                     "authorization keys differ from the required set "
@@ -799,7 +1387,7 @@ class RunAuthorization:
                 )
 
         fixed = {
-            "schema_version": AUTHORIZATION_SCHEMA_VERSION,
+            "schema_version": schema_version,
             "protocol_id": PROTOCOL_ID,
             "base_image_reference": BASE_IMAGE_REFERENCE,
             "vllm_version": REQUIRED_VLLM_VERSION,
@@ -864,7 +1452,7 @@ class RunAuthorization:
         )
         if docker_execution_config_digest != expected_docker_execution_config_digest:
             raise HostOrchestrationError(
-                "docker_execution_config_sha256 does not match " "docker_execution_mode"
+                "docker_execution_config_sha256 does not match docker_execution_mode"
             )
         rate_usd_per_hour = _canonical_decimal(
             data["rate_usd_per_hour"], field_name="rate_usd_per_hour"
@@ -926,6 +1514,45 @@ class RunAuthorization:
             )
         nonce = _require_pattern(data["nonce"], _NONCE_HEX, field_name="nonce")
 
+        host_key_ed25519_sha256: str | None = None
+        host_key_fingerprint_sha256: str | None = None
+        known_hosts_sha256: str | None = None
+        tofu_enrollment_receipt_sha256: str | None = None
+        host_key_trust_binding_sha256: str | None = None
+        if host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            if (
+                data["tofu_unverified_acknowledgement"]
+                != TOFU_UNVERIFIED_ACKNOWLEDGEMENT
+            ):
+                raise HostOrchestrationError(
+                    "authorization lacks the exact TOFU unverified acknowledgement"
+                )
+            host_key_ed25519_sha256 = _require_pattern(
+                data["host_key_ed25519_sha256"],
+                _SHA256_HEX,
+                field_name="host_key_ed25519_sha256",
+            )
+            host_key_fingerprint_sha256 = _require_pattern(
+                data["host_key_fingerprint_sha256"],
+                _OPENSSH_SHA256_FINGERPRINT,
+                field_name="host_key_fingerprint_sha256",
+            )
+            known_hosts_sha256 = _require_pattern(
+                data["known_hosts_sha256"],
+                _SHA256_HEX,
+                field_name="known_hosts_sha256",
+            )
+            tofu_enrollment_receipt_sha256 = _require_pattern(
+                data["tofu_enrollment_receipt_sha256"],
+                _SHA256_HEX,
+                field_name="tofu_enrollment_receipt_sha256",
+            )
+            host_key_trust_binding_sha256 = _require_pattern(
+                data["host_key_trust_binding_sha256"],
+                _SHA256_HEX,
+                field_name="host_key_trust_binding_sha256",
+            )
+
         expected_seal = sha256_json(
             {
                 k: v
@@ -969,6 +1596,12 @@ class RunAuthorization:
             authorization_expiry=authorization_expiry,
             nonce=nonce,
             authorization_sha256=data["authorization_sha256"],
+            host_key_trust_policy=host_key_trust_policy,
+            host_key_ed25519_sha256=host_key_ed25519_sha256,
+            host_key_fingerprint_sha256=host_key_fingerprint_sha256,
+            known_hosts_sha256=known_hosts_sha256,
+            tofu_enrollment_receipt_sha256=tofu_enrollment_receipt_sha256,
+            host_key_trust_binding_sha256=host_key_trust_binding_sha256,
             signature_path=signature_path,
             authorized_signers_path=authorized_signers_path,
         )
@@ -988,7 +1621,22 @@ class RunAuthorization:
         """Publication-safe view: every field here is already a digest,
         commitment, timestamp, or non-sensitive identity value."""
 
-        return self.to_dict()
+        payload = self.to_dict()
+        if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            for key in (
+                "host_key_ed25519_sha256",
+                "host_key_fingerprint_sha256",
+                "known_hosts_sha256",
+            ):
+                del payload[key]
+            payload["host_identity_fields_redacted"] = True
+        return payload
+
+    @property
+    def signature_namespace(self) -> str:
+        if self.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            return TOFU_AUTHORIZATION_SIGNATURE_NAMESPACE
+        return AUTHORIZATION_SIGNATURE_NAMESPACE
 
 
 def build_authorization_seal(payload_without_seal: Mapping[str, Any]) -> str:
@@ -1033,7 +1681,7 @@ def verify_authorization_signature(
             "-I",
             AUTHORIZATION_SIGNER_IDENTITY,
             "-n",
-            AUTHORIZATION_SIGNATURE_NAMESPACE,
+            authorization.signature_namespace,
             "-s",
             str(signature_path),
         ),
@@ -1175,7 +1823,7 @@ class SubprocessCommandRunner:
                 stderr="",
                 timed_out=True,
             )
-        except OSError:
+        except (OSError, UnicodeError):
             return CommandResult(
                 returncode=-1,
                 stdout="",
@@ -1187,6 +1835,156 @@ class SubprocessCommandRunner:
             stdout=completed.stdout,
             stderr=completed.stderr,
         )
+
+
+def _parse_keyscan_output(
+    result: CommandResult, *, host: str, port: int
+) -> tuple[str, str]:
+    if result.timed_out:
+        raise HostOrchestrationError("TOFU ssh-keyscan timed out")
+    if result.start_failed:
+        raise HostOrchestrationError("TOFU ssh-keyscan could not start")
+    if result.returncode != 0:
+        raise HostOrchestrationError("TOFU ssh-keyscan returned a nonzero status")
+    if result.stderr:
+        prefixes = (f"# {host}:{port} SSH-", f"# [{host}]:{port} SSH-")
+        for line in result.stderr.splitlines():
+            if (
+                len(line) > 512
+                or any(ord(character) < 32 for character in line)
+                or not line.startswith(prefixes)
+            ):
+                raise HostOrchestrationError("TOFU ssh-keyscan stderr was ambiguous")
+    if "\r" in result.stdout or not result.stdout.endswith("\n"):
+        raise HostOrchestrationError("TOFU ssh-keyscan output was truncated")
+    lines = result.stdout.splitlines()
+    if len(lines) != 1:
+        raise HostOrchestrationError(
+            "TOFU ssh-keyscan must return exactly one host-key line"
+        )
+    parts = lines[0].split()
+    if len(parts) != 3:
+        raise HostOrchestrationError("TOFU ssh-keyscan output was malformed")
+    expected_endpoint = f"[{host}]:{port}"
+    if parts[0] != expected_endpoint:
+        raise HostOrchestrationError(
+            "TOFU ssh-keyscan endpoint does not match the preregistered endpoint"
+        )
+    if parts[1] != "ssh-ed25519":
+        raise HostOrchestrationError(
+            "TOFU ssh-keyscan returned an unexpected host-key algorithm"
+        )
+    key_blob = _decode_ed25519_public_key(parts[2])
+    return parts[2], openssh_sha256_fingerprint(key_blob)
+
+
+def enroll_tofu_host_key(
+    request_path: Path,
+    runner: CommandRunner,
+    *,
+    now_fn: NowFn = lambda: datetime.now(timezone.utc),
+) -> TofuEnrollmentReceipt:
+    """Enroll one unauthenticated ED25519 key for one preregistered IP endpoint."""
+
+    request = TofuEnrollmentRequest.read(request_path)
+    flags = os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(request.known_hosts_path, flags)
+    except OSError as exc:
+        raise HostOrchestrationError(
+            f"known_hosts_path could not be opened safely: {exc}"
+        ) from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_uid != os.geteuid()
+            or stat.S_IMODE(opened.st_mode) != 0o600
+            or opened.st_size != 0
+        ):
+            raise HostOrchestrationError(
+                "known_hosts_path must remain a fresh current-user-owned mode-0600 "
+                "empty regular file"
+            )
+        argv = (
+            SSH_KEYSCAN_PATH,
+            "-T",
+            str(SSH_KEYSCAN_CONNECT_TIMEOUT_SECONDS),
+            "-t",
+            "ed25519",
+            "-p",
+            str(request.port),
+            request.host,
+        )
+        result = runner.run(
+            argv,
+            description="enroll_tofu_host_key",
+            timeout=SSH_KEYSCAN_PROCESS_TIMEOUT_SECONDS,
+        )
+        key_base64, fingerprint = _parse_keyscan_output(
+            result, host=request.host, port=request.port
+        )
+        current = request.known_hosts_path.lstat()
+        if (
+            current.st_dev != opened.st_dev
+            or current.st_ino != opened.st_ino
+            or current.st_size != 0
+        ):
+            raise HostOrchestrationError(
+                "known_hosts_path changed during TOFU enrollment"
+            )
+        known_hosts_content = (
+            f"[{request.host}]:{request.port} ssh-ed25519 {key_base64}\n"
+        ).encode("ascii")
+        os.write(descriptor, known_hosts_content)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+    known_hosts_sha256 = hashlib.sha256(known_hosts_content).hexdigest()
+    observed_at = now_fn().astimezone(timezone.utc)
+    unsealed = {
+        "schema_version": TOFU_ENROLLMENT_RECEIPT_SCHEMA_VERSION,
+        "policy": HostKeyTrustPolicy.TOFU_UNVERIFIED.value,
+        "provider_identity_independently_authenticated": False,
+        "identity_statement": TOFU_IDENTITY_STATEMENT,
+        "endpoint": {"host": request.host, "port": request.port},
+        "host_key": {
+            "algorithm": "ssh-ed25519",
+            "base64": key_base64,
+            "fingerprint_sha256": fingerprint,
+        },
+        "observed_at": _canonical_timestamp(observed_at),
+        "tool": {
+            "path": SSH_KEYSCAN_PATH,
+            "argv": list(argv),
+            "environment": SSH_KEYSCAN_ENVIRONMENT,
+            "process_timeout_seconds": SSH_KEYSCAN_PROCESS_TIMEOUT_SECONDS,
+        },
+        "known_hosts": {
+            "path": str(request.known_hosts_path),
+            "content_sha256": known_hosts_sha256,
+        },
+    }
+    payload = {**unsealed, "receipt_sha256": sha256_json(unsealed)}
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("ascii")
+    receipt_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        receipt_flags |= os.O_NOFOLLOW
+    try:
+        receipt_descriptor = os.open(request.receipt_path, receipt_flags, 0o600)
+    except OSError as exc:
+        raise HostOrchestrationError(
+            f"TOFU enrollment receipt must be a new non-symlink file: {exc}"
+        ) from exc
+    try:
+        os.write(receipt_descriptor, encoded)
+        os.fsync(receipt_descriptor)
+    finally:
+        os.close(receipt_descriptor)
+    return TofuEnrollmentReceipt.from_dict(payload)
 
 
 def checked(
@@ -1454,7 +2252,7 @@ class StrictSSHOptions:
         """Publication-safe: only the fixed option *names*, never values
         that could identify the host/user/key/known-hosts path."""
 
-        return {
+        record = {
             "batch_mode": True,
             "identities_only": True,
             "password_authentication": False,
@@ -1465,6 +2263,20 @@ class StrictSSHOptions:
             "control_master": False,
             "control_path": "none",
         }
+        if self.config.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            record.update(
+                {
+                    "host_key_trust_policy": (HostKeyTrustPolicy.TOFU_UNVERIFIED.value),
+                    "provider_identity_independently_authenticated": False,
+                    "enrollment_mitm_resistance_supported": False,
+                    "secure_provider_provenance_supported": False,
+                    "independent_host_key_verification_supported": False,
+                    "tofu_enrollment_receipt_sha256": (
+                        self.config.tofu_enrollment_receipt_sha256
+                    ),
+                }
+            )
+        return record
 
 
 # ---------------------------------------------------------------------------
@@ -1938,6 +2750,40 @@ class RemoteOrchestrator:
         self.authorization = authorization
         self.runner = runner
         self.now_fn = now_fn
+        if config.host_key_trust_policy is not authorization.host_key_trust_policy:
+            raise HostOrchestrationError(
+                "protected config host-key trust policy does not match authorization"
+            )
+        if config.host_key_trust_policy is HostKeyTrustPolicy.TOFU_UNVERIFIED:
+            assert config.host_key_ed25519_base64 is not None
+            expected_key_sha256 = hashlib.sha256(
+                _decode_ed25519_public_key(config.host_key_ed25519_base64)
+            ).hexdigest()
+            mismatches = []
+            if expected_key_sha256 != authorization.host_key_ed25519_sha256:
+                mismatches.append("ED25519 key")
+            if (
+                config.host_key_fingerprint_sha256
+                != authorization.host_key_fingerprint_sha256
+            ):
+                mismatches.append("fingerprint")
+            if config.known_hosts_sha256 != authorization.known_hosts_sha256:
+                mismatches.append("known_hosts digest")
+            if (
+                config.tofu_enrollment_receipt_sha256
+                != authorization.tofu_enrollment_receipt_sha256
+            ):
+                mismatches.append("TOFU enrollment receipt digest")
+            if (
+                config.host_key_trust_binding_sha256()
+                != authorization.host_key_trust_binding_sha256
+            ):
+                mismatches.append("host-key trust binding")
+            if mismatches:
+                raise HostOrchestrationError(
+                    "protected config TOFU bindings do not match authorization: "
+                    + ", ".join(mismatches)
+                )
         if config.docker_execution_mode is not authorization.docker_execution_mode:
             raise HostOrchestrationError(
                 "protected config Docker execution mode does not match authorization"
@@ -2173,8 +3019,7 @@ class RemoteOrchestrator:
         docker_info = self.docker.shell("info")
         docker_version = self.docker.shell("version", "--format", "{{.Server.Version}}")
         docker_failure = (
-            "{ echo LLMTRACEFX_REASON=preflight_docker_execution_denied >&2; "
-            "exit 1; }"
+            "{ echo LLMTRACEFX_REASON=preflight_docker_execution_denied >&2; exit 1; }"
         )
         script = "\n".join(
             [
@@ -2472,7 +3317,7 @@ class RemoteOrchestrator:
                 f"mkdir -p {_quote(self.paths.repo_dir)}",
                 f"tar -xf {_quote(self.paths.source_archive_remote_path)} "
                 f"-C {_quote(self.paths.repo_dir)}",
-                f"test \"$(cat {_quote(self.paths.repo_dir + '/' + _COMMIT_HEAD_MEMBER)})\" "
+                f'test "$(cat {_quote(self.paths.repo_dir + "/" + _COMMIT_HEAD_MEMBER)})" '
                 f"= {_quote(self.authorization.repository_head)}",
                 f"echo EXPECTED_HEAD={_quote(self.authorization.repository_head)}",
                 f"cd {_quote(self.paths.repo_dir)}",
@@ -2617,8 +3462,7 @@ class RemoteOrchestrator:
             )
         if "EXPECTED_HEAD" not in markers:
             raise HostOrchestrationError(
-                "image preparation output did not confirm the extracted source "
-                "commit"
+                "image preparation output did not confirm the extracted source commit"
             )
         remote_head = markers["EXPECTED_HEAD"].strip()
         if remote_head != self.authorization.repository_head:
@@ -3152,7 +3996,7 @@ class RemoteOrchestrator:
         private_bundle = evidence.PrivateEvidenceBundle(
             run_mode=evidence.RUN_MODE_REAL_RUN,
             experiment_nonce=self.authorization.nonce,
-            authorization=self.authorization.to_dict(),
+            authorization=self.authorization.redact(),
             ssh_options_public_record=self.ssh_options.public_record(),
             lane_receipts=lane_receipts,
             claim_matrix=claim_matrix,
@@ -3239,8 +4083,7 @@ class RemoteOrchestrator:
                 "  fi",
                 '  if [ "$cleanup_failed" -ne 0 ] && '
                 '[ "$shutdown_failed" -ne 0 ]; then',
-                "    echo "
-                '"LLMTRACEFX_REASON=teardown_cleanup_and_shutdown_failed" >&2',
+                '    echo "LLMTRACEFX_REASON=teardown_cleanup_and_shutdown_failed" >&2',
                 "    exit 1",
                 "  fi",
                 '  if [ "$shutdown_failed" -ne 0 ]; then',
@@ -3302,8 +4145,7 @@ class RemoteOrchestrator:
                 "  fi",
                 '  chmod --reference="$AUTHORIZED_KEYS" "$KEY_TMP" || '
                 '{ rm -f "$KEY_TMP"; return 1; }',
-                '  mv "$KEY_TMP" "$AUTHORIZED_KEYS" || '
-                '{ rm -f "$KEY_TMP"; return 1; }',
+                '  mv "$KEY_TMP" "$AUTHORIZED_KEYS" || { rm -f "$KEY_TMP"; return 1; }',
                 '  test "$(awk -v marker="$KEY_MARKER" '
                 "'$NF == marker { count++ } END { print count + 0 }' "
                 '"$AUTHORIZED_KEYS")" = "0"',

--- a/vllm_kv_truth/lifecycle.py
+++ b/vllm_kv_truth/lifecycle.py
@@ -285,6 +285,7 @@ def _require_canonical_ip_literal(value: Any, *, field_name: str) -> str:
 
 
 def _require_private_parent(path: Path, *, label: str) -> None:
+    _require_trusted_ancestry(path, label=label)
     parent = path.parent
     try:
         info = parent.lstat()
@@ -298,6 +299,32 @@ def _require_private_parent(path: Path, *, label: str) -> None:
         raise HostOrchestrationError(
             f"{label} parent must be current-user-owned with mode 0700"
         )
+
+
+def _require_trusted_ancestry(path: Path, *, label: str) -> None:
+    cursor = Path("/")
+    for component in path.parent.parts[1:]:
+        cursor /= component
+        try:
+            info = cursor.lstat()
+        except OSError as exc:
+            raise HostOrchestrationError(
+                f"{label} ancestor could not be inspected: {exc}"
+            ) from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise HostOrchestrationError(
+                f"{label} ancestry must contain only non-symlink directories"
+            )
+        if info.st_uid not in {0, os.geteuid()}:
+            raise HostOrchestrationError(
+                f"{label} ancestry contains an untrusted owner"
+            )
+        if stat.S_IMODE(info.st_mode) & 0o022:
+            root_owned_sticky = info.st_uid == 0 and bool(info.st_mode & stat.S_ISVTX)
+            if not root_owned_sticky:
+                raise HostOrchestrationError(
+                    f"{label} ancestry contains a group- or world-writable directory"
+                )
 
 
 def _decode_ed25519_public_key(key_base64: Any) -> bytes:
@@ -333,6 +360,10 @@ def _decode_ed25519_public_key(key_base64: Any) -> bytes:
 def openssh_sha256_fingerprint(key_blob: bytes) -> str:
     encoded = base64.b64encode(hashlib.sha256(key_blob).digest())
     return "SHA256:" + encoded.rstrip(b"=").decode("ascii")
+
+
+def openssh_known_hosts_host_token(host: str, port: int) -> str:
+    return host if port == 22 else f"[{host}]:{port}"
 
 
 def _require_private_key_permissions(path: Path, *, label: str) -> Path:
@@ -851,6 +882,8 @@ class ProtectedExecutionConfig:
             _require_nonempty_str(payload["known_hosts_path"], "known_hosts_path"),
             label="known_hosts_path",
         )
+        _require_trusted_ancestry(private_key_path, label="private_key_path")
+        _require_trusted_ancestry(known_hosts_path, label="known_hosts_path")
         _require_private_key_permissions(private_key_path, label="private_key_path")
         _require_not_group_or_world_readable(known_hosts_path, label="known_hosts_path")
         remote_workspace = _require_safe_remote_path(
@@ -926,7 +959,8 @@ class ProtectedExecutionConfig:
             )
             receipt = TofuEnrollmentReceipt.read(tofu_enrollment_receipt_path)
             expected_known_hosts = (
-                f"[{host}]:{port} ssh-ed25519 {host_key_ed25519_base64}\n"
+                f"{openssh_known_hosts_host_token(host, port)} "
+                f"ssh-ed25519 {host_key_ed25519_base64}\n"
             ).encode("ascii")
             try:
                 actual_known_hosts = read_bounded_regular_bytes(
@@ -1847,25 +1881,32 @@ def _parse_keyscan_output(
     if result.returncode != 0:
         raise HostOrchestrationError("TOFU ssh-keyscan returned a nonzero status")
     if result.stderr:
-        prefixes = (f"# {host}:{port} SSH-", f"# [{host}]:{port} SSH-")
-        for line in result.stderr.splitlines():
-            if (
-                len(line) > 512
-                or any(ord(character) < 32 for character in line)
-                or not line.startswith(prefixes)
-            ):
-                raise HostOrchestrationError("TOFU ssh-keyscan stderr was ambiguous")
+        raise HostOrchestrationError("TOFU ssh-keyscan stderr was ambiguous")
     if "\r" in result.stdout or not result.stdout.endswith("\n"):
         raise HostOrchestrationError("TOFU ssh-keyscan output was truncated")
     lines = result.stdout.splitlines()
-    if len(lines) != 1:
+    key_lines: list[str] = []
+    banner_prefixes = (f"# {host}:{port} SSH-", f"# [{host}]:{port} SSH-")
+    for line in lines:
+        if line.startswith("#"):
+            if (
+                len(line) > 512
+                or any(ord(character) < 32 for character in line)
+                or not line.startswith(banner_prefixes)
+            ):
+                raise HostOrchestrationError(
+                    "TOFU ssh-keyscan output contained an ambiguous banner"
+                )
+        else:
+            key_lines.append(line)
+    if len(key_lines) != 1:
         raise HostOrchestrationError(
             "TOFU ssh-keyscan must return exactly one host-key line"
         )
-    parts = lines[0].split()
+    parts = key_lines[0].split()
     if len(parts) != 3:
         raise HostOrchestrationError("TOFU ssh-keyscan output was malformed")
-    expected_endpoint = f"[{host}]:{port}"
+    expected_endpoint = openssh_known_hosts_host_token(host, port)
     if parts[0] != expected_endpoint:
         raise HostOrchestrationError(
             "TOFU ssh-keyscan endpoint does not match the preregistered endpoint"
@@ -1936,7 +1977,8 @@ def enroll_tofu_host_key(
                 "known_hosts_path changed during TOFU enrollment"
             )
         known_hosts_content = (
-            f"[{request.host}]:{request.port} ssh-ed25519 {key_base64}\n"
+            f"{openssh_known_hosts_host_token(request.host, request.port)} "
+            f"ssh-ed25519 {key_base64}\n"
         ).encode("ascii")
         os.write(descriptor, known_hosts_content)
         os.fsync(descriptor)


### PR DESCRIPTION
## Summary

- preserve the existing provider-pinned config-schema-2 / authorization-schema-3 path without fallback or migration
- add explicit `tofu_unverified` enrollment through the trusted native `/usr/bin/env -i` bootstrap only
- invoke fixed `/usr/bin/ssh-keyscan` argv against a canonical literal IP, accept exactly one ED25519 key, and write hash-bound protected known-hosts and enrollment receipts
- bind policy, key/fingerprint, known-hosts digest, receipt digest, endpoint commitment, and acknowledgement into protected config schema 3 and authorization schema 4
- retain strict key-only SSH/SCP enforcement and explicitly label unsupported provider identity, enrollment MITM resistance, provider provenance, and independent host-key verification claims
- document CloudRift's missing independent host-key source, rent-time client-key selection, sealing order, abort cleanup, and the September 10 operational-only refusal

## Validation

- 4,729 passed, 1 skipped across the full suite
- 659 deploy tests passed, 1 skipped in independent operations/methodology review
- exact changed-file quality ratchet passed
- Python 3.12 no-isolation wheel build, `--no-deps` clean install, trust-manifest enrollment, contaminated-parent native `env -i` preflight, and installed-wheel imports passed
- exact-head code, security, operations, and methodology/evidence reviews approved `64ceee43925776f908961e62f47ec1d16fcc68ba` against `a67c6df71128f24af3854d927cbdc0c2a34a47b7`

No provider resource was provisioned, contacted, reserved, authenticated to, or charged during this work.